### PR TITLE
Fixes for rendering partial views

### DIFF
--- a/dev/view.c
+++ b/dev/view.c
@@ -572,6 +572,7 @@ PHP_METHOD(Phalcon_View, _engineRender){
 	zval *t7 = NULL;
 	zval *r0 = NULL, *r1 = NULL, *r2 = NULL, *r3 = NULL, *r4 = NULL, *r5 = NULL, *r6 = NULL;
 	zval *i0 = NULL;
+	zval *rendered = NULL;
 	HashTable *ah0;
 	HashPosition hp0;
 	zval **hd;
@@ -588,6 +589,8 @@ PHP_METHOD(Phalcon_View, _engineRender){
 		RETURN_NULL();
 	}
 
+	PHALCON_INIT_VAR(rendered);
+	ZVAL_NULL(rendered);
 	PHALCON_INIT_VAR(not_exists);
 	ZVAL_BOOL(not_exists, 1);
 	
@@ -680,7 +683,7 @@ PHP_METHOD(Phalcon_View, _engineRender){
 		PHALCON_CONCAT_VV(r5, views_dir_path, extension);
 		PHALCON_CPY_WRT(view_engine_path, r5);
 		if (phalcon_file_exists(view_engine_path TSRMLS_CC) == SUCCESS) {
-			PHALCON_CALL_METHOD_PARAMS_2_NORETURN(engine, "render", view_engine_path, view_params, PHALCON_NO_CHECK);
+			PHALCON_CALL_METHOD_PARAMS_2(rendered, engine, "render", view_engine_path, view_params, PHALCON_NO_CHECK);
 			
 			PHALCON_INIT_VAR(not_exists);
 			ZVAL_BOOL(not_exists, 0);
@@ -705,7 +708,7 @@ PHP_METHOD(Phalcon_View, _engineRender){
 		}
 	}
 	
-	PHALCON_MM_RESTORE();
+	RETURN_DZVAL(rendered);
 }
 
 /**
@@ -757,6 +760,7 @@ PHP_METHOD(Phalcon_View, render){
 	zval *r0 = NULL, *r1 = NULL, *r2 = NULL, *r3 = NULL, *r4 = NULL, *r5 = NULL, *r6 = NULL;
 	zval *r7 = NULL, *r8 = NULL, *r9 = NULL, *r10 = NULL, *r11 = NULL, *r12 = NULL, *r13 = NULL;
 	zval *r14 = NULL, *r15 = NULL, *r16 = NULL, *r17 = NULL;
+	zval *render_buffer = NULL;
 	HashTable *ah0, *ah1;
 	HashPosition hp0, hp1;
 	zval **hd;
@@ -843,7 +847,11 @@ PHP_METHOD(Phalcon_View, render){
 		PHALCON_INIT_VAR(r6);
 		is_smaller_or_equal_function(r6, t4, render_level TSRMLS_CC);
 		if (zend_is_true(r6)) {
-			PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, render_view, silence, cache, PHALCON_NO_CHECK);
+			PHALCON_INIT_VAR(render_buffer);
+			PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, render_view, silence, cache, PHALCON_NO_CHECK);
+			if (zend_is_true(render_buffer)) {
+				PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+			}
 		}
 		
 		PHALCON_INIT_VAR(t5);
@@ -870,7 +878,11 @@ PHP_METHOD(Phalcon_View, render){
 						ZVAL_ZVAL(template_before, *hd, 1, 0);
 						PHALCON_INIT_VAR(r8);
 						PHALCON_CONCAT_VV(r8, layouts_dir, template_before);
-						PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, r8, silence, cache, PHALCON_NO_CHECK);
+						PHALCON_INIT_VAR(render_buffer);
+						PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, r8, silence, cache, PHALCON_NO_CHECK);
+						if (zend_is_true(render_buffer)) {
+							PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+						}
 						zend_hash_move_forward_ex(ah0, &hp0);
 						goto fes_b0d8_2;
 						fee_b0d8_2:
@@ -881,7 +893,11 @@ PHP_METHOD(Phalcon_View, render){
 				} else {
 					PHALCON_ALLOC_ZVAL_MM(r9);
 					PHALCON_CONCAT_VV(r9, layouts_dir, template_before);
-					PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, r9, silence, cache, PHALCON_NO_CHECK);
+					PHALCON_INIT_VAR(render_buffer);
+					PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, r9, silence, cache, PHALCON_NO_CHECK);
+					if (zend_is_true(render_buffer)) {
+						PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+					}
 				}
 				
 				PHALCON_INIT_VAR(silence);
@@ -897,7 +913,12 @@ PHP_METHOD(Phalcon_View, render){
 		if (zend_is_true(r10)) {
 			PHALCON_ALLOC_ZVAL_MM(r11);
 			PHALCON_CONCAT_VV(r11, layouts_dir, render_controller);
-			PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, r11, silence, cache, PHALCON_NO_CHECK);
+			PHALCON_INIT_VAR(render_buffer);
+			PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, r11, silence, cache, PHALCON_NO_CHECK);
+			if (zend_is_true(render_buffer)) {
+				PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+			}
+
 		}
 		
 		PHALCON_INIT_VAR(t8);
@@ -924,7 +945,11 @@ PHP_METHOD(Phalcon_View, render){
 						ZVAL_ZVAL(template_after, *hd, 1, 0);
 						PHALCON_INIT_VAR(r13);
 						PHALCON_CONCAT_VV(r13, layouts_dir, template_after);
-						PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, r13, silence, cache, PHALCON_NO_CHECK);
+						PHALCON_INIT_VAR(render_buffer);
+						PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, r13, silence, cache, PHALCON_NO_CHECK);
+						if (zend_is_true(render_buffer)) {
+							PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+						}
 						zend_hash_move_forward_ex(ah1, &hp1);
 						goto fes_b0d8_3;
 						fee_b0d8_3:
@@ -935,7 +960,11 @@ PHP_METHOD(Phalcon_View, render){
 				} else {
 					PHALCON_ALLOC_ZVAL_MM(r14);
 					PHALCON_CONCAT_VV(r14, layouts_dir, templates_after);
-					PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, r14, silence, cache, PHALCON_NO_CHECK);
+					PHALCON_INIT_VAR(render_buffer);
+					PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, r14, silence, cache, PHALCON_NO_CHECK);
+					if (zend_is_true(render_buffer)) {
+						PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+					}
 				}
 				
 				PHALCON_INIT_VAR(silence);
@@ -951,7 +980,11 @@ PHP_METHOD(Phalcon_View, render){
 		if (zend_is_true(r15)) {
 			PHALCON_ALLOC_ZVAL_MM(t11);
 			phalcon_read_property(&t11, this_ptr, SL("_mainView"), PHALCON_NOISY TSRMLS_CC);
-			PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", engines, t11, silence, cache, PHALCON_NO_CHECK);
+			PHALCON_INIT_VAR(render_buffer);
+			PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", engines, t11, silence, cache, PHALCON_NO_CHECK);
+			if (zend_is_true(render_buffer)) {
+				PHALCON_CALL_METHOD_PARAMS_1_NORETURN(this_ptr, "setcontent", render_buffer, PHALCON_NO_CHECK);
+			}
 		}
 		
 		if (zend_is_true(cache)) {
@@ -1035,6 +1068,7 @@ PHP_METHOD(Phalcon_View, pick){
 PHP_METHOD(Phalcon_View, partial){
 
 	zval *partial_path = NULL, *vfalse = NULL;
+	zval *render_buffer = NULL;
 	zval *r0 = NULL;
 
 	PHALCON_MM_GROW();
@@ -1047,11 +1081,12 @@ PHP_METHOD(Phalcon_View, partial){
 	PHALCON_INIT_VAR(vfalse);
 	ZVAL_BOOL(vfalse, 0);
 	
+	PHALCON_INIT_VAR(render_buffer);
 	PHALCON_ALLOC_ZVAL_MM(r0);
 	PHALCON_CALL_METHOD(r0, this_ptr, "_loadtemplateengines", PHALCON_NO_CHECK);
-	PHALCON_CALL_METHOD_PARAMS_4_NORETURN(this_ptr, "_enginerender", r0, partial_path, vfalse, vfalse, PHALCON_NO_CHECK);
+	PHALCON_CALL_METHOD_PARAMS_4(render_buffer, this_ptr, "_enginerender", r0, partial_path, vfalse, vfalse, PHALCON_NO_CHECK);
 	
-	PHALCON_MM_RESTORE();
+	RETURN_DZVAL(render_buffer);
 }
 
 /**

--- a/dev/view/engine.c
+++ b/dev/view/engine.c
@@ -210,10 +210,12 @@ PHP_METHOD(Phalcon_View_Engine, path){
  * Renders a partial inside another view
  *
  * @param string $partialPath
+ * @return string
  */
 PHP_METHOD(Phalcon_View_Engine, partial){
 
 	zval *partial_path = NULL;
+	zval *render_buffer = NULL;
 	zval *t0 = NULL;
 
 	PHALCON_MM_GROW();
@@ -225,8 +227,9 @@ PHP_METHOD(Phalcon_View_Engine, partial){
 
 	PHALCON_ALLOC_ZVAL_MM(t0);
 	phalcon_read_property(&t0, this_ptr, SL("_view"), PHALCON_NOISY TSRMLS_CC);
-	PHALCON_CALL_METHOD_PARAMS_1_NORETURN(t0, "partial", partial_path, PHALCON_NO_CHECK);
+	PHALCON_INIT_VAR(render_buffer);
+	PHALCON_CALL_METHOD_PARAMS_1(render_buffer, t0, "partial", partial_path, PHALCON_NO_CHECK);
 	
-	PHALCON_MM_RESTORE();
+	RETURN_DZVAL(render_buffer);
 }
 

--- a/dev/view/engine/mustache.c
+++ b/dev/view/engine/mustache.c
@@ -95,6 +95,7 @@ PHP_METHOD(Phalcon_View_Engine_Mustache, __construct){
  *
  * @param string $path
  * @param array $params
+ * @return string
  */
 PHP_METHOD(Phalcon_View_Engine_Mustache, render){
 
@@ -122,9 +123,8 @@ PHP_METHOD(Phalcon_View_Engine_Mustache, render){
 	PHALCON_ALLOC_ZVAL_MM(r1);
 	PHALCON_CALL_FUNC_PARAMS_1(r1, "file_get_contents", path);
 	PHALCON_CALL_METHOD_PARAMS_2(r0, t1, "render", r1, this_ptr, PHALCON_NO_CHECK);
-	PHALCON_CALL_METHOD_PARAMS_1_NORETURN(t0, "setcontent", r0, PHALCON_NO_CHECK);
-	
-	PHALCON_MM_RESTORE();
+
+	RETURN_DZVAL(r0);
 }
 
 PHP_METHOD(Phalcon_View_Engine_Mustache, __isset){

--- a/dev/view/engine/php.c
+++ b/dev/view/engine/php.c
@@ -69,6 +69,7 @@ PHP_METHOD(Phalcon_View_Engine_Php, __construct){
  *
  * @param string $path
  * @param array $params
+ * @return string
  */
 PHP_METHOD(Phalcon_View_Engine_Php, render){
 
@@ -90,7 +91,7 @@ PHP_METHOD(Phalcon_View_Engine_Php, render){
 		RETURN_NULL();
 	}
 
-	PHALCON_CALL_FUNC_NORETURN("ob_clean");
+	PHALCON_CALL_FUNC_NORETURN("ob_start");
 	if (phalcon_valid_foreach(params TSRMLS_CC)) {
 		ah0 = Z_ARRVAL_P(params);
 		zend_hash_internal_pointer_reset_ex(ah0, &hp0);
@@ -122,8 +123,8 @@ PHP_METHOD(Phalcon_View_Engine_Php, render){
 	
 	PHALCON_ALLOC_ZVAL_MM(r0);
 	PHALCON_CALL_FUNC(r0, "ob_get_contents");
-	PHALCON_CALL_METHOD_PARAMS_1_NORETURN(t0, "setcontent", r0, PHALCON_NO_CHECK);
-	
-	PHALCON_MM_RESTORE();
+	PHALCON_CALL_FUNC_NORETURN("ob_end_clean");
+
+	RETURN_DZVAL(r0);
 }
 

--- a/dev/view/engine/twig.c
+++ b/dev/view/engine/twig.c
@@ -111,6 +111,7 @@ PHP_METHOD(Phalcon_View_Engine_Twig, __construct){
  *
  * @param string $path
  * @param array $params
+ * @return string
  */
 PHP_METHOD(Phalcon_View_Engine_Twig, render){
 
@@ -161,8 +162,7 @@ PHP_METHOD(Phalcon_View_Engine_Twig, render){
 	PHALCON_ALLOC_ZVAL_MM(t2);
 	phalcon_read_property(&t2, this_ptr, SL("_twig"), PHALCON_NOISY TSRMLS_CC);
 	PHALCON_CALL_METHOD_PARAMS_2(r3, t2, "render", relative_path, twig_params, PHALCON_NO_CHECK);
-	PHALCON_CALL_METHOD_PARAMS_1_NORETURN(t1, "setcontent", r3, PHALCON_NO_CHECK);
-	
-	PHALCON_MM_RESTORE();
+
+	RETURN_DZVAL(r3);
 }
 

--- a/unit-tests/ViewTest.php
+++ b/unit-tests/ViewTest.php
@@ -21,7 +21,6 @@
 class ViewTest extends PHPUnit_Framework_TestCase {
 
 	public function testStandardRender(){
-
 		$view = new Phalcon_View();
 		$view->setBasePath(__DIR__.'/../');
 
@@ -32,12 +31,12 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->start();
 		$view->render('test2', 'index');
 		$view->finish();
-		$this->assertEquals($view->getContent(), '<html>here</html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>here</html>'.PHP_EOL);
 
 		$view->start();
 		$view->render('test3', 'other');
 		$view->finish();
-		$this->assertEquals($view->getContent(), '<html>lolhere</html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>lolhere</html>'.PHP_EOL);
 
 		//Variables
 		$view->setParamToView('a_cool_var', 'le-this');
@@ -46,7 +45,7 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->render('test3', 'another');
 		$view->finish();
 
-		$this->assertEquals($view->getContent(), '<html>lol<p>le-this</p></html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>lol<p>le-this</p></html>'.PHP_EOL);
 
 		//Templates
 		$view->setTemplateAfter('test');
@@ -55,7 +54,7 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->render('test3', 'other');
 		$view->finish();
 
-		$this->assertEquals($view->getContent(), '<html>zuplolhere</html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>zuplolhere</html>'.PHP_EOL);
 
 		$view->cleanTemplateAfter();
 
@@ -65,7 +64,7 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->start();
 		$view->render('test3', 'other');
 		$view->finish();
-		$this->assertEquals($view->getContent(), '<html>lolhere</html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>lolhere</html>'.PHP_EOL);
 
 		$view->setRenderLevel(Phalcon_View::LEVEL_LAYOUT);
 
@@ -87,7 +86,7 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->pick('test3/yup');
 		$view->render('test3', 'other');
 		$view->finish();
-		$this->assertEquals($view->getContent(), '<html>lolyup</html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>lolyup</html>'.PHP_EOL);
 
 	}
 
@@ -105,7 +104,13 @@ class ViewTest extends PHPUnit_Framework_TestCase {
 		$view->render('test5', 'index');
 		$view->finish();
 
-		$this->assertEquals($view->getContent(), '<html>Hey, this is a partial, also le-this</html>'."\n");
+		$this->assertEquals($view->getContent(), '<html>Hey, this is a partial, also le-this</html>'.PHP_EOL);
+
+		$view->start();
+		$view->render('test9', 'index');
+		$view->finish();
+
+		$this->assertEquals($view->getContent(), '<html>Hey, this is a partial, also le-this<br />Hey, this is a second partial, also le-this</html>'.PHP_EOL);
 
 	}
 

--- a/unit-tests/views/partials/_partial2.phtml
+++ b/unit-tests/views/partials/_partial2.phtml
@@ -1,0 +1,1 @@
+Hey, this is a second partial, also <?php echo $cool_var; ?>

--- a/unit-tests/views/test5/index.phtml
+++ b/unit-tests/views/test5/index.phtml
@@ -1,1 +1,1 @@
-<?php $this->partial("partials/_partial1") ?>
+<?= $this->partial("partials/_partial1") ?>

--- a/unit-tests/views/test9/index.phtml
+++ b/unit-tests/views/test9/index.phtml
@@ -1,0 +1,5 @@
+<?php 
+echo $this->partial("partials/_partial1");
+echo '<br />';
+echo $this->partial("partials/_partial2");
+?>


### PR DESCRIPTION
This changes a lot of the render methods to return strings instead of directly calling setContent.  It does result in some repetitive code which could probably be refactored to be cleaner.  I'm happy to do that if you would like.

The benefit of that is that partial views can render without calling setContent.  They do have to be echo'd now which is a change to their usage, but I just couldn't think of a solution that kept their current usage without rewriting the entire thing.  I took the easy way out. :)

I also added a test case for multiple partial views and modified the rest of the views tests so that they pass on Windows.  Using PHP_EOL instead of a hard coded "\n" should let them pass on Linux and Windows.
