### PR TITLE
[PR] Missing main/php_variables.h header breaks compilation on Windows

### DIFF
--- a/build/_resource/config/phalcon_c_header.php
+++ b/build/_resource/config/phalcon_c_header.php
@@ -13,6 +13,7 @@ return <<<HEADER
 #include "phalcon.h"
 
 #include "main/php_main.h"
+#include "main/php_variables.h"
 #include "main/php_streams.h"
 #include "main/php_output.h"
 #include "main/php_ini.h"


### PR DESCRIPTION
Please see #1548 . Without the header declaration build fails.
