### PR TITLE
Fix BUG Model\Query::_getJoins when set schema empty string

### DIFF
--- a/ext/mvc/model/query.c
+++ b/ext/mvc/model/query.c
@@ -1887,7 +1887,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, _getJoins){
 		PHALCON_INIT_NVAR(complete_source);
 		array_init_size(complete_source, 2);
 		phalcon_array_append(&complete_source, source, PH_SEPARATE);
-		phalcon_array_append(&complete_source, schema, 0);
+
+		if (zend_is_true(schema)) {
+			phalcon_array_append(&complete_source, schema, 0);
+		}
 	
 		/** 
 		 * Check join alias


### PR DESCRIPTION
When

``` php
class Contacts extends \Phalcon\Mvc\Model
{
    /**
     * Initialize method for model.
     */
    public function initialize()
    {
        $this->setSchema("");
    }
}
// ...
$result= $this->getDI()->get('modelsManager')
    ->createBuilder()
    ->columns('*')
    ->from('Accounts')
    ->join('Contacts', 'Contacts.account_id = Accounts.id')
   ->limit(10)
   -> getQuery()->execute();
```

SQL error in `""."contacts"`:

``` SQL
SELECT ... FROM "accounts" INNER JOIN ""."contacts" ON "contacts"."account_id" = "accounts"."id"  LIMIT 10
```
