### PR TITLE
[PR] LoaderTest::testsEvents() fails on windows

### DIFF
--- a/build/32bits/phalcon.c
+++ b/build/32bits/phalcon.c
@@ -9770,7 +9770,7 @@ static void phalcon_fix_path(zval **return_value, zval *path, zval *directory_se
 	}
 
 	if (Z_STRLEN_P(path) > 0 && Z_STRLEN_P(directory_separator) > 0) {
-		if (Z_STRVAL_P(path)[Z_STRLEN_P(path) - 1] != Z_STRVAL_P(directory_separator)[0]) {
+		if (Z_STRVAL_P(path)[Z_STRLEN_P(path) - 1] != '\\' && Z_STRVAL_P(path)[Z_STRLEN_P(path) - 1] != '/') {
 			PHALCON_CONCAT_VV(*return_value, path, directory_separator);
 			return;
 		}

--- a/ext/kernel/file.c
+++ b/ext/kernel/file.c
@@ -110,7 +110,7 @@ void phalcon_fix_path(zval **return_value, zval *path, zval *directory_separator
 	}
 
 	if (Z_STRLEN_P(path) > 0 && Z_STRLEN_P(directory_separator) > 0) {
-		if (Z_STRVAL_P(path)[Z_STRLEN_P(path) - 1] != Z_STRVAL_P(directory_separator)[0]) {
+		if (Z_STRVAL_P(path)[Z_STRLEN_P(path) - 1] != '\\' && Z_STRVAL_P(path)[Z_STRLEN_P(path) - 1] != '/') {
 			PHALCON_CONCAT_VV(*return_value, path, directory_separator);
 			return;
 		}


### PR DESCRIPTION
This PR addresses an issue in Phalcon\Loader.

Affected function is Phalcon\Loader::getCheckedPath() which returns invalid path on windows in some cases.
To reproduce this issue just run LoaderTest::testsEvents() on windows. See attached screenshot for result

![loadertest-testevents](https://f.cloud.github.com/assets/2228236/1609104/c5a208a0-552d-11e3-85d3-f28bc4e67025.png)

The problem is in function **phalcon_fix_path()** where a conditional statement incorrectly assumes that
 if a trailing path separator from users was specified it'll always be the same as system path separator. 

---

This PR was tested on
- Windows 7 x64, PHP 5.5.3 x86, Phalcon 1.2.5 x86
