### PR TITLE
NFR #1171 Adding code support for Phalcon/Validation/Message

### DIFF
--- a/ext/validation/message.c
+++ b/ext/validation/message.c
@@ -53,6 +53,7 @@ PHALCON_INIT_CLASS(Phalcon_Validation_Message){
 	zend_declare_property_null(phalcon_validation_message_ce, SL("_type"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_validation_message_ce, SL("_message"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_validation_message_ce, SL("_field"), ZEND_ACC_PROTECTED TSRMLS_CC);
+	zend_declare_property_long(phalcon_validation_message_ce, SL("_code"), 0, ZEND_ACC_PROTECTED TSRMLS_CC);
 
 	return SUCCESS;
 }
@@ -63,14 +64,15 @@ PHALCON_INIT_CLASS(Phalcon_Validation_Message){
  * @param string $message
  * @param string $field
  * @param string $type
+ * @param int    $code
  */
 PHP_METHOD(Phalcon_Validation_Message, __construct){
 
-	zval *message, *field = NULL, *type = NULL;
+	zval *message, *field = NULL, *type = NULL, *code = NULL;
 
 	PHALCON_MM_GROW();
 
-	phalcon_fetch_params(1, 1, 2, &message, &field, &type);
+	phalcon_fetch_params(1, 1, 3, &message, &field, &type, &code);
 	
 	if (!field) {
 		PHALCON_INIT_VAR(field);
@@ -79,10 +81,15 @@ PHP_METHOD(Phalcon_Validation_Message, __construct){
 	if (!type) {
 		PHALCON_INIT_VAR(type);
 	}
+
+	if (!code) {
+		PHALCON_INIT_VAR(code);
+	}
 	
 	phalcon_update_property_this(this_ptr, SL("_message"), message TSRMLS_CC);
 	phalcon_update_property_this(this_ptr, SL("_field"), field TSRMLS_CC);
 	phalcon_update_property_this(this_ptr, SL("_type"), type TSRMLS_CC);
+    phalcon_update_property_this(this_ptr, SL("_code"), code TSRMLS_CC);
 	
 	PHALCON_MM_RESTORE();
 }
@@ -112,6 +119,32 @@ PHP_METHOD(Phalcon_Validation_Message, getType){
 
 
 	RETURN_MEMBER(this_ptr, "_type");
+}
+
+/**
+ * Sets message code
+ *
+ * @param int $code
+ * @return Phalcon\Mvc\Model\Message
+ */
+PHP_METHOD(Phalcon_Validation_Message, setCode){
+
+	zval *code;
+
+	phalcon_fetch_params(0, 1, 0, &code);
+
+	phalcon_update_property_this(this_ptr, SL("_code"), code TSRMLS_CC);
+	RETURN_THISW();
+}
+
+/**
+ * Returns message code
+ *
+ * @return int
+ */
+PHP_METHOD(Phalcon_Validation_Message, getCode){
+
+	RETURN_MEMBER(this_ptr, "_code");
 }
 
 /**
@@ -187,7 +220,7 @@ PHP_METHOD(Phalcon_Validation_Message, __toString){
  */
 PHP_METHOD(Phalcon_Validation_Message, __set_state){
 
-	zval *message, *message_text, *field, *type;
+	zval *message, *message_text, *field, *type, *code;
 
 	PHALCON_MM_GROW();
 
@@ -201,6 +234,9 @@ PHP_METHOD(Phalcon_Validation_Message, __set_state){
 	
 	PHALCON_OBS_VAR(type);
 	phalcon_array_fetch_string(&type, message, SL("_type"), PH_NOISY);
+
+	PHALCON_OBS_VAR(code);
+	phalcon_array_fetch_string(&code, message, SL("_code"), PH_NOISY);
 	object_init_ex(return_value, phalcon_validation_message_ce);
 	phalcon_call_method_p3_noret(return_value, "__construct", message_text, field, type);
 	

--- a/ext/validation/message.h
+++ b/ext/validation/message.h
@@ -24,6 +24,8 @@ PHALCON_INIT_CLASS(Phalcon_Validation_Message);
 PHP_METHOD(Phalcon_Validation_Message, __construct);
 PHP_METHOD(Phalcon_Validation_Message, setType);
 PHP_METHOD(Phalcon_Validation_Message, getType);
+PHP_METHOD(Phalcon_Validation_Message, setCode);
+PHP_METHOD(Phalcon_Validation_Message, getCode);
 PHP_METHOD(Phalcon_Validation_Message, setMessage);
 PHP_METHOD(Phalcon_Validation_Message, getMessage);
 PHP_METHOD(Phalcon_Validation_Message, setField);
@@ -35,6 +37,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_validation_message___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, message)
 	ZEND_ARG_INFO(0, field)
 	ZEND_ARG_INFO(0, type)
+	ZEND_ARG_INFO(0, code)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_validation_message_settype, 0, 0, 1)
@@ -49,6 +52,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_validation_message_setfield, 0, 0, 1)
 	ZEND_ARG_INFO(0, field)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_validation_message_setcode, 0, 0, 1)
+ZEND_ARG_INFO(0, code)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_validation_message___set_state, 0, 0, 1)
 	ZEND_ARG_INFO(0, message)
 ZEND_END_ARG_INFO()
@@ -60,7 +67,9 @@ PHALCON_INIT_FUNCS(phalcon_validation_message_method_entry){
 	PHP_ME(Phalcon_Validation_Message, setMessage, arginfo_phalcon_validation_message_setmessage, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Validation_Message, getMessage, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Validation_Message, setField, arginfo_phalcon_validation_message_setfield, ZEND_ACC_PUBLIC) 
-	PHP_ME(Phalcon_Validation_Message, getField, NULL, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Validation_Message, getField, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Validation_Message, setCode, arginfo_phalcon_validation_message_setcode, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Validation_Message, getCode, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Validation_Message, __toString, NULL, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Validation_Message, __set_state, arginfo_phalcon_validation_message___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC) 
 	PHP_FE_END


### PR DESCRIPTION
This should add _code class variable, setter, getter and hopefully not break everything. If maintainers will approve I will continue adding code support to Model messages and validators.
