### PR TITLE
Add support \Phalcon\Mvc\Model::selectWriteConnection

### DIFF
--- a/ext/mvc/model/query.c
+++ b/ext/mvc/model/query.c
@@ -4038,8 +4038,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, _executeInsert){
 	/** 
 	 * Get the model connection
 	 */
-	PHALCON_INIT_VAR(connection);
-	phalcon_call_method(connection, model, "getwriteconnection");
+	if (phalcon_method_exists_ex(model, SS("selectwriteconnection") TSRMLS_CC) == SUCCESS) {
+		PHALCON_INIT_VAR(connection);
+		phalcon_call_method_p3(connection, model, "selectwriteconnection", intermediate, bind_params, bind_types);
+		if (Z_TYPE_P(connection) != IS_OBJECT) {
+			PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "'selectWriteConnection' didn't returned a valid connection");
+			return;
+		}
+	} else {
+		PHALCON_INIT_VAR(connection);
+		phalcon_call_method(connection, model, "getwriteconnection");
+	}
 	
 	PHALCON_OBS_VAR(meta_data);
 	phalcon_read_property_this(&meta_data, this_ptr, SL("_metaData"), PH_NOISY_CC);
@@ -4380,8 +4389,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, _executeUpdate){
 		phalcon_call_method_p1(model, manager, "load", model_name);
 	}
 	
-	PHALCON_INIT_VAR(connection);
-	phalcon_call_method(connection, model, "getwriteconnection");
+	if (phalcon_method_exists_ex(model, SS("selectwriteconnection") TSRMLS_CC) == SUCCESS) {
+		PHALCON_INIT_VAR(connection);
+		phalcon_call_method_p3(connection, model, "selectwriteconnection", intermediate, bind_params, bind_types);
+		if (Z_TYPE_P(connection) != IS_OBJECT) {
+			PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "'selectWriteConnection' didn't returned a valid connection");
+			return;
+		}
+	} else {
+		PHALCON_INIT_VAR(connection);
+		phalcon_call_method(connection, model, "getwriteconnection");
+	}
 	
 	PHALCON_INIT_VAR(dialect);
 	phalcon_call_method(dialect, connection, "getdialect");
@@ -4630,8 +4648,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, _executeDelete){
 		RETURN_MM();
 	}
 	
-	PHALCON_INIT_VAR(connection);
-	phalcon_call_method(connection, model, "getwriteconnection");
+	if (phalcon_method_exists_ex(model, SS("selectwriteconnection") TSRMLS_CC) == SUCCESS) {
+		PHALCON_INIT_VAR(connection);
+		phalcon_call_method_p3(connection, model, "selectwriteconnection", intermediate, bind_params, bind_types);
+		if (Z_TYPE_P(connection) != IS_OBJECT) {
+			PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "'selectWriteConnection' didn't returned a valid connection");
+			return;
+		}
+	} else {
+		PHALCON_INIT_VAR(connection);
+		phalcon_call_method(connection, model, "getwriteconnection");
+	}
 	
 	/** 
 	 * Create a transaction in the write connection


### PR DESCRIPTION
``` php
class Robots extends Phalcon\Mvc\Model
{
    /**
     * Dynamically selects a shard
     *
     * @param array $intermediate
     * @param array $bindParams
     * @param array $bindTypes
     */
    public function selectWriteConnection($intermediate, $bindParams, $bindTypes)
    {
        //Check if there is a 'where' clause in the select
        if (isset($intermediate['where'])) {

            $conditions = $intermediate['where'];

            //Choose the possible shard according to the conditions
            if ($conditions['left']['name'] == 'id') {
                $id = $conditions['right']['value'];
                if ($id > 0 && $id < 10000) {
                    return $this->getDI()->get('dbShard1');
                }
                if ($id > 10000) {
                    return $this->getDI()->get('dbShard2');
                }
            }
        }

        //Use a default shard
        return $this->getDI()->get('dbShard0');
    }

}
```
