### PR TITLE
Added test for negating the acl roles

### DIFF
--- a/unit-tests/AclTest.php
+++ b/unit-tests/AclTest.php
@@ -89,4 +89,20 @@ class AclTest extends PHPUnit_Framework_TestCase
 
 	}
 
+	public function testNegationOfInheritedRoles()
+	{
+		$acl = new \Phalcon\Acl\Adapter\Memory;
+		$acl->setDefaultAction(\Phalcon\Acl::DENY);
+
+		$acl->addRole('Guests');
+		$acl->addRole('Members', 'Guests');
+
+		$acl->addResource('Login', array('index'));
+
+		$acl->allow('Guests', 'Login', 'index');
+		$acl->deny('Members', 'Login', 'index');
+
+		$this->assertFalse((bool) $acl->isAllowed('Members', 'Login', 'index'));
+	}
+
 }


### PR DESCRIPTION
If access rights are inherited and the access to the resource from inherited resource will be negated, isAllowed should return 0.
