### PR TITLE
Database Savepoints (Nested Transactions With Savepoints)

### DIFF
--- a/ext/db/adapter.c
+++ b/ext/db/adapter.c
@@ -55,6 +55,8 @@ PHALCON_INIT_CLASS(Phalcon_Db_Adapter){
 
 	PHALCON_REGISTER_CLASS(Phalcon\\Db, Adapter, db_adapter, phalcon_db_adapter_method_entry, ZEND_ACC_EXPLICIT_ABSTRACT_CLASS);
 
+	zend_declare_property_bool(phalcon_db_adapter_ce, SL("_transactionsWithSavepoints"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+	zend_declare_property_long(phalcon_db_adapter_ce, SL("_transactionLevel"), 0, ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_db_adapter_ce, SL("_eventsManager"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_db_adapter_ce, SL("_descriptor"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_db_adapter_ce, SL("_dialectType"), ZEND_ACC_PROTECTED TSRMLS_CC);
@@ -1732,5 +1734,184 @@ PHP_METHOD(Phalcon_Db_Adapter, getDialect){
 
 
 	RETURN_MEMBER(this_ptr, "_dialect");
+}
+
+/**
+ * Creates a new savepoint
+ *
+ * @param string $savepoint Name of a savepoint to create
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Adapter, createSavepoint) {
+
+	zval *savepoint, *dialect, *supports_sp, *success, *sql;
+
+	PHALCON_MM_GROW();
+
+	phalcon_fetch_params(1, 1, 0, &savepoint);
+
+	PHALCON_OBS_VAR(dialect);
+	phalcon_read_property_this(&dialect, this_ptr, SL("_dialect"), PH_NOISY_CC);
+
+	PHALCON_INIT_VAR(supports_sp);
+	phalcon_call_method(supports_sp, dialect, "supportssavepoints");
+
+	if (!zend_is_true(supports_sp)) {
+		PHALCON_THROW_EXCEPTION_STR(phalcon_db_exception_ce, "Savepoints are not supported by this database adapter.");
+		return;
+	}
+
+	PHALCON_INIT_VAR(sql);
+	phalcon_call_method_p1(sql, dialect, "createsavepoint", savepoint);
+
+	PHALCON_INIT_VAR(success);
+	phalcon_call_method_p1(success, this_ptr, "execute", sql);
+
+	RETURN_CCTOR(success);
+}
+
+/**
+ * Releases given savepoint
+ *
+ * @param string $savepoint Name of a savepoint to release
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Adapter, releaseSavepoint) {
+
+	zval *savepoint, *dialect, *supports_sp, *supports_rsp, *success, *sql;
+
+	PHALCON_MM_GROW();
+
+	phalcon_fetch_params(1, 1, 0, &savepoint);
+
+	PHALCON_OBS_VAR(dialect);
+	phalcon_read_property_this(&dialect, this_ptr, SL("_dialect"), PH_NOISY_CC);
+
+	PHALCON_INIT_VAR(supports_sp);
+	phalcon_call_method(supports_sp, dialect, "supportssavepoints");
+
+	if (!zend_is_true(supports_sp)) {
+		PHALCON_THROW_EXCEPTION_STR(phalcon_db_exception_ce, "Savepoints are not supported by this database adapter.");
+		return;
+	}
+
+	PHALCON_INIT_VAR(supports_rsp);
+	phalcon_call_method(supports_rsp, dialect, "supportsreleasesavepoints");
+
+	if (!zend_is_true(supports_rsp)) {
+		RETURN_MM_FALSE;
+		return;
+	}
+
+	PHALCON_INIT_VAR(sql);
+	phalcon_call_method_p1(sql, dialect, "releasesavepoint", savepoint);
+
+	PHALCON_INIT_VAR(success);
+	phalcon_call_method_p1(success, this_ptr, "execute", sql);
+
+	RETURN_CCTOR(success);
+}
+
+/**
+ * Releases given savepoint
+ *
+ * @param string $savepoint Name of a savepoint to rollback to
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Adapter, rollbackSavepoint){
+
+	zval *savepoint, *dialect, *supports_sp, *success, *sql;
+
+	PHALCON_MM_GROW();
+
+	phalcon_fetch_params(1, 1, 0, &savepoint);
+
+	PHALCON_OBS_VAR(dialect);
+	phalcon_read_property_this(&dialect, this_ptr, SL("_dialect"), PH_NOISY_CC);
+
+	PHALCON_INIT_VAR(supports_sp);
+	phalcon_call_method(supports_sp, dialect, "supportssavepoints");
+
+	if (!zend_is_true(supports_sp)) {
+		PHALCON_THROW_EXCEPTION_STR(phalcon_db_exception_ce, "Savepoints are not supported by this database adapter.");
+		return;
+	}
+
+	PHALCON_INIT_VAR(sql);
+	phalcon_call_method_p1(sql, dialect, "rollbacksavepoint", savepoint);
+
+	PHALCON_INIT_VAR(success);
+	phalcon_call_method_p1(success, this_ptr, "execute", sql);
+
+	RETURN_CCTOR(success);
+}
+
+/**
+ * Set if nested transactions should use savepoints
+ *
+ * @param boolean $nestedTransactionsWithSavepoints
+ * @return Phalcon\Db\AdapterInterface
+ */
+PHP_METHOD(Phalcon_Db_Adapter, setNestedTransactionsWithSavepoints){
+
+	zval *ntw_sp, *tran_nest_lvl, *dialect, *supports_sp;
+
+	PHALCON_MM_GROW();
+
+	PHALCON_OBS_VAR(tran_nest_lvl);
+	phalcon_read_property_this(&tran_nest_lvl, this_ptr, SL("_transactionLevel"), PH_NOISY_CC);
+
+	if (phalcon_get_intval(tran_nest_lvl) > 0) {
+		PHALCON_THROW_EXCEPTION_STR(phalcon_db_exception_ce, "May not alter the nested transaction with savepoints behavior while a transaction is open.");
+		return;
+	}
+
+	PHALCON_OBS_VAR(dialect);
+	phalcon_read_property_this(&dialect, this_ptr, SL("_dialect"), PH_NOISY_CC);
+
+	PHALCON_INIT_VAR(supports_sp);
+	phalcon_call_method(supports_sp, dialect, "supportssavepoints");
+
+	if (!zend_is_true(supports_sp)) {
+		PHALCON_THROW_EXCEPTION_STR(phalcon_db_exception_ce, "Savepoints are not supported by this database adapter.");
+		return;
+	}
+
+	phalcon_fetch_params(1, 1, 0, &ntw_sp);
+	convert_to_boolean(ntw_sp);
+
+	phalcon_update_property_this(this_ptr, SL("_transactionsWithSavepoints"), ntw_sp TSRMLS_CC);
+
+	RETURN_THIS();
+}
+
+/**
+ * Gets if nested transactions should use savepoints
+ *
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Adapter, isNestedTransactionsWithSavepoints){
+
+	RETURN_MEMBER(this_ptr, "_transactionsWithSavepoints");
+}
+
+/**
+ * Returns the savepoint name to use for nested transactions
+ *
+ * @return string
+ */
+PHP_METHOD(Phalcon_Db_Adapter, _getNestedTransactionSavepointName){
+
+	zval *savepoint, *tran_nest_lvl;
+
+	PHALCON_MM_GROW();
+
+	PHALCON_OBS_VAR(tran_nest_lvl);
+	phalcon_read_property_this(&tran_nest_lvl, this_ptr, SL("_transactionLevel"), PH_NOISY_CC);
+
+	PHALCON_INIT_VAR(savepoint);
+	PHALCON_CONCAT_SV(savepoint, "PHALCON_SAVEPOINT_", tran_nest_lvl);
+
+	RETURN_CCTOR(savepoint);
 }
 

--- a/ext/db/adapter.h
+++ b/ext/db/adapter.h
@@ -63,6 +63,12 @@ PHP_METHOD(Phalcon_Db_Adapter, getSQLBindTypes);
 PHP_METHOD(Phalcon_Db_Adapter, getType);
 PHP_METHOD(Phalcon_Db_Adapter, getDialectType);
 PHP_METHOD(Phalcon_Db_Adapter, getDialect);
+PHP_METHOD(Phalcon_Db_Adapter, createSavepoint);
+PHP_METHOD(Phalcon_Db_Adapter, releaseSavepoint);
+PHP_METHOD(Phalcon_Db_Adapter, rollbackSavepoint);
+PHP_METHOD(Phalcon_Db_Adapter, setNestedTransactionsWithSavepoints);
+PHP_METHOD(Phalcon_Db_Adapter, isNestedTransactionsWithSavepoints);
+PHP_METHOD(Phalcon_Db_Adapter, _getNestedTransactionSavepointName);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_seteventsmanager, 0, 0, 1)
 	ZEND_ARG_INFO(0, eventsManager)
@@ -219,6 +225,23 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_tableoptions, 0, 0, 1)
 	ZEND_ARG_INFO(0, schemaName)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_createsavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_releasesavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_rollbacksavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapter_setnestedtransactionswithsavepoints, 0, 0, 1)
+	ZEND_ARG_INFO(0, nestedTransactionsWithSavepoints)
+ZEND_END_ARG_INFO()
+
+
 PHALCON_INIT_FUNCS(phalcon_db_adapter_method_entry){
 	PHP_ME(Phalcon_Db_Adapter, __construct, NULL, ZEND_ACC_PROTECTED|ZEND_ACC_CTOR) 
 	PHP_ME(Phalcon_Db_Adapter, setEventsManager, arginfo_phalcon_db_adapter_seteventsmanager, ZEND_ACC_PUBLIC) 
@@ -262,6 +285,12 @@ PHALCON_INIT_FUNCS(phalcon_db_adapter_method_entry){
 	PHP_ME(Phalcon_Db_Adapter, getType, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Adapter, getDialectType, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Adapter, getDialect, NULL, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Db_Adapter, createSavepoint, arginfo_phalcon_db_adapter_createsavepoint, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Adapter, releaseSavepoint, arginfo_phalcon_db_adapter_releasesavepoint, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Adapter, rollbackSavepoint, arginfo_phalcon_db_adapter_rollbacksavepoint, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Adapter, setNestedTransactionsWithSavepoints, arginfo_phalcon_db_adapter_setnestedtransactionswithsavepoints, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Adapter, isNestedTransactionsWithSavepoints, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Adapter, _getNestedTransactionSavepointName, NULL, ZEND_ACC_PROTECTED)
 	PHP_FE_END
 };
 

--- a/ext/db/adapterinterface.c
+++ b/ext/db/adapterinterface.c
@@ -509,3 +509,42 @@ PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, supportSequences);
  */
 PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, describeColumns);
 
+/**
+ * Creates a new savepoint
+ *
+ * @param string $savepoint Name of a savepoint to create
+ * @return boolean
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, createSavepoint);
+
+/**
+ * Releases given savepoint
+ *
+ * @param string $savepoint Name of a savepoint to release
+ * @return boolean
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, releaseSavepoint);
+
+/**
+ * Releases given savepoint
+ *
+ * @param string $savepoint Name of a savepoint to rollback to
+ * @return boolean
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, rollbackSavepoint);
+
+/**
+ * Set if nested transactions should use savepoints
+ *
+ * @param boolean $nestedTransactionsWithSavepoints
+ * @return Phalcon\Db\AdapterInterface
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, setNestedTransactionsWithSavepoints);
+
+/**
+ * Gets if nested transactions should use savepoints
+ *
+ * @return boolean
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_AdapterInterface, isNestedTransactionsWithSavepoints);
+

--- a/ext/db/adapterinterface.h
+++ b/ext/db/adapterinterface.h
@@ -212,6 +212,23 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapterinterface_describecolumns, 0, 0
 	ZEND_ARG_INFO(0, schema)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapterinterface_createsavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapterinterface_releasesavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapterinterface_rollbacksavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_adapterinterface_setnestedtransactionswithsavepoints, 0, 0, 1)
+	ZEND_ARG_INFO(0, nestedTransactionsWithSavepoints)
+ZEND_END_ARG_INFO()
+
+
 PHALCON_INIT_FUNCS(phalcon_db_adapterinterface_method_entry){
 	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, __construct, arginfo_phalcon_db_adapterinterface___construct)
 	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, fetchOne, arginfo_phalcon_db_adapterinterface_fetchone)
@@ -268,6 +285,11 @@ PHALCON_INIT_FUNCS(phalcon_db_adapterinterface_method_entry){
 	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, getDefaultIdValue, NULL)
 	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, supportSequences, NULL)
 	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, describeColumns, arginfo_phalcon_db_adapterinterface_describecolumns)
+	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, createSavepoint, arginfo_phalcon_db_adapterinterface_createsavepoint)
+	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, releaseSavepoint, arginfo_phalcon_db_adapterinterface_releasesavepoint)
+	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, rollbackSavepoint, arginfo_phalcon_db_adapterinterface_rollbacksavepoint)
+	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, setNestedTransactionsWithSavepoints, arginfo_phalcon_db_adapterinterface_setnestedtransactionswithsavepoints)
+	PHP_ABSTRACT_ME(Phalcon_Db_AdapterInterface, isNestedTransactionsWithSavepoints, NULL)
 	PHP_FE_END
 };
 

--- a/ext/db/dialect.c
+++ b/ext/db/dialect.c
@@ -941,3 +941,91 @@ PHP_METHOD(Phalcon_Db_Dialect, select){
 	RETURN_CTOR(sql);
 }
 
+/**
+ * Whether the platform supports savepoints.
+ *
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Dialect, supportsSavepoints){
+
+	RETURN_TRUE;
+}
+
+/**
+ * Whether the platform supports releasing savepoints.
+ *
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Dialect, supportsReleaseSavepoints){
+
+	zval *supports_sp;
+
+	PHALCON_MM_GROW();
+
+	PHALCON_INIT_VAR(supports_sp);
+	phalcon_call_method(supports_sp, this_ptr, "supportssavepoints");
+
+	RETURN_CCTOR(supports_sp);
+}
+
+/**
+ * Generate SQL to create a new savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHP_METHOD(Phalcon_Db_Dialect, createSavepoint){
+
+	zval *savepoint, *sql;
+
+	PHALCON_MM_GROW();
+
+	phalcon_fetch_params(1, 1, 0, &savepoint);
+
+	PHALCON_INIT_VAR(sql);
+	PHALCON_CONCAT_SV(sql, "SAVEPOINT ", savepoint);
+
+	RETURN_CTOR(sql);
+}
+
+/**
+ * Generate SQL to release a savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHP_METHOD(Phalcon_Db_Dialect, releaseSavepoint){
+
+	zval *savepoint, *sql;
+
+	PHALCON_MM_GROW();
+
+	phalcon_fetch_params(1, 1, 0, &savepoint);
+
+	PHALCON_INIT_VAR(sql);
+	PHALCON_CONCAT_SV(sql, "RELEASE SAVEPOINT ", savepoint);
+
+	RETURN_CTOR(sql);
+}
+
+/**
+ * Generate SQL to rollback a savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHP_METHOD(Phalcon_Db_Dialect, rollbackSavepoint){
+
+	zval *savepoint, *sql;
+
+	PHALCON_MM_GROW();
+
+	phalcon_fetch_params(1, 1, 0, &savepoint);
+
+	PHALCON_INIT_VAR(sql);
+	PHALCON_CONCAT_SV(sql, "ROLLBACK TO SAVEPOINT ", savepoint);
+
+	RETURN_CTOR(sql);
+}
+
+

--- a/ext/db/dialect.h
+++ b/ext/db/dialect.h
@@ -28,6 +28,11 @@ PHP_METHOD(Phalcon_Db_Dialect, getColumnList);
 PHP_METHOD(Phalcon_Db_Dialect, getSqlExpression);
 PHP_METHOD(Phalcon_Db_Dialect, getSqlTable);
 PHP_METHOD(Phalcon_Db_Dialect, select);
+PHP_METHOD(Phalcon_Db_Dialect, supportsSavepoints);
+PHP_METHOD(Phalcon_Db_Dialect, supportsReleaseSavepoints);
+PHP_METHOD(Phalcon_Db_Dialect, createSavepoint);
+PHP_METHOD(Phalcon_Db_Dialect, releaseSavepoint);
+PHP_METHOD(Phalcon_Db_Dialect, rollbackSavepoint);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_limit, 0, 0, 2)
 	ZEND_ARG_INFO(0, sqlQuery)
@@ -60,6 +65,19 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_select, 0, 0, 1)
 	ZEND_ARG_INFO(0, definition)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_createsavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_releasesavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_rollbacksavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+
 PHALCON_INIT_FUNCS(phalcon_db_dialect_method_entry){
 	PHP_ME(Phalcon_Db_Dialect, limit, arginfo_phalcon_db_dialect_limit, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Dialect, forUpdate, arginfo_phalcon_db_dialect_forupdate, ZEND_ACC_PUBLIC) 
@@ -68,6 +86,11 @@ PHALCON_INIT_FUNCS(phalcon_db_dialect_method_entry){
 	PHP_ME(Phalcon_Db_Dialect, getSqlExpression, arginfo_phalcon_db_dialect_getsqlexpression, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Dialect, getSqlTable, arginfo_phalcon_db_dialect_getsqltable, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Dialect, select, arginfo_phalcon_db_dialect_select, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Db_Dialect, supportsSavepoints, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Dialect, supportsReleaseSavepoints, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Dialect, createSavepoint, arginfo_phalcon_db_dialect_createsavepoint, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Dialect, releaseSavepoint, arginfo_phalcon_db_dialect_releasesavepoint, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Dialect, rollbackSavepoint, arginfo_phalcon_db_dialect_rollbacksavepoint, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 

--- a/ext/db/dialect/oracle.c
+++ b/ext/db/dialect/oracle.c
@@ -1013,3 +1013,24 @@ PHP_METHOD(Phalcon_Db_Dialect_Oracle, select){
 	RETURN_CTOR(sql);
 }
 
+/**
+ * Whether the platform supports releasing savepoints.
+ *
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Dialect_Oracle, supportsReleaseSavepoints){
+
+	RETURN_FALSE;
+}
+
+/**
+ * Generate SQL to release a savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHP_METHOD(Phalcon_Db_Dialect_Oracle, releaseSavepoint){
+
+	RETURN_STRING("", 1);
+}
+

--- a/ext/db/dialect/oracle.h
+++ b/ext/db/dialect/oracle.h
@@ -43,6 +43,8 @@ PHP_METHOD(Phalcon_Db_Dialect_Oracle, describeReferences);
 PHP_METHOD(Phalcon_Db_Dialect_Oracle, tableOptions);
 PHP_METHOD(Phalcon_Db_Dialect_Oracle, limit);
 PHP_METHOD(Phalcon_Db_Dialect_Oracle, select);
+PHP_METHOD(Phalcon_Db_Dialect_Oracle, supportsReleaseSavepoints);
+PHP_METHOD(Phalcon_Db_Dialect_Oracle, releaseSavepoint);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_oracle_getcolumndefinition, 0, 0, 1)
 	ZEND_ARG_INFO(0, column)
@@ -151,6 +153,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_oracle_select, 0, 0, 1)
 	ZEND_ARG_INFO(0, definition)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialect_oracle_releasesavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+
 PHALCON_INIT_FUNCS(phalcon_db_dialect_oracle_method_entry){
 	PHP_ME(Phalcon_Db_Dialect_Oracle, getColumnDefinition, arginfo_phalcon_db_dialect_oracle_getcolumndefinition, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Dialect_Oracle, addColumn, arginfo_phalcon_db_dialect_oracle_addcolumn, ZEND_ACC_PUBLIC) 
@@ -172,7 +179,9 @@ PHALCON_INIT_FUNCS(phalcon_db_dialect_oracle_method_entry){
 	PHP_ME(Phalcon_Db_Dialect_Oracle, describeReferences, arginfo_phalcon_db_dialect_oracle_describereferences, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Dialect_Oracle, tableOptions, arginfo_phalcon_db_dialect_oracle_tableoptions, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Db_Dialect_Oracle, limit, arginfo_phalcon_db_dialect_oracle_limit, ZEND_ACC_PUBLIC) 
-	PHP_ME(Phalcon_Db_Dialect_Oracle, select, arginfo_phalcon_db_dialect_oracle_select, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Db_Dialect_Oracle, select, arginfo_phalcon_db_dialect_oracle_select, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Dialect_Oracle, supportsReleaseSavepoints, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Dialect_Oracle, releaseSavepoint, arginfo_phalcon_db_dialect_oracle_releasesavepoint, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 

--- a/ext/db/dialectinterface.c
+++ b/ext/db/dialectinterface.c
@@ -246,3 +246,42 @@ PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, describeReferences);
  */
 PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, tableOptions);
 
+/**
+ * Whether the platform supports savepoints.
+ *
+ * @return boolean
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, supportsSavepoints);
+
+/**
+ * Whether the platform supports releasing savepoints.
+ *
+ * @return boolean
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, supportsReleaseSavepoints);
+
+/**
+ * Generate SQL to create a new savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, createSavepoint);
+
+/**
+ * Generate SQL to release a savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, releaseSavepoint);
+
+/**
+ * Generate SQL to rollback a savepoint
+ *
+ * @param string $savepoint
+ * @return string
+ */
+PHALCON_DOC_METHOD(Phalcon_Db_DialectInterface, rollbackSavepoint);
+
+

--- a/ext/db/dialectinterface.h
+++ b/ext/db/dialectinterface.h
@@ -139,6 +139,18 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialectinterface_tableoptions, 0, 0, 1
 	ZEND_ARG_INFO(0, schema)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialectinterface_createsavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialectinterface_releasesavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_dialectinterface_rollbacksavepoint, 0, 0, 1)
+	ZEND_ARG_INFO(0, savepoint)
+ZEND_END_ARG_INFO()
+
 PHALCON_INIT_FUNCS(phalcon_db_dialectinterface_method_entry){
 	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, limit, arginfo_phalcon_db_dialectinterface_limit)
 	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, forUpdate, arginfo_phalcon_db_dialectinterface_forupdate)
@@ -163,6 +175,11 @@ PHALCON_INIT_FUNCS(phalcon_db_dialectinterface_method_entry){
 	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, describeIndexes, arginfo_phalcon_db_dialectinterface_describeindexes)
 	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, describeReferences, arginfo_phalcon_db_dialectinterface_describereferences)
 	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, tableOptions, arginfo_phalcon_db_dialectinterface_tableoptions)
+	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, supportsSavepoints, NULL)
+	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, supportsReleaseSavepoints, NULL)
+	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, createSavepoint, arginfo_phalcon_db_dialectinterface_createsavepoint)
+	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, releaseSavepoint, arginfo_phalcon_db_dialectinterface_releasesavepoint)
+	PHP_ABSTRACT_ME(Phalcon_Db_DialectInterface, rollbackSavepoint, arginfo_phalcon_db_dialectinterface_rollbacksavepoint)
 	PHP_FE_END
 };
 

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -222,6 +222,18 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 
 	}
 
+	public function testSavepoints()
+	{
+		$dialect = new \Phalcon\Db\Dialect\Mysql();
+
+		$this->assertEquals($dialect->createSavepoint('PHALCON_SAVEPOINT_1'), 'SAVEPOINT PHALCON_SAVEPOINT_1');
+		$this->assertEquals($dialect->releaseSavepoint('PHALCON_SAVEPOINT_1'), 'RELEASE SAVEPOINT PHALCON_SAVEPOINT_1');
+		$this->assertEquals($dialect->rollbackSavepoint('PHALCON_SAVEPOINT_1'), 'ROLLBACK TO SAVEPOINT PHALCON_SAVEPOINT_1');
+		$this->assertTrue($dialect->supportsSavepoints());
+		$this->assertTrue($dialect->supportsReleaseSavepoints());
+		
+	}
+
 	public function testMysqlDialect()
 	{
 


### PR DESCRIPTION
Was implemented functionality: SAVEPOINT (Nested Transactions With Savepoints)

In dialect was added a new methods:
- createSavepoint
- releaseSavepoint
- rollbackSavepoint
- supportsSavepoints
- supportsReleaseSavepoints

In database adapter was added a new methods:
- createSavepoint
- releaseSavepoint
- rollbackSavepoint
- isNestedTransactionsWithSavepoints
- setNestedTransactionsWithSavepoints

Also was changed logic of transactions, so now nested transactions fully supported by database level :)

Was extended Unit-Tests:
- DbTest
- DbDialectTest
