### PR TITLE
add cross-db transaction support 1.2.0

### DIFF
--- a/ext/kernel/memory.c
+++ b/ext/kernel/memory.c
@@ -178,8 +178,8 @@ int PHALCON_FASTCALL phalcon_memory_restore_stack(TSRMLS_D) {
 			}*/
 
 			if ((Z_REFCOUNT_PP(active_memory->addresses[i]) - 1) == 0) {
-				zval_ptr_dtor(active_memory->addresses[i]);
-				active_memory->addresses[i] = NULL;
+                        	zval_ptr_dtor(active_memory->addresses[i]);
+                        	active_memory->addresses[i] = NULL;
 			} else {
 				Z_DELREF_PP(active_memory->addresses[i]);
 				if (Z_REFCOUNT_PP(active_memory->addresses[i]) == 1) {

--- a/ext/kernel/memory.c
+++ b/ext/kernel/memory.c
@@ -178,8 +178,8 @@ int PHALCON_FASTCALL phalcon_memory_restore_stack(TSRMLS_D) {
 			}*/
 
 			if ((Z_REFCOUNT_PP(active_memory->addresses[i]) - 1) == 0) {
-                        	zval_ptr_dtor(active_memory->addresses[i]);
-                        	active_memory->addresses[i] = NULL;
+				zval_ptr_dtor(active_memory->addresses[i]);
+				active_memory->addresses[i] = NULL;
 			} else {
 				Z_DELREF_PP(active_memory->addresses[i]);
 				if (Z_REFCOUNT_PP(active_memory->addresses[i]) == 1) {

--- a/ext/mvc/model/transaction.c
+++ b/ext/mvc/model/transaction.c
@@ -89,6 +89,7 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Model_Transaction){
 	zend_declare_property_bool(phalcon_mvc_model_transaction_ce, SL("_rollbackOnAbort"), 0, ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_model_transaction_ce, SL("_manager"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_model_transaction_ce, SL("_messages"), ZEND_ACC_PROTECTED TSRMLS_CC);
+	zend_declare_property_string(phalcon_mvc_model_transaction_ce, SL("_service"), "db", ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_model_transaction_ce, SL("_rollbackRecord"), ZEND_ACC_PROTECTED TSRMLS_CC);
 
 	zend_class_implements(phalcon_mvc_model_transaction_ce TSRMLS_CC, 1, phalcon_mvc_model_transactioninterface_ce);
@@ -135,6 +136,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, __construct){
 	PHALCON_INIT_VAR(connection);
 	phalcon_call_method_p1(connection, dependency_injector, "get", service);
 	phalcon_update_property_this(this_ptr, SL("_connection"), connection TSRMLS_CC);
+
+        phalcon_update_property_this(this_ptr, SL("_service"), service TSRMLS_CC);
+        
 	if (zend_is_true(auto_begin)) {
 		phalcon_call_method_noret(connection, "begin");
 	}
@@ -413,3 +417,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, setRollbackedRecord){
 	
 }
 
+PHP_METHOD(Phalcon_Mvc_Model_Transaction, getService){
+
+  RETURN_MEMBER(this_ptr, "_service");
+}

--- a/ext/mvc/model/transaction.h
+++ b/ext/mvc/model/transaction.h
@@ -31,6 +31,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, setIsNewTransaction);
 PHP_METHOD(Phalcon_Mvc_Model_Transaction, setRollbackOnAbort);
 PHP_METHOD(Phalcon_Mvc_Model_Transaction, isManaged);
 PHP_METHOD(Phalcon_Mvc_Model_Transaction, getMessages);
+PHP_METHOD(Phalcon_Mvc_Model_Transaction, getService);
 PHP_METHOD(Phalcon_Mvc_Model_Transaction, isValid);
 PHP_METHOD(Phalcon_Mvc_Model_Transaction, setRollbackedRecord);
 
@@ -71,7 +72,8 @@ PHALCON_INIT_FUNCS(phalcon_mvc_model_transaction_method_entry){
 	PHP_ME(Phalcon_Mvc_Model_Transaction, setIsNewTransaction, arginfo_phalcon_mvc_model_transaction_setisnewtransaction, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Mvc_Model_Transaction, setRollbackOnAbort, arginfo_phalcon_mvc_model_transaction_setrollbackonabort, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Mvc_Model_Transaction, isManaged, NULL, ZEND_ACC_PUBLIC) 
-	PHP_ME(Phalcon_Mvc_Model_Transaction, getMessages, NULL, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Mvc_Model_Transaction, getMessages, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Mvc_Model_Transaction, getService, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Transaction, isValid, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Mvc_Model_Transaction, setRollbackedRecord, arginfo_phalcon_mvc_model_transaction_setrollbackedrecord, ZEND_ACC_PUBLIC) 
 	PHP_FE_END

--- a/ext/mvc/model/transaction/manager.c
+++ b/ext/mvc/model/transaction/manager.c
@@ -294,10 +294,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction){
 
 	zval *auto_begin = NULL, *dependency_injector, *number;
 	zval *transactions, *transaction = NULL, *false_value = NULL;
-	zval *service;
+	zval *service, *transaction_service;
 	HashTable *ah0;
 	HashPosition hp0;
 	zval **hd;
+        int cmp;
 
 	PHALCON_MM_GROW();
 
@@ -314,7 +315,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction){
 		PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_transaction_exception_ce, "A dependency injector container is required to obtain the services related to the ORM");
 		return;
 	}
-	
+
+	PHALCON_OBS_VAR(service);
+	phalcon_read_property_this(&service, this_ptr, SL("_service"), PH_NOISY_CC);
+
 	PHALCON_OBS_VAR(number);
 	phalcon_read_property_this(&number, this_ptr, SL("_number"), PH_NOISY_CC);
 	if (zend_is_true(number)) {
@@ -326,16 +330,20 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction){
 			if (!phalcon_is_iterable(transactions, &ah0, &hp0, 0, 1 TSRMLS_CC)) {
 				return;
 			}
-	
+                        PHALCON_INIT_VAR(transaction_service);
 			while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
 	
 				PHALCON_GET_HVALUE(transaction);
 	
 				if (Z_TYPE_P(transaction) == IS_OBJECT) {
+                                  phalcon_call_method(transaction_service, transaction, "getservice");
+                                  cmp = strcmp(Z_STRVAL_P(service), Z_STRVAL_P(transaction_service));
+                                  if(cmp == 0) {
 					PHALCON_INIT_NVAR(false_value);
 					ZVAL_BOOL(false_value, 0);
 					phalcon_call_method_p1_noret(transaction, "setisnewtransaction", false_value);
 					RETURN_CCTOR(transaction);
+                                  }
 				}
 	
 				zend_hash_move_backwards_ex(ah0, &hp0);
@@ -343,19 +351,19 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction){
 	
 		}
 	}
+
+        zval *new_transaction = NULL;
+	PHALCON_INIT_VAR(new_transaction);
+	object_init_ex(new_transaction, phalcon_mvc_model_transaction_ce);
+	phalcon_call_method_p3_noret(new_transaction, "__construct", dependency_injector, auto_begin, service);
 	
-	PHALCON_OBS_VAR(service);
-	phalcon_read_property_this(&service, this_ptr, SL("_service"), PH_NOISY_CC);
-	
-	PHALCON_INIT_VAR(transaction);
-	object_init_ex(transaction, phalcon_mvc_model_transaction_ce);
-	phalcon_call_method_p3_noret(transaction, "__construct", dependency_injector, auto_begin, service);
-	
-	phalcon_call_method_p1_noret(transaction, "settransactionmanager", this_ptr);
-	phalcon_update_property_array_append(this_ptr, SL("_transactions"), transaction TSRMLS_CC);
+	phalcon_call_method_p1_noret(new_transaction, "settransactionmanager", this_ptr);
+
+	phalcon_update_property_array_append(this_ptr, SL("_transactions"), new_transaction TSRMLS_CC);
+
 	phalcon_property_incr(this_ptr, SL("_number") TSRMLS_CC);
-	
-	RETURN_CTOR(transaction);
+
+	RETURN_CTOR(new_transaction);
 }
 
 /**


### PR DESCRIPTION
You can do cross-db transactions now:

``` php
 $manager = new \Phalcon\Mvc\Model\Transaction\Manager();

 $manager->setDbService("vs_hotel");
 $tran1 = $manager->get();

 $manager->setDbService("vs_common");
 $tran2 = $manager->get();

 $pointModel = new PointModel();
 $pointModel->setTransaction($tran2);
 $pointModel->name = "ttt";
 $pointModel->position = "[122, 3432]";
 $pointModel->city_id = 323;
 $pointModel->city_py = "hello";

 if($pointModel->save() == false) {
     foreach($pointModel->getMessages() as $message) {
         echo $message->__toString() . PHP_EOL;
     }
     $manager->rollback();
 }

 $eqsModel = new EQSModel();
 $eqsModel->setTransaction($tran1);
 $eqsModel->out_id = "343";
 $eqsModel->entity_id = 3343;
 $eqsModel->vendors = "[fdfd]";

 if($eqsModel->save() == false) {
     foreach($eqsModel->getMessages() as $message) {
         echo $message->__toString() . PHP_EOL;
     }
     echo "=====---eqs rollback---======\n";
     $manager->rollback();
 }
$manager->commit();
```
