### PR TITLE
Fix Log Formatter getTypeString EMERGENCY bug

### DIFF
--- a/ext/logger/formatter.c
+++ b/ext/logger/formatter.c
@@ -1,4 +1,3 @@
-
 /*
   +------------------------------------------------------------------------+
   | Phalcon Framework                                                      |
@@ -70,7 +69,7 @@ PHP_METHOD(Phalcon_Logger_Formatter, getTypeString){
 	phalcon_fetch_params(0, 1, 0, &type);
 	
 	itype = phalcon_get_intval(type);
-	if (itype > 0 && itype < 10) {
+	if (itype >= 0 && itype < 10) {
 		RETURN_STRING(lut[itype], 1);
 	}
 	


### PR DESCRIPTION
This fixes a bug that prevents the EMERGENCY log type being displayed correctly.
