### PR TITLE
Fix #1513 Use zend_symtable_update instead of  zend_hash_update

### DIFF
--- a/ext/kernel/object.c
+++ b/ext/kernel/object.c
@@ -1015,7 +1015,7 @@ int phalcon_update_property_array(zval *object, char *property, unsigned int pro
 		Z_ADDREF_P(value);
 
 		if (Z_TYPE_P(index) == IS_STRING) {
-			zend_hash_update(Z_ARRVAL_P(tmp), Z_STRVAL_P(index), Z_STRLEN_P(index) + 1, &value, sizeof(zval *), NULL);
+			zend_symtable_update(Z_ARRVAL_P(tmp), Z_STRVAL_P(index), Z_STRLEN_P(index) + 1, &value, sizeof(zval*), NULL);
 		} else {
 			if (Z_TYPE_P(index) == IS_LONG) {
 				zend_hash_index_update(Z_ARRVAL_P(tmp), Z_LVAL_P(index), &value, sizeof(zval *), NULL);

--- a/unit-tests/AclTest.php
+++ b/unit-tests/AclTest.php
@@ -93,4 +93,17 @@ class AclTest extends PHPUnit_Framework_TestCase
 		$acl->allow('*', '*', '*');
 */
 	}
+
+	public function testIssues1513()
+	{
+		try {
+			$acl = new \Phalcon\Acl\Adapter\Memory();
+			$acl->setDefaultAction(Phalcon\Acl::DENY);
+			$acl->addRole(new \Phalcon\Acl\Role('11'));
+			$acl->addResource(new \Phalcon\Acl\Resource('11'), array('index'));
+			$this->assertTrue(TRUE);
+		} catch (Exception $e) {
+			$this->assertTrue(FALSE);
+		}
+	}
 }


### PR DESCRIPTION
In `phalcon_update_property_array`
See #1513
