### PR TITLE
Add Test for numeric memory

### DIFF
--- a/unit-tests/CacheTest.php
+++ b/unit-tests/CacheTest.php
@@ -240,6 +240,17 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		return $memcache;
 	}
 
+    public function testMemoryCache()
+    {
+        $frontCache = new Phalcon\Cache\Frontend\Output(array(
+            'lifetime' => 20
+        ));
+
+        $cache = new Phalcon\Cache\Backend\Memory($frontCache);
+        $cache->save('foo', 2);
+        $this->assertEquals(2, $cache->get('foo'));
+    }
+
 	public function testOutputMemcacheCache()
 	{
 


### PR DESCRIPTION
Storing numeric's in memory cache adapter currently breaks the values. Will resolve and fix it with increment & decrement implementation
