### PR TITLE
Fix #2002 Tag::linkTo() to allow the addition of query string parameters

### DIFF
--- a/ext/tag.c
+++ b/ext/tag.c
@@ -726,7 +726,7 @@ PHP_METHOD(Phalcon_Tag, resetInput){
  */
 PHP_METHOD(Phalcon_Tag, linkTo){
 
-	zval *parameters, *text = NULL, *local = NULL,  *params = NULL, *action, *url, *internal_url, *link_text, *z_local;
+	zval *parameters, *text = NULL, *local = NULL,  *params = NULL, *action, *url, *internal_url, *query, *query_string, *link_text, *z_local;
 	zval *code;
 
 	PHALCON_MM_GROW();
@@ -777,14 +777,44 @@ PHP_METHOD(Phalcon_Tag, linkTo){
 		ZVAL_TRUE(z_local);
 	}
 
+	if (phalcon_array_isset_string_fetch(&query, params, SS("query"))) {
+		phalcon_array_unset_string(&params, SS("query"), 0);
+
+		PHALCON_INIT_VAR(query_string);
+		phalcon_http_build_query(query_string, *query, "&" TSRMLS_CC);
+	}
+	else {
+		PHALCON_INIT_VAR(query_string);
+		ZVAL_EMPTY_STRING(query_string);
+	}
+
 	if (zend_is_true(z_local) || Z_TYPE_P(params) == IS_ARRAY) {
 		PHALCON_OBS_VAR(url);
 		PHALCON_CALL_SELF(&url, "geturlservice");
 		
 		PHALCON_INIT_VAR(internal_url);
 		phalcon_call_method_p1(internal_url, url, "get", action);
+		
+		if (Z_TYPE_P(query_string) == IS_STRING && Z_STRLEN_P(query_string)) {
+				if (phalcon_memnstr_str(internal_url, "?", 1)) {
+						PHALCON_SCONCAT_SV(internal_url, "&", query_string);
+				}
+				else {
+						PHALCON_SCONCAT_SV(internal_url, "?", query_string);
+				}
+		}
+
 		phalcon_array_update_string(&params, SL("href"), internal_url, PH_COPY);
 	} else {
+		if (Z_TYPE_P(query_string) == IS_STRING && Z_STRLEN_P(query_string)) {
+				if (phalcon_memnstr_str(action, "?", 1)) {
+						PHALCON_SCONCAT_SV(action, "&", query_string);
+				}
+				else {
+						PHALCON_SCONCAT_SV(action, "?", query_string);
+				}
+		}
+
 		phalcon_array_update_string(&params, SL("href"), action, PH_COPY);
 	}
 

--- a/ext/tag.c
+++ b/ext/tag.c
@@ -781,7 +781,7 @@ PHP_METHOD(Phalcon_Tag, linkTo){
 		phalcon_array_unset_string(&params, SS("query"), 0);
 
 		PHALCON_INIT_VAR(query_string);
-		phalcon_http_build_query(query_string, *query, "&" TSRMLS_CC);
+		phalcon_http_build_query(query_string, query, "&" TSRMLS_CC);
 	}
 	else {
 		PHALCON_INIT_VAR(query_string);

--- a/ext/tag.c
+++ b/ext/tag.c
@@ -726,7 +726,7 @@ PHP_METHOD(Phalcon_Tag, resetInput){
  */
 PHP_METHOD(Phalcon_Tag, linkTo){
 
-	zval *parameters, *text = NULL, *local = NULL,  *params = NULL, *action, *url, *internal_url, *query, *query_string, *link_text, *z_local;
+	zval *parameters, *text = NULL, *local = NULL,  *params = NULL, *action, *url, *internal_url = NULL, *query, *query_string, *link_text, *z_local;
 	zval *code;
 
 	PHALCON_MM_GROW();
@@ -788,9 +788,8 @@ PHP_METHOD(Phalcon_Tag, linkTo){
 	if (zend_is_true(z_local) || Z_TYPE_P(params) == IS_ARRAY) {
 		PHALCON_OBS_VAR(url);
 		PHALCON_CALL_SELF(&url, "geturlservice");
-		
-		PHALCON_INIT_VAR(internal_url);
-		phalcon_call_method_p2(internal_url, url, "get", action, query);
+
+		PHALCON_CALL_METHOD(&internal_url, url, "get", action, query);
 		phalcon_array_update_string(&params, SL("href"), internal_url, PH_COPY);
 	} else {
 		if (Z_TYPE_P(query) != IS_NULL) {

--- a/ext/tag.c
+++ b/ext/tag.c
@@ -779,13 +779,10 @@ PHP_METHOD(Phalcon_Tag, linkTo){
 
 	if (phalcon_array_isset_string_fetch(&query, params, SS("query"))) {
 		phalcon_array_unset_string(&params, SS("query"), 0);
-
-		PHALCON_INIT_VAR(query_string);
-		phalcon_http_build_query(query_string, query, "&" TSRMLS_CC);
 	}
 	else {
-		PHALCON_INIT_VAR(query_string);
-		ZVAL_EMPTY_STRING(query_string);
+		PHALCON_INIT_VAR(query);
+		ZVAL_NULL(query);
 	}
 
 	if (zend_is_true(z_local) || Z_TYPE_P(params) == IS_ARRAY) {
@@ -793,26 +790,21 @@ PHP_METHOD(Phalcon_Tag, linkTo){
 		PHALCON_CALL_SELF(&url, "geturlservice");
 		
 		PHALCON_INIT_VAR(internal_url);
-		phalcon_call_method_p1(internal_url, url, "get", action);
-		
-		if (Z_TYPE_P(query_string) == IS_STRING && Z_STRLEN_P(query_string)) {
-				if (phalcon_memnstr_str(internal_url, "?", 1)) {
-						PHALCON_SCONCAT_SV(internal_url, "&", query_string);
-				}
-				else {
-						PHALCON_SCONCAT_SV(internal_url, "?", query_string);
-				}
-		}
-
+		phalcon_call_method_p2(internal_url, url, "get", action, query);
 		phalcon_array_update_string(&params, SL("href"), internal_url, PH_COPY);
 	} else {
-		if (Z_TYPE_P(query_string) == IS_STRING && Z_STRLEN_P(query_string)) {
-				if (phalcon_memnstr_str(action, "?", 1)) {
-						PHALCON_SCONCAT_SV(action, "&", query_string);
-				}
-				else {
-						PHALCON_SCONCAT_SV(action, "?", query_string);
-				}
+		if (Z_TYPE_P(query) != IS_NULL) {
+			PHALCON_INIT_VAR(query_string);
+			phalcon_http_build_query(query_string, query, "&" TSRMLS_CC);
+		
+			if (Z_TYPE_P(query_string) == IS_STRING && Z_STRLEN_P(query_string)) {
+					if (phalcon_memnstr_str(action, "?", 1)) {
+							PHALCON_SCONCAT_SV(action, "&", query_string);
+					}
+					else {
+							PHALCON_SCONCAT_SV(action, "?", query_string);
+					}
+			}
 		}
 
 		phalcon_array_update_string(&params, SL("href"), action, PH_COPY);

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -101,10 +101,10 @@ HTML;
 
 		$html = \Phalcon\Tag::javascriptInclude(array('js/phalcon.js'));
 		$this->assertEquals($html, '<script type="text/javascript" src="/js/phalcon.js"></script>'.PHP_EOL);
-	 }
+	}
 
 	public function testIssue1679()
-    {
+	{
 		$di = new Phalcon\DI\FactoryDefault();
 		$di->getshared('url')->setBaseUri('/');
 		\Phalcon\Tag::setDI($di);
@@ -131,5 +131,20 @@ HTML;
 
 		$html = Phalcon\Tag::linkTo('mailto:dreamsxin@gmail.com', 'dreamsxin@gmail.com', FALSE);
 		$this->assertEquals($html, '<a href="mailto:dreamsxin@gmail.com">dreamsxin@gmail.com</a>');
+	 }
+
+	public function testIssue2002()
+	{
+		$di = new Phalcon\DI\FactoryDefault();
+		$di->getshared('url')->setBaseUri('/');
+		\Phalcon\Tag::setDI($di);
+
+		$html = Phalcon\Tag::linkTo(array('signup/register', 'Register Here!', 'query' => array('a' => 1, 'b' => 2)));
+		$this->assertEquals($html, '<a href="/signup/register?a=1&b2">Register Here!</a>');
+
+		// remote
+
+		$html = Phalcon\Tag::linkTo(array('http://phalconphp.com/en/', 'Phalcon Home', FALSE, 'query' => array('a' => 1, 'b' => 2)));
+		$this->assertEquals($html, '<a href="http://phalconphp.com/en/?a=1&b2">Phalcon Home</a>');
 	 }
 }


### PR DESCRIPTION
See https://github.com/phalcon/cphalcon/issues/2002

``` php
echo Phalcon\Tag::linkTo(array('signup/register', 'Register Here!', 'query' => array('a' => 1, 'b' => 2)))
```

``` output
<a href="/signup/register?a=1&b2">Register Here!</a>
```
