### PR TITLE
Updated kernel/hash.h

### DIFF
--- a/ext/kernel/hash.h
+++ b/ext/kernel/hash.h
@@ -20,7 +20,7 @@
 #ifndef PHALCON_KERNEL_HASH_H
 #define PHALCON_KERNEL_HASH_H
 
-#include <main/php_config.h>
+#include "php_phalcon.h"
 #include <Zend/zend.h>
 
 int phalcon_hash_exists(const HashTable *ht, const char *arKey, uint nKeyLength);


### PR DESCRIPTION
Not sure if this is the best way of doing it but without this fix build fails with the fallowing fatal error

```
ext\phalcon\phalcon.c(2353) : fatal error C1083: Cannot open include file: 'main/php_config.h': No such file or directory
```
