### PR TITLE
Fix #706 add two param for \Phalcon\Forms\Form::add

### DIFF
--- a/ext/forms/form.c
+++ b/ext/forms/form.c
@@ -639,15 +639,21 @@ PHP_METHOD(Phalcon_Forms_Form, hasMessagesFor){
  * Adds an element to the form
  *
  * @param Phalcon\Forms\ElementInterface $element
+ * @param string $postion
+ * @param bool $type If $type is TRUE, the element wile add before $postion, else is after
  * @return Phalcon\Forms\Form
  */
 PHP_METHOD(Phalcon_Forms_Form, add){
 
-	zval *element, *name;
+	zval *element, *pos = NULL, *type = NULL, *name, *values, *elements, *key = NULL, *tmp0, *tmp1, *length, *offset, *preserve_keys;
+	HashTable *ah0;
+	HashPosition hp0;
+	zval **hd;
+	int found = 0, i = 0;
 
 	PHALCON_MM_GROW();
 
-	phalcon_fetch_params(1, 1, 0, &element);
+	phalcon_fetch_params(1, 1, 2, &element, &pos, &type);
 	
 	if (Z_TYPE_P(element) != IS_OBJECT) {
 		PHALCON_THROW_EXCEPTION_STR(phalcon_forms_exception_ce, "The element is not valid");
@@ -664,108 +670,77 @@ PHP_METHOD(Phalcon_Forms_Form, add){
 	 * Link the element to the form
 	 */
 	phalcon_call_method_p1_noret(element, "setform", this_ptr);
-	
-	/** 
-	 * Append the element by its name
-	 */
-	phalcon_update_property_array(this_ptr, SL("_elements"), name, element TSRMLS_CC);
-	
-	RETURN_THIS();
-}
 
-/**
- * Adds an element to the form before or after specific pos
- *
- * @param Phalcon\Forms\ElementInterface $element
- * @param string $postion
- * @param bool $type true is after, false is before, default false
- * @return Phalcon\Forms\Form
- */
-PHP_METHOD(Phalcon_Forms_Form, addAt){
-
-	zval *element, *pos = NULL, *type = NULL, *name, *values, *elements, *key = NULL, *tmp0, *tmp1, *length, *offset, *preserve_keys;
-	HashTable *ah0;
-	HashPosition hp0;
-	zval **hd;
-	int found = 0, i = 0;
-
-	PHALCON_MM_GROW();
-
-	phalcon_fetch_params(1, 2, 1, &element, &pos, &type);
-	
-	if (Z_TYPE_P(element) != IS_OBJECT) {
-		PHALCON_THROW_EXCEPTION_STR(phalcon_forms_exception_ce, "The element is not valid");
-		return;
-	}
-	
-	if (!type) {
-		type = PHALCON_GLOBAL(z_false);
-	}
-
-	if (zend_is_true(type)) {
-		i = -1;
-	}
-
-	PHALCON_INIT_VAR(name);
-	phalcon_call_method(name, element, "getname");
-
-	phalcon_call_method_p1_noret(element, "setform", this_ptr);
-
-	PHALCON_INIT_VAR(values);
-	array_init_size(values, 1);
-
-	phalcon_array_update_zval(&values, name, &element, PH_COPY);
-
-	PHALCON_OBS_VAR(elements);
-	phalcon_read_property_this(&elements, this_ptr, SL("_elements"), PH_NOISY_CC);
-
-	if (Z_TYPE_P(elements) != IS_ARRAY) {
-		convert_to_array(elements);
-	}
-
-	phalcon_is_iterable(elements, &ah0, &hp0, 0, 0);
-	while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
-		PHALCON_GET_HKEY(key, ah0, hp0);
-
-		i++;
-
-		if (PHALCON_IS_EQUAL(key, pos)) {
-			found = 1;
-			break;
+	if (!pos) {	
+		/** 
+		 * Append the element by its name
+		 */
+		phalcon_update_property_array(this_ptr, SL("_elements"), name, element TSRMLS_CC);
+	} else {
+		if (!type) {
+			type = PHALCON_GLOBAL(z_false);
 		}
 
-		zend_hash_move_forward_ex(ah0, &hp0);
+		if (zend_is_true(type)) {
+			i = -1;
+		}
+
+		PHALCON_INIT_VAR(values);
+		array_init_size(values, 1);
+
+		phalcon_array_update_zval(&values, name, &element, PH_COPY);
+
+		PHALCON_OBS_VAR(elements);
+		phalcon_read_property_this(&elements, this_ptr, SL("_elements"), PH_NOISY_CC);
+
+		if (Z_TYPE_P(elements) != IS_ARRAY) {
+			convert_to_array(elements);
+		}
+
+		phalcon_is_iterable(elements, &ah0, &hp0, 0, 0);
+		while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
+			PHALCON_GET_HKEY(key, ah0, hp0);
+
+			i++;
+
+			if (PHALCON_IS_EQUAL(key, pos)) {
+				found = 1;
+				break;
+			}
+
+			zend_hash_move_forward_ex(ah0, &hp0);
+		}
+
+		if (!found) {
+			PHALCON_THROW_EXCEPTION_STR(phalcon_forms_exception_ce, "Array position does not exist");
+			return;
+		}
+
+		PHALCON_INIT_VAR(offset);
+		ZVAL_LONG(offset, i);
+
+		PHALCON_INIT_VAR(length);
+		ZVAL_LONG(length, 0);
+
+		preserve_keys = PHALCON_GLOBAL(z_true);
+
+		PHALCON_INIT_VAR(tmp0);
+		phalcon_call_func_p4(tmp0, "array_slice", elements, length, offset, preserve_keys);
+
+		PHALCON_INIT_NVAR(length);
+
+		PHALCON_INIT_VAR(tmp1);
+		phalcon_call_func_p4(tmp1, "array_slice", elements, offset, length, preserve_keys);
+
+		PHALCON_INIT_NVAR(elements);
+		array_init(elements);
+
+		phalcon_array_merge_recursive_n(&elements, tmp0);
+		phalcon_array_merge_recursive_n(&elements, values);
+		phalcon_array_merge_recursive_n(&elements, tmp1);
+
+		phalcon_update_property_this(this_ptr, SL("_elements"), elements TSRMLS_CC);
 	}
-
-	if (!found) {
-		PHALCON_THROW_EXCEPTION_STR(phalcon_forms_exception_ce, "Array position does not exist");
-		return;
-	}
-
-	PHALCON_INIT_VAR(offset);
-	ZVAL_LONG(offset, i);
-
-	PHALCON_INIT_VAR(length);
-	ZVAL_LONG(length, 0);
-
-	preserve_keys = PHALCON_GLOBAL(z_true);
-
-	PHALCON_INIT_VAR(tmp0);
-	phalcon_call_func_p4(tmp0, "array_slice", elements, length, offset, preserve_keys);
-
-	PHALCON_INIT_NVAR(length);
-
-	PHALCON_INIT_VAR(tmp1);
-	phalcon_call_func_p4(tmp1, "array_slice", elements, offset, length, preserve_keys);
-
-	PHALCON_INIT_NVAR(elements);
-	array_init(elements);
-
-	phalcon_array_merge_recursive_n(&elements, tmp0);
-	phalcon_array_merge_recursive_n(&elements, values);
-	phalcon_array_merge_recursive_n(&elements, tmp1);
-
-	phalcon_update_property_this(this_ptr, SL("_elements"), elements TSRMLS_CC);
 	
 	RETURN_THIS();
 }

--- a/ext/forms/form.h
+++ b/ext/forms/form.h
@@ -37,7 +37,6 @@ PHP_METHOD(Phalcon_Forms_Form, getMessages);
 PHP_METHOD(Phalcon_Forms_Form, getMessagesFor);
 PHP_METHOD(Phalcon_Forms_Form, hasMessagesFor);
 PHP_METHOD(Phalcon_Forms_Form, add);
-PHP_METHOD(Phalcon_Forms_Form, addAt);
 PHP_METHOD(Phalcon_Forms_Form, render);
 PHP_METHOD(Phalcon_Forms_Form, get);
 PHP_METHOD(Phalcon_Forms_Form, label);
@@ -105,10 +104,6 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_add, 0, 0, 1)
 	ZEND_ARG_INFO(0, element)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_addat, 0, 0, 1)
-	ZEND_ARG_INFO(0, element)
 	ZEND_ARG_INFO(0, postion)
 	ZEND_ARG_INFO(0, type)
 ZEND_END_ARG_INFO()
@@ -164,7 +159,6 @@ PHALCON_INIT_FUNCS(phalcon_forms_form_method_entry){
 	PHP_ME(Phalcon_Forms_Form, getMessagesFor, arginfo_phalcon_forms_form_getmessagesfor, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, hasMessagesFor, arginfo_phalcon_forms_form_hasmessagesfor, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, add, arginfo_phalcon_forms_form_add, ZEND_ACC_PUBLIC) 
-	PHP_ME(Phalcon_Forms_Form, addAt, arginfo_phalcon_forms_form_addat, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, render, arginfo_phalcon_forms_form_render, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, get, arginfo_phalcon_forms_form_get, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, label, arginfo_phalcon_forms_form_label, ZEND_ACC_PUBLIC) 

--- a/ext/forms/form.h
+++ b/ext/forms/form.h
@@ -37,6 +37,7 @@ PHP_METHOD(Phalcon_Forms_Form, getMessages);
 PHP_METHOD(Phalcon_Forms_Form, getMessagesFor);
 PHP_METHOD(Phalcon_Forms_Form, hasMessagesFor);
 PHP_METHOD(Phalcon_Forms_Form, add);
+PHP_METHOD(Phalcon_Forms_Form, addAt);
 PHP_METHOD(Phalcon_Forms_Form, render);
 PHP_METHOD(Phalcon_Forms_Form, get);
 PHP_METHOD(Phalcon_Forms_Form, label);
@@ -106,6 +107,12 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_add, 0, 0, 1)
 	ZEND_ARG_INFO(0, element)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_addat, 0, 0, 1)
+	ZEND_ARG_INFO(0, element)
+	ZEND_ARG_INFO(0, postion)
+	ZEND_ARG_INFO(0, type)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_forms_form_render, 0, 0, 1)
 	ZEND_ARG_INFO(0, name)
 	ZEND_ARG_INFO(0, attributes)
@@ -157,6 +164,7 @@ PHALCON_INIT_FUNCS(phalcon_forms_form_method_entry){
 	PHP_ME(Phalcon_Forms_Form, getMessagesFor, arginfo_phalcon_forms_form_getmessagesfor, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, hasMessagesFor, arginfo_phalcon_forms_form_hasmessagesfor, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, add, arginfo_phalcon_forms_form_add, ZEND_ACC_PUBLIC) 
+	PHP_ME(Phalcon_Forms_Form, addAt, arginfo_phalcon_forms_form_addat, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, render, arginfo_phalcon_forms_form_render, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, get, arginfo_phalcon_forms_form_get, ZEND_ACC_PUBLIC) 
 	PHP_ME(Phalcon_Forms_Form, label, arginfo_phalcon_forms_form_label, ZEND_ACC_PUBLIC) 

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -485,4 +485,22 @@ class FormsTest extends PHPUnit_Framework_TestCase
 		$expected = '<label for="test">Test</label>';
 		$this->assertEquals($actual, $expected);
 	}
+
+	public function testIssue706()
+	{
+		$form = new \Phalcon\Forms\Form();
+		$form->add(new \Phalcon\Forms\Element\Text('name'));
+
+		$form->addAt(new \Phalcon\Forms\Element\Text('before'), 'name', true);
+		$form->addAt(new \Phalcon\Forms\Element\Text('after'), 'name');
+
+		$data = array('before', 'name', 'after');
+		$result = array();
+
+		foreach ($form as $element) {
+			$result[] = $element->getName();
+		}
+
+		$this->assertEquals($result, $data);
+	}
 }

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -491,8 +491,8 @@ class FormsTest extends PHPUnit_Framework_TestCase
 		$form = new \Phalcon\Forms\Form();
 		$form->add(new \Phalcon\Forms\Element\Text('name'));
 
-		$form->addAt(new \Phalcon\Forms\Element\Text('before'), 'name', true);
-		$form->addAt(new \Phalcon\Forms\Element\Text('after'), 'name');
+		$form->add(new \Phalcon\Forms\Element\Text('before'), 'name', true);
+		$form->add(new \Phalcon\Forms\Element\Text('after'), 'name');
 
 		$data = array('before', 'name', 'after');
 		$result = array();


### PR DESCRIPTION
See #706

``` php
$form = new \Phalcon\Forms\Form();
$form->add(new \Phalcon\Forms\Element\Text('name'));

$form->add(new \Phalcon\Forms\Element\Text('before'), 'name', true); // add before
$form->add(new \Phalcon\Forms\Element\Text('after'), 'name'); // add after
```
