### PR TITLE
0.6.0 \Phalcon\Cache exists method implementation for backends.

### DIFF
--- a/ext/cache/backend/apc.c
+++ b/ext/cache/backend/apc.c
@@ -294,3 +294,50 @@ PHP_METHOD(Phalcon_Cache_Backend_Apc, queryKeys){
 	RETURN_CTOR(keys);
 }
 
+/**
+ * Checks if cache exists.
+ *
+ * @param string $keyName
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Cache_Backend_Apc, exists){
+
+	zval *key_name = NULL, *last_key = NULL, *prefix;
+	zval *cache_exists;
+
+	PHALCON_MM_GROW();
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &key_name) == FAILURE) {
+		PHALCON_MM_RESTORE();
+		RETURN_FALSE;
+	}
+
+	if (!key_name) {
+		PHALCON_INIT_NVAR(key_name);
+	}
+
+	if (Z_TYPE_P(key_name) == IS_NULL) {
+		PHALCON_INIT_VAR(last_key);
+		phalcon_read_property(&last_key, this_ptr, SL("_lastKey"), PH_NOISY_CC);
+	} else {
+		PHALCON_INIT_VAR(prefix);
+		phalcon_read_property(&prefix, this_ptr, SL("_prefix"), PH_NOISY_CC);
+		PHALCON_INIT_NVAR(last_key);
+		PHALCON_CONCAT_SVV(last_key, "_PHCA", prefix, key_name);
+	}
+
+	if (!zend_is_true(last_key)) {
+		PHALCON_MM_RESTORE();
+		RETURN_FALSE;
+	}
+
+	PHALCON_INIT_VAR(cache_exists);
+	PHALCON_CALL_FUNC_PARAMS_1(cache_exists, "apc_exists", last_key);
+	if (PHALCON_IS_FALSE(cache_exists)) {
+		PHALCON_MM_RESTORE();
+		RETURN_FALSE;
+	}
+
+	PHALCON_MM_RESTORE();
+	RETURN_TRUE;
+}

--- a/ext/cache/backend/apc.c
+++ b/ext/cache/backend/apc.c
@@ -326,18 +326,15 @@ PHP_METHOD(Phalcon_Cache_Backend_Apc, exists){
 		PHALCON_CONCAT_SVV(last_key, "_PHCA", prefix, key_name);
 	}
 
-	if (!zend_is_true(last_key)) {
-		PHALCON_MM_RESTORE();
-		RETURN_FALSE;
-	}
-
-	PHALCON_INIT_VAR(cache_exists);
-	PHALCON_CALL_FUNC_PARAMS_1(cache_exists, "apc_exists", last_key);
-	if (PHALCON_IS_FALSE(cache_exists)) {
-		PHALCON_MM_RESTORE();
-		RETURN_FALSE;
+	if (zend_is_true(last_key)) {
+		PHALCON_INIT_VAR(cache_exists);
+		PHALCON_CALL_FUNC_PARAMS_1(cache_exists, "apc_exists", last_key);
+		if (PHALCON_IS_NOT_FALSE(cache_exists)) {
+			PHALCON_MM_RESTORE();
+			RETURN_TRUE;
+		}
 	}
 
 	PHALCON_MM_RESTORE();
-	RETURN_TRUE;
+	RETURN_FALSE;
 }

--- a/ext/cache/backend/file.c
+++ b/ext/cache/backend/file.c
@@ -449,25 +449,22 @@ PHP_METHOD(Phalcon_Cache_Backend_File, exists){
 		PHALCON_CONCAT_VV(last_key, prefix, filtered);
 	}
 
-	if (!zend_is_true(last_key)) {
-		PHALCON_MM_RESTORE();
-		RETURN_FALSE;
-	}
+	if (zend_is_true(last_key)) {
+		PHALCON_INIT_VAR(backend);
+		phalcon_read_property(&backend, this_ptr, SL("_backendOptions"), PH_NOISY_CC);
 
-	PHALCON_INIT_VAR(backend);
-	phalcon_read_property(&backend, this_ptr, SL("_backendOptions"), PH_NOISY_CC);
-
-	PHALCON_INIT_VAR(cache_dir);
-	phalcon_array_fetch_string(&cache_dir, backend, SL("cacheDir"), PH_NOISY_CC);
+		PHALCON_INIT_VAR(cache_dir);
+		phalcon_array_fetch_string(&cache_dir, backend, SL("cacheDir"), PH_NOISY_CC);
 	
-	PHALCON_INIT_VAR(cache_file);
-	PHALCON_CONCAT_VV(cache_file, cache_dir, last_key);
-	if (phalcon_file_exists(cache_file TSRMLS_CC) == FAILURE) {
-		PHALCON_MM_RESTORE();
-		RETURN_FALSE;
+		PHALCON_INIT_VAR(cache_file);
+		PHALCON_CONCAT_VV(cache_file, cache_dir, last_key);
+		if (phalcon_file_exists(cache_file TSRMLS_CC) == SUCCESS) {
+			PHALCON_MM_RESTORE();
+			RETURN_TRUE;
+		}
 	}
 
 	PHALCON_MM_RESTORE();
-	RETURN_TRUE;
+	RETURN_FALSE;
 }
 

--- a/ext/cache/backend/memcache.c
+++ b/ext/cache/backend/memcache.c
@@ -567,27 +567,24 @@ PHP_METHOD(Phalcon_Cache_Backend_Memcache, exists){
 		PHALCON_CONCAT_VV(last_key, prefix, key_name);
 	}
 
-	if (!zend_is_true(last_key)) {
-		PHALCON_MM_RESTORE();
-		RETURN_FALSE;
-	}
-
-	PHALCON_INIT_VAR(memcache);
-	phalcon_read_property(&memcache, this_ptr, SL("_memcache"), PH_NOISY_CC);
-	if (!zend_is_true(memcache)) {
-		PHALCON_CALL_METHOD_NORETURN(this_ptr, "_connect", PH_NO_CHECK);
-
-		PHALCON_INIT_NVAR(memcache);
+	if (zend_is_true(last_key)) {
+		PHALCON_INIT_VAR(memcache);
 		phalcon_read_property(&memcache, this_ptr, SL("_memcache"), PH_NOISY_CC);
-	}
+		if (!zend_is_true(memcache)) {
+			PHALCON_CALL_METHOD_NORETURN(this_ptr, "_connect", PH_NO_CHECK);
 
-	PHALCON_INIT_VAR(cache_exists);
-	PHALCON_CALL_METHOD_PARAMS_1(cache_exists, memcache, "get", last_key, PH_NO_CHECK);
-	if (PHALCON_IS_FALSE(cache_exists)) {
-		PHALCON_MM_RESTORE();
-		RETURN_FALSE;
+			PHALCON_INIT_NVAR(memcache);
+			phalcon_read_property(&memcache, this_ptr, SL("_memcache"), PH_NOISY_CC);
+		}
+
+		PHALCON_INIT_VAR(cache_exists);
+		PHALCON_CALL_METHOD_PARAMS_1(cache_exists, memcache, "get", last_key, PH_NO_CHECK);
+		if (PHALCON_IS_NOT_FALSE(cache_exists)) {
+			PHALCON_MM_RESTORE();
+			RETURN_TRUE;
+		}
 	}
 
 	PHALCON_MM_RESTORE();
-	RETURN_TRUE;
+	RETURN_FALSE;
 }

--- a/ext/phalcon.h
+++ b/ext/phalcon.h
@@ -730,18 +730,21 @@ PHP_METHOD(Phalcon_Cache_Backend_Memcache, get);
 PHP_METHOD(Phalcon_Cache_Backend_Memcache, save);
 PHP_METHOD(Phalcon_Cache_Backend_Memcache, delete);
 PHP_METHOD(Phalcon_Cache_Backend_Memcache, queryKeys);
+PHP_METHOD(Phalcon_Cache_Backend_Memcache, exists);
 PHP_METHOD(Phalcon_Cache_Backend_Memcache, __destruct);
 
 PHP_METHOD(Phalcon_Cache_Backend_Apc, get);
 PHP_METHOD(Phalcon_Cache_Backend_Apc, save);
 PHP_METHOD(Phalcon_Cache_Backend_Apc, delete);
 PHP_METHOD(Phalcon_Cache_Backend_Apc, queryKeys);
+PHP_METHOD(Phalcon_Cache_Backend_Apc, exists);
 
 PHP_METHOD(Phalcon_Cache_Backend_File, __construct);
 PHP_METHOD(Phalcon_Cache_Backend_File, get);
 PHP_METHOD(Phalcon_Cache_Backend_File, save);
 PHP_METHOD(Phalcon_Cache_Backend_File, delete);
 PHP_METHOD(Phalcon_Cache_Backend_File, queryKeys);
+PHP_METHOD(Phalcon_Cache_Backend_File, exists);
 
 
 PHP_METHOD(Phalcon_Acl_Adapter_Memory, __construct);
@@ -2442,6 +2445,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_memcache_querykeys, 0, 0, 0
 	ZEND_ARG_INFO(0, prefix)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_memcache_exists, 0, 0, 0)
+	ZEND_ARG_INFO(0, keyName)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_apc_get, 0, 0, 1)
 	ZEND_ARG_INFO(0, keyName)
 	ZEND_ARG_INFO(0, lifetime)
@@ -2460,6 +2467,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_apc_querykeys, 0, 0, 0)
 	ZEND_ARG_INFO(0, prefix)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_apc_exists, 0, 0, 0)
+	ZEND_ARG_INFO(0, keyName)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_file___construct, 0, 0, 1)
@@ -2485,6 +2496,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_file_querykeys, 0, 0, 0)
 	ZEND_ARG_INFO(0, prefix)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_cache_backend_file_exists, 0, 0, 0)
+	ZEND_ARG_INFO(0, keyName)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_acl_adapter_memory_setdefaultaction, 0, 0, 1)
@@ -4167,6 +4182,7 @@ PHALCON_INIT_FUNCS(phalcon_cache_backend_memcache_method_entry){
 	PHP_ME(Phalcon_Cache_Backend_Memcache, save, arginfo_phalcon_cache_backend_memcache_save, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_Memcache, delete, arginfo_phalcon_cache_backend_memcache_delete, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_Memcache, queryKeys, arginfo_phalcon_cache_backend_memcache_querykeys, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Cache_Backend_Memcache, exists, arginfo_phalcon_cache_backend_memcache_exists, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_Memcache, __destruct, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_DTOR) 
 	PHP_FE_END
 };
@@ -4176,6 +4192,7 @@ PHALCON_INIT_FUNCS(phalcon_cache_backend_apc_method_entry){
 	PHP_ME(Phalcon_Cache_Backend_Apc, save, arginfo_phalcon_cache_backend_apc_save, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_Apc, delete, arginfo_phalcon_cache_backend_apc_delete, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_Apc, queryKeys, arginfo_phalcon_cache_backend_apc_querykeys, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Cache_Backend_Apc, exists, arginfo_phalcon_cache_backend_apc_exists, ZEND_ACC_PUBLIC) 
 	PHP_FE_END
 };
 
@@ -4185,6 +4202,7 @@ PHALCON_INIT_FUNCS(phalcon_cache_backend_file_method_entry){
 	PHP_ME(Phalcon_Cache_Backend_File, save, arginfo_phalcon_cache_backend_file_save, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_File, delete, arginfo_phalcon_cache_backend_file_delete, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Cache_Backend_File, queryKeys, arginfo_phalcon_cache_backend_file_querykeys, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Cache_Backend_File, exists, arginfo_phalcon_cache_backend_file_exists, ZEND_ACC_PUBLIC) 
 	PHP_FE_END
 };
 


### PR DESCRIPTION
Related issue #81

I've done functional tests for _File_ and _APC_ backends on OSX.
