### PR TITLE
[BUG] 1.1.0+ Oracle numRows

### DIFF
--- a/ext/db/result/pdo.c
+++ b/ext/db/result/pdo.c
@@ -255,7 +255,7 @@ PHP_METHOD(Phalcon_Db_Result_Pdo, numRows){
 	
 		PHALCON_INIT_VAR(type);
 		PHALCON_CALL_METHOD(type, connection, "gettype");
-		if (PHALCON_IS_STRING(type, "sqlite")) {
+		if (PHALCON_IS_STRING(type, "sqlite") || PHALCON_IS_STRING(type, "oci")) {
 	
 			/** 
 			 * SQLite returns resultsets that to the client eyes (PDO) has an arbitrary number


### PR DESCRIPTION
Oracle adapter need this fix, to work in 1.1.0+

Apply this for 1.1.0 and 1.2.0
