### PR TITLE
Added the user ability to define an initialize() method

### DIFF
--- a/ext/cli/task.c
+++ b/ext/cli/task.c
@@ -1,4 +1,3 @@
-
 /*
   +------------------------------------------------------------------------+
   | Phalcon Framework                                                      |
@@ -77,8 +76,10 @@ PHALCON_INIT_CLASS(Phalcon_CLI_Task){
  * Phalcon\CLI\Task constructor
  */
 PHP_METHOD(Phalcon_CLI_Task, __construct){
-
-
 	
+	// Checks for the initialize() method, in case it exists, calls it.
+	if (phalcon_method_exists_ex(this_ptr, SS("initialize") TSRMLS_CC) == SUCCESS) {
+		PHALCON_CALL_METHOD_NORETURN(this_ptr, "initialize");
+	}
 }
 


### PR DESCRIPTION
Since you can't override the constructor of a Task derived class, I think can be useful let the user to implement an initialize() method, to init all the stuff every action, implemented in the task itself, needs.
