### PR TITLE
[2.0.0] Query Builder fixes

### DIFF
--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -429,7 +429,7 @@ class Builder
 	 * @param array bindTypes
 	 * @return Phalcon\Mvc\Model\Query\Builder
 	 */
-	public function where(string! conditions, bindParams=null, bindTypes=null) -> <Phalcon\Mvc\Model\Query\Builder>
+	public function where(conditions, bindParams=null, bindTypes=null) -> <Phalcon\Mvc\Model\Query\Builder>
 	{
 		var currentBindParams, currentBindTypes, mergedParams, mergedTypes;
 
@@ -1113,7 +1113,7 @@ class Builder
 		 */
 		if typeof conditions == "string" {
 			if !empty conditions {
-				let phql .= " WHERE ".conditions;
+				let phql .= " WHERE " . conditions;
 			}
 		}
 


### PR DESCRIPTION
Hi,

I changed small detail - where() method can take int(unit tests proves that).

Btw. I figure out that parent constructor isn't called when extending Phalcon\Mvc\Model class. After fixing that issue most of unit test of Query builder will work(maybe all of them). Could somebody give me a hand with that?

Thanks in advance,

Kamil
