### PR TITLE
Fix #1662 for 1.2.5

### DIFF
--- a/ext/tag.c
+++ b/ext/tag.c
@@ -1776,6 +1776,9 @@ PHP_METHOD(Phalcon_Tag, getDocType){
 	else if (phalcon_compare_strict_long(doctype, 4 TSRMLS_CC)) {
 		RETVAL_STRING("<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Frameset//EN\"" PHP_EOL"\t\"http://www.w3.org/TR/html4/frameset.dtd\">" PHP_EOL, 1);
 	}
+	else if (phalcon_compare_strict_long(doctype, 5 TSRMLS_CC)) {
+		RETVAL_STRING("<!DOCTYPE html>" PHP_EOL, 1);
+	}
 	else if (phalcon_compare_strict_long(doctype, 6 TSRMLS_CC)) {
 		RETVAL_STRING("<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"" PHP_EOL "\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">" PHP_EOL, 1);
 	}

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -102,7 +102,7 @@ class TagTest extends PHPUnit_Framework_TestCase
 	 }
 
 	public function testIssue1486()
-        {
+	{
 		$di = new Phalcon\DI\FactoryDefault();
 		$di->getshared('url')->setBaseUri('/');
 		\Phalcon\Tag::setDI($di);
@@ -119,4 +119,15 @@ class TagTest extends PHPUnit_Framework_TestCase
 		$html = \Phalcon\Tag::javascriptInclude(array('js/phalcon.js'));
 		$this->assertEquals($html, '<script src="/js/phalcon.js" type="text/javascript"></script>'.PHP_EOL);
 	 }
+
+	public function testIssue1662()
+	{
+		$di = new Phalcon\DI\FactoryDefault();
+		\Phalcon\Tag::setDI($di);
+
+		\Phalcon\Tag::setDocType(Phalcon\Tag::HTML5);
+
+		$html = \Phalcon\Tag::getDocType();
+		$this->assertEquals($html, '<!DOCTYPE html>'.PHP_EOL);
+	}
 }


### PR DESCRIPTION
See #1662 when `setDocType(HTML5)` then `getDocType` not return.
