### PR TITLE
Fix #2131 Add Phalcon\Mvc\Model\Criteria::cache method

### DIFF
--- a/ext/mvc/model/criteria.c
+++ b/ext/mvc/model/criteria.c
@@ -87,6 +87,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getOrder);
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, getParams);
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, fromInput);
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, execute);
+PHP_METHOD(Phalcon_Mvc_Model_Criteria, cache);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_model_criteria_innerjoin, 0, 0, 1)
 	ZEND_ARG_INFO(0, model)
@@ -104,6 +105,10 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_model_criteria_rightjoin, 0, 0, 1)
 	ZEND_ARG_INFO(0, model)
 	ZEND_ARG_INFO(0, conditions)
 	ZEND_ARG_INFO(0, alias)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_model_criteria_cache, 0, 0, 1)
+	ZEND_ARG_INFO(0, option)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry phalcon_mvc_model_criteria_method_entry[] = {
@@ -140,6 +145,7 @@ static const zend_function_entry phalcon_mvc_model_criteria_method_entry[] = {
 	PHP_ME(Phalcon_Mvc_Model_Criteria, getParams, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, fromInput, arginfo_phalcon_mvc_model_criteriainterface_frominput, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, execute, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Mvc_Model_Criteria, cache, arginfo_phalcon_mvc_model_criteria_cache, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -1460,3 +1466,26 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, execute){
 	
 	PHALCON_MM_RESTORE();
 }
+
+/**
+ * Sets the cache options in the criteria
+ * This method replaces all previously set cache options
+ *
+ * @param array $options
+ * @return Phalcon\Mvc\Model\CriteriaInterface
+ */
+PHP_METHOD(Phalcon_Mvc_Model_Criteria, cache){
+
+	zval *options;
+
+	phalcon_fetch_params(0, 1, 0, &options);
+	
+	if (Z_TYPE_P(options) != IS_ARRAY) { 
+		PHALCON_THROW_EXCEPTION_STRW(phalcon_mvc_model_exception_ce, "Cache options must be an Array");
+		return;
+	}
+	phalcon_update_property_array_string(this_ptr, SL("_params"), SS("cache"), options TSRMLS_CC);
+	
+	RETURN_THISW();
+}
+

--- a/unit-tests/ModelsCriteriaTest.php
+++ b/unit-tests/ModelsCriteriaTest.php
@@ -74,6 +74,7 @@ class ModelsCriteriaTest extends PHPUnit_Framework_TestCase
 		$this->_executeTestsNormal($di);
 		$this->_executeTestsRenamed($di);
 		$this->_executeTestsFromInput($di);
+		$this->_executeTestIssues2131($di);
 	}
 
 	public function testModelsPostgresql()
@@ -94,6 +95,7 @@ class ModelsCriteriaTest extends PHPUnit_Framework_TestCase
 		$this->_executeTestsNormal($di);
 		$this->_executeTestsRenamed($di);
 		$this->_executeTestsFromInput($di);
+		$this->_executeTestIssues2131($di);
 	}
 
 	public function testModelsSQLite()
@@ -114,6 +116,7 @@ class ModelsCriteriaTest extends PHPUnit_Framework_TestCase
 		$this->_executeTestsNormal($di);
 		$this->_executeTestsRenamed($di);
 		$this->_executeTestsFromInput($di);
+		$this->_executeTestIssues2131($di);
 	}
 
 	protected function _executeTestsNormal($di)
@@ -328,6 +331,25 @@ class ModelsCriteriaTest extends PHPUnit_Framework_TestCase
 				'name' => '%ol%',
 			)
 		));
+	}
+	
+	public function _executeTestIssues2131($di)
+	{
+		$di->set('modelsCache', function(){
+			$frontCache = new Phalcon\Cache\Frontend\Data();
+			$modelsCache = new Phalcon\Cache\Backend\File($frontCache, array(
+				'cacheDir' => 'unit-tests/cache/'
+			));
+
+			$modelsCache->delete("cache-2131");
+			return $modelsCache;
+		}, true);
+
+		$personas = Personas::query()->where("estado='I'")->cache(array("key" => "cache-2131"))->execute();
+		$this->assertTrue($personas->isFresh());
+
+		$personas = Personas::query()->where("estado='I'")->cache(array("key" => "cache-2131"))->execute();
+		$this->assertFalse($personas->isFresh());
 	}
 
 }


### PR DESCRIPTION
See #2131

``` php
Comment::query()
    ->where('topicid=:topicid:')
    ->bind(array('topicid' => 1)
    ->cache(array('lifetime' => 70, 'key' => 'questions'))
    ->execute() ;
```
