### PR TITLE
Fix #1409

### DIFF
--- a/ext/acl/adapter/memory.c
+++ b/ext/acl/adapter/memory.c
@@ -623,7 +623,10 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, _allowOrDeny){
  */
 PHP_METHOD(Phalcon_Acl_Adapter_Memory, allow){
 
-	zval *role_name, *resource_name, *access, *action;
+	zval *role_name, *resource_name, *access, *action, *roles_names;
+	HashTable *ah0;
+	HashPosition hp0;
+	zval **hd;
 
 	PHALCON_MM_GROW();
 
@@ -631,7 +634,24 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allow){
 	
 	PHALCON_INIT_VAR(action);
 	ZVAL_LONG(action, 1);
-	phalcon_call_method_p4(return_value, this_ptr, "_allowordeny", role_name, resource_name, access, action);
+
+	if (!PHALCON_IS_STRING(role_name, "*")) {
+		phalcon_call_method_p4(return_value, this_ptr, "_allowordeny", role_name, resource_name, access, action);
+	} else {
+		PHALCON_SEPARATE_PARAM(role_name);
+
+		PHALCON_OBS_VAR(roles_names);
+		phalcon_read_property_this(&roles_names, this_ptr, SL("_rolesNames"), PH_NOISY_CC);
+
+		phalcon_is_iterable(roles_names, &ah0, &hp0, 0, 0);	
+		while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
+			PHALCON_GET_HKEY(role_name, ah0, hp0);
+
+			phalcon_call_method_p4_noret(this_ptr, "_allowordeny", role_name, resource_name, access, action);
+			zend_hash_move_forward_ex(ah0, &hp0);
+		}
+	}
+
 	RETURN_MM();
 }
 
@@ -662,7 +682,10 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allow){
  */
 PHP_METHOD(Phalcon_Acl_Adapter_Memory, deny){
 
-	zval *role_name, *resource_name, *access, *action;
+	zval *role_name, *resource_name, *access, *action, *roles_names;
+	HashTable *ah0;
+	HashPosition hp0;
+	zval **hd;
 
 	PHALCON_MM_GROW();
 
@@ -670,7 +693,24 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, deny){
 	
 	PHALCON_INIT_VAR(action);
 	ZVAL_LONG(action, 0);
-	phalcon_call_method_p4(return_value, this_ptr, "_allowordeny", role_name, resource_name, access, action);
+
+	if (!PHALCON_IS_STRING(role_name, "*")) {
+		phalcon_call_method_p4(return_value, this_ptr, "_allowordeny", role_name, resource_name, access, action);
+	} else {
+		PHALCON_SEPARATE_PARAM(role_name);
+
+		PHALCON_OBS_VAR(roles_names);
+		phalcon_read_property_this(&roles_names, this_ptr, SL("_rolesNames"), PH_NOISY_CC);
+
+		phalcon_is_iterable(roles_names, &ah0, &hp0, 0, 0);
+		while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
+			PHALCON_GET_HKEY(role_name, ah0, hp0);
+
+			phalcon_call_method_p4_noret(this_ptr, "_allowordeny", role_name, resource_name, access, action);
+			zend_hash_move_forward_ex(ah0, &hp0);
+		}
+	}
+
 	RETURN_MM();
 }
 

--- a/ext/acl/adapter/memory.c
+++ b/ext/acl/adapter/memory.c
@@ -38,6 +38,7 @@
 #include "kernel/concat.h"
 #include "kernel/exception.h"
 #include "kernel/operators.h"
+#include "kernel/hash.h"
 
 /**
  * Phalcon\Acl\Adapter\Memory

--- a/unit-tests/AclTest.php
+++ b/unit-tests/AclTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2012 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  +------------------------------------------------------------------------+
+*/
+
+class AclTest extends PHPUnit_Framework_TestCase
+{
+
+	public function testMemory()
+	{
+		$acl = new \Phalcon\Acl\Adapter\Memory();
+		$acl->setDefaultAction(Phalcon\Acl::DENY);
+
+		$roles = array(
+			'Admin' => new \Phalcon\Acl\Role('Admin'),
+			'Users' => new \Phalcon\Acl\Role('Users'),
+			'Guests' => new \Phalcon\Acl\Role('Guests')
+		);
+
+		$resources = array(
+			'welcome' => array('index', 'about'),
+			'account' => array('index'),
+		);
+
+		foreach ($roles as $role => $object) {
+			$acl->addRole($object);
+		}
+
+		foreach ($resources as $resource => $actions) {
+			$acl->addResource(new \Phalcon\Acl\Resource($resource), $actions);
+		}
+/*		
+		$this->assertFalse($acl->isAllowed('Admin', 'welcome', 'index'));
+		$this->assertFalse($acl->isAllowed('Admin', 'welcome', 'about'));
+
+		$acl->allow('Admin', 'welcome', '*');
+
+		$this->assertTrue($acl->isAllowed('Admin', 'welcome', 'index'));
+		$this->assertTrue($acl->isAllowed('Admin', 'welcome', 'about'));
+
+		$this->assertFalse($acl->isAllowed('Admin', 'account', 'index'));
+		$this->assertFalse($acl->isAllowed('Admin', 'account', 'about'));
+
+		$acl->allow('Admin', '*', '*');	
+
+		$this->assertTrue($acl->isAllowed('Admin', 'welcome', 'index'));
+		$this->assertTrue($acl->isAllowed('Admin', 'welcome', 'about'));
+
+		$this->assertTrue($acl->isAllowed('Admin', 'account', 'index'));
+		$this->assertTrue($acl->isAllowed('Admin', 'account', 'about'));
+
+		$acl->deny('Admin', '*', '*');	
+
+		foreach ($roles as $role => $object) {
+			$this->assertFalse($acl->isAllowed($role, 'welcome', 'about'));
+		}
+*/
+		$acl->allow("*", "welcome", "index");
+
+		foreach ($roles as $role => $object) {
+			$this->assertTrue($acl->isAllowed($role, 'welcome', 'index'));
+		}
+
+		$acl->deny("*", "welcome", "index");
+
+		foreach ($roles as $role => $object) {
+			$this->assertFalse($acl->isAllowed($role, 'welcome', 'index'));
+		}
+/*		
+		$acl->allow('Admin', '*', 'index');
+
+		foreach ($resources as $resource => $actions) {
+			$this->assertTrue($acl->isAllowed('admin', $resource, 'index'));
+		}
+
+		$acl->allow('*', '*', 'index');
+
+		$acl->allow('*', '*', '*');
+*/
+	}
+}


### PR DESCRIPTION
See #1409

``` php
$Acl = new Phalcon\Acl\Adapter\Memory();
$Acl->allow('*', $resource, $actions);
```

Fatal error: Uncaught exception 'Phalcon\Acl\Exception' with message 'Role "*" does not exist in ACL
