### PR TITLE
Getting syntax error when running php unit tests.

### DIFF
--- a/php-tests/tests/Phalcon/Filter/UnitTest.php
+++ b/php-tests/tests/Phalcon/Filter/UnitTest.php
@@ -884,7 +884,3 @@ class UnitTest extends PhTestUnitTestCase
         );
     }
 }
-
-);
-
-        $this-


### PR DESCRIPTION
Trying to run the php-unit tests and I am getting a syntax error. Looks like there is some misplaced code in here.
