### PR TITLE
Fix macro parsing in Volt template engine

### DIFF
--- a/ext/mvc/view/engine/volt/base.c
+++ b/ext/mvc/view/engine/volt/base.c
@@ -89,6 +89,8 @@ const phvolt_token_names phvolt_tokens[] =
   { SL("BREAK"),          PHVOLT_T_BREAK },
   { SL("WITH"),           PHVOLT_T_WITH },
   { SL("RETURN"),         PHVOLT_T_RETURN },
+  { SL("MACRO"),          PHVOLT_T_MACRO },
+  { SL("ENDMACRO"),       PHVOLT_T_ENDMACRO },
   { NULL, 0, 0 }
 };
 


### PR DESCRIPTION
This fixes the "Syntax error, unexpected token IDENTIFIER" when using macros.

See: http://forum.phalconphp.com/discussion/729/macros-do-not-work

This is my first pull request. Please, comment if I'm not following some pattern.
