### PR TITLE
Fix #1422 Tag select support optgroup

### DIFF
--- a/ext/tag/select.c
+++ b/ext/tag/select.c
@@ -357,7 +357,7 @@ PHP_METHOD(Phalcon_Tag_Select, _optionsFromResultset){
 PHP_METHOD(Phalcon_Tag_Select, _optionsFromArray){
 
 	zval *data, *value, *close_option, *code, *option_text = NULL;
-	zval *option_value = NULL, *escaped;
+	zval *option_value = NULL, *escaped, *array_options = NULL;
 	HashTable *ah0;
 	HashPosition hp0;
 	zval **hd;
@@ -378,22 +378,32 @@ PHP_METHOD(Phalcon_Tag_Select, _optionsFromArray){
 		PHALCON_GET_HKEY(option_value, ah0, hp0);
 		PHALCON_GET_HVALUE(option_text);
 
-		phalcon_htmlspecialchars(escaped, option_value, NULL, NULL TSRMLS_CC);
-	
-		if (Z_TYPE_P(value) == IS_ARRAY) { 
-			if (phalcon_fast_in_array(option_value, value TSRMLS_CC)) {
-				PHALCON_SCONCAT_SVSVV(code, "\t<option selected=\"selected\" value=\"", escaped, "\">", option_text, close_option);
-			} else {
-				PHALCON_SCONCAT_SVSVV(code, "\t<option value=\"", escaped, "\">", option_text, close_option);
-			}
+		if (Z_TYPE_P(option_text) == IS_ARRAY) {
+			phalcon_htmlspecialchars(escaped, option_value, NULL, NULL TSRMLS_CC);
+
+
+			PHALCON_INIT_NVAR(array_options);
+			phalcon_call_self_p3(array_options, this_ptr, "_optionsfromarray", option_text, value, close_option);
+
+			PHALCON_SCONCAT_SVSVS(code, "\t<optgroup label=\"", escaped, "\">", array_options, "\t</optgroup>");
 		} else {
-			if (PHALCON_IS_EQUAL(option_value, value)) {
-				PHALCON_SCONCAT_SVSVV(code, "\t<option selected=\"selected\" value=\"", escaped, "\">", option_text, close_option);
+			phalcon_htmlspecialchars(escaped, option_value, NULL, NULL TSRMLS_CC);
+		
+			if (Z_TYPE_P(value) == IS_ARRAY) { 
+				if (phalcon_fast_in_array(option_value, value TSRMLS_CC)) {
+					PHALCON_SCONCAT_SVSVV(code, "\t<option selected=\"selected\" value=\"", escaped, "\">", option_text, close_option);
+				} else {
+					PHALCON_SCONCAT_SVSVV(code, "\t<option value=\"", escaped, "\">", option_text, close_option);
+				}
 			} else {
-				PHALCON_SCONCAT_SVSVV(code, "\t<option value=\"", escaped, "\">", option_text, close_option);
+				if (PHALCON_IS_EQUAL(option_value, value)) {
+					PHALCON_SCONCAT_SVSVV(code, "\t<option selected=\"selected\" value=\"", escaped, "\">", option_text, close_option);
+				} else {
+					PHALCON_SCONCAT_SVSVV(code, "\t<option value=\"", escaped, "\">", option_text, close_option);
+				}
 			}
 		}
-
+		
 		zval_dtor(escaped);
 		ZVAL_NULL(escaped);
 	

--- a/ext/tag/select.c
+++ b/ext/tag/select.c
@@ -385,7 +385,7 @@ PHP_METHOD(Phalcon_Tag_Select, _optionsFromArray){
 			PHALCON_INIT_NVAR(array_options);
 			phalcon_call_self_p3(array_options, this_ptr, "_optionsfromarray", option_text, value, close_option);
 
-			PHALCON_SCONCAT_SVSVS(code, "\t<optgroup label=\"", escaped, "\">", array_options, "\t</optgroup>");
+			PHALCON_SCONCAT_SVSVS(code, "\t<optgroup label=\"", escaped, "\">" PHP_EOL, array_options, "\t</optgroup>" PHP_EOL);
 		} else {
 			phalcon_htmlspecialchars(escaped, option_value, NULL, NULL TSRMLS_CC);
 		

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -23,6 +23,28 @@ use Phalcon\Tag as Tag;
 class TagTest extends PHPUnit_Framework_TestCase
 {
 
+	public function testSelect()
+	{
+		$html = <<<HTML
+<select id="status" name="status">
+	<optgroup label="Active">
+	<option value="A1">A One</option>
+	<option value="A2">A Two</option>
+	</optgroup>
+	<option value="B">B One</option>
+</select>
+HTML;
+
+		$di = new Phalcon\DI\FactoryDefault();
+		Tag::setDI($di);
+		$ret = Tag::selectStatic(array(
+			"status",
+			array("Active" => array('A1' => 'A One', 'A2' => 'A Two'), "B" => "B One")
+		));
+
+		$this->assertEquals($ret, $html);
+	}
+
 	public function testSetTitleSeparator()
 	{
 

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -25,6 +25,11 @@ class TagTest extends PHPUnit_Framework_TestCase
 
 	public function testSelect()
 	{
+		$data = array(
+			"status",
+			array("Active" => array('A1' => 'A One', 'A2' => 'A Two'), "B" => "B One")
+		);
+
 		$html = <<<HTML
 <select id="status" name="status">
 	<optgroup label="Active">
@@ -37,10 +42,22 @@ HTML;
 
 		$di = new Phalcon\DI\FactoryDefault();
 		Tag::setDI($di);
-		$ret = Tag::selectStatic(array(
-			"status",
-			array("Active" => array('A1' => 'A One', 'A2' => 'A Two'), "B" => "B One")
-		));
+		$ret = Tag::selectStatic($data);
+
+		$this->assertEquals($ret, $html);
+
+		$html = <<<HTML
+<select id="status" name="status">
+	<optgroup label="Active">
+	<option selected="selected" value="A1">A One</option>
+	<option value="A2">A Two</option>
+	</optgroup>
+	<option value="B">B One</option>
+</select>
+HTML;
+		Tag::setDefault("status", "A1");
+
+		$ret = Tag::selectStatic($data);
 
 		$this->assertEquals($ret, $html);
 	}


### PR DESCRIPTION
Fix #1422 

``` php
$data = array(
    "status",
    array("Active" => array('A1' => 'A One', 'A2' => 'A Two'), "B" => "B One")
);
echo Tag::selectStatic($data);
```

``` html
<select id="status" name="status">
    <optgroup label="Active">
    <option value="A1">A One</option>
    <option value="A2">A Two</option>
    </optgroup>
    <option value="B">B One</option>
</select>
```
