### PR TITLE
StringLength validator to return code on Max error

### DIFF
--- a/ext/mvc/model/validator/stringlength.c
+++ b/ext/mvc/model/validator/stringlength.c
@@ -195,7 +195,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Validator_StringLength, validate){
 				ZVAL_LONG(code, 0);
 			}
 
-			phalcon_call_method_p3_noret(this_ptr, "appendmessage", message, field, type);
+			phalcon_call_method_p4_noret(this_ptr, "appendmessage", message, field, type, code);
 			RETURN_MM_FALSE;
 		}
 	}


### PR DESCRIPTION
StringLength validator did not return error code on maximum length violation
