### PR TITLE
[NFR] Add param for Phalcon\Forms\Form::label()

### DIFF
--- a/ext/forms/element.c
+++ b/ext/forms/element.c
@@ -579,15 +579,17 @@ PHP_METHOD(Phalcon_Forms_Element, getLabel){
  */
 PHP_METHOD(Phalcon_Forms_Element, label){
 
-	zval *label, *attributes, *name = NULL, *html = NULL;
+	zval *label, *attributes = NULL, *name = NULL, *html = NULL, *key = NULL, *value = NULL;
+	HashTable *ah0;
+	HashPosition hp0;
+	zval **hd;
 
 	PHALCON_MM_GROW();
 
+	phalcon_fetch_params(1, 0, 1, &attributes);
+
 	PHALCON_OBS_VAR(label);
 	phalcon_read_property_this(&label, this_ptr, SL("_label"), PH_NOISY_CC);
-	
-	PHALCON_OBS_VAR(attributes);
-	phalcon_read_property_this(&attributes, this_ptr, SL("_attributes"), PH_NOISY_CC);
 	
 	/** 
 	 * Check if there is an 'id' attribute defined
@@ -599,16 +601,32 @@ PHP_METHOD(Phalcon_Forms_Element, label){
 		PHALCON_OBS_NVAR(name);
 		phalcon_read_property_this(&name, this_ptr, SL("_name"), PH_NOISY_CC);
 	}
-	
+
+	PHALCON_INIT_VAR(html);
+	PHALCON_CONCAT_SVS(html, "<label for=\"", name, "\"");
+
+	if (attributes && Z_TYPE_P(attributes) == IS_ARRAY) {	
+		phalcon_is_iterable(attributes, &ah0, &hp0, 0, 0);
+		
+		while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
+			PHALCON_GET_HKEY(key, ah0, hp0);
+			PHALCON_GET_HVALUE(value);
+		
+			if (Z_TYPE_P(key) != IS_LONG) {
+				PHALCON_SCONCAT_SVSVS(html, " ", key, "=\"", value, "\"");
+			}
+		
+			zend_hash_move_forward_ex(ah0, &hp0);
+		}
+	}
+		
 	/** 
 	 * Use the default label or leave the same name as label
 	 */
 	if (zend_is_true(label)) {
-		PHALCON_INIT_VAR(html);
-		PHALCON_CONCAT_SVSVS(html, "<label for=\"", name, "\">", label, "</label>");
+		PHALCON_SCONCAT_SVS(html, ">", label, "</label>");
 	} else {
-		PHALCON_INIT_NVAR(html);
-		PHALCON_CONCAT_SVSVS(html, "<label for=\"", name, "\">", name, "</label>");
+		PHALCON_SCONCAT_SVS(html, ">", name, "</label>");
 	}
 	
 	RETURN_CTOR(html);

--- a/ext/forms/element.h
+++ b/ext/forms/element.h
@@ -117,8 +117,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_element_setuseroptions, 0, 0, 1)
 	ZEND_ARG_INFO(0, options)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_element_setlabel, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_element_setlabel, 0, 0, 0)
 	ZEND_ARG_INFO(0, label)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_element_label, 0, 0, 1)
+	ZEND_ARG_INFO(0, attributes)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_element_setdefault, 0, 0, 1)
@@ -156,7 +160,7 @@ PHALCON_INIT_FUNCS(phalcon_forms_element_method_entry){
 	PHP_ME(Phalcon_Forms_Element, getUserOptions, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Element, setLabel, arginfo_phalcon_forms_element_setlabel, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Element, getLabel, NULL, ZEND_ACC_PUBLIC) 
-	PHP_ME(Phalcon_Forms_Element, label, NULL, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Forms_Element, label, arginfo_phalcon_forms_element_label, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Element, setDefault, arginfo_phalcon_forms_element_setdefault, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Element, getDefault, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Element, getValue, NULL, ZEND_ACC_PUBLIC) 

--- a/ext/forms/form.c
+++ b/ext/forms/form.c
@@ -780,12 +780,16 @@ PHP_METHOD(Phalcon_Forms_Form, get){
  */
 PHP_METHOD(Phalcon_Forms_Form, label){
 
-	zval *name, *elements, *exception_message, *element;
+	zval *name, *attributes = NULL, *elements, *exception_message, *element;
 	zval *html;
 
 	PHALCON_MM_GROW();
 
-	phalcon_fetch_params(1, 1, 0, &name);
+	phalcon_fetch_params(1, 1, 1, &name, &attributes);
+
+	if (!attributes) {
+		PHALCON_INIT_VAR(attributes);
+	}
 	
 	PHALCON_OBS_VAR(elements);
 	phalcon_read_property_this(&elements, this_ptr, SL("_elements"), PH_NOISY_CC);
@@ -800,7 +804,7 @@ PHP_METHOD(Phalcon_Forms_Form, label){
 	phalcon_array_fetch(&element, elements, name, PH_NOISY);
 	
 	PHALCON_INIT_VAR(html);
-	phalcon_call_method(html, element, "label");
+	phalcon_call_method_p1(html, element, "label", attributes);
 	
 	RETURN_CCTOR(html);
 }

--- a/ext/forms/form.h
+++ b/ext/forms/form.h
@@ -117,6 +117,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_label, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
+	ZEND_ARG_INFO(0, attributes)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_getlabel, 0, 0, 1)

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -446,5 +446,19 @@ class FormsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($entity->getAddress(), 'hello');
 	}
 
+	public function testIssues1029()
+	{
+		$form = new Form();
+		$form->add(new Text("name"));
+
+		$telephone = new Text("telephone");
+		$telephone->setLabel("The Telephone");
+
+		$form->add($telephone);
+
+		$this->assertEquals($form->label('name', array('class' => 'form-control')), '<label for="name" class="form-control">name</label>');
+		$this->assertEquals($form->label('telephone', array('class' => 'form-control')), '<label for="telephone" class="form-control">The Telephone</label>');
+	}
+
 }
 


### PR DESCRIPTION
See https://github.com/phalcon/cphalcon/issues/1029

``` php
echo $form->label('telephone', array('class' => 'form-control'));
```

``` dispaly
<label for="telephone" class="form-control">telephone</label>
```
