### PR TITLE
Acl: Corrected typo in the Acl tests

### DIFF
--- a/php-tests/tests/Phalcon/Acl/Adapter/Memory/UnitTest.php
+++ b/php-tests/tests/Phalcon/Acl/Adapter/Memory/UnitTest.php
@@ -183,7 +183,7 @@ class Acl_Adapter_Memory_UnitTest extends Phalcon_Test_UnitTestCase
         $acl->setDefaultAction(PhAcl::DENY);
 
         $acl->addRole($aclRole);
-        $acl->addResource($aclResource. array('search', 'destroy'));
+        $acl->addResource($aclResource, array('search', 'destroy'));
 
         $expected = PhAcl::DENY;
         $actual   = $acl->isAllowed('Administrators', 'Customers', 'search');


### PR DESCRIPTION
modified:   php-tests/tests/Phalcon/Acl/Adapter/Memory/UnitTest.php
