### PR TITLE
Camelize ignores last character

### DIFF
--- a/ext/kernel/string.c
+++ b/ext/kernel/string.c
@@ -237,7 +237,7 @@ void phalcon_camelize(zval *return_value, const zval *str){
 	marker = Z_STRVAL_P(str);
 	len    = Z_STRLEN_P(str);
 
-	for (i = 0; i < len - 1; i++) {
+	for (i = 0; i < len; i++) {
 		ch = *marker;
 		if (i == 0 || ch == '-' || ch == '_') {
 			if (ch == '-' || ch == '_') {

--- a/php-tests/tests/Phalcon/Text/UnitTest.php
+++ b/php-tests/tests/Phalcon/Text/UnitTest.php
@@ -80,6 +80,8 @@ class UnitTest extends PhTestUnitTestCase
             'Camelize'        => 'camelize',
             'camel_ize'       => 'camel_ize',
             'CameLize'        => 'came_lize',
+            'CAMELIZE'        => 'Camelize',
+            'camelizE'        => 'Camelize',
         );
 
         $template = "Text::uncamelize did not convert the string '%s' correctly";


### PR DESCRIPTION
Camelize now loops through the last character. Before it stopped one character short and would not change the case of that character.
