### PR TITLE
Camelize was ignoring the last character of a string.

### DIFF
--- a/ext/kernel/string.c
+++ b/ext/kernel/string.c
@@ -246,7 +246,7 @@ void phalcon_camelize(zval *return_value, const zval *str){
 	marker = Z_STRVAL_P(str);
 	len    = Z_STRLEN_P(str);
 
-	for (i = 0; i < len - 1; i++) {
+	for (i = 0; i < len; i++) {
 		ch = *marker;
 		if (i == 0 || ch == '-' || ch == '_') {
 			if (ch == '-' || ch == '_') {

--- a/php-tests/tests/Phalcon/Text/UnitTest.php
+++ b/php-tests/tests/Phalcon/Text/UnitTest.php
@@ -46,6 +46,8 @@ class UnitTest extends PhTestUnitTestCase
             'Camelize'        => 'Camelize',
             'camel_ize'       => 'CamelIze',
             'CameLize'        => 'Camelize',
+            'CAMELIZE'        => 'Camelize',
+            'camelizE'        => 'Camelize'
         );
 
         $template = "Text::camelize did not convert the string '%s' correctly";


### PR DESCRIPTION
This is the same as issue #1435, I just moved it to the 1.3.0 branch. Last character was being ignored in camelize so CAMELIZE would return CamelizE.
