### PR TITLE
[NFR]When not found option renturn null

### DIFF
--- a/ext/mvc/model/validator.c
+++ b/ext/mvc/model/validator.c
@@ -170,7 +170,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Validator, getOption){
 		RETURN_CCTOR(value);
 	}
 	
-	RETURN_MM_EMPTY_STRING();
+	RETURN_MM_EMPTY_NULL();
 }
 
 /**

--- a/ext/mvc/model/validator.c
+++ b/ext/mvc/model/validator.c
@@ -170,7 +170,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Validator, getOption){
 		RETURN_CCTOR(value);
 	}
 	
-	RETURN_MM_EMPTY_NULL();
+	RETURN_MM_NULL();
 }
 
 /**


### PR DESCRIPTION
``` php
        $this->validate(new StringLengthValidator(array(
            'max' => 20,
            'min' => 1,
            'messageMaximum' => 'messageMaximum',
            'messageMinimum' => 'messageMinimum'
        )));
```

That must be throw error

``` c
    PHALCON_INIT_VAR(field);
    phalcon_call_method_p1(field, this_ptr, "getoption", option);
    if (Z_TYPE_P(field) != IS_STRING) {
        PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "Field name must be a string");
        return;
    }
```

`````` c
PHP_METHOD(Phalcon_Mvc_Model_Validator, getOption){
    // ```
    RETURN_MM_EMPTY_STRING(); // change to RETURN_MM_NULL()
}
``````
