### PR TITLE
[2.0.0] Double % Int workaround

### DIFF
--- a/ext/phalcon/cache/backend/mongo.c
+++ b/ext/phalcon/cache/backend/mongo.c
@@ -358,7 +358,7 @@ PHP_METHOD(Phalcon_Cache_Backend_Mongo, delete) {
 	zephir_call_method_p1_noret(collection, "remove", conditions);
 	ZEPHIR_INIT_VAR(_0);
 	zephir_call_func(_0, "rand");
-	if (((zephir_get_numberval(_0) % 100) == 0)) {
+	if (((zephir_get_intval(_0) % 100) == 0)) {
 		zephir_call_method_noret(this_ptr, "gc");
 	}
 	RETURN_MM_BOOL(1);
@@ -658,7 +658,7 @@ PHP_METHOD(Phalcon_Cache_Backend_Mongo, flush) {
 	zephir_call_method_noret(collection, "remove");
 	ZEPHIR_INIT_VAR(_0);
 	zephir_call_func(_0, "rand");
-	if (((zephir_get_numberval(_0) % 100) == 0)) {
+	if (((zephir_get_intval(_0) % 100) == 0)) {
 		zephir_call_method_noret(this_ptr, "gc");
 	}
 	RETURN_MM_BOOL(1);

--- a/ext/phalcon/security.c
+++ b/ext/phalcon/security.c
@@ -308,7 +308,7 @@ PHP_METHOD(Phalcon_Security, isLegacyHash) {
  */
 PHP_METHOD(Phalcon_Security, getTokenKey) {
 
-	zval *numberBytes_param = NULL, *randomBytes, *base64Bytes, *filter, *safeBytes, *dependencyInjector, *session, _0, *_1, *_2;
+	zval *numberBytes_param = NULL, *randomBytes, *base64Bytes, *filter, *safeBytes, *dependencyInjector, *session, _0 = zval_used_for_init, *_1, *_2;
 	int numberBytes;
 
 	ZEPHIR_MM_GROW();
@@ -328,15 +328,15 @@ PHP_METHOD(Phalcon_Security, getTokenKey) {
 		ZEPHIR_THROW_EXCEPTION_STR(phalcon_security_exception_ce, "Openssl extension must be loaded");
 		return;
 	}
-	ZEPHIR_INIT_VAR(_2);
-	ZVAL_LONG(_2, numberBytes);
+	ZEPHIR_SINIT_NVAR(_0);
+	ZVAL_LONG(&_0, numberBytes);
 	ZEPHIR_INIT_VAR(randomBytes);
-	zephir_call_func_p1(randomBytes, "openssl_random_pseudo_bytes", _2);
+	zephir_call_func_p1(randomBytes, "openssl_random_pseudo_bytes", &_0);
 	ZEPHIR_INIT_VAR(base64Bytes);
 	zephir_call_func_p1(base64Bytes, "base64_encode", randomBytes);
 	ZEPHIR_INIT_VAR(filter);
 	object_init_ex(filter, phalcon_filter_ce);
-	ZEPHIR_INIT_BNVAR(_2);
+	ZEPHIR_INIT_VAR(_2);
 	ZVAL_STRING(_2, "alphnum", 1);
 	ZEPHIR_INIT_VAR(safeBytes);
 	zephir_call_method_p2(safeBytes, filter, "sanitize", base64Bytes, _2);
@@ -364,7 +364,7 @@ PHP_METHOD(Phalcon_Security, getTokenKey) {
  */
 PHP_METHOD(Phalcon_Security, getToken) {
 
-	zval *numberBytes_param = NULL, *token, *dependencyInjector, *session, _0, *_1, *_2;
+	zval *numberBytes_param = NULL, *token, *dependencyInjector, *session, _0 = zval_used_for_init, *_1, *_2;
 	int numberBytes;
 
 	ZEPHIR_MM_GROW();
@@ -388,16 +388,16 @@ PHP_METHOD(Phalcon_Security, getToken) {
 		ZEPHIR_THROW_EXCEPTION_STR(phalcon_security_exception_ce, "Openssl extension must be loaded");
 		return;
 	}
-	ZEPHIR_INIT_VAR(_2);
-	ZVAL_LONG(_2, numberBytes);
+	ZEPHIR_SINIT_NVAR(_0);
+	ZVAL_LONG(&_0, numberBytes);
 	ZEPHIR_INIT_VAR(token);
-	zephir_call_func_p1(token, "openssl_random_pseudo_bytes", _2);
+	zephir_call_func_p1(token, "openssl_random_pseudo_bytes", &_0);
 	dependencyInjector = zephir_fetch_nproperty_this(this_ptr, SL("_dependencyInjector"), PH_NOISY_CC);
 	if ((Z_TYPE_P(dependencyInjector) != IS_OBJECT)) {
 		ZEPHIR_THROW_EXCEPTION_STR(phalcon_security_exception_ce, "A dependency injection container is required to access the 'session' service");
 		return;
 	}
-	ZEPHIR_INIT_BNVAR(_2);
+	ZEPHIR_INIT_VAR(_2);
 	ZVAL_STRING(_2, "session", 1);
 	ZEPHIR_INIT_VAR(session);
 	zephir_call_method_p1(session, dependencyInjector, "getshared", _2);

--- a/phalcon/cache/backend/mongo.zep
+++ b/phalcon/cache/backend/mongo.zep
@@ -278,7 +278,7 @@ class Mongo extends Phalcon\Cache\Backend implements Phalcon\Cache\BackendInterf
 		let conditions["key"] = prefixedKey;
 		collection->remove(conditions);
 
-		if rand() % 100 == 0 {
+		if (int) rand() % 100 == 0 {
 			this->gc();
 		}
 
@@ -500,7 +500,7 @@ class Mongo extends Phalcon\Cache\Backend implements Phalcon\Cache\BackendInterf
 		
 		collection->remove();
 
-		if rand() % 100 == 0 {
+		if (int) rand() % 100 == 0 {
 			this->gc();
 		}
 


### PR DESCRIPTION
Mongo db workaround

Next compilation issue is:

```
/var/www/cphalcon/ext/phalcon/db/adapter.c: In function 'zim_Phalcon_Db_Adapter_insert':
/var/www/cphalcon/ext/phalcon/db/adapter.c:451:6: error: 'zend_phalcon_globals' has no member named 'db'
/var/www/cphalcon/ext/phalcon/db/adapter.c:461:7: error: 'zend_phalcon_globals' has no member named 'db'
/var/www/cphalcon/ext/phalcon/db/adapter.c: In function 'zim_Phalcon_Db_Adapter_update':
/var/www/cphalcon/ext/phalcon/db/adapter.c:550:7: error: 'zend_phalcon_globals' has no member named 'db'
/var/www/cphalcon/ext/phalcon/db/adapter.c:580:6: error: 'zend_phalcon_globals' has no member named 'db'
/var/www/cphalcon/ext/phalcon/db/adapter.c: In function 'zim_Phalcon_Db_Adapter_delete':
/var/www/cphalcon/ext/phalcon/db/adapter.c:654:6: error: 'zend_phalcon_globals' has no member named 'db'
make: *** [phalcon/db/adapter.lo] Error 1
```

this line generates one of above:

```
if globals_get("db.escape_identifiers") {
```

which means that globals_get function doesn't return false or anything like that - but where is it actually declared?

PS. I would like to get to the point that I will be able to compile Phalcon 2.0 then I will write dev documentation(mentioned in different PR)

Thanks in advance,

Kamil
