### PR TITLE
Fix libtoolize bug (Gentoo specific)

### DIFF
--- a/build/install-gentoo
+++ b/build/install-gentoo
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+#  Phalcon Framework
+#
+#  Copyright (c) 2011-2013 Phalcon Team (http://www.phalconphp.com)
+#
+#  This source file is subject to the New BSD License that is bundled
+#  with this package in the file docs/LICENSE.txt.
+#
+#  If you did not receive a copy of the license and are unable to
+#  obtain it through the world-wide-web, please send an email
+#  to license@phalconphp.com so we can send you a copy immediately.
+#
+#  Authors: Andres Gutierrez <andres@phalconphp.com>
+#            Eduar Carvajal <eduar@phalconphp.com>
+
+# Check best compilation flags for GCC
+export CC="gcc"
+export CFLAGS="-march=native -mtune=native -O2 -fno-delete-null-pointer-checks -finline-functions -fomit-frame-pointer -fno-builtin-memcmp"
+echo "int main() {}" > t.c
+gcc $CFLAGS t.c -o t 2> t.t
+if [ $? != 0 ]; then
+	chmod +x gcccpuopt
+	BFLAGS=`./gcccpuopt`
+	export CFLAGS="-O2 -fno-delete-null-pointer-checks -finline-functions -fomit-frame-pointer -fno-builtin-memcmp $BFLAGS"
+	gcc $CFLAGS t.c -o t 2> t.t
+	if [ $? != 0 ]; then
+		export CFLAGS="-O2 -fno-delete-null-pointer-checks"
+	fi
+fi
+
+if [ $(gcc -dumpversion | cut -f1 -d.) -ge 4 ]; then
+	gcc $CFLAGS -fvisibility=hidden t.c -o t 2> t.t && export CFLAGS="$CFLAGS -fvisibility=hidden"
+fi
+
+#gcc $CFLAGS -flto t.c -o t 2> t.t && { export CFLAGS="$CFLAGS -flto"; export LDFLAGS="$LDFLAGS $CFLAGS"; }
+rm -f t.t t.c t
+
+#Check processor architecture
+if [ -z $1 ]; then
+	DIR="32bits"
+	gcc gccarch.c -o gccarch
+	if [ -f gccarch ]; then
+		P64BITS=`./gccarch`
+		if [ "$P64BITS" == "1" ]; then
+			DIR="64bits"
+		fi
+	fi
+else
+	DIR=$1
+fi
+
+#Move to specified architecture
+cd $DIR
+
+#Clean current compilation
+if [ -f Makefile ]; then
+	make clean
+	phpize --clean
+fi
+
+LIBTOOLIZE_BIN="libtoolize"
+
+#GNU 'libtoolize' on MAC OS X is called 'glibtoolize'
+if [ "$(uname -s 2>/dev/null)" = "Darwin" ] && $(which glibtoolize > /dev/null 2>&1)
+then
+LIBTOOLIZE_BIN="glibtoolize"
+fi
+
+#Perform the compilation
+phpize && aclocal && $LIBTOOLIZE_BIN --force && autoheader && autoconf && ./configure --enable-phalcon && make && make install && echo -e "\nThanks for compiling Phalcon!\nBuild succeed: Please restart your web server to complete the installation"


### PR DESCRIPTION
I found a problem with `install` script:

```
/root/php/cphalcon/build/64bits/libtool: line 482: CDPATH: command not found
libtool: Version mismatch error.  This is libtool 2.4.2, but the
libtool: definition of this LT_INIT comes from an older release.
libtool: You should recreate aclocal.m4 with macros from libtool 2.4.2
libtool: and run autoconf again.
```

Solution is running `aclocal`, `libtoolize`, `autoheader` and `autoreconf` before running `configure` and `make`. I found that similar lines was added to `travis-install` some time ago. So I used it here to fix problem.

As requested branch 1.2.5.
