### PR TITLE
Use the lifetime option of the frontend adapter at 'modelsCache' operation.

### DIFF
--- a/ext/mvc/model/query.c
+++ b/ext/mvc/model/query.c
@@ -4895,9 +4895,6 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 	
 	PHALCON_OBS_VAR(cache_options);
 	phalcon_read_property_this(&cache_options, this_ptr, SL("_cacheOptions"), PH_NOISY_CC);
-    
-	PHALCON_INIT_NVAR(frontend);
-	phalcon_call_method(frontend, cache, "getfrontend");
 	if (Z_TYPE_P(cache_options) != IS_NULL) {
 		if (Z_TYPE_P(cache_options) != IS_ARRAY) { 
 			PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "Invalid caching options");
@@ -4922,6 +4919,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 			PHALCON_OBS_VAR(lifetime);
 			phalcon_array_fetch_string(&lifetime, cache_options, SL("lifetime"), PH_NOISY);
 		} else {
+			PHALCON_INIT_NVAR(frontend);
+			phalcon_call_method(frontend, cache, "getfrontend");
 			PHALCON_INIT_NVAR(lifetime);
 			if (Z_TYPE_P(frontend) == IS_OBJECT) {
 				phalcon_call_method(lifetime, frontend, "getlifetime");

--- a/ext/mvc/model/query.c
+++ b/ext/mvc/model/query.c
@@ -4895,6 +4895,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 	
 	PHALCON_OBS_VAR(cache_options);
 	phalcon_read_property_this(&cache_options, this_ptr, SL("_cacheOptions"), PH_NOISY_CC);
+    
+	PHALCON_INIT_NVAR(frontend);
+	phalcon_call_method(frontend, cache, "getfrontend");
 	if (Z_TYPE_P(cache_options) != IS_NULL) {
 		if (Z_TYPE_P(cache_options) != IS_ARRAY) { 
 			PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "Invalid caching options");
@@ -4920,7 +4923,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 			phalcon_array_fetch_string(&lifetime, cache_options, SL("lifetime"), PH_NOISY);
 		} else {
 			PHALCON_INIT_NVAR(lifetime);
-			ZVAL_LONG(lifetime, 3600);
+			if (Z_TYPE_P(frontend) == IS_OBJECT) {
+				phalcon_call_method(lifetime, frontend, "getlifetime");
+			} else {
+				ZVAL_LONG(lifetime, 3600);
+			}
 		}
 	
 		/** 

--- a/ext/mvc/model/query.c
+++ b/ext/mvc/model/query.c
@@ -4913,23 +4913,6 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 		}
 	
 		/** 
-		 * By defaut use use 3600 seconds (1 hour) as cache lifetime
-		 */
-		if (phalcon_array_isset_string(cache_options, SS("lifetime"))) {
-			PHALCON_OBS_VAR(lifetime);
-			phalcon_array_fetch_string(&lifetime, cache_options, SL("lifetime"), PH_NOISY);
-		} else {
-			PHALCON_INIT_NVAR(frontend);
-			phalcon_call_method(frontend, cache, "getfrontend");
-			PHALCON_INIT_NVAR(lifetime);
-			if (Z_TYPE_P(frontend) == IS_OBJECT) {
-				phalcon_call_method(lifetime, frontend, "getlifetime");
-			} else {
-				ZVAL_LONG(lifetime, 3600);
-			}
-		}
-	
-		/** 
 		 * 'modelsCache' is the default name for the models cache service
 		 */
 		if (phalcon_array_isset_string(cache_options, SS("service"))) {
@@ -4948,6 +4931,23 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 		if (Z_TYPE_P(cache) != IS_OBJECT) {
 			PHALCON_THROW_EXCEPTION_STR(phalcon_mvc_model_exception_ce, "The cache service must be an object");
 			return;
+		}
+	
+		/** 
+		 * By defaut use use 3600 seconds (1 hour) as cache lifetime
+		 */
+		if (phalcon_array_isset_string(cache_options, SS("lifetime"))) {
+			PHALCON_OBS_VAR(lifetime);
+			phalcon_array_fetch_string(&lifetime, cache_options, SL("lifetime"), PH_NOISY);
+		} else {
+			PHALCON_INIT_NVAR(frontend);
+			phalcon_call_method(frontend, cache, "getfrontend");
+			PHALCON_INIT_NVAR(lifetime);
+			if (Z_TYPE_P(frontend) == IS_OBJECT) {
+				phalcon_call_method(lifetime, frontend, "getlifetime");
+			} else {
+				ZVAL_LONG(lifetime, 3600);
+			}
 		}
 	
 		PHALCON_INIT_VAR(result);

--- a/ext/mvc/model/query.c
+++ b/ext/mvc/model/query.c
@@ -4873,7 +4873,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute){
 
 	zval *bind_params = NULL, *bind_types = NULL, *unique_row;
 	zval *cache_options, *key, *lifetime = NULL, *cache_service = NULL;
-	zval *dependency_injector, *cache, *result = NULL, *is_fresh;
+	zval *dependency_injector, *cache, *frontend, *result = NULL, *is_fresh;
 	zval *prepared_result = NULL, *intermediate, *default_bind_params;
 	zval *merged_params = NULL, *default_bind_types;
 	zval *merged_types = NULL, *type, *exception_message;


### PR DESCRIPTION
http://docs.phalconphp.com/en/latest/reference/models-cache.html#caching-resultsets

I found the 'lifetime' option for using models cache at this reference.
However, the 'lifetime' option does not work.
So I propose to use this change, or fix reference.
