### PR TITLE
Phalcon\Mvc\Query\Builder's constructor sample code in comment + support...

### DIFF
--- a/ext/mvc/model/query/builder.c
+++ b/ext/mvc/model/query/builder.c
@@ -93,15 +93,29 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Model_Query_Builder){
 /**
  * Phalcon\Mvc\Model\Query\Builder constructor
  *
+ *<code>
+ * $params = array(
+ *    'models'     => array('Users'),
+ *    'columns'    => array('id', 'name', 'status'),
+ *    'conditions' => "created > '2013-01-01' AND created < '2014-01-01'",
+ *    'group'      => array('id', 'name'),
+ *    'having'     => "name = 'Kamil'",
+ *    'order'      => array('name', 'id'),
+ *    'limit'      => 20,
+ *    'offset'     => 20,
+ *);
+ *$queryBuilder = new Phalcon\Mvc\Model\Query\Builder($params);
+ *</code> 
+ *
  * @param array $params
  * @param Phalcon\DI $dependencyInjector
  */
 PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 
 	zval *params = NULL, *dependency_injector = NULL, *conditions = NULL;
-	zval *columns, *group_clause, *having_clause;
-	zval *order_clause, *limit_clause, *for_update;
-	zval *shared_lock;
+	zval *models, *columns, *group_clause;
+	zval *having_clause, *order_clause, *limit_clause;
+	zval *offset_clause, *for_update, *shared_lock;
 
 	phalcon_fetch_params(0, 0, 2, &params, &dependency_injector);
 	
@@ -115,7 +129,14 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 		} else if (phalcon_array_isset_string_fetch(&conditions, params, SS("conditions"))) {
 			phalcon_update_property_this(this_ptr, SL("_conditions"), conditions TSRMLS_CC);
 		}
-	
+
+		/** 
+		 * Assign 'FROM' clause
+		 */
+		if (phalcon_array_isset_string_fetch(&models, params, SS("models"))) {
+			phalcon_update_property_this(this_ptr, SL("_models"), models TSRMLS_CC);
+		}
+
 		/** 
 		 * Assign COLUMNS clause
 		 */
@@ -150,7 +171,14 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 		if (phalcon_array_isset_string_fetch(&limit_clause, params, SS("limit"))) {
 			phalcon_update_property_this(this_ptr, SL("_limit"), limit_clause TSRMLS_CC);
 		}
-	
+		
+		/** 
+		 * Assign OFFSET clause
+		 */
+		if (phalcon_array_isset_string_fetch(&offset_clause, params, SS("offset"))) {
+			phalcon_update_property_this(this_ptr, SL("_offset"), offset_clause TSRMLS_CC);
+		}
+
 		/** 
 		 * Assign FOR UPDATE clause
 		 */


### PR DESCRIPTION
Hi,

I added support for defining 'offset' via constructor but there's many more to updated:

limit key could take array of 2 values (limit, offset) as the limit() method does limit (int $limit, [int $offset])

'conditions' key could take:
array(
    array(string $conditions, [array $bindParams], [array $bindTypes])
)
or at least:
array(string $conditions, [array $bindParams], [array $bindTypes])

'having' key could work in the same way as 'conditions' but it could be simplified to single array(string $conditions, [array $bindParams], [array $bindTypes])

adding explicit DESC or ASC to 'order' value like that array('name DESC', 'id ASC') causes following exception thrown:
Uncaught exception 'Phalcon\Mvc\Model\Exception' with message 'Scanning error before 'name DESC], [id ...'

'models' key(added by me) could take also alias to be the same as addFrom (string $model, [string $alias])

lack of support for following: join, innejJoin, leftJoin, rightJoin, orWhere, betweenWhere, notBetweenWhere, inWhere, notInWhere.

PS. Why all those function aren't simply using methods of that class instead of setting them inside constructor?

PS. PS. On master branch there's still this 'having' typo which makes usage of 'having' key impossible.

I hope that all above makes sense and it' at least a little bit helpful.

Thanks,

Kamil
