### PR TITLE
Added EventManager::fire can send extra data to event listener.

### DIFF
--- a/ext/cli/console.c
+++ b/ext/cli/console.c
@@ -264,7 +264,7 @@ PHP_METHOD(Phalcon_CLI_Console, handle){
 			ZVAL_STRING(event_name, "console:beforeStartModule", 1);
 			
 			PHALCON_INIT_VAR(status);
-			PHALCON_CALL_METHOD_PARAMS_2(status, events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+			PHALCON_CALL_METHOD_PARAMS_3(status, events_manager, "fire", event_name, this_ptr, module_name, PH_NO_CHECK);
 			if (PHALCON_IS_FALSE(status)) {
 				PHALCON_MM_RESTORE();
 				RETURN_FALSE;
@@ -332,7 +332,7 @@ PHP_METHOD(Phalcon_CLI_Console, handle){
 			ZVAL_STRING(event_name, "console:afterStartModule", 1);
 			
 			PHALCON_INIT_VAR(status);
-			PHALCON_CALL_METHOD_PARAMS_2(status, events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+			PHALCON_CALL_METHOD_PARAMS_3(status, events_manager, "fire", event_name, this_ptr, module_name, PH_NO_CHECK);
 			if (PHALCON_IS_FALSE(status)) {
 				PHALCON_MM_RESTORE();
 				RETURN_FALSE;
@@ -362,7 +362,7 @@ PHP_METHOD(Phalcon_CLI_Console, handle){
 		ZVAL_STRING(event_name, "console:beforeHandleTask", 1);
 		
 		PHALCON_INIT_VAR(status);
-		PHALCON_CALL_METHOD_PARAMS_2(status, events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3(status, events_manager, "fire", event_name, this_ptr, dispatcher, PH_NO_CHECK);
 		if (PHALCON_IS_FALSE(status)) {
 			PHALCON_MM_RESTORE();
 			RETURN_FALSE;
@@ -374,7 +374,7 @@ PHP_METHOD(Phalcon_CLI_Console, handle){
 	if (Z_TYPE_P(events_manager) == IS_OBJECT) {
 		PHALCON_INIT_VAR(event_name);
 		ZVAL_STRING(event_name, "console:afterHandleTask", 1);
-		PHALCON_CALL_METHOD_PARAMS_2_NORETURN(events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3_NORETURN(events_manager, "fire", event_name, this_ptr, task, PH_NO_CHECK);
 	}
 	
 	

--- a/ext/events/event.c
+++ b/ext/events/event.c
@@ -45,20 +45,27 @@
  *
  * @param string $type
  * @param object $source
+ * @param object $data
  */
 PHP_METHOD(Phalcon_Events_Event, __construct){
 
-	zval *type = NULL, *source = NULL;
+	zval *type = NULL, *source = NULL, *data = NULL;
 
 	PHALCON_MM_GROW();
 	
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz", &type, &source) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "zz|z", &type, &source, &data) == FAILURE) {
 		PHALCON_MM_RESTORE();
 		RETURN_NULL();
 	}
 
+	if (!data) {
+		PHALCON_ALLOC_ZVAL_MM(data);
+		ZVAL_NULL(data);
+	}
+
 	phalcon_update_property_zval(this_ptr, SL("_type"), type TSRMLS_CC);
 	phalcon_update_property_zval(this_ptr, SL("_source"), source TSRMLS_CC);
+	phalcon_update_property_zval(this_ptr, SL("_data"), data TSRMLS_CC);
 	
 	PHALCON_MM_RESTORE();
 }
@@ -80,6 +87,32 @@ PHP_METHOD(Phalcon_Events_Event, setType){
 	}
 
 	phalcon_update_property_zval(this_ptr, SL("_type"), event_type TSRMLS_CC);
+	
+	PHALCON_MM_RESTORE();
+}
+
+/**
+ * Set the event's data
+ *
+ * @param object $data
+ */
+PHP_METHOD(Phalcon_Events_Event, setData){
+
+	zval *data = NULL;
+
+	PHALCON_MM_GROW();
+	
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &data) == FAILURE) {
+		PHALCON_MM_RESTORE();
+		RETURN_NULL();
+	}
+
+	if (!data) {
+		PHALCON_ALLOC_ZVAL_MM(data);
+		ZVAL_NULL(data);
+	}
+
+	phalcon_update_property_zval(this_ptr, SL("_data"), data TSRMLS_CC);
 	
 	PHALCON_MM_RESTORE();
 }
@@ -114,5 +147,21 @@ PHP_METHOD(Phalcon_Events_Event, getSource){
 	phalcon_read_property(&source, this_ptr, SL("_source"), PH_NOISY_CC);
 	
 	RETURN_CCTOR(source);
+}
+
+/**
+ * Returns the event's data
+ *
+ * @return object
+ */
+PHP_METHOD(Phalcon_Events_Event, getData){
+
+	zval *data = NULL;
+
+	PHALCON_MM_GROW();
+	PHALCON_INIT_VAR(data);
+	phalcon_read_property(&data, this_ptr, SL("_data"), PH_NOISY_CC);
+	
+	RETURN_CCTOR(data);
 }
 

--- a/ext/loader.c
+++ b/ext/loader.c
@@ -322,7 +322,7 @@ PHP_METHOD(Phalcon_Loader, autoLoad){
 	if (Z_TYPE_P(events_manager) == IS_OBJECT) {
 		PHALCON_INIT_VAR(event_name);
 		ZVAL_STRING(event_name, "loader:beforeCheckClass", 1);
-		PHALCON_CALL_METHOD_PARAMS_2_NORETURN(events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3_NORETURN(events_manager, "fire", event_name, this_ptr, class_name, PH_NO_CHECK);
 	}
 	
 	PHALCON_INIT_VAR(classes);
@@ -627,7 +627,7 @@ PHP_METHOD(Phalcon_Loader, autoLoad){
 	if (Z_TYPE_P(events_manager) == IS_OBJECT) {
 		PHALCON_INIT_VAR(event_name);
 		ZVAL_STRING(event_name, "loader:afterCheckClass", 1);
-		PHALCON_CALL_METHOD_PARAMS_2_NORETURN(events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3_NORETURN(events_manager, "fire", event_name, this_ptr, class_name, PH_NO_CHECK);
 	}
 	
 	PHALCON_MM_RESTORE();

--- a/ext/mvc/application.c
+++ b/ext/mvc/application.c
@@ -258,7 +258,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle){
 			ZVAL_STRING(event_name, "application:beforeStartModule", 1);
 			
 			PHALCON_INIT_VAR(status);
-			PHALCON_CALL_METHOD_PARAMS_2(status, events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+			PHALCON_CALL_METHOD_PARAMS_3(status, events_manager, "fire", event_name, this_ptr, module_name, PH_NO_CHECK);
 			if (PHALCON_IS_FALSE(status)) {
 				PHALCON_MM_RESTORE();
 				RETURN_FALSE;
@@ -326,7 +326,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle){
 			ZVAL_STRING(event_name, "application:afterStartModule", 1);
 			
 			PHALCON_INIT_VAR(status);
-			PHALCON_CALL_METHOD_PARAMS_2(status, events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+			PHALCON_CALL_METHOD_PARAMS_3(status, events_manager, "fire", event_name, this_ptr, module_name, PH_NO_CHECK);
 			if (PHALCON_IS_FALSE(status)) {
 				PHALCON_MM_RESTORE();
 				RETURN_FALSE;
@@ -363,7 +363,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle){
 		ZVAL_STRING(event_name, "application:beforeHandleRequest", 1);
 		
 		PHALCON_INIT_VAR(status);
-		PHALCON_CALL_METHOD_PARAMS_2(status, events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3(status, events_manager, "fire", event_name, this_ptr, dispatcher, PH_NO_CHECK);
 		if (PHALCON_IS_FALSE(status)) {
 			PHALCON_MM_RESTORE();
 			RETURN_FALSE;
@@ -375,7 +375,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle){
 	if (Z_TYPE_P(events_manager) == IS_OBJECT) {
 		PHALCON_INIT_VAR(event_name);
 		ZVAL_STRING(event_name, "application:afterHandleRequest", 1);
-		PHALCON_CALL_METHOD_PARAMS_2_NORETURN(events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3_NORETURN(events_manager, "fire", event_name, this_ptr, controller, PH_NO_CHECK);
 	}
 	
 	if (Z_TYPE_P(controller) == IS_OBJECT) {
@@ -404,7 +404,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle){
 	if (Z_TYPE_P(events_manager) == IS_OBJECT) {
 		PHALCON_INIT_VAR(event_name);
 		ZVAL_STRING(event_name, "application:beforeSendResponse", 1);
-		PHALCON_CALL_METHOD_PARAMS_2_NORETURN(events_manager, "fire", event_name, this_ptr, PH_NO_CHECK);
+		PHALCON_CALL_METHOD_PARAMS_3_NORETURN(events_manager, "fire", event_name, this_ptr, response, PH_NO_CHECK);
 	}
 	
 	PHALCON_CALL_METHOD_NORETURN(response, "sendheaders", PH_NO_CHECK);

--- a/ext/phalcon.c
+++ b/ext/phalcon.c
@@ -523,6 +523,7 @@ PHP_MINIT_FUNCTION(phalcon){
 	PHALCON_REGISTER_CLASS(Phalcon\\Events, Event, events_event, phalcon_events_event_method_entry, 0);
 	zend_declare_property_null(phalcon_events_event_ce, SL("_type"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_events_event_ce, SL("_source"), ZEND_ACC_PROTECTED TSRMLS_CC);
+	zend_declare_property_null(phalcon_events_event_ce, SL("_data"), ZEND_ACC_PROTECTED TSRMLS_CC);
 
 	PHALCON_REGISTER_CLASS(Phalcon\\Events, Manager, events_manager, phalcon_events_manager_method_entry, 0);
 	zend_declare_property_null(phalcon_events_manager_ce, SL("_events"), ZEND_ACC_PROTECTED TSRMLS_CC);

--- a/ext/phalcon.h
+++ b/ext/phalcon.h
@@ -1062,8 +1062,10 @@ PHP_METHOD(Phalcon_DI_FactoryDefault, __construct);
 
 PHP_METHOD(Phalcon_Events_Event, __construct);
 PHP_METHOD(Phalcon_Events_Event, setType);
+PHP_METHOD(Phalcon_Events_Event, setData);
 PHP_METHOD(Phalcon_Events_Event, getType);
 PHP_METHOD(Phalcon_Events_Event, getSource);
+PHP_METHOD(Phalcon_Events_Event, getData);
 
 
 PHP_METHOD(Phalcon_Events_Manager, __construct);
@@ -3089,6 +3091,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_events_event_settype, 0, 0, 1)
 	ZEND_ARG_INFO(0, eventType)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_events_event_setdata, 0, 0, 1)
+	ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_events_manager_attach, 0, 0, 2)
 	ZEND_ARG_INFO(0, eventType)
 	ZEND_ARG_INFO(0, handler)
@@ -4354,8 +4360,10 @@ PHALCON_INIT_FUNCS(phalcon_di_factorydefault_method_entry){
 PHALCON_INIT_FUNCS(phalcon_events_event_method_entry){
 	PHP_ME(Phalcon_Events_Event, __construct, arginfo_phalcon_events_event___construct, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR) 
 	PHP_ME(Phalcon_Events_Event, setType, arginfo_phalcon_events_event_settype, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Events_Event, setData, arginfo_phalcon_events_event_setdata, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Events_Event, getType, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Events_Event, getSource, NULL, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Events_Event, getData, NULL, ZEND_ACC_PUBLIC) 
 	PHP_FE_END
 };
 

--- a/unit-tests/EventsTest.php
+++ b/unit-tests/EventsTest.php
@@ -30,9 +30,9 @@ class LeDummyComponent
 
 	public function leAction()
 	{
-		$this->_eventsManager->fire('dummy:beforeAction', $this);
+		$this->_eventsManager->fire('dummy:beforeAction', $this, "extra data");
 
-		$this->_eventsManager->fire('dummy:afterAction', $this);
+		$this->_eventsManager->fire('dummy:afterAction', $this, array("extra","data"));
 	}
 
 }
@@ -69,11 +69,13 @@ class LeDummyListener
 		$this->_testCase = $testCase;
 	}
 
-	public function beforeAction($event, $component)
+	public function beforeAction($event, $component, $data)
 	{
 		$this->_testCase->assertInstanceOf('Phalcon\Events\Event', $event);
 		$this->_testCase->assertInstanceOf('LeDummyComponent', $component);
 		$this->_before++;
+                // check data from arguments
+                $this->_testCase->assertEquals($data, "extra data");
 	}
 
 	public function afterAction($event, $component)
@@ -81,6 +83,8 @@ class LeDummyListener
 		$this->_testCase->assertInstanceOf('Phalcon\Events\Event', $event);
 		$this->_testCase->assertInstanceOf('LeDummyComponent', $component);
 		$this->_after++;
+                // check data from $event->getData()
+                $this->_testCase->assertEquals($event->getData(), array("extra","data"));
 	}
 
 	public function getBeforeCount()


### PR DESCRIPTION
Hi, 

I have patched EventManager and Event class that EventManager::fire can send data to EventLisener.

It's useful that we can send (temperate) data to event listener instead of setting in object's properties. 

And I also patched CLI\Console , Mvc\Application 's 'beforeStartModule' and 'afterStartModule' send module_name to event listener, so listener can determine which module will starting or started.

Similar:
http://api.jquery.com/event.data/

Signed-off-by: Rack Lin racklin@gmail.com
