### PR TITLE
\Phalcon\Validation\MessageInterface does not exist

### DIFF
--- a/ext/validation.c
+++ b/ext/validation.c
@@ -1,4 +1,3 @@
-
 /*
   +------------------------------------------------------------------------+
   | Phalcon Framework                                                      |
@@ -334,7 +333,7 @@ PHP_METHOD(Phalcon_Validation, getMessages){
 /**
  * Appends a message to the messages list
  *
- * @param Phalcon\Validation\MessageInterface $message
+ * @param Phalcon\Validation\Message $message
  * @return Phalcon\Validation
  */
 PHP_METHOD(Phalcon_Validation, appendMessage){


### PR DESCRIPTION
\Phalcon\Validation\Message must has been meant.
