### PR TITLE
cgi/php.ini php5-fpm phalcon.php read and execute permissions

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,17 +1,20 @@
 #!/usr/bin/env python
 
+
 import os
 import stat
 from subprocess import check_call, Popen
 
+
 REPO = "https://github.com/phalcon/cphalcon.git"
 DEV_TOOLS_REPO = "https://github.com/phalcon/phalcon-devtools.git"
 
+
 HOME_PATH = os.environ['HOME']
 GIT_PATH = "/usr/bin/git"
-CURL_PATH = "/usr/bin/curl"
 APT_GET_PATH = "/usr/bin/apt-get"
 PHP_PATH = "/usr/bin/php"
+
 
 PHALCON_DIR = HOME_PATH + "/.phalcon"
 PHALCON_SCRIPT = PHALCON_DIR + "/phalcon-devtools/phalcon.sh"
@@ -19,25 +22,34 @@ PHALCON_COMMAND = PHALCON_DIR + "/phalcon-devtools/phalcon.php"
 PHALCON_SCRIPT_BIN_PATH = "/usr/bin/phalcon"
 CPHALCON_BUILD_DIR = PHALCON_DIR + "/cphalcon/build"
 
-LIBS = ("git-core gcc autoconf php5 php5-dev php5-imagick php5-mcrypt php5-pgsql php5-cgi php5-cli php5-common php5-gd php5-curl php5-geoip make")
 
-PHP_INIT_FILE_PATH = ("/etc/php5/apache2/php.ini", "/etc/php5/cli/php.ini", "/etc/php5/cgi/php.ini")
+LIBS = ("git-core gcc autoconf php5 php5-dev php5-imagick php5-mcrypt\
+    php5-pgsql php5-cgi php5-cli php5-common php5-gd php5-curl php5-geoip make\
+    php5-fpm")
+
+
+PHP_INIT_FILE_PATH = ("/etc/php5/apache2/php.ini", "/etc/php5/cli/php.ini",
+                      "/etc/php5/cgi/php.ini")
+
 
 def devtools():
     print("Installing DevTools ... \n")
     os.chdir(PHALCON_DIR)
     check_call([GIT_PATH, "clone", DEV_TOOLS_REPO])
-    proc = Popen(PHALCON_SCRIPT, shell=True, stdin=None, executable="/bin/bash")
+    proc = Popen(PHALCON_SCRIPT, shell=True, stdin=None,
+                 executable="/bin/bash")
     proc.wait()
-    os.chmod(PHALCON_COMMAND, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    os.chmod(PHALCON_COMMAND, stat.S_IXUSR | stat.S_IRUSR | stat.S_IXGRP |
+             stat.S_IRGRP | stat.S_IXOTH | stat.S_IROTH)
     os.symlink(PHALCON_COMMAND, PHALCON_SCRIPT_BIN_PATH)
     print("Finish Installing DevTools \n")
+
 
 def install_phalcon():
     print("Installing Phalcon ... \n")
     os.mkdir(PHALCON_DIR)
     os.chdir(PHALCON_DIR)
-    check_call([GIT_PATH,"clone", REPO])
+    check_call([GIT_PATH, "clone", REPO])
     os.chdir(CPHALCON_BUILD_DIR)
     proc = Popen("./install", shell=True, stdin=None, executable="/bin/bash")
     proc.wait()
@@ -50,9 +62,11 @@ def install_phalcon():
 
 def install_dependencies():
     print("Installing Dependencies ... \n")
-    proc = Popen(APT_GET_PATH + " -y install " + LIBS, shell=True, stdin=None, executable="/bin/bash")
+    proc = Popen(APT_GET_PATH + " -y install " + LIBS, shell=True, stdin=None,
+                 executable="/bin/bash")
     proc.wait()
     print("Finish Installing Dependencies \n")
+
 
 if __name__ == '__main__':
     install_dependencies()


### PR DESCRIPTION
phalcon.php has now -r-xr-xr-x permissions on root, after installing the user should do
`sudo chown {user}.{user} ~/.phalcon/phalcon-devtools/phalcon.php`
`sudo chown {user}.{user} /usr/bin/phalcon`
so he/she can execute the command phalcon without sudo
