### PR TITLE
Phalcon\Mvc\Query\Builder's constructor sample code in comment + having ...

### DIFF
--- a/ext/mvc/model/query/builder.c
+++ b/ext/mvc/model/query/builder.c
@@ -90,15 +90,29 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Model_Query_Builder){
 /**
  * Phalcon\Mvc\Model\Query\Builder constructor
  *
+ *<code>
+ * $params = array(
+ *    'models'     => array('Users'),
+ *    'columns'    => array('id', 'name', 'status'),
+ *    'conditions' => "created > '2013-01-01' AND created < '2014-01-01'",
+ *    'group'      => array('id', 'name'),
+ *    'having'     => "name = 'Kamil'",
+ *    'order'      => array('name', 'id'),
+ *    'limit'      => 20,
+ *    'offset'     => 20,
+ *);
+ *$queryBuilder = new Phalcon\Mvc\Model\Query\Builder($params);
+ *</code>
+ *
  * @param array $params
  * @param Phalcon\DI $dependencyInjector
  */
 PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 
 	zval *params = NULL, *dependency_injector = NULL, *conditions = NULL;
-	zval *columns, *group_clause, *having_clause;
-	zval *order_clause, *limit_clause, *for_update;
-	zval *shared_lock;
+	zval *models, *columns, *group_clause;
+	zval *having_clause, *order_clause, *limit_clause;
+	zval *offset, *for_update, *shared_lock;
 
 	PHALCON_MM_GROW();
 
@@ -128,6 +142,15 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 				phalcon_update_property_this(this_ptr, SL("_conditions"), conditions TSRMLS_CC);
 			}
 		}
+		
+		/** 
+		 * Assign 'FROM' clause
+		 */
+		if (phalcon_array_isset_string(params, SS("models"))) {
+			PHALCON_OBS_VAR(models);
+			phalcon_array_fetch_string(&models, params, SL("models"), PH_NOISY);
+			phalcon_update_property_this(this_ptr, SL("_models"), models TSRMLS_CC);
+		}		
 	
 		/** 
 		 * Assign COLUMNS clause
@@ -153,7 +176,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 		if (phalcon_array_isset_string(params, SS("having"))) {
 			PHALCON_OBS_VAR(having_clause);
 			phalcon_array_fetch_string(&having_clause, params, SL("having"), PH_NOISY);
-			phalcon_update_property_this(this_ptr, SL("_group"), having_clause TSRMLS_CC);
+			phalcon_update_property_this(this_ptr, SL("_having"), having_clause TSRMLS_CC);
 		}
 	
 		/** 
@@ -173,6 +196,15 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 			phalcon_array_fetch_string(&limit_clause, params, SL("limit"), PH_NOISY);
 			phalcon_update_property_this(this_ptr, SL("_limit"), limit_clause TSRMLS_CC);
 		}
+		
+		/** 
+		 * Assign OFFSET clause
+		 */
+		if (phalcon_array_isset_string(params, SS("offset"))) {
+			PHALCON_OBS_VAR(offset);
+			phalcon_array_fetch_string(&offset, params, SL("offset"), PH_NOISY);
+			phalcon_update_property_this(this_ptr, SL("_offset"), offset TSRMLS_CC);
+		}		
 	
 		/** 
 		 * Assign FOR UPDATE clause


### PR DESCRIPTION
Hi,

I fixed 'having' key in parameters I also added 'offset' but there's many more to update:
- limit key could take array of 2 values (limit, offset) as the limit() method does limit (int $limit, [int $offset])
- 'conditions' key could take:
  array(
      array(string $conditions, [array $bindParams], [array $bindTypes])
  )
  or at least:
  array(string $conditions, [array $bindParams], [array $bindTypes])
- 'having' key could work in the same way as 'conditions' but it could be simplified to single  array(string $conditions, [array $bindParams], [array $bindTypes])
- adding explicit DESC or ASC to 'order' value like that array('name DESC', 'id ASC') causes following exception thrown:
  Uncaught exception 'Phalcon\Mvc\Model\Exception' with message 'Scanning error before 'name DESC], [id ...'

PS. Why all those function aren't simply using methods of that class instead of setting them inside constructor?

I hope that all above makes sense and it' at least a little bit helpful.

Thanks,

Kamil
