### PR TITLE
dot directive parsing of ini files.

### DIFF
--- a/ext/config/adapter/ini.c
+++ b/ext/config/adapter/ini.c
@@ -78,25 +78,25 @@ static inline void phalcon_config_adapter_ini_update_zval_directive(zval **arr, 
 	n = zend_hash_num_elements(Z_ARRVAL_P(directive));
 
 	if (Z_TYPE_PP(arr) == IS_ARRAY) {
-		phalcon_array_fetch(&temp1, *arr, section, PH_SILENT_CC);
+		phalcon_array_fetch(&temp1, *arr, section, PH_SILENT);
 		if (Z_REFCOUNT_P(temp1) > 1) {
-			phalcon_array_update_zval(arr, section, &temp1, PH_COPY | PH_CTOR TSRMLS_CC);
+			phalcon_array_update_zval(arr, section, &temp1, PH_COPY | PH_CTOR);
 		}
 		if (Z_TYPE_P(temp1) != IS_ARRAY) {
 			convert_to_array(temp1);
-			phalcon_array_update_zval(arr, section, &temp1, PH_COPY TSRMLS_CC);
+			phalcon_array_update_zval(arr, section, &temp1, PH_COPY);
 		}
 
 		for (i = 0; i < n - 1; i++) {
-			phalcon_array_fetch_long(&index, directive, i, PH_NOISY_CC);
+			phalcon_array_fetch_long(&index, directive, i, PH_NOISY);
 
-			phalcon_array_fetch(&temp2, temp1, index, PH_SILENT_CC);
+			phalcon_array_fetch(&temp2, temp1, index, PH_SILENT);
 			if (Z_REFCOUNT_P(temp2) > 1) {
-				phalcon_array_update_zval(&temp1, index, &temp2, PH_COPY | PH_CTOR TSRMLS_CC);
+				phalcon_array_update_zval(&temp1, index, &temp2, PH_COPY | PH_CTOR);
 			}
 			if (Z_TYPE_P(temp2) != IS_ARRAY) {
 				convert_to_array(temp2);
-				phalcon_array_update_zval(&temp1, index, &temp2, PH_COPY TSRMLS_CC);
+				phalcon_array_update_zval(&temp1, index, &temp2, PH_COPY);
 			}
 			zval_ptr_dtor(&index);
 
@@ -107,8 +107,8 @@ static inline void phalcon_config_adapter_ini_update_zval_directive(zval **arr, 
 			temp2 = NULL;
 		}
 
-		phalcon_array_fetch_long(&index, directive, n - 1, PH_NOISY_CC);
-		phalcon_array_update_zval(&temp1, index, value, PH_COPY TSRMLS_CC);
+		phalcon_array_fetch_long(&index, directive, n - 1, PH_NOISY);
+		phalcon_array_update_zval(&temp1, index, value, PH_COPY);
 
 		zval_ptr_dtor(&index);
 
@@ -200,7 +200,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, __construct){
 	
 			if (phalcon_memnstr_str(key, SL("."))) {
 				PHALCON_INIT_NVAR(directive_parts);
-				phalcon_fast_explode_str(directive_parts, SL("."), key TSRMLS_CC);
+				phalcon_fast_explode_str(directive_parts, SL("."), key);
 				phalcon_config_adapter_ini_update_zval_directive(&config, section, directive_parts, &value, 0 TSRMLS_CC);
 			} else {
 				phalcon_array_update_multi_2(&config, section, key, &value, 0);

--- a/unit-tests/ConfigTest.php
+++ b/unit-tests/ConfigTest.php
@@ -253,5 +253,36 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals($actual, $expected);
 	}
+
+	public function testIniConfigDirective()
+	{
+		$config = new \Phalcon\Config\Adapter\Ini('unit-tests/config/directive.ini');
+		$actual = $config->toArray();
+		$expected = array(
+			'test' => array(
+				'parent' => array(
+					'property' => 1,
+					'property2' => 'yeah',
+					'property3' => array('baseuri' => '/phalcon/'),
+					'property4' => array(
+						'models' => array('metadata' => 'memory'),
+					),
+					'property5' => array(
+						'database' => array(
+							'adapter' => 'mysql',
+							'host' => 'localhost',
+							'username' => 'user',
+							'password' => 'passwd',
+							'name' => 'demo'),
+					),
+					'property6' => array(
+						'test' => array('a', 'b', 'c'),
+					),
+				),
+			),
+		);
+
+		$this->assertEquals($actual, $expected);
+	}
 }
 

--- a/unit-tests/config/directive.ini
+++ b/unit-tests/config/directive.ini
@@ -1,0 +1,13 @@
+[test]
+parent.property = On
+parent.property2 = "yeah"
+parent.property3.baseuri = /phalcon/
+parent.property4.models.metadata = memory
+parent.property5.database.adapter = mysql
+parent.property5.database.host = localhost
+parent.property5.database.username = user
+parent.property5.database.password = passwd
+parent.property5.database.name = demo
+parent.property6.test[] = a
+parent.property6.test[] = b
+parent.property6.test[] = c


### PR DESCRIPTION
Update dot direvtive parse of Ini files.

INI file.

```
# test.ini
[test]
parent.property = On
parent.property2 = "yeah"
parent.property3.baseuri = /phalcon/
parent.property4.models.metadata = memory
parent.property5.database.adapter = mysql
parent.property5.database.host = localhost
parent.property5.database.username = user
parent.property5.database.password = passwd
parent.property5.database.name = demo
parent.property6.test[] = a
parent.property6.test[] = b
parent.property6.test[] = c
```

PHP execute.

```
$ini = new \Phalcon\Config\Adapter\Ini('/test.ini');
$ini->toArray();
```

Result (default)

```
array(
  'test' => array(
    'parent' => array(
      'property' => 1,
      'property2' => 'yeah',
      'property3' => '/phalcon/',
      'property4' => 'memory',
      'property5' => 'demo',
      'property6' => array(a', 'b', 'c'),
    )))
```

Result (Update source)

```
array(
  'test' => array(
    'parent' => array(
      'property' => 1,
      'property2' => 'yeah',
      'property3' => array('baseuri' => '/phalcon/'),
      'property4' => array(
        'models' => array('metadata' => 'memory')
      ),
      'property5' => array(
        'database' => array(
          'adapter' => 'mysql',
          'host' => 'localhost',
          'username' => 'user',
          'password' => 'passwd',
          'name' => 'demo')
        ),
      'property6' => array(
        'test' => array('a', 'b', 'c')
      ))))
```
