### PR TITLE
Multiple Http headers fix

### DIFF
--- a/ext/http/response/headers.c
+++ b/ext/http/response/headers.c
@@ -40,6 +40,7 @@ zend_class_entry *phalcon_http_response_headers_ce;
 PHP_METHOD(Phalcon_Http_Response_Headers, set);
 PHP_METHOD(Phalcon_Http_Response_Headers, get);
 PHP_METHOD(Phalcon_Http_Response_Headers, setRaw);
+PHP_METHOD(Phalcon_Http_Response_Headers, remove);
 PHP_METHOD(Phalcon_Http_Response_Headers, send);
 PHP_METHOD(Phalcon_Http_Response_Headers, reset);
 PHP_METHOD(Phalcon_Http_Response_Headers, toArray);
@@ -53,6 +54,7 @@ static const zend_function_entry phalcon_http_response_headers_method_entry[] = 
 	PHP_ME(Phalcon_Http_Response_Headers, set, arginfo_phalcon_http_response_headersinterface_set, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Response_Headers, get, arginfo_phalcon_http_response_headersinterface_get, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Response_Headers, setRaw, arginfo_phalcon_http_response_headersinterface_setraw, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Http_Response_Headers, remove, arginfo_phalcon_http_response_headersinterface_remove, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Response_Headers, send, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Response_Headers, reset, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Response_Headers, toArray, NULL, ZEND_ACC_PUBLIC)
@@ -122,6 +124,24 @@ PHP_METHOD(Phalcon_Http_Response_Headers, setRaw){
 	phalcon_fetch_params(0, 1, 0, &header);
 	
 	phalcon_update_property_array(this_ptr, SL("_headers"), header, PHALCON_GLOBAL(z_null) TSRMLS_CC);
+}
+
+/**
+ * Removes a header to be sent at the end of the request
+ *
+ * @param string $header Header name
+ */
+PHP_METHOD(Phalcon_Http_Response_Headers, remove){
+
+	zval *header_index, *headers;
+
+	phalcon_fetch_params(0, 1, 0, &header_index);
+
+    headers = phalcon_fetch_nproperty_this(this_ptr, SL("_headers"), PH_NOISY TSRMLS_CC);
+
+    phalcon_array_unset(&headers, header_index, 0);
+
+	phalcon_update_property_this(this_ptr, SL("_headers"), headers TSRMLS_CC);
 }
 
 /**

--- a/ext/http/response/headersinterface.h
+++ b/ext/http/response/headersinterface.h
@@ -39,4 +39,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_http_response_headersinterface_setraw, 0,
 	ZEND_ARG_INFO(0, header)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_http_response_headersinterface_remove, 0, 0, 1)
+	ZEND_ARG_INFO(0, header_index)
+ZEND_END_ARG_INFO()
+
 #endif /* PHALCON_HTTP_RESPONSE_HEADERSINTERFACE_H */

--- a/unit-tests/ResponseTest.php
+++ b/unit-tests/ResponseTest.php
@@ -199,4 +199,19 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($actual, $expected);
 		$this->assertEquals($this->_response->isSent(), true);
 	}
+
+    public function testMultipleHttpHeadersBug1892()
+    {
+        $this->_response->resetHeaders();
+        $this->_response->setStatusCode(200, 'OK');
+        $this->_response->setStatusCode(404, 'Not Found');
+        $this->_response->setStatusCode(409, 'Conflict');
+
+        $expected = array(
+            'HTTP/1.1 409 Conflict' => null,
+            'Status'                => '409 Conflict',
+        );
+
+        $this->assertEquals($expected, $this->_response->getHeaders()->toArray());
+    }
 }


### PR DESCRIPTION
Hi

I found that by calling:

`$response->setStatusCode(200, 'OK');
   $response->setStatusCode('404', 'NotFound');
   $response->setStatusCode('409', 'Conflict');`

Phalcon\Response will `setRaw` 3 HTTP headers (which are invalid response). Code here:
https://github.com/phalcon/cphalcon/blob/1.3.0/ext/http/response.c#L250

There's some problem with that code - could somebody please give me a hand?

Thanks in advance,

Kamil
