### PR TITLE
[NFR]Add new param local for Phalcon\Tag::linkTo

### DIFF
--- a/ext/tag.c
+++ b/ext/tag.c
@@ -505,30 +505,39 @@ PHP_METHOD(Phalcon_Tag, resetInput){
  *	echo Phalcon\Tag::linkTo('signup/register', 'Register Here!');
  *	echo Phalcon\Tag::linkTo(array('signup/register', 'Register Here!'));
  *	echo Phalcon\Tag::linkTo(array('signup/register', 'Register Here!', 'class' => 'btn-primary'));
+ *	echo Phalcon\Tag::linkTo('http://google.com/', 'Google', FALSE);
+ *	echo Phalcon\Tag::linkTo(array('http://google.com/', 'Google', FALSE));
+ *	echo Phalcon\Tag::linkTo(array('http://google.com/', 'Google', 'local' =>FALSE));
  *</code>
  *
  * @param array|string $parameters
- * @param   string $text
+ * @param string $text
+ * @param boolean $local
  * @return string
  */
 PHP_METHOD(Phalcon_Tag, linkTo){
 
-	zval *parameters, *text = NULL, *params = NULL, *action, *url, *internal_url, *link_text;
+	zval *parameters, *text = NULL, *local = NULL,  *params = NULL, *action, *url, *internal_url, *link_text, *z_local;
 	zval *code;
 
 	PHALCON_MM_GROW();
 
-	phalcon_fetch_params(1, 1, 1, &parameters, &text);
+	phalcon_fetch_params(1, 1, 2, &parameters, &text, &local);
 	
 	if (!text) {
 		text = PHALCON_GLOBAL(z_null);
 	}
+
+	if (!local) {
+		local = PHALCON_GLOBAL(z_true);
+	}
 	
 	if (Z_TYPE_P(parameters) != IS_ARRAY) { 
 		PHALCON_INIT_VAR(params);
-		array_init_size(params, 2);
+		array_init_size(params, 3);
 		phalcon_array_append(&params, parameters, 0);
 		phalcon_array_append(&params, text, 0);
+		phalcon_array_append(&params, local, 0);
 	} else {
 		PHALCON_CPY_WRT_CTOR(params, parameters);
 	}
@@ -550,14 +559,25 @@ PHP_METHOD(Phalcon_Tag, linkTo){
 		PHALCON_INIT_VAR(link_text);
 		ZVAL_EMPTY_STRING(link_text);
 	}
-	
-	PHALCON_INIT_VAR(url);
-	phalcon_call_self(url, this_ptr, "geturlservice");
-	
-	PHALCON_INIT_VAR(internal_url);
-	phalcon_call_method_p1(internal_url, url, "get", action);
 
-	phalcon_array_update_string(&params, SL("href"), &internal_url, PH_COPY);
+	if (phalcon_array_isset_long_fetch(&z_local, params, 2)) {
+	} else if (phalcon_array_isset_string_fetch(&z_local, params, SS("local"))) {
+		phalcon_array_unset_string(&params, SS("local"), 0);
+	} else {
+		PHALCON_INIT_VAR(z_local);
+		ZVAL_TRUE(z_local);
+	}
+
+	if (zend_is_true(z_local)) {
+		PHALCON_INIT_VAR(url);
+		phalcon_call_self(url, this_ptr, "geturlservice");
+		
+		PHALCON_INIT_VAR(internal_url);
+		phalcon_call_method_p1(internal_url, url, "get", action);
+		phalcon_array_update_string(&params, SL("href"), &internal_url, PH_COPY);
+	} else {
+		phalcon_array_update_string(&params, SL("href"), &action, PH_COPY);
+	}
 
 	PHALCON_INIT_VAR(code);
 	ZVAL_STRING(code, "<a", 1);

--- a/ext/tag.c
+++ b/ext/tag.c
@@ -505,9 +505,9 @@ PHP_METHOD(Phalcon_Tag, resetInput){
  *	echo Phalcon\Tag::linkTo('signup/register', 'Register Here!');
  *	echo Phalcon\Tag::linkTo(array('signup/register', 'Register Here!'));
  *	echo Phalcon\Tag::linkTo(array('signup/register', 'Register Here!', 'class' => 'btn-primary'));
- *	echo Phalcon\Tag::linkTo('http://google.com/', 'Google', FALSE);
- *	echo Phalcon\Tag::linkTo(array('http://google.com/', 'Google', FALSE));
- *	echo Phalcon\Tag::linkTo(array('http://google.com/', 'Google', 'local' =>FALSE));
+ *	echo Phalcon\Tag::linkTo('http://phalconphp.com/', 'Google', FALSE);
+ *	echo Phalcon\Tag::linkTo(array('http://phalconphp.com/', 'Phalcon Home', FALSE));
+ *	echo Phalcon\Tag::linkTo(array('http://phalconphp.com/', 'Phalcon Home', 'local' =>FALSE));
  *</code>
  *
  * @param array|string $parameters

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -91,15 +91,42 @@ HTML;
 		\Phalcon\Tag::setDI($di);
 
 		$html = \Phalcon\Tag::stylesheetLink('css/phalcon.css');
-		$this->assertEquals($html, '<link rel="stylesheet" href="/css/phalcon.css" type="text/css" />'.PHP_EOL);
+		$this->assertEquals($html, '<link rel="stylesheet" type="text/css" href="/css/phalcon.css" />'.PHP_EOL);
 
 		$html = \Phalcon\Tag::stylesheetLink(array('css/phalcon.css'));
-		$this->assertEquals($html, '<link rel="stylesheet" href="/css/phalcon.css" type="text/css" />'.PHP_EOL);
+		$this->assertEquals($html, '<link rel="stylesheet" type="text/css" href="/css/phalcon.css" />'.PHP_EOL);
 
 		$html = \Phalcon\Tag::javascriptInclude('js/phalcon.js');
-		$this->assertEquals($html, '<script src="/js/phalcon.js" type="text/javascript"></script>'.PHP_EOL);
+		$this->assertEquals($html, '<script type="text/javascript" src="/js/phalcon.js"></script>'.PHP_EOL);
 
 		$html = \Phalcon\Tag::javascriptInclude(array('js/phalcon.js'));
-		$this->assertEquals($html, '<script src="/js/phalcon.js" type="text/javascript"></script>'.PHP_EOL);
+		$this->assertEquals($html, '<script type="text/javascript" src="/js/phalcon.js"></script>'.PHP_EOL);
+	 }
+
+	public function testIssue1679()
+    {
+		$di = new Phalcon\DI\FactoryDefault();
+		$di->getshared('url')->setBaseUri('/');
+		\Phalcon\Tag::setDI($di);
+
+		// local
+		$html = Phalcon\Tag::linkTo('signup/register', 'Register Here!');
+		$this->assertEquals($html, '<a href="/signup/register">Register Here!</a>');
+
+		$html = Phalcon\Tag::linkTo(array('signup/register', 'Register Here!'));
+		$this->assertEquals($html, '<a href="/signup/register">Register Here!</a>');
+
+		$html = Phalcon\Tag::linkTo(array('signup/register', 'Register Here!', 'class' => 'btn-primary'));
+		$this->assertEquals($html, '<a href="/signup/register" class="btn-primary">Register Here!</a>');
+
+		// remote
+		$html = Phalcon\Tag::linkTo('http://phalconphp.com/en/', 'Phalcon Home', FALSE);
+		$this->assertEquals($html, '<a href="http://phalconphp.com/en/">Phalcon Home</a>');
+
+		$html = Phalcon\Tag::linkTo(array('http://phalconphp.com/en/', 'Phalcon Home', FALSE));
+		$this->assertEquals($html, '<a href="http://phalconphp.com/en/">Phalcon Home</a>');
+
+		$html = Phalcon\Tag::linkTo(array('http://phalconphp.com/en/', 'text' => 'Phalcon Home', 'local' => FALSE));
+		$this->assertEquals($html, '<a href="http://phalconphp.com/en/">Phalcon Home</a>');
 	 }
 }

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -128,5 +128,8 @@ HTML;
 
 		$html = Phalcon\Tag::linkTo(array('http://phalconphp.com/en/', 'text' => 'Phalcon Home', 'local' => FALSE));
 		$this->assertEquals($html, '<a href="http://phalconphp.com/en/">Phalcon Home</a>');
+
+		$html = Phalcon\Tag::linkTo('mailto:dreamsxin@gmail.com', 'dreamsxin@gmail.com', FALSE);
+		$this->assertEquals($html, '<a href="mailto:dreamsxin@gmail.com">dreamsxin@gmail.com</a>');
 	 }
 }


### PR DESCRIPTION
See #1679

``` php
echo Phalcon\Tag::linkTo('http://phalconphp.com/en/', 'Phalcon Home', FALSE);
echo Phalcon\Tag::linkTo(array('http://phalconphp.com/en/', 'text' => 'Phalcon Home', 'local' => FALSE));
echo Phalcon\Tag::linkTo('mailto:dreamsxin@gmail.com', 'dreamsxin@gmail.com', FALSE);
```

output:
`<a href="<a href="http://phalconphp.com/en/">Phalcon Home</a>`
`<a href="<a href="http://phalconphp.com/en/">Phalcon Home</a>`
`<a href="mailto:dreamsxin@gmail.com">dreamsxin@gmail.com</a>`
