### PR TITLE
[TESTS] Minor addition to ViewCacheTest and and testing on Windows

### DIFF
--- a/ext/mvc/view.c
+++ b/ext/mvc/view.c
@@ -1243,7 +1243,7 @@ PHP_METHOD(Phalcon_Mvc_View, render){
 		phalcon_call_method_p2_noret(events_manager, "fire", event_name, this_ptr);
 	}
 	
-	RETURN_MM_NULL();
+	RETURN_THIS();
 }
 
 /**

--- a/unit-tests/AssetsTest.php
+++ b/unit-tests/AssetsTest.php
@@ -212,19 +212,19 @@ class AssetsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($filtered, '');
 
 		$filtered = $jsmin->filter('{}}');
-		$this->assertEquals($filtered, PHP_EOL . '{}}');
+		$this->assertEquals($filtered, "\n" . '{}}');
 
 		$filtered = $jsmin->filter('if ( a == b ) {    document . writeln("hello") ; }');
-		$this->assertEquals($filtered, PHP_EOL . 'if(a==b){document.writeln("hello");}');
+		$this->assertEquals($filtered, "\n" . 'if(a==b){document.writeln("hello");}');
 
 		$filtered = $jsmin->filter("if ( a == b ) {    document . writeln('\t') ; }");
-		$this->assertEquals($filtered, PHP_EOL . "if(a==b){document.writeln('\t');}");
+		$this->assertEquals($filtered, "\n" . "if(a==b){document.writeln('\t');}");
 
 		$filtered = $jsmin->filter("/** this is a comment */ if ( a == b ) {    document . writeln('\t') ; /** this is a comment */ }");
-		$this->assertEquals($filtered, PHP_EOL . "if(a==b){document.writeln('\t');}");
+		$this->assertEquals($filtered, "\n" . "if(a==b){document.writeln('\t');}");
 
 		$filtered = $jsmin->filter("\t\ta\t\r\n= \n \r\n100;\t");
-		$this->assertEquals($filtered, PHP_EOL . 'a=100;');
+		$this->assertEquals($filtered, "\n" . 'a=100;');
 	}
 
 	public function testCssminFilter()

--- a/unit-tests/ConsoleCliTest.php
+++ b/unit-tests/ConsoleCliTest.php
@@ -198,7 +198,7 @@ class ConsoleCliTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(class_exists('Issue787Task'));
 
 		$actual   = Issue787Task::$output;
-		$expected = "beforeExecuteRoute\ninitialize\n";
+		$expected = "beforeExecuteRoute".PHP_EOL."initialize".PHP_EOL;
 		$this->assertEquals($actual, $expected);
 	}
 }

--- a/unit-tests/CryptTest.php
+++ b/unit-tests/CryptTest.php
@@ -21,6 +21,9 @@
 class CryptTest extends PHPUnit_Framework_TestCase
 {
 
+	/**
+	 * @requires extension fileinfo
+	 */
 	public function testEncryption()
 	{
 
@@ -49,6 +52,9 @@ class CryptTest extends PHPUnit_Framework_TestCase
 		}
 	}
 
+	/**
+	 * @requires extension fileinfo
+	 */
 	public function testPadding()
 	{
 		$texts = array('');
@@ -82,6 +88,9 @@ class CryptTest extends PHPUnit_Framework_TestCase
 		}
 	}
 
+	/**
+	 * @requires extension fileinfo
+	 */
 	public function testEncryptBase64()
 	{
 		$crypt = new \Phalcon\Crypt();

--- a/unit-tests/CryptTest.php
+++ b/unit-tests/CryptTest.php
@@ -22,7 +22,7 @@ class CryptTest extends PHPUnit_Framework_TestCase
 {
 
 	/**
-	 * @requires extension fileinfo
+	 * @requires extension mcrypt
 	 */
 	public function testEncryption()
 	{
@@ -53,7 +53,7 @@ class CryptTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @requires extension fileinfo
+	 * @requires extension mcrypt
 	 */
 	public function testPadding()
 	{
@@ -89,7 +89,7 @@ class CryptTest extends PHPUnit_Framework_TestCase
 	}
 
 	/**
-	 * @requires extension fileinfo
+	 * @requires extension mcrypt
 	 */
 	public function testEncryptBase64()
 	{

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -342,10 +342,12 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 				$columns['column2'],
 			)
 		);
-		$this->assertEquals($dialect->createTable('table', null, $definition), 'CREATE TABLE `table` (
-	`column1` VARCHAR(10),
-	`column2` INT(18) UNSIGNED
-)');
+
+		$expected  = "CREATE TABLE `table` (\n";
+		$expected .= "	`column1` VARCHAR(10),\n";
+		$expected .= "	`column2` INT(18) UNSIGNED\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
 
 		$definition = array(
 			'columns' => array(
@@ -357,12 +359,14 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 				$indexes['PRIMARY']
 			)
 		);
-		$this->assertEquals($dialect->createTable('table', null, $definition), 'CREATE TABLE `table` (
-	`column2` INT(18) UNSIGNED,
-	`column3` DECIMAL(10,2) NOT NULL,
-	`column1` VARCHAR(10),
-	PRIMARY KEY (`column3`)
-)');
+
+		$expected  = "CREATE TABLE `table` (\n";
+		$expected .= "	`column2` INT(18) UNSIGNED,\n";
+		$expected .= "	`column3` DECIMAL(10,2) NOT NULL,\n";
+		$expected .= "	`column1` VARCHAR(10),\n";
+		$expected .= "	PRIMARY KEY (`column3`)\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
 
 	}
 

--- a/unit-tests/README.md
+++ b/unit-tests/README.md
@@ -26,3 +26,5 @@ Additionally, the file cphalcon/.travis.yml contains full instructions to test P
 Please report any issue if you find out bugs or memory leaks. Thanks!
 
 Note: Cache unit-tests are slower than others tests because they make waits (sleeps) to expire generated caches.
+
+Note: For testing on Windows copy folder php-tests/tests/app/configs to unit-tests/config as Windows doesn't recognize symbolic links

--- a/unit-tests/RequestTest.php
+++ b/unit-tests/RequestTest.php
@@ -330,6 +330,9 @@ class RequestTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($request->getPost('array', 'string', NULL, TRUE, TRUE), NULL);
 	}
 
+	/**
+	 * @requires extension fileinfo
+	 */
 	public function testIssues1442()
 	{
 		$request = new \Phalcon\Http\Request();

--- a/unit-tests/assets/1198.css
+++ b/unit-tests/assets/1198.css
@@ -1,0 +1,7 @@
+a {
+    text-decoration: none;
+}
+
+b {
+    font-weight: bold;
+}

--- a/unit-tests/assets/1198.css
+++ b/unit-tests/assets/1198.css
@@ -1,7 +1,0 @@
-a {
-    text-decoration: none;
-}
-
-b {
-    font-weight: bold;
-}

--- a/unit-tests/assets/1198.css
+++ b/unit-tests/assets/1198.css
@@ -1,1 +1,7 @@
-../../ext/tests/assets/1198.css
+a {
+    text-decoration: none;
+}
+
+b {
+    font-weight: bold;
+}

--- a/unit-tests/tasks/Issue787Task.php
+++ b/unit-tests/tasks/Issue787Task.php
@@ -1,1 +1,0 @@
-../../ext/tests/tasks/Issue787Task.php

--- a/unit-tests/tasks/Issue787Task.php
+++ b/unit-tests/tasks/Issue787Task.php
@@ -1,0 +1,1 @@
+<?php require '/../../ext/tests/tasks/Issue787Task.php';

--- a/unit-tests/tasks/Issue787Task.php
+++ b/unit-tests/tasks/Issue787Task.php
@@ -1,1 +1,23 @@
-<?php require '/../../ext/tests/tasks/Issue787Task.php';
+<?php
+
+class Issue787Task extends \Phalcon\CLI\Task
+{
+	static $output = '';
+
+	public function beforeExecuteRoute()
+	{
+		$this->dispatcher;
+		$this->dispatcher;
+		self::$output .= "beforeExecuteRoute" . PHP_EOL;
+		return true;
+	}
+
+	public function initialize()
+	{
+		self::$output .= "initialize" . PHP_EOL;
+	}
+
+	public function mainAction()
+	{
+	}
+}


### PR DESCRIPTION
This PR addresses some minor differences in unit testing between windows and *nix
Apperently windows wasn't taken into account when writting the tests, which doesn't surprise me at all =]

In most cases different line ends when comparing two strings. PHPUnit won't like these and fail the asserts.

There are also some symlinked files which don't work on windows since it won't recognise them.
Let me know if you know a better way for handling this, I simply replaced the simlinks with the files they were pointing to.
I realize this is not elegant solution.

---

The PR also includes a few minor stubs for ViewCacheTest and updated Phalcon\Mvc\View::render() to return instance of itself as expected in docblock

``` php
/**
* Executes render process from dispatching data
*
*<code>
* //Shows recent posts view (app/views/posts/recent.phtml)
* $view->start()->render('posts', 'recent')->finish();
*</code>
*
* @param string $controllerName
* @param string $actionName
* @param array $params
* @return Phalcon\Mvc\View
*/
```

Excuse me for submitting two things in the same PR. I'm happy to make them separate if you prefer that 

EDIT: There actually three different things here. I've also marked some of the tests with docblock **@require extension** 

These require mcrypt
- CryptTest::testEncryption()
- CryptTest::testPadding()
- CryptTest::testEncryptBase64()

This one requires fileinfo
- RequestTest::testIssues1442()

---

This PR was tested on
- Windows 7 x64, PHP 5.5.3 x86, Phalcon 1.3.0 x86
- Ubuntu 13.10, PHP 5.5.3 x86, Phalcon 1.3.0 x86
