### PR TITLE
Problem with performance and getRouteByName

### DIFF
--- a/ext/mvc/router.c
+++ b/ext/mvc/router.c
@@ -1405,9 +1405,15 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 	PHALCON_MM_GROW();
 
 	phalcon_fetch_params(1, 1, 0, &name);
+
 	PHALCON_OBS_VAR(routes_name_lookup);
+	if (name && unlikely(Z_TYPE_P(name) != IS_STRING)) {
+		PHALCON_SEPARATE_PARAM(name);
+		convert_to_string(name);
+	}
+
 	phalcon_read_property_this(&routes_name_lookup, this_ptr, SL("_routesNameLookup"), PH_NOISY_CC);
-	if(Z_TYPE_P(name) == IS_STRING && phalcon_hash_find(Z_ARRVAL_P(routes_name_lookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
+	if(PHALCON_IS_NOT_EMPTY(name) && phalcon_hash_find(Z_ARRVAL_P(routes_name_lookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
 		PHALCON_GET_HVALUE(lookup_route);
 		RETURN_CTOR(lookup_route);
 	}
@@ -1421,6 +1427,7 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 		) {
 			PHALCON_INIT_NVAR(route_name);
 			phalcon_call_method(route_name, *route, "getname");
+			convert_to_string(route_name);
 			if (Z_TYPE_P(route_name) == IS_STRING && PHALCON_IS_NOT_EMPTY(route_name)) {
 				phalcon_update_property_array_string(this_ptr, SL("_routesNameLookup"), Z_STRVAL_P(route_name), Z_STRLEN_P(route_name) + 1, *route TSRMLS_CC);
 			}

--- a/ext/mvc/router.c
+++ b/ext/mvc/router.c
@@ -1398,7 +1398,7 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteById){
  */
 PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 
-	zval *name, *routes, **route, *routes_name_lookup = NULL, *route_name = NULL;
+	zval *name, *routes, **route, *lookup_route = NULL, *routes_name_lookup = NULL, *route_name = NULL;
 	HashPosition hp0;
 	zval **hd;
 
@@ -1408,8 +1408,8 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 	PHALCON_OBS_VAR(routes_name_lookup);
 	phalcon_read_property_this(&routes_name_lookup, this_ptr, SL("_routesNameLookup"), PH_NOISY_CC);
 	if(phalcon_hash_find(Z_ARRVAL_P(routes_name_lookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
-		PHALCON_GET_HVALUE(*route);
-		RETURN_CCTOR(*route);
+		PHALCON_GET_HVALUE(lookup_route);
+		RETURN_CTOR(lookup_route);
 	}
 
 	routes = phalcon_fetch_nproperty_this(this_ptr, SL("_routes"), PH_NOISY_CC);

--- a/ext/mvc/router.c
+++ b/ext/mvc/router.c
@@ -1398,16 +1398,16 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteById){
  */
 PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 
-	zval *name, *routes, **route, *routesNameLookup = NULL, *route_name = NULL;
+	zval *name, *routes, **route, *routes_name_lookup = NULL, *route_name = NULL;
 	HashPosition hp0;
 	zval **hd;
 
 	PHALCON_MM_GROW();
 
 	phalcon_fetch_params(1, 1, 0, &name);
-	PHALCON_OBS_VAR(routesNameLookup);
-	phalcon_read_property_this(&routesNameLookup, this_ptr, SL("_routesNameLookup"), PH_NOISY_CC);
-	if(phalcon_hash_find(Z_ARRVAL_P(routesNameLookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
+	PHALCON_OBS_VAR(routes_name_lookup);
+	phalcon_read_property_this(&routes_name_lookup, this_ptr, SL("_routesNameLookup"), PH_NOISY_CC);
+	if(phalcon_hash_find(Z_ARRVAL_P(routes_name_lookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
 		PHALCON_GET_HVALUE(*route);
 		RETURN_CCTOR(*route);
 	}

--- a/ext/mvc/router.c
+++ b/ext/mvc/router.c
@@ -217,7 +217,7 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Router){
  */
 PHP_METHOD(Phalcon_Mvc_Router, __construct){
 
-	zval *default_routes = NULL, *routes, *routesNameLookup, *paths = NULL, *action_pattern;
+	zval *default_routes = NULL, *routes, *routes_name_lookup, *paths = NULL, *action_pattern;
 	zval *route = NULL, *params_pattern, *params;
 
 	PHALCON_MM_GROW();
@@ -269,11 +269,11 @@ PHP_METHOD(Phalcon_Mvc_Router, __construct){
 
 	PHALCON_INIT_VAR(params);
 	array_init(params);
-	PHALCON_INIT_VAR(routesNameLookup);
-	array_init(routesNameLookup);
+	PHALCON_INIT_VAR(routes_name_lookup);
+	array_init(routes_name_lookup);
 	phalcon_update_property_this(this_ptr, SL("_params"), params TSRMLS_CC);
 	phalcon_update_property_this(this_ptr, SL("_routes"), routes TSRMLS_CC);
-	phalcon_update_property_this(this_ptr, SL("_routesNameLookup"), routesNameLookup TSRMLS_CC);
+	phalcon_update_property_this(this_ptr, SL("_routesNameLookup"), routes_name_lookup TSRMLS_CC);
 
 	PHALCON_MM_RESTORE();
 }
@@ -1407,7 +1407,7 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 	phalcon_fetch_params(1, 1, 0, &name);
 	PHALCON_OBS_VAR(routes_name_lookup);
 	phalcon_read_property_this(&routes_name_lookup, this_ptr, SL("_routesNameLookup"), PH_NOISY_CC);
-	if(phalcon_hash_find(Z_ARRVAL_P(routes_name_lookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
+	if(Z_TYPE_P(name) == IS_STRING && phalcon_hash_find(Z_ARRVAL_P(routes_name_lookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
 		PHALCON_GET_HVALUE(lookup_route);
 		RETURN_CTOR(lookup_route);
 	}
@@ -1421,7 +1421,7 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 		) {
 			PHALCON_INIT_NVAR(route_name);
 			phalcon_call_method(route_name, *route, "getname");
-			if (PHALCON_IS_NOT_EMPTY(route_name)) {
+			if (Z_TYPE_P(route_name) == IS_STRING && PHALCON_IS_NOT_EMPTY(route_name)) {
 				phalcon_update_property_array_string(this_ptr, SL("_routesNameLookup"), Z_STRVAL_P(route_name), Z_STRLEN_P(route_name) + 1, *route TSRMLS_CC);
 			}
 			if (phalcon_is_equal(route_name, name TSRMLS_CC)) {

--- a/ext/mvc/router.c
+++ b/ext/mvc/router.c
@@ -190,6 +190,7 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Router){
 	zend_declare_property_null(phalcon_mvc_router_ce, SL("_action"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_router_ce, SL("_params"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_router_ce, SL("_routes"), ZEND_ACC_PROTECTED TSRMLS_CC);
+	zend_declare_property_null(phalcon_mvc_router_ce, SL("_routesNameLookup"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_router_ce, SL("_matchedRoute"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_mvc_router_ce, SL("_matches"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_bool(phalcon_mvc_router_ce, SL("_wasMatched"), 0, ZEND_ACC_PROTECTED TSRMLS_CC);
@@ -216,7 +217,7 @@ PHALCON_INIT_CLASS(Phalcon_Mvc_Router){
  */
 PHP_METHOD(Phalcon_Mvc_Router, __construct){
 
-	zval *default_routes = NULL, *routes, *paths = NULL, *action_pattern;
+	zval *default_routes = NULL, *routes, *routesNameLookup, *paths = NULL, *action_pattern;
 	zval *route = NULL, *params_pattern, *params;
 
 	PHALCON_MM_GROW();
@@ -268,8 +269,11 @@ PHP_METHOD(Phalcon_Mvc_Router, __construct){
 
 	PHALCON_INIT_VAR(params);
 	array_init(params);
+	PHALCON_INIT_VAR(routesNameLookup);
+	array_init(routesNameLookup);
 	phalcon_update_property_this(this_ptr, SL("_params"), params TSRMLS_CC);
 	phalcon_update_property_this(this_ptr, SL("_routes"), routes TSRMLS_CC);
+	phalcon_update_property_this(this_ptr, SL("_routesNameLookup"), routesNameLookup TSRMLS_CC);
 
 	PHALCON_MM_RESTORE();
 }
@@ -1249,6 +1253,7 @@ PHP_METHOD(Phalcon_Mvc_Router, clear){
 	PHALCON_INIT_VAR(empty_routes);
 	array_init(empty_routes);
 	phalcon_update_property_this(this_ptr, SL("_routes"), empty_routes TSRMLS_CC);
+	phalcon_update_property_this(this_ptr, SL("_routesNameLookup"), empty_routes TSRMLS_CC);
 
 	PHALCON_MM_RESTORE();
 }
@@ -1393,12 +1398,19 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteById){
  */
 PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 
-	zval *name, *routes, **route, *route_name = NULL;
+	zval *name, *routes, **route, *routesNameLookup = NULL, *route_name = NULL;
 	HashPosition hp0;
+	zval **hd;
 
 	PHALCON_MM_GROW();
 
 	phalcon_fetch_params(1, 1, 0, &name);
+	PHALCON_OBS_VAR(routesNameLookup);
+	phalcon_read_property_this(&routesNameLookup, this_ptr, SL("_routesNameLookup"), PH_NOISY_CC);
+	if(phalcon_hash_find(Z_ARRVAL_P(routesNameLookup), Z_STRVAL_P(name), Z_STRLEN_P(name) + 1, (void **)&hd) == SUCCESS) {
+		PHALCON_GET_HVALUE(*route);
+		RETURN_CCTOR(*route);
+	}
 
 	routes = phalcon_fetch_nproperty_this(this_ptr, SL("_routes"), PH_NOISY_CC);
 	if (Z_TYPE_P(routes) == IS_ARRAY) {
@@ -1409,6 +1421,9 @@ PHP_METHOD(Phalcon_Mvc_Router, getRouteByName){
 		) {
 			PHALCON_INIT_NVAR(route_name);
 			phalcon_call_method(route_name, *route, "getname");
+			if (PHALCON_IS_NOT_EMPTY(route_name)) {
+				phalcon_update_property_array_string(this_ptr, SL("_routesNameLookup"), Z_STRVAL_P(route_name), Z_STRLEN_P(route_name) + 1, *route TSRMLS_CC);
+			}
 			if (phalcon_is_equal(route_name, name TSRMLS_CC)) {
 				RETURN_CTOR(*route);
 			}

--- a/ext/psr/log/nulllogger.c
+++ b/ext/psr/log/nulllogger.c
@@ -4,7 +4,7 @@
 
 zend_class_entry *psr_log_nulllogger_ce;
 
-PHP_METHOD(Psr_Log_NullLogger, log)
+static PHP_METHOD(Psr_Log_NullLogger, log)
 {
 	zval *level, *message, *context = NULL;
 

--- a/ext/psr/log/nulllogger.c
+++ b/ext/psr/log/nulllogger.c
@@ -4,7 +4,7 @@
 
 zend_class_entry *psr_log_nulllogger_ce;
 
-static PHP_METHOD(Psr_Log_NullLogger, log)
+PHP_METHOD(Psr_Log_NullLogger, log)
 {
 	zval *level, *message, *context = NULL;
 

--- a/unit-tests/RouterMvcTest.php
+++ b/unit-tests/RouterMvcTest.php
@@ -357,6 +357,8 @@ class RouterMvcTest extends PHPUnit_Framework_TestCase
 		$usersAdd = $router->add('/api/users/add')->setHttpMethods('POST')->setName('usersAdd');
 
 		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
+		//second check when the same route goes from name lookup
+		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
 		$this->assertEquals($usersFind, $router->getRouteById(0));
 
 	}


### PR DESCRIPTION
Because almost all bases on Router::getRouteByName (for example Url plugin in
views) it is a bottleneck in a
application with bigger set of routes. Each time when Router::getRouteByName
won't find a route in a lookput table, it will try to generate this
table.

I know it's not the cleaniest solution and it can be improved. The best way would be requiring to define a route name while adding it to router. Also weren't if merge was correct (based on code from master) because branch 1.3.0 does not compile.
