### PR TITLE
Fix build script bug

### DIFF
--- a/build/_resource/Phalcon/Build/Util.php
+++ b/build/_resource/Phalcon/Build/Util.php
@@ -29,7 +29,7 @@ class Util
             if ($entry->isDot()) {
                 continue;
             }
-            if ($entry->isDir()) {
+            if ($entry->isDir() && !$entry->isLink()) {
                 self::cleanDirectory($entry->getPathname());
                 rmdir($entry->getPathname());
             } else {


### PR DESCRIPTION
Determine if current DirectoryIterator item is a symbolic link

1) CacheTest::testDataMemcachedCache

PHP Notice: Undefined index: SCRIPT_NAME in /home/travis/.phpenv/versions/5.5.0/share/pyrus/.pear/php/PHPUnit/Util/Filter.php on line 69

Notice: Undefined index: SCRIPT_NAME in /home/travis/.phpenv/versions/5.5.0/share/pyrus/.pear/php/PHPUnit/Util/Filter.php on line 69

Failed asserting that false is true
