### PR TITLE
Fix bug for image: The last commit did not submit complete

### DIFF
--- a/ext/image/adapter.c
+++ b/ext/image/adapter.c
@@ -365,9 +365,6 @@ PHP_METHOD(Phalcon_Image_Adapter, crop){
 	tmp_image_width  = phalcon_get_intval(image_width);
 	tmp_image_height = phalcon_get_intval(image_height);
 
-	zend_print_zval_r(image_width, 0);
-	zend_print_zval_r(image_height, 0);
-
 	if (tmp_width > tmp_image_width) {
 		tmp_width = tmp_image_width;
 	}


### PR DESCRIPTION
Did not submit complete for https://github.com/phalcon/cphalcon/pull/1120

Cause the following error last submission 1120, I am sorry, next time I will pay attention to.

``` display
/home/travis/build/phalcon/cphalcon/ext/image/adapter.c: In function ‘zim_Phalcon_Image_Adapter_crop’:

/home/travis/build/phalcon/cphalcon/ext/image/adapter.c:368:2: error: too few arguments to function ‘zend_print_zval_r’

/home/travis/.phpenv/versions/5.3.26/include/php/Zend/zend.h:577:15: note: declared here

/home/travis/build/phalcon/cphalcon/ext/image/adapter.c:369:2: error: too few arguments to function ‘zend_print_zval_r’

/home/travis/.phpenv/versions/5.3.26/include/php/Zend/zend.h:577:15: note: declared here

/home/travis/build/phalcon/cphalcon/ext/image/adapter.c: In function ‘zim_Phalcon_Image_Adapter_text’:

/home/travis/build/phalcon/cphalcon/ext/image/adapter.c:708:37: warning: unused variable ‘replacement’ [-Wunused-variable]

/home/travis/build/phalcon/cphalcon/ext/image/adapter.c:708:27: warning: unused variable ‘pattern’ [-Wunused-variable]

make: *** [image/adapter.lo] Error 1

make: *** Waiting for unfinished jobs....
```
