### PR TITLE
Added support PostgreSQL schema

### DIFF
--- a/dev/phalcon.h
+++ b/dev/phalcon.h
@@ -234,6 +234,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeIndexes);
 PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeReferences);
 PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, tableOptions);
 
+PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, connect);
 PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns);
 PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeIndexes);
 PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeReferences);
@@ -1283,6 +1284,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_pdo_mysql_tableoptions, 0, 0, 1)
 	ZEND_ARG_INFO(0, tableName)
 	ZEND_ARG_INFO(0, schemaName)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_pdo_postgresql_connect, 0, 0, 0)
+	ZEND_ARG_INFO(0, descriptor)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_pdo_postgresql_describecolumns, 0, 0, 1)
@@ -3143,7 +3148,8 @@ PHALCON_INIT_FUNCS(phalcon_db_adapter_pdo_mysql_method_entry){
 };
 
 PHALCON_INIT_FUNCS(phalcon_db_adapter_pdo_postgresql_method_entry){
-	PHP_ME(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns, arginfo_phalcon_db_adapter_pdo_postgresql_describecolumns, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Db_Adapter_Pdo_Postgresql, connect, arginfo_phalcon_db_adapter_pdo_postgresql_connect, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns, arginfo_phalcon_db_adapter_pdo_postgresql_describecolumns, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Db_Adapter_Pdo_Postgresql, describeIndexes, arginfo_phalcon_db_adapter_pdo_postgresql_describeindexes, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Adapter_Pdo_Postgresql, describeReferences, arginfo_phalcon_db_adapter_pdo_postgresql_describereferences, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Adapter_Pdo_Postgresql, tableOptions, arginfo_phalcon_db_adapter_pdo_postgresql_tableoptions, ZEND_ACC_PUBLIC) 

--- a/unit-tests/config.db.php
+++ b/unit-tests/config.db.php
@@ -11,5 +11,6 @@ $configPostgresql = array(
 	'host' => '127.0.0.1',
 	'username' => 'postgres',
 	'password' => '',
-	'dbname' => 'phalcon_test'
+	'dbname' => 'phalcon_test',
+    'schema' => 'public'
 );


### PR DESCRIPTION
PostgreSQL adapter will execute "SET search_path TO '???'" statement when connectted if schema is setting in config.

Ex:

``` php

$configPostgresql = array(
  'host' => '127.0.0.1',
  'username' => 'postgres',
  'password' => '',
  'dbname' => 'phalcon_test',
  'schema' => 'public'
);

$connection = new Phalcon\Db\Adapter\Pdo\Postgresql($configPostgresql);

```

Signed-off-by: Rack Lin racklin@gmail.com
