### PR TITLE
PDO/Adapter: decribeColumns method fixes.

### DIFF
--- a/ext/db/adapter/pdo/mysql.c
+++ b/ext/db/adapter/pdo/mysql.c
@@ -196,109 +196,130 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeColumns){
 		PHALCON_OBS_NVAR(column_type);
 		phalcon_array_fetch_long(&column_type, field, 1, PH_NOISY);
 	
+		/** 
+		 * Check the column type to get the correct Phalcon type
+		 */
 		while (1) {
-	
-			/** 
-			 * Point are varchars
-			 */
-			if (phalcon_memnstr_str(column_type, SL("point"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Enum are treated as char
-			 */
-			if (phalcon_memnstr_str(column_type, SL("enum"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Smallint/Bigint/Integers/Int are int
-			 */
-			if (phalcon_memnstr_str(column_type, SL("int"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-				phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Varchar are varchars
-			 */
-			if (phalcon_memnstr_str(column_type, SL("varchar"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Special type for datetime
-			 */
-			if (phalcon_memnstr_str(column_type, SL("datetime"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Decimals are floats
-			 */
-			if (phalcon_memnstr_str(column_type, SL("decimal"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Chars are chars
-			 */
-			if (phalcon_memnstr_str(column_type, SL("char"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Date/Datetime are varchars
-			 */
-			if (phalcon_memnstr_str(column_type, SL("date"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Text are varchars
-			 */
-			if (phalcon_memnstr_str(column_type, SL("text"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Float/Smallfloats/Decimals are float
-			 */
-			if (phalcon_memnstr_str(column_type, SL("float"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * Double are floats
-			 */
-			if (phalcon_memnstr_str(column_type, SL("double"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 9, PH_SEPARATE);
-				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-				break;
-			}
-	
-			/** 
-			 * By default is string
-			 */
-			phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-			break;
+		  
+		  /** 
+		   * Point are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("point"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Enum are treated as char
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("enum"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /**
+		   * Tinyint(1) is boolean
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+		    ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
+		    break;
+		  }
+		  
+		  /** 
+		   * Smallint/Bigint/Integers/Int are int
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("int"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Varchar are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("varchar"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Special type for datetime
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("datetime"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Decimals are floats
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("decimal"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Chars are chars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("char"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Date/Datetime are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("date"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Timestamp as date
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("TIMESTAMP"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("text"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Float/Smallfloats/Decimals are float
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("float"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Double are floats
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("double"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 9, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * By default is string
+		   */
+		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		  break;
 		}
 	
 		/** 

--- a/ext/db/adapter/pdo/mysql.c
+++ b/ext/db/adapter/pdo/mysql.c
@@ -282,7 +282,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeColumns){
 		  /** 
 		   * Timestamp as date
 		   */
-		  if (phalcon_memnstr_str(column_type, SL("TIMESTAMP"))) {
+		  if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
 		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
 		    break;
 		  }

--- a/ext/db/adapter/pdo/mysql.c
+++ b/ext/db/adapter/pdo/mysql.c
@@ -200,126 +200,127 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeColumns){
 		 * Check the column type to get the correct Phalcon type
 		 */
 		while (1) {
-		  
-		  /** 
-		   * Point are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("point"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Enum are treated as char
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("enum"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /**
-		   * Tinyint(1) is boolean
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
-		    ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
-		    break;
-		  }
-		  
-		  /** 
-		   * Smallint/Bigint/Integers/Int are int
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("int"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Varchar are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("varchar"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Special type for datetime
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("datetime"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Decimals are floats
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("decimal"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Chars are chars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("char"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Date/Datetime are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("date"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Timestamp as date
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("text"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Float/Smallfloats/Decimals are float
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("float"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Double are floats
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("double"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 9, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * By default is string
-		   */
-		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		  break;
+
+			/**
+			 * Point are varchars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("point"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Enum are treated as char
+			 */
+			if (phalcon_memnstr_str(column_type, SL("enum"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Tinyint(1) is boolean
+			 */
+			if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+				PHALCON_INIT_NVAR(column_type);
+				ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
+				break;
+			}
+
+			/**
+			 * Smallint/Bigint/Integers/Int are int
+			 */
+			if (phalcon_memnstr_str(column_type, SL("int"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Varchar are varchars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("varchar"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Special type for datetime
+			 */
+			if (phalcon_memnstr_str(column_type, SL("datetime"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Decimals are floats
+			 */
+			if (phalcon_memnstr_str(column_type, SL("decimal"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Chars are chars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("char"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Date/Datetime are varchars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("date"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Timestamp as date
+			 */
+			if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Text are varchars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("text"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Float/Smallfloats/Decimals are float
+			 */
+			if (phalcon_memnstr_str(column_type, SL("float"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Double are floats
+			 */
+			if (phalcon_memnstr_str(column_type, SL("double"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 9, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("isNumeric"), &ztrue, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * By default is string
+			 */
+			phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+			break;
 		}
 	
 		/** 

--- a/ext/db/adapter/pdo/oracle.c
+++ b/ext/db/adapter/pdo/oracle.c
@@ -213,115 +213,114 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Oracle, describeColumns){
 		 * Check the column type to get the correct Phalcon type
 		 */
 		while (1) {
-		  
-		  /** 
-		   * Integer
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("NUMBER"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /**
-		   * Tinyint(1) is boolean
-		   */
-		  if(phalcon_memnstr_str(column_type, SL("TINYINT(1)"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Smallint/Bigint/Integers/Int are int
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("INTEGER"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Float/Smallfloats/Decimals are float
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("FLOAT"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Date
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("TIMESTAMP"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("RAW"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("BLOB"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("CLOB"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Chars2 are string
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("VARCHAR2"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Chars are chars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("CHAR"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("text"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /**
-		   * By default is string
-		   */
-		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		  break;
-		}     
+			/**
+			 * Integer
+			 */
+			if (phalcon_memnstr_str(column_type, SL("NUMBER"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Tinyint(1) is boolean
+			 */
+			if (phalcon_memnstr_str(column_type, SL("TINYINT(1)"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Smallint/Bigint/Integers/Int are int
+			 */
+			if (phalcon_memnstr_str(column_type, SL("INTEGER"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Float/Smallfloats/Decimals are float
+			 */
+			if (phalcon_memnstr_str(column_type, SL("FLOAT"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Date
+			 */
+			if (phalcon_memnstr_str(column_type, SL("TIMESTAMP"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Text
+			 */
+			if (phalcon_memnstr_str(column_type, SL("RAW"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Text
+			 */
+			if (phalcon_memnstr_str(column_type, SL("BLOB"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Text
+			 */
+			if (phalcon_memnstr_str(column_type, SL("CLOB"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Chars2 are string
+			 */
+			if (phalcon_memnstr_str(column_type, SL("VARCHAR2"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Chars are chars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("CHAR"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Text are varchars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("text"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * By default is string
+			 */
+			phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+			break;
+		}
 	
 		if (Z_TYPE_P(old_column) == IS_NULL) {
 			phalcon_array_update_string_bool(&definition, SL("first"), 1, PH_SEPARATE);

--- a/ext/db/adapter/pdo/oracle.c
+++ b/ext/db/adapter/pdo/oracle.c
@@ -212,61 +212,116 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Oracle, describeColumns){
 		/** 
 		 * Check the column type to get the correct Phalcon type
 		 */
-		if (phalcon_memnstr_str(column_type, SL("NUMBER"))) {
-			phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-			phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-			phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
-			phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
-			phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		} else {
-			if (phalcon_memnstr_str(column_type, SL("INTEGER"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-				phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
-				phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-			} else {
-				if (phalcon_memnstr_str(column_type, SL("VARCHAR2"))) {
-					phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-					phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-				} else {
-					if (phalcon_memnstr_str(column_type, SL("FLOAT"))) {
-						phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-						phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-						phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-						phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
-						phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-					} else {
-						if (phalcon_memnstr_str(column_type, SL("TIMESTAMP"))) {
-							phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-						} else {
-							if (phalcon_memnstr_str(column_type, SL("RAW"))) {
-								phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-							} else {
-								if (phalcon_memnstr_str(column_type, SL("BLOB"))) {
-									phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-								} else {
-									if (phalcon_memnstr_str(column_type, SL("CLOB"))) {
-										phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-									} else {
-										if (phalcon_memnstr_str(column_type, SL("VARCHAR2"))) {
-											phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-											phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-										} else {
-											if (phalcon_memnstr_str(column_type, SL("CHAR"))) {
-												phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-												phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
-											} else {
-												phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
+		while (1) {
+		  
+		  /** 
+		   * Integer
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("NUMBER"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /**
+		   * Tinyint(1) is boolean
+		   */
+		  if(phalcon_memnstr_str(column_type, SL("TINYINT(1)"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Smallint/Bigint/Integers/Int are int
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("INTEGER"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &column_precision, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Float/Smallfloats/Decimals are float
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("FLOAT"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("scale"), &column_scale, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Date
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("TIMESTAMP"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("RAW"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("BLOB"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("CLOB"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Chars2 are string
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("VARCHAR2"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Chars are chars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("CHAR"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &column_size, PH_COPY | PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("text"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /**
+		   * By default is string
+		   */
+		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		  break;
+		}     
 	
 		if (Z_TYPE_P(old_column) == IS_NULL) {
 			phalcon_array_update_string_bool(&definition, SL("first"), 1, PH_SEPARATE);

--- a/ext/db/adapter/pdo/postgresql.c
+++ b/ext/db/adapter/pdo/postgresql.c
@@ -198,65 +198,119 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns){
 		/** 
 		 * Check the column type to get the correct Phalcon type
 		 */
-		if (phalcon_memnstr_str(column_type, SL("int"))) {
-			phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-			phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-			phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
-			phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-		} else {
-			if (phalcon_memnstr_str(column_type, SL("varying"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-				phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-			} else {
-				if (phalcon_memnstr_str(column_type, SL("date"))) {
-					phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-					phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
-				} else {
-					if (phalcon_memnstr_str(column_type, SL("numeric"))) {
-						phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-						phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-						phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
-						phalcon_array_update_string(&definition, SL("scale"), &numeric_scale, PH_COPY | PH_SEPARATE);
-						phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-					} else {
-						if (phalcon_memnstr_str(column_type, SL("char"))) {
-							phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-							phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-						} else {
-							if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
-								phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
-								phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
-							} else {
-								if (phalcon_memnstr_str(column_type, SL("text"))) {
-									phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-									phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-								} else {
-									if (phalcon_memnstr_str(column_type, SL("float"))) {
-										phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-										phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-										phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
-										phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-									} else {
-										if (phalcon_memnstr_str(column_type, SL("bool"))) {
-											phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-											phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
-											phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
-										} else {
-											if (phalcon_memnstr_str(column_type, SL("uuid"))) {
-												phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-												phalcon_array_update_string_long(&definition, SL("size"), 36, PH_SEPARATE);
-											} else {
-												phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-												phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+		while (1) {           
+		  /**
+		   * Tinyint(1) is boolean
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("smallint(1)"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);		    
+		    break;
+		  }
+		  
+		  /** 
+		   * Smallint/Bigint/Integers/Int are int
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("int"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Varchar
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("varying"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Special type for datetime
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("date"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Numeric
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("numeric"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("scale"), &numeric_scale, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Chars are chars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("char"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Date
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("text"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Float/Smallfloats/Decimals are float
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("float"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Boolean
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("bool"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * UUID
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("uuid"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("size"), 36, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * By default is string
+		   */
+		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		  break;
 		}
 	
 		if (phalcon_memnstr_str(column_type, SL("unsigned"))) {

--- a/ext/db/adapter/pdo/postgresql.c
+++ b/ext/db/adapter/pdo/postgresql.c
@@ -198,119 +198,119 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns){
 		/** 
 		 * Check the column type to get the correct Phalcon type
 		 */
-		while (1) {           
-		  /**
-		   * Tinyint(1) is boolean
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("smallint(1)"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);		    
-		    break;
-		  }
-		  
-		  /** 
-		   * Smallint/Bigint/Integers/Int are int
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("int"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Varchar
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("varying"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Special type for datetime
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("date"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Numeric
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("numeric"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("scale"), &numeric_scale, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Chars are chars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("char"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Date
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("text"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Float/Smallfloats/Decimals are float
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("float"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Boolean
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("bool"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * UUID
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("uuid"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("size"), 36, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * By default is string
-		   */
-		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		  break;
+		while (1) {
+			/**
+			 * Tinyint(1) is boolean
+			 */
+			if (phalcon_memnstr_str(column_type, SL("smallint(1)"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Smallint/Bigint/Integers/Int are int
+			 */
+			if (phalcon_memnstr_str(column_type, SL("int"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Varchar
+			 */
+			if (phalcon_memnstr_str(column_type, SL("varying"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Special type for datetime
+			 */
+			if (phalcon_memnstr_str(column_type, SL("date"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Numeric
+			 */
+			if (phalcon_memnstr_str(column_type, SL("numeric"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("scale"), &numeric_scale, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Chars are chars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("char"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Date
+			 */
+			if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Text are varchars
+			 */
+			if (phalcon_memnstr_str(column_type, SL("text"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &char_size, PH_COPY | PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Float/Smallfloats/Decimals are float
+			 */
+			if (phalcon_memnstr_str(column_type, SL("float"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+				phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+				phalcon_array_update_string(&definition, SL("size"), &numeric_size, PH_COPY | PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * Boolean
+			 */
+			if (phalcon_memnstr_str(column_type, SL("bool"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("size"), 0, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * UUID
+			 */
+			if (phalcon_memnstr_str(column_type, SL("uuid"))) {
+				phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+				phalcon_array_update_string_long(&definition, SL("size"), 36, PH_SEPARATE);
+				break;
+			}
+
+			/**
+			 * By default is string
+			 */
+			phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+			break;
 		}
 	
 		if (phalcon_memnstr_str(column_type, SL("unsigned"))) {

--- a/ext/db/adapter/pdo/sqlite.c
+++ b/ext/db/adapter/pdo/sqlite.c
@@ -177,124 +177,125 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 		phalcon_array_fetch_long(&column_type, field, 2, PH_NOISY);
 		
 		/** 
-		 * Check the column type to get the correct Phalcon type
+	 * Check the column type to get the correct Phalcon type
+	 */
+	while (1) {
+
+		/**
+		 * Tinyint(1) is boolean
 		 */
-		while (1) {
-		  
-		  /**
-		   * Tinyint(1) is boolean
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
-		    ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
-		    break;
-		  }
-		  
-		  /** 
-		   * Smallint/Bigint/Integers/Int are int
-		   */
-		  PHALCON_INIT_NVAR(pos);
-		  phalcon_fast_stripos_str(pos, column_type, SL("int"));
-		  if (PHALCON_IS_NOT_FALSE(pos)) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-		    
-		    PHALCON_OBS_NVAR(attribute);
-		    phalcon_array_fetch_long(&attribute, field, 5, PH_NOISY);
-		    
-		    /** 
-		     * Check if the column is auto increment
-		     */
-		    if (zend_is_true(attribute)) {
-		      phalcon_array_update_string_bool(&definition, SL("autoIncrement"), 1, PH_SEPARATE);
-		    }
-		    break;
-		  }
-		  
-		  /** 
-		   * Varchar are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("varchar"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Date/Datetime are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("date"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Timestamp as date
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Decimals are floats
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("decimal"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Chars are chars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("char"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Special type for datetime
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("datetime"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Text are varchars
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("text"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Float/Smallfloats/Decimals are float
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("float"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * Enum are treated as char
-		   */
-		  if (phalcon_memnstr_str(column_type, SL("enum"))) {
-		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-		    break;
-		  }
-		  
-		  /** 
-		   * By default is string
-		   */
-		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		  break;
+		if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+			phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
+			PHALCON_INIT_NVAR(column_type);
+			ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
+			break;
 		}
+
+		/**
+		 * Smallint/Bigint/Integers/Int are int
+		 */
+		PHALCON_INIT_NVAR(pos);
+		phalcon_fast_stripos_str(pos, column_type, SL("int"));
+		if (PHALCON_IS_NOT_FALSE(pos)) {
+			phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+			phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+			phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+
+			PHALCON_OBS_NVAR(attribute);
+			phalcon_array_fetch_long(&attribute, field, 5, PH_NOISY);
+
+			/**
+			 * Check if the column is auto increment
+			 */
+			if (zend_is_true(attribute)) {
+				phalcon_array_update_string_bool(&definition, SL("autoIncrement"), 1, PH_SEPARATE);
+			}
+			break;
+		}
+
+		/**
+		 * Varchar are varchars
+		 */
+		if (phalcon_memnstr_str(column_type, SL("varchar"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Date/Datetime are varchars
+		 */
+		if (phalcon_memnstr_str(column_type, SL("date"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Timestamp as date
+		 */
+		if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Decimals are floats
+		 */
+		if (phalcon_memnstr_str(column_type, SL("decimal"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+			phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+			phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Chars are chars
+		 */
+		if (phalcon_memnstr_str(column_type, SL("char"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Special type for datetime
+		 */
+		if (phalcon_memnstr_str(column_type, SL("datetime"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Text are varchars
+		 */
+		if (phalcon_memnstr_str(column_type, SL("text"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Float/Smallfloats/Decimals are float
+		 */
+		if (phalcon_memnstr_str(column_type, SL("float"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+			phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+			phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * Enum are treated as char
+		 */
+		if (phalcon_memnstr_str(column_type, SL("enum"))) {
+			phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+			break;
+		}
+
+		/**
+		 * By default is string
+		 */
+		phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		break;
+	}
 	
 		if (phalcon_memnstr_str(column_type, SL("("))) {
 	

--- a/ext/db/adapter/pdo/sqlite.c
+++ b/ext/db/adapter/pdo/sqlite.c
@@ -163,7 +163,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 	
 	PHALCON_INIT_VAR(old_column);
 	
-	phalcon_is_iterable(describe, &ah0, &hp0, 0, 0);
+	phalcon_is_iterable(describe, &ah0, &hp0, 0, 0);			
 	
 	while (zend_hash_get_current_data_ex(ah0, (void**) &hd, &hp0) == SUCCESS) {
 	
@@ -175,17 +175,18 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 	
 		PHALCON_OBS_NVAR(column_type);
 		phalcon_array_fetch_long(&column_type, field, 2, PH_NOISY);
-	
+		
 		/** 
 		 * Check the column type to get the correct Phalcon type
 		 */
-		while (1) {           
+		while (1) {
+		  
 		  /**
 		   * Tinyint(1) is boolean
 		   */
 		  if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
 		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
-		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);    
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);
 		    ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
 		    break;
 		  }
@@ -193,7 +194,9 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 		  /** 
 		   * Smallint/Bigint/Integers/Int are int
 		   */
-		  if (phalcon_memnstr_str(column_type, SL("int"))) {
+		  PHALCON_INIT_NVAR(pos);
+		  phalcon_fast_stripos_str(pos, column_type, SL("int"));
+		  if (PHALCON_IS_NOT_FALSE(pos)) {
 		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
 		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
 		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
@@ -227,6 +230,14 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 		  }
 		  
 		  /** 
+		   * Timestamp as date
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("timestamp"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
 		   * Decimals are floats
 		   */
 		  if (phalcon_memnstr_str(column_type, SL("decimal"))) {
@@ -245,7 +256,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 		  }
 		  
 		  /** 
-		   * Date/Datetime are varchars
+		   * Special type for datetime
 		   */
 		  if (phalcon_memnstr_str(column_type, SL("datetime"))) {
 		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
@@ -277,11 +288,12 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
 		    break;
 		  }
+		  
 		  /** 
 		   * By default is string
 		   */
 		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-		  break;		  
+		  break;
 		}
 	
 		if (phalcon_memnstr_str(column_type, SL("("))) {

--- a/ext/db/adapter/pdo/sqlite.c
+++ b/ext/db/adapter/pdo/sqlite.c
@@ -176,60 +176,112 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns){
 		PHALCON_OBS_NVAR(column_type);
 		phalcon_array_fetch_long(&column_type, field, 2, PH_NOISY);
 	
-		PHALCON_INIT_NVAR(pos);
-		phalcon_fast_stripos_str(pos, column_type, SL("int"));
-		if (PHALCON_IS_NOT_FALSE(pos)) {
-			phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
-			phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-			phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
-	
-			PHALCON_OBS_NVAR(attribute);
-			phalcon_array_fetch_long(&attribute, field, 5, PH_NOISY);
-	
-			/** 
-			 * Check if the column is auto increment
-			 */
-			if (zend_is_true(attribute)) {
-				phalcon_array_update_string_bool(&definition, SL("autoIncrement"), 1, PH_SEPARATE);
-			}
-		} else {
-			if (phalcon_memnstr_str(column_type, SL("varchar"))) {
-				phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-			} else {
-				if (phalcon_memnstr_str(column_type, SL("date"))) {
-					phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
-				} else {
-					if (phalcon_memnstr_str(column_type, SL("decimal"))) {
-						phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
-						phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-						phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-					} else {
-						if (phalcon_memnstr_str(column_type, SL("char"))) {
-							phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-						} else {
-							if (phalcon_memnstr_str(column_type, SL("datetime"))) {
-								phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
-							} else {
-								if (phalcon_memnstr_str(column_type, SL("text"))) {
-									phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
-								} else {
-									if (phalcon_memnstr_str(column_type, SL("float"))) {
-										phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
-										phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
-										phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
-									} else {
-										if (phalcon_memnstr_str(column_type, SL("enum"))) {
-											phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
-										} else {
-											phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
+		/** 
+		 * Check the column type to get the correct Phalcon type
+		 */
+		while (1) {           
+		  /**
+		   * Tinyint(1) is boolean
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("tinyint(1)"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 8, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 5, PH_SEPARATE);    
+		    ZVAL_STRING(column_type, "boolean", 1); // Change column type to skip size check.
+		    break;
+		  }
+		  
+		  /** 
+		   * Smallint/Bigint/Integers/Int are int
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("int"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 0, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 1, PH_SEPARATE);
+		    
+		    PHALCON_OBS_NVAR(attribute);
+		    phalcon_array_fetch_long(&attribute, field, 5, PH_NOISY);
+		    
+		    /** 
+		     * Check if the column is auto increment
+		     */
+		    if (zend_is_true(attribute)) {
+		      phalcon_array_update_string_bool(&definition, SL("autoIncrement"), 1, PH_SEPARATE);
+		    }
+		    break;
+		  }
+		  
+		  /** 
+		   * Varchar are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("varchar"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Date/Datetime are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("date"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 1, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Decimals are floats
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("decimal"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 3, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Chars are chars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("char"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Date/Datetime are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("datetime"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 4, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Text are varchars
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("text"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 6, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Float/Smallfloats/Decimals are float
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("float"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 7, PH_SEPARATE);
+		    phalcon_array_update_string_bool(&definition, SL("isNumeric"), 1, PH_SEPARATE);
+		    phalcon_array_update_string_long(&definition, SL("bindType"), 32, PH_SEPARATE);
+		    break;
+		  }
+		  
+		  /** 
+		   * Enum are treated as char
+		   */
+		  if (phalcon_memnstr_str(column_type, SL("enum"))) {
+		    phalcon_array_update_string_long(&definition, SL("type"), 5, PH_SEPARATE);
+		    break;
+		  }
+		  /** 
+		   * By default is string
+		   */
+		  phalcon_array_update_string_long(&definition, SL("type"), 2, PH_SEPARATE);
+		  break;		  
 		}
 	
 		if (phalcon_memnstr_str(column_type, SL("("))) {

--- a/ext/db/dialect/mysql.c
+++ b/ext/db/dialect/mysql.c
@@ -471,21 +471,22 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, addForeignKey){
 	}
 	if (zend_is_true(schema_name)) {
 		PHALCON_INIT_VAR(sql);
-		PHALCON_CONCAT_SVSVS(sql, "ALTER TABLE `", schema_name, "`.`", table_name, "` ADD FOREIGN KEY ");
+		PHALCON_CONCAT_SVSVS(sql, "ALTER TABLE `", schema_name, "`.`", table_name, "` ");
 	} else {
 		PHALCON_INIT_NVAR(sql);
-		PHALCON_CONCAT_SVS(sql, "ALTER TABLE `", table_name, "` ADD FOREIGN KEY ");
+		PHALCON_CONCAT_SVS(sql, "ALTER TABLE `", table_name, "` ");
 	}
-	
+
+    PHALCON_INIT_VAR(reference_name);
+    phalcon_call_method(reference_name, reference, "getname");
+	PHALCON_SCONCAT_SVS(sql, "ADD CONSTRAINT `", reference_name, "` FOREIGN KEY ");
+
 	PHALCON_INIT_VAR(columns);
 	phalcon_call_method(columns, reference, "getcolumns");
 	
 	PHALCON_INIT_VAR(quoted_column_list);
 	phalcon_call_method_p1(quoted_column_list, this_ptr, "getcolumnlist", columns);
-	
-	PHALCON_INIT_VAR(reference_name);
-	phalcon_call_method(reference_name, reference, "getname");
-	PHALCON_SCONCAT_SVSVS(sql, "`", reference_name, "`(", quoted_column_list, ") REFERENCES ");
+	PHALCON_SCONCAT_SVS(sql, "(", quoted_column_list, ") REFERENCES ");
 	
 	/** 
 	 * Add the schema

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -327,10 +327,10 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$references = $this->getReferences();
 
 		//Add Foreign Key
-		$this->assertEquals($dialect->addForeignKey('table', null, $references['fk1']), 'ALTER TABLE `table` ADD FOREIGN KEY `fk1`(`column1`) REFERENCES `ref_table`(`column2`)');
-		$this->assertEquals($dialect->addForeignKey('table', 'schema', $references['fk1']), 'ALTER TABLE `schema`.`table` ADD FOREIGN KEY `fk1`(`column1`) REFERENCES `ref_table`(`column2`)');
-		$this->assertEquals($dialect->addForeignKey('table', null, $references['fk2']), 'ALTER TABLE `table` ADD FOREIGN KEY `fk2`(`column3`, `column4`) REFERENCES `ref_table`(`column5`, `column6`)');
-		$this->assertEquals($dialect->addForeignKey('table', 'schema', $references['fk2']), 'ALTER TABLE `schema`.`table` ADD FOREIGN KEY `fk2`(`column3`, `column4`) REFERENCES `ref_table`(`column5`, `column6`)');
+        $this->assertEquals($dialect->addForeignKey('table', null, $references['fk1']), 'ALTER TABLE `table` ADD CONSTRAINT `fk1` FOREIGN KEY (`column1`) REFERENCES `ref_table`(`column2`)');
+        $this->assertEquals($dialect->addForeignKey('table', 'schema', $references['fk1']), 'ALTER TABLE `schema`.`table` ADD CONSTRAINT `fk1` FOREIGN KEY (`column1`) REFERENCES `ref_table`(`column2`)');
+        $this->assertEquals($dialect->addForeignKey('table', null, $references['fk2']), 'ALTER TABLE `table` ADD CONSTRAINT `fk2` FOREIGN KEY (`column3`, `column4`) REFERENCES `ref_table`(`column5`, `column6`)');
+        $this->assertEquals($dialect->addForeignKey('table', 'schema', $references['fk2']), 'ALTER TABLE `schema`.`table` ADD CONSTRAINT `fk2` FOREIGN KEY (`column3`, `column4`) REFERENCES `ref_table`(`column5`, `column6`)');
 
 		$this->assertEquals($dialect->dropForeignKey('table', null, 'fk1'), 'ALTER TABLE `table` DROP FOREIGN KEY `fk1`');
 		$this->assertEquals($dialect->dropForeignKey('table', 'schema', 'fk1'), 'ALTER TABLE `schema`.`table` DROP FOREIGN KEY `fk1`');


### PR DESCRIPTION
- added tinyint(1) as boolean for mysql, oracle, postresql, sqlite.
- added timestamp as date for mysql.
- decribeColumns method has been refactored in oracle, postesql, sqlite.
- added constraint creation for foreign key
