### PR TITLE
Support for array(limit, offset) as a 'limit' constructor key(Query Builder)

### DIFF
--- a/ext/mvc/model/query/builder.c
+++ b/ext/mvc/model/query/builder.c
@@ -103,6 +103,7 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Model_Query_Builder){
  *    'order'      => array('name', 'id'),
  *    'limit'      => 20,
  *    'offset'     => 20,
+ *    // or 'limit' => array(20, 20),
  *);
  *$queryBuilder = new Phalcon\Mvc\Model\Query\Builder($params);
  *</code> 
@@ -116,6 +117,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 	zval *models, *columns, *group_clause;
 	zval *having_clause, *order_clause, *limit_clause;
 	zval *offset_clause, *for_update, *shared_lock;
+	zval *limit, *offset;
 
 	phalcon_fetch_params(0, 0, 2, &params, &dependency_injector);
 	
@@ -169,7 +171,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 		 * Assign LIMIT clause
 		 */
 		if (phalcon_array_isset_string_fetch(&limit_clause, params, SS("limit"))) {
-			phalcon_update_property_this(this_ptr, SL("_limit"), limit_clause TSRMLS_CC);
+			if (phalcon_is_numeric(limit_clause)) { 			
+				phalcon_update_property_this(this_ptr, SL("_limit"), limit_clause TSRMLS_CC);
+			} else if (Z_TYPE_P(limit_clause) == IS_ARRAY) {
+				phalcon_array_fetch_long(&limit, limit_clause, 0, PH_NOISY);
+				phalcon_array_fetch_long(&offset, limit_clause, 1, PH_NOISY);
+				if (phalcon_is_numeric(limit) && phalcon_is_numeric(offset)) {
+					phalcon_update_property_this(this_ptr, SL("_limit"), limit TSRMLS_CC);
+					phalcon_update_property_this(this_ptr, SL("_offset"), offset TSRMLS_CC);				
+				}
+			}
 		}
 		
 		/** 

--- a/ext/mvc/model/query/builder.c
+++ b/ext/mvc/model/query/builder.c
@@ -171,15 +171,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct){
 		 * Assign LIMIT clause
 		 */
 		if (phalcon_array_isset_string_fetch(&limit_clause, params, SS("limit"))) {
-			if (phalcon_is_numeric(limit_clause)) { 			
+			if (Z_TYPE_P(limit_clause) == IS_ARRAY
+				&& phalcon_array_isset_long_fetch(&limit, limit_clause, 0)
+				&& phalcon_array_isset_long_fetch(&offset, limit_clause, 1)
+				&& phalcon_is_numeric(limit)
+				&& phalcon_is_numeric(offset)
+			) {
+				phalcon_update_property_this(this_ptr, SL("_limit"), limit TSRMLS_CC);
+				phalcon_update_property_this(this_ptr, SL("_offset"), offset TSRMLS_CC);
+			} else {
 				phalcon_update_property_this(this_ptr, SL("_limit"), limit_clause TSRMLS_CC);
-			} else if (Z_TYPE_P(limit_clause) == IS_ARRAY) {
-				phalcon_array_fetch_long(&limit, limit_clause, 0, PH_NOISY);
-				phalcon_array_fetch_long(&offset, limit_clause, 1, PH_NOISY);
-				if (phalcon_is_numeric(limit) && phalcon_is_numeric(offset)) {
-					phalcon_update_property_this(this_ptr, SL("_limit"), limit TSRMLS_CC);
-					phalcon_update_property_this(this_ptr, SL("_offset"), offset TSRMLS_CC);				
-				}
 			}
 		}
 		

--- a/unit-tests/ModelsQueryBuilderTest.php
+++ b/unit-tests/ModelsQueryBuilderTest.php
@@ -347,7 +347,7 @@ class ModelsQueryBuilderTest extends PHPUnit_Framework_TestCase
 	}
 	
 	/**
-	 * Test checks passing query params and dependency injectior into
+	 * Test checks passing query params and dependency injector into
 	 * constructor
 	 */
 	public function testConstructor()
@@ -383,8 +383,10 @@ class ModelsQueryBuilderTest extends PHPUnit_Framework_TestCase
 	}
 	
 	/**
-	 * Test checks passing query params and dependency injectior into
-	 * constructor
+	 * Test checks passing 'limit'/'offset' query param into constructor.
+	 * limit key can take:
+	 * - signle numeric value
+	 * - array of 2 values (limit, offset)
 	 */
 	public function testConstructorLimit()
 	{


### PR DESCRIPTION
Hi,

This time I added support for 'limit' key working as limit (int $limit, [int $offset]) method.

I'll try to code as many points as I will be able to form my previous pull request(https://github.com/phalcon/cphalcon/pull/1205). Sorry for pushing this "one by one" but it take huge amount of time for me to get my head around C(as I'm not a C developer) so I prefer to send something before somebody else will fix/write it.

Thanks,

Kamil
