### PR TITLE
criteria: fix issue #2157 and added tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -325,6 +325,9 @@
  - Refactored, improved and optimized build script (#1218)
  - Other bug fixes (#1051, #1131, #1040, #1275, #1392, #1396, #1399, #1425, #1426...)
 
+1.2.6
+ - Phalcon\Security::checkHash() now correctly handles non-bcrypt hashes (#1912)
+
 1.2.5
  - Http\Cookie::__toString() will not throw exceptions (#1427)
  - Phalcon\Http\Cookie::__toString() will return a string value (#1428)
@@ -343,6 +346,15 @@
  - Fix Phalcon\Session\Bag::remove() (#1637)
  - Bug fixes in beanstalkd protocol implementation
  - Phalcon\Paginator\Adapter\Model returns correct results even when page number is incorrect (#1654)
+ - Bug fix: no arguments were passed to beforeMatch handler in Phalcon\Mvc\Router (#1556)
+ - Phalcon\Logger\Adapter::setLogLevel() is honored by transactions (#1716)
+ - Bug fixes in Phalcon\Db\Adapter\Pdo::describeColumns() (#1562)
+ - Phalcon\Session\Adapter::__destruct() now calls session_write_close() (#1624)
+ - Volt: fixed bug in email_filed() (#1723)
+ - Fixed PHP Notices in Phalcon\Debug::onUncaughtException() (#1683)
+ - Phalcon\Logger\Adapter::commit() clears the queue (#1748)
+ - Constant-time string comparison in Phalcon\Security::checkHash() (#1755)
+ - Fix phalcon_escape_multi() to generate valid UTF-8 (#1681)
 
 1.2.4
  - Fixed broken ACL inheritance (#905)

--- a/build/32bits/phalcon.c
+++ b/build/32bits/phalcon.c
@@ -45360,11 +45360,11 @@ static PHP_METHOD(Phalcon_DI_Service, setSharedInstance)
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 1, 0, &shared_instance);
-	
+
 	if (obj->shared_instance) {
 		zval_ptr_dtor(&obj->shared_instance);
 	}
-	
+
 	obj->shared_instance = shared_instance;
 }
 
@@ -45374,7 +45374,7 @@ static PHP_METHOD(Phalcon_DI_Service, setDefinition)
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 1, 0, &definition);
-	
+
 	if (obj->definition) {
 		zval_ptr_dtor(&obj->definition);
 	}
@@ -45396,28 +45396,28 @@ static PHP_METHOD(Phalcon_DI_Service, resolve){
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 0, 2, &parameters, &dependency_injector);
-	
+
 	if (!parameters) {
 		parameters = PHALCON_GLOBAL(z_null);
 	}
-	
+
 	if (!dependency_injector) {
 		dependency_injector = PHALCON_GLOBAL(z_null);
 	}
-	
+
 	/* Check if the service is shared */
 	if (obj->shared && obj->shared_instance) {
 		RETURN_ZVAL(obj->shared_instance, 1, 0);
 	}
-	
+
 	PHALCON_MM_GROW();
-	
+
 	definition = obj->definition;
 	found      = 0;
 	if (Z_TYPE_P(definition) == IS_STRING) {
 		/* String definitions can be class names without implicit parameters */
-		found = 1;
 		if (phalcon_class_exists(Z_STRVAL_P(definition), Z_STRLEN_P(definition), 1 TSRMLS_CC)) {
+			found = 1;
 			if (Z_TYPE_P(parameters) == IS_ARRAY) {
 				PHALCON_INIT_VAR(instance);
 				RETURN_MM_ON_FAILURE(phalcon_create_instance_params(instance, definition, parameters TSRMLS_CC));
@@ -45451,24 +45451,28 @@ static PHP_METHOD(Phalcon_DI_Service, resolve){
 		PHALCON_CALL_METHOD(&instance, builder, "build", dependency_injector, definition, parameters);
 		found = 1;
 	}
-	
+
+	if (EG(exception)) {
+		return;
+	}
+
 	/* If the service can't be built, we must throw an exception */
 	if (!found) {
 		zend_throw_exception_ex(phalcon_di_exception_ce, 0 TSRMLS_CC, "Service '%s' cannot be resolved", obj->name);
 		PHALCON_MM_RESTORE();
 		return;
 	}
-	
-	if (Z_TYPE_P(instance) != IS_OBJECT) {
-		php_error_docref0(NULL TSRMLS_CC, E_DEPRECATED, "Usage of Phalcon\\DI to store non-objects is deprecated, please use Phalcon\\Registry instead");
-	}
+
+	//if (Z_TYPE_P(instance) != IS_OBJECT) {
+	//	php_error_docref0(NULL TSRMLS_CC, E_DEPRECATED, "Usage of Phalcon\\DI to store non-objects is deprecated, please use Phalcon\\Registry instead");
+	//}
 
 	/* Update the shared instance if the service is shared */
 	if (obj->shared) {
 		Z_ADDREF_P(instance);
 		obj->shared_instance = instance;
 	}
-	
+
 	obj->resolved = 1;
 
 	RETURN_CTOR(instance);
@@ -45481,18 +45485,18 @@ static PHP_METHOD(Phalcon_DI_Service, setParameter){
 
 	phalcon_fetch_params_ex(2, 0, &position, &parameter);
 	PHALCON_ENSURE_IS_LONG(position);
-	
+
 	definition = obj->definition;
-	if (unlikely(Z_TYPE_P(definition) != IS_ARRAY)) { 
+	if (unlikely(Z_TYPE_P(definition) != IS_ARRAY)) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "Definition must be an array to update its parameters");
 		return;
 	}
-	
+
 	if (unlikely(Z_TYPE_PP(parameter) != IS_ARRAY)) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "The parameter must be an array");
 		return;
 	}
-	
+
 	/* Update the parameter */
 	if (phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))) {
 		phalcon_array_update_zval(&arguments, *position, *parameter, PH_COPY);
@@ -45502,7 +45506,7 @@ static PHP_METHOD(Phalcon_DI_Service, setParameter){
 		phalcon_array_update_zval(&arguments, *position, *parameter, PH_COPY);
 		phalcon_array_update_string(&definition, SL("arguments"), arguments, 0);
 	}
-	
+
 	RETURN_THISW();
 }
 
@@ -45513,16 +45517,16 @@ static PHP_METHOD(Phalcon_DI_Service, getParameter){
 
 	phalcon_fetch_params_ex(1, 0, &position);
 	PHALCON_ENSURE_IS_LONG(position);
-	
+
 	definition = obj->definition;
-	if (Z_TYPE_P(definition) != IS_ARRAY) { 
+	if (Z_TYPE_P(definition) != IS_ARRAY) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "Definition must be an array to obtain its parameters");
 		return;
 	}
-	
+
 	/* Update the parameter */
 	if (
-		    phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
+			phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
 		 && phalcon_array_isset_fetch(&parameter, arguments, *position)
 	) {
 		RETURN_ZVAL(parameter, 1, 0);
@@ -45542,9 +45546,9 @@ static PHP_METHOD(Phalcon_DI_Service, __set_state){
 	zval *attributes, *name, *definition, *shared;
 
 	phalcon_fetch_params(0, 1, 0, &attributes);
-	
+
 	if (
-		    !phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
+			!phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
 		 || !phalcon_array_isset_string_fetch(&definition, attributes, SS("_definition"))
 		 || !phalcon_array_isset_string_fetch(&shared, attributes, SS("_shared"))
 	) {

--- a/build/64bits/phalcon.c
+++ b/build/64bits/phalcon.c
@@ -45360,11 +45360,11 @@ static PHP_METHOD(Phalcon_DI_Service, setSharedInstance)
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 1, 0, &shared_instance);
-	
+
 	if (obj->shared_instance) {
 		zval_ptr_dtor(&obj->shared_instance);
 	}
-	
+
 	obj->shared_instance = shared_instance;
 }
 
@@ -45374,7 +45374,7 @@ static PHP_METHOD(Phalcon_DI_Service, setDefinition)
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 1, 0, &definition);
-	
+
 	if (obj->definition) {
 		zval_ptr_dtor(&obj->definition);
 	}
@@ -45396,28 +45396,28 @@ static PHP_METHOD(Phalcon_DI_Service, resolve){
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 0, 2, &parameters, &dependency_injector);
-	
+
 	if (!parameters) {
 		parameters = PHALCON_GLOBAL(z_null);
 	}
-	
+
 	if (!dependency_injector) {
 		dependency_injector = PHALCON_GLOBAL(z_null);
 	}
-	
+
 	/* Check if the service is shared */
 	if (obj->shared && obj->shared_instance) {
 		RETURN_ZVAL(obj->shared_instance, 1, 0);
 	}
-	
+
 	PHALCON_MM_GROW();
-	
+
 	definition = obj->definition;
 	found      = 0;
 	if (Z_TYPE_P(definition) == IS_STRING) {
 		/* String definitions can be class names without implicit parameters */
-		found = 1;
 		if (phalcon_class_exists(Z_STRVAL_P(definition), Z_STRLEN_P(definition), 1 TSRMLS_CC)) {
+			found = 1;
 			if (Z_TYPE_P(parameters) == IS_ARRAY) {
 				PHALCON_INIT_VAR(instance);
 				RETURN_MM_ON_FAILURE(phalcon_create_instance_params(instance, definition, parameters TSRMLS_CC));
@@ -45451,24 +45451,28 @@ static PHP_METHOD(Phalcon_DI_Service, resolve){
 		PHALCON_CALL_METHOD(&instance, builder, "build", dependency_injector, definition, parameters);
 		found = 1;
 	}
-	
+
+	if (EG(exception)) {
+		return;
+	}
+
 	/* If the service can't be built, we must throw an exception */
 	if (!found) {
 		zend_throw_exception_ex(phalcon_di_exception_ce, 0 TSRMLS_CC, "Service '%s' cannot be resolved", obj->name);
 		PHALCON_MM_RESTORE();
 		return;
 	}
-	
-	if (Z_TYPE_P(instance) != IS_OBJECT) {
-		php_error_docref0(NULL TSRMLS_CC, E_DEPRECATED, "Usage of Phalcon\\DI to store non-objects is deprecated, please use Phalcon\\Registry instead");
-	}
+
+	//if (Z_TYPE_P(instance) != IS_OBJECT) {
+	//	php_error_docref0(NULL TSRMLS_CC, E_DEPRECATED, "Usage of Phalcon\\DI to store non-objects is deprecated, please use Phalcon\\Registry instead");
+	//}
 
 	/* Update the shared instance if the service is shared */
 	if (obj->shared) {
 		Z_ADDREF_P(instance);
 		obj->shared_instance = instance;
 	}
-	
+
 	obj->resolved = 1;
 
 	RETURN_CTOR(instance);
@@ -45481,18 +45485,18 @@ static PHP_METHOD(Phalcon_DI_Service, setParameter){
 
 	phalcon_fetch_params_ex(2, 0, &position, &parameter);
 	PHALCON_ENSURE_IS_LONG(position);
-	
+
 	definition = obj->definition;
-	if (unlikely(Z_TYPE_P(definition) != IS_ARRAY)) { 
+	if (unlikely(Z_TYPE_P(definition) != IS_ARRAY)) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "Definition must be an array to update its parameters");
 		return;
 	}
-	
+
 	if (unlikely(Z_TYPE_PP(parameter) != IS_ARRAY)) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "The parameter must be an array");
 		return;
 	}
-	
+
 	/* Update the parameter */
 	if (phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))) {
 		phalcon_array_update_zval(&arguments, *position, *parameter, PH_COPY);
@@ -45502,7 +45506,7 @@ static PHP_METHOD(Phalcon_DI_Service, setParameter){
 		phalcon_array_update_zval(&arguments, *position, *parameter, PH_COPY);
 		phalcon_array_update_string(&definition, SL("arguments"), arguments, 0);
 	}
-	
+
 	RETURN_THISW();
 }
 
@@ -45513,16 +45517,16 @@ static PHP_METHOD(Phalcon_DI_Service, getParameter){
 
 	phalcon_fetch_params_ex(1, 0, &position);
 	PHALCON_ENSURE_IS_LONG(position);
-	
+
 	definition = obj->definition;
-	if (Z_TYPE_P(definition) != IS_ARRAY) { 
+	if (Z_TYPE_P(definition) != IS_ARRAY) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "Definition must be an array to obtain its parameters");
 		return;
 	}
-	
+
 	/* Update the parameter */
 	if (
-		    phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
+			phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
 		 && phalcon_array_isset_fetch(&parameter, arguments, *position)
 	) {
 		RETURN_ZVAL(parameter, 1, 0);
@@ -45542,9 +45546,9 @@ static PHP_METHOD(Phalcon_DI_Service, __set_state){
 	zval *attributes, *name, *definition, *shared;
 
 	phalcon_fetch_params(0, 1, 0, &attributes);
-	
+
 	if (
-		    !phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
+			!phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
 		 || !phalcon_array_isset_string_fetch(&definition, attributes, SS("_definition"))
 		 || !phalcon_array_isset_string_fetch(&shared, attributes, SS("_shared"))
 	) {

--- a/build/safe/phalcon.c
+++ b/build/safe/phalcon.c
@@ -45360,11 +45360,11 @@ static PHP_METHOD(Phalcon_DI_Service, setSharedInstance)
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 1, 0, &shared_instance);
-	
+
 	if (obj->shared_instance) {
 		zval_ptr_dtor(&obj->shared_instance);
 	}
-	
+
 	obj->shared_instance = shared_instance;
 }
 
@@ -45374,7 +45374,7 @@ static PHP_METHOD(Phalcon_DI_Service, setDefinition)
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 1, 0, &definition);
-	
+
 	if (obj->definition) {
 		zval_ptr_dtor(&obj->definition);
 	}
@@ -45396,28 +45396,28 @@ static PHP_METHOD(Phalcon_DI_Service, resolve){
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 0, 2, &parameters, &dependency_injector);
-	
+
 	if (!parameters) {
 		parameters = PHALCON_GLOBAL(z_null);
 	}
-	
+
 	if (!dependency_injector) {
 		dependency_injector = PHALCON_GLOBAL(z_null);
 	}
-	
+
 	/* Check if the service is shared */
 	if (obj->shared && obj->shared_instance) {
 		RETURN_ZVAL(obj->shared_instance, 1, 0);
 	}
-	
+
 	PHALCON_MM_GROW();
-	
+
 	definition = obj->definition;
 	found      = 0;
 	if (Z_TYPE_P(definition) == IS_STRING) {
 		/* String definitions can be class names without implicit parameters */
-		found = 1;
 		if (phalcon_class_exists(Z_STRVAL_P(definition), Z_STRLEN_P(definition), 1 TSRMLS_CC)) {
+			found = 1;
 			if (Z_TYPE_P(parameters) == IS_ARRAY) {
 				PHALCON_INIT_VAR(instance);
 				RETURN_MM_ON_FAILURE(phalcon_create_instance_params(instance, definition, parameters TSRMLS_CC));
@@ -45451,24 +45451,28 @@ static PHP_METHOD(Phalcon_DI_Service, resolve){
 		PHALCON_CALL_METHOD(&instance, builder, "build", dependency_injector, definition, parameters);
 		found = 1;
 	}
-	
+
+	if (EG(exception)) {
+		return;
+	}
+
 	/* If the service can't be built, we must throw an exception */
 	if (!found) {
 		zend_throw_exception_ex(phalcon_di_exception_ce, 0 TSRMLS_CC, "Service '%s' cannot be resolved", obj->name);
 		PHALCON_MM_RESTORE();
 		return;
 	}
-	
-	if (Z_TYPE_P(instance) != IS_OBJECT) {
-		php_error_docref0(NULL TSRMLS_CC, E_DEPRECATED, "Usage of Phalcon\\DI to store non-objects is deprecated, please use Phalcon\\Registry instead");
-	}
+
+	//if (Z_TYPE_P(instance) != IS_OBJECT) {
+	//	php_error_docref0(NULL TSRMLS_CC, E_DEPRECATED, "Usage of Phalcon\\DI to store non-objects is deprecated, please use Phalcon\\Registry instead");
+	//}
 
 	/* Update the shared instance if the service is shared */
 	if (obj->shared) {
 		Z_ADDREF_P(instance);
 		obj->shared_instance = instance;
 	}
-	
+
 	obj->resolved = 1;
 
 	RETURN_CTOR(instance);
@@ -45481,18 +45485,18 @@ static PHP_METHOD(Phalcon_DI_Service, setParameter){
 
 	phalcon_fetch_params_ex(2, 0, &position, &parameter);
 	PHALCON_ENSURE_IS_LONG(position);
-	
+
 	definition = obj->definition;
-	if (unlikely(Z_TYPE_P(definition) != IS_ARRAY)) { 
+	if (unlikely(Z_TYPE_P(definition) != IS_ARRAY)) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "Definition must be an array to update its parameters");
 		return;
 	}
-	
+
 	if (unlikely(Z_TYPE_PP(parameter) != IS_ARRAY)) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "The parameter must be an array");
 		return;
 	}
-	
+
 	/* Update the parameter */
 	if (phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))) {
 		phalcon_array_update_zval(&arguments, *position, *parameter, PH_COPY);
@@ -45502,7 +45506,7 @@ static PHP_METHOD(Phalcon_DI_Service, setParameter){
 		phalcon_array_update_zval(&arguments, *position, *parameter, PH_COPY);
 		phalcon_array_update_string(&definition, SL("arguments"), arguments, 0);
 	}
-	
+
 	RETURN_THISW();
 }
 
@@ -45513,16 +45517,16 @@ static PHP_METHOD(Phalcon_DI_Service, getParameter){
 
 	phalcon_fetch_params_ex(1, 0, &position);
 	PHALCON_ENSURE_IS_LONG(position);
-	
+
 	definition = obj->definition;
-	if (Z_TYPE_P(definition) != IS_ARRAY) { 
+	if (Z_TYPE_P(definition) != IS_ARRAY) {
 		PHALCON_THROW_EXCEPTION_STRW(phalcon_di_exception_ce, "Definition must be an array to obtain its parameters");
 		return;
 	}
-	
+
 	/* Update the parameter */
 	if (
-		    phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
+			phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
 		 && phalcon_array_isset_fetch(&parameter, arguments, *position)
 	) {
 		RETURN_ZVAL(parameter, 1, 0);
@@ -45542,9 +45546,9 @@ static PHP_METHOD(Phalcon_DI_Service, __set_state){
 	zval *attributes, *name, *definition, *shared;
 
 	phalcon_fetch_params(0, 1, 0, &attributes);
-	
+
 	if (
-		    !phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
+			!phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
 		 || !phalcon_array_isset_string_fetch(&definition, attributes, SS("_definition"))
 		 || !phalcon_array_isset_string_fetch(&shared, attributes, SS("_shared"))
 	) {

--- a/ext/db/result/pdo.c
+++ b/ext/db/result/pdo.c
@@ -487,4 +487,3 @@ PHP_METHOD(Phalcon_Db_Result_Pdo, nextRowset){
 
 	RETURN_MM();
 }
-

--- a/ext/db/result/pdo.c
+++ b/ext/db/result/pdo.c
@@ -57,6 +57,7 @@ PHP_METHOD(Phalcon_Db_Result_Pdo, numRows);
 PHP_METHOD(Phalcon_Db_Result_Pdo, dataSeek);
 PHP_METHOD(Phalcon_Db_Result_Pdo, setFetchMode);
 PHP_METHOD(Phalcon_Db_Result_Pdo, getInternalResult);
+PHP_METHOD(Phalcon_Db_Result_Pdo, nextRowset);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_result___construct, 0, 0, 2)
 	ZEND_ARG_INFO(0, connection)
@@ -76,6 +77,7 @@ static const zend_function_entry phalcon_db_result_pdo_method_entry[] = {
 	PHP_ME(Phalcon_Db_Result_Pdo, dataSeek, arginfo_phalcon_db_resultinterface_dataseek, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Db_Result_Pdo, setFetchMode, arginfo_phalcon_db_resultinterface_setfetchmode, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Db_Result_Pdo, getInternalResult, arginfo_phalcon_db_resultinterface_getinternalresult, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Db_Result_Pdo, nextRowset, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -467,5 +469,22 @@ PHP_METHOD(Phalcon_Db_Result_Pdo, getInternalResult){
 
 
 	RETURN_MEMBER(this_ptr, "_pdoStatement");
+}
+
+/**
+ * Advances to the next rowset in a multi-rowset statement handle
+ *
+ * @return boolean
+ */
+PHP_METHOD(Phalcon_Db_Result_Pdo, nextRowset){
+
+	zval *pdo_statement;
+
+	PHALCON_MM_GROW();
+
+	pdo_statement = phalcon_fetch_nproperty_this(this_ptr, SL("_pdoStatement"), PH_NOISY TSRMLS_CC);
+	PHALCON_RETURN_CALL_METHOD(pdo_statement, "nextrowset");
+
+	RETURN_MM();
 }
 

--- a/ext/di/service.c
+++ b/ext/di/service.c
@@ -376,7 +376,7 @@ PHP_METHOD(Phalcon_DI_Service, resolve){
 
 	zval *parameters = NULL, *dependency_injector = NULL;
 	zval *instance = NULL, *definition, *builder;
-	int found, i;
+	int found;
 	phalcon_di_service_object *obj = phalcon_di_service_get_object(getThis() TSRMLS_CC);
 
 	phalcon_fetch_params(0, 0, 2, &parameters, &dependency_injector);
@@ -523,7 +523,7 @@ PHP_METHOD(Phalcon_DI_Service, getParameter){
 
 	/* Update the parameter */
 	if (
-		    phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
+			phalcon_array_isset_string_fetch(&arguments, definition, SS("arguments"))
 		 && phalcon_array_isset_fetch(&parameter, arguments, *position)
 	) {
 		RETURN_ZVAL(parameter, 1, 0);
@@ -556,7 +556,7 @@ PHP_METHOD(Phalcon_DI_Service, __set_state){
 	phalcon_fetch_params(0, 1, 0, &attributes);
 
 	if (
-		    !phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
+			!phalcon_array_isset_string_fetch(&name, attributes, SS("_name"))
 		 || !phalcon_array_isset_string_fetch(&definition, attributes, SS("_definition"))
 		 || !phalcon_array_isset_string_fetch(&shared, attributes, SS("_shared"))
 	) {

--- a/ext/dispatcher.c
+++ b/ext/dispatcher.c
@@ -575,6 +575,7 @@ PHP_METHOD(Phalcon_Dispatcher, dispatch){
 	zval *exception = NULL;
 	zval *dependency_injector, *events_manager, *tmp;
 	zval *handler_suffix, *action_suffix, *namespace_name, *handler_name, *action_name;
+	zval *camelized_namespace = NULL;
 	int number_dispatches = 0;
 
 	PHALCON_MM_GROW();
@@ -710,7 +711,9 @@ PHP_METHOD(Phalcon_Dispatcher, dispatch){
 			if (phalcon_end_with_str(namespace_name, SL("\\"))) {
 				PHALCON_CONCAT_VVV(handler_class, namespace_name, camelized_class, handler_suffix);
 			} else {
-				PHALCON_CONCAT_VSVV(handler_class, namespace_name, "\\", camelized_class, handler_suffix);
+				PHALCON_INIT_VAR(camelized_namespace);
+				phalcon_camelize(camelized_namespace, namespace_name);
+				PHALCON_CONCAT_VSVV(handler_class, camelized_namespace, "\\", camelized_class, handler_suffix);
 			}
 		} else {
 			PHALCON_CONCAT_VV(handler_class, camelized_class, handler_suffix);
@@ -1097,6 +1100,7 @@ PHP_METHOD(Phalcon_Dispatcher, getHandlerClass){
 
 	zval *camelized_class = NULL;
 	zval *handler_suffix, *namespace_name, *handler_name;
+	zval *camelized_namespace;
 
 	PHALCON_MM_GROW();
 
@@ -1143,7 +1147,9 @@ PHP_METHOD(Phalcon_Dispatcher, getHandlerClass){
 		if (phalcon_end_with_str(namespace_name, SL("\\"))) {
 			PHALCON_CONCAT_VVV(return_value, namespace_name, camelized_class, handler_suffix);
 		} else {
-			PHALCON_CONCAT_VSVV(return_value, namespace_name, "\\", camelized_class, handler_suffix);
+			PHALCON_INIT_VAR(camelized_namespace);
+			phalcon_camelize(camelized_namespace, namespace_name);
+			PHALCON_CONCAT_VSVV(return_value, camelized_namespace, "\\", camelized_class, handler_suffix);
 		}
 	} else {
 		PHALCON_CONCAT_VV(return_value, camelized_class, handler_suffix);

--- a/ext/http/request/file.c
+++ b/ext/http/request/file.c
@@ -21,6 +21,7 @@
 #include "http/request/exception.h"
 
 #include <main/SAPI.h>
+#include <ext/spl/spl_directory.h>
 
 #include "kernel/main.h"
 #include "kernel/memory.h"
@@ -66,6 +67,7 @@ PHP_METHOD(Phalcon_Http_Request_File, getKey);
 PHP_METHOD(Phalcon_Http_Request_File, isUploadedFile);
 PHP_METHOD(Phalcon_Http_Request_File, moveTo);
 PHP_METHOD(Phalcon_Http_Request_File, __set_state);
+PHP_METHOD(Phalcon_Http_Request_File, getExtension);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_http_request_file___construct, 0, 0, 1)
 	ZEND_ARG_INFO(0, file)
@@ -87,6 +89,7 @@ static const zend_function_entry phalcon_http_request_file_method_entry[] = {
 	PHP_ME(Phalcon_Http_Request_File, isUploadedFile, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Request_File, moveTo, arginfo_phalcon_http_request_fileinterface_moveto, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Http_Request_File, __set_state, arginfo_phalcon_http_request_file___set_state, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Phalcon_Http_Request_File, getExtension, NULL, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -95,7 +98,7 @@ static const zend_function_entry phalcon_http_request_file_method_entry[] = {
  */
 PHALCON_INIT_CLASS(Phalcon_Http_Request_File){
 
-	PHALCON_REGISTER_CLASS(Phalcon\\Http\\Request, File, http_request_file, phalcon_http_request_file_method_entry, 0);
+	PHALCON_REGISTER_CLASS_EX(Phalcon\\Http\\Request, File, http_request_file, spl_ce_SplFileInfo, phalcon_http_request_file_method_entry, 0);
 
 	zend_declare_property_null(phalcon_http_request_file_ce, SL("_name"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_http_request_file_ce, SL("_tmp"), ZEND_ACC_PROTECTED TSRMLS_CC);
@@ -104,6 +107,7 @@ PHALCON_INIT_CLASS(Phalcon_Http_Request_File){
 	zend_declare_property_null(phalcon_http_request_file_ce, SL("_real_type"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_http_request_file_ce, SL("_error"), ZEND_ACC_PROTECTED TSRMLS_CC);
 	zend_declare_property_null(phalcon_http_request_file_ce, SL("_key"), ZEND_ACC_PROTECTED TSRMLS_CC);
+	zend_declare_property_null(phalcon_http_request_file_ce, SL("_extension"), ZEND_ACC_PROTECTED TSRMLS_CC);
 
 	zend_class_implements(phalcon_http_request_file_ce TSRMLS_CC, 1, phalcon_http_request_fileinterface_ce);
 
@@ -118,6 +122,7 @@ PHALCON_INIT_CLASS(Phalcon_Http_Request_File){
 PHP_METHOD(Phalcon_Http_Request_File, __construct){
 
 	zval *file, *name, *temp_name, *size, *type, *error, *key = NULL;
+	zval *constant, *extension = NULL;
 
 	PHALCON_MM_GROW();
 
@@ -131,13 +136,22 @@ PHP_METHOD(Phalcon_Http_Request_File, __construct){
 		PHALCON_OBS_VAR(name);
 		phalcon_array_fetch_string(&name, file, SL("name"), PH_NOISY);
 		phalcon_update_property_this(this_ptr, SL("_name"), name TSRMLS_CC);
+
+		PHALCON_INIT_VAR(constant);
+		if (zend_get_constant(SL("PATHINFO_EXTENSION"), constant TSRMLS_CC)) {
+			PHALCON_CALL_FUNCTION(&extension, "pathinfo", name, constant);
+			phalcon_update_property_this(this_ptr, SL("_extension"), extension TSRMLS_CC);
+		}
 	}
 	
 	if (phalcon_array_isset_string(file, SS("tmp_name"))) {
 		PHALCON_OBS_VAR(temp_name);
 		phalcon_array_fetch_string(&temp_name, file, SL("tmp_name"), PH_NOISY);
 		phalcon_update_property_this(this_ptr, SL("_tmp"), temp_name TSRMLS_CC);
-	}
+	} else {
+		PHALCON_INIT_VAR(temp_name);
+		ZVAL_NULL(temp_name);
+ 	}
 	
 	if (phalcon_array_isset_string(file, SS("size"))) {
 		PHALCON_OBS_VAR(size);
@@ -160,6 +174,8 @@ PHP_METHOD(Phalcon_Http_Request_File, __construct){
 	if (key) {
 		phalcon_update_property_this(this_ptr, SL("_key"), key TSRMLS_CC);
 	}
+
+	PHALCON_CALL_PARENT(NULL, phalcon_http_request_file_ce, this_ptr, "__construct", temp_name);
 
 	PHALCON_MM_RESTORE();
 }
@@ -318,4 +334,15 @@ PHP_METHOD(Phalcon_Http_Request_File, __set_state) {
 	PHALCON_MM_GROW();
 	PHALCON_CALL_METHOD(NULL, return_value, "__construct", data);
 	PHALCON_MM_RESTORE();
+}
+
+/**
+ * Returns the file extension
+ *
+ * @return string
+ */
+PHP_METHOD(Phalcon_Http_Request_File, getExtension){
+
+
+	RETURN_MEMBER(this_ptr, "_extension ");
 }

--- a/ext/mvc/model/criteria.c
+++ b/ext/mvc/model/criteria.c
@@ -312,8 +312,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, columns){
  */
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, join){
 
-	zval *model, *conditions = NULL, *alias = NULL, *type = NULL, *join, *params;
-	zval *current_joins, *merged_joins = NULL;
+	zval *model, *conditions = NULL, *alias = NULL, *type = NULL, *new_join, *params;
+	zval *current_joins, *merged_joins = NULL, *new_join_array = NULL;
 
 	PHALCON_MM_GROW();
 
@@ -331,29 +331,33 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, join){
 		type = PHALCON_GLOBAL(z_null);
 	}
 	
-	PHALCON_INIT_VAR(join);
-	array_init_size(join, 4);
-	phalcon_array_append(&join, model, 0);
-	phalcon_array_append(&join, conditions, 0);
-	phalcon_array_append(&join, alias, 0);
-	phalcon_array_append(&join, type, 0);
+	PHALCON_INIT_VAR(new_join);
+	array_init_size(new_join, 4);
+	phalcon_array_append(&new_join, model, 0);
+	phalcon_array_append(&new_join, conditions, 0);
+	phalcon_array_append(&new_join, alias, 0);
+	phalcon_array_append(&new_join, type, 0);
 	
 	PHALCON_OBS_VAR(params);
 	phalcon_read_property_this(&params, this_ptr, SL("_params"), PH_NOISY TSRMLS_CC);
 	if (phalcon_array_isset_string(params, SS("joins"))) {
-	
+		
+		PHALCON_INIT_VAR(new_join_array);
+		array_init_size(new_join_array, 1);
+		phalcon_array_append(&new_join_array, new_join, 0);
+
 		PHALCON_OBS_VAR(current_joins);
 		phalcon_array_fetch_string(&current_joins, params, SL("joins"), PH_NOISY);
 		if (Z_TYPE_P(current_joins) == IS_ARRAY) { 
 			PHALCON_INIT_VAR(merged_joins);
-			phalcon_fast_array_merge(merged_joins, &current_joins, &join TSRMLS_CC);
+			phalcon_fast_array_merge(merged_joins, &current_joins, &new_join_array TSRMLS_CC);
 		} else {
-			PHALCON_CPY_WRT(merged_joins, join);
+			PHALCON_CPY_WRT(merged_joins, new_join_array);
 		}
 	} else {
 		PHALCON_INIT_NVAR(merged_joins);
 		array_init_size(merged_joins, 1);
-		phalcon_array_append(&merged_joins, join, 0);
+		phalcon_array_append(&merged_joins, new_join, 0);
 	}
 	
 	phalcon_update_property_array_string(this_ptr, SL("_params"), SS("joins"), merged_joins TSRMLS_CC);
@@ -378,8 +382,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, join){
  */
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, innerJoin){
 
-	zval *model, *conditions = NULL, *alias = NULL, *type, *join, *params;
-	zval *current_joins, *merged_joins = NULL;
+	zval *model, *conditions = NULL, *alias = NULL, *type, *new_join, *params;
+	zval *current_joins, *merged_joins = NULL, *new_join_array = NULL;
 
 	PHALCON_MM_GROW();
 
@@ -396,29 +400,33 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, innerJoin){
 	PHALCON_INIT_VAR(type);
 	ZVAL_STRING(type, "INNER", 1);
 	
-	PHALCON_INIT_VAR(join);
-	array_init_size(join, 4);
-	phalcon_array_append(&join, model, 0);
-	phalcon_array_append(&join, conditions, 0);
-	phalcon_array_append(&join, alias, 0);
-	phalcon_array_append(&join, type, 0);
+	PHALCON_INIT_VAR(new_join);
+	array_init_size(new_join, 4);
+	phalcon_array_append(&new_join, model, 0);
+	phalcon_array_append(&new_join, conditions, 0);
+	phalcon_array_append(&new_join, alias, 0);
+	phalcon_array_append(&new_join, type, 0);
 	
 	PHALCON_OBS_VAR(params);
 	phalcon_read_property_this(&params, this_ptr, SL("_params"), PH_NOISY TSRMLS_CC);
 	if (phalcon_array_isset_string(params, SS("joins"))) {
-	
+		
+		PHALCON_INIT_VAR(new_join_array);
+		array_init_size(new_join_array, 1);
+		phalcon_array_append(&new_join_array, new_join, 0);
+
 		PHALCON_OBS_VAR(current_joins);
 		phalcon_array_fetch_string(&current_joins, params, SL("joins"), PH_NOISY);
 		if (Z_TYPE_P(current_joins) == IS_ARRAY) { 
 			PHALCON_INIT_VAR(merged_joins);
-			phalcon_fast_array_merge(merged_joins, &current_joins, &join TSRMLS_CC);
+			phalcon_fast_array_merge(merged_joins, &current_joins, &new_join_array TSRMLS_CC);
 		} else {
-			PHALCON_CPY_WRT(merged_joins, join);
+			PHALCON_CPY_WRT(merged_joins, new_join_array);
 		}
 	} else {
 		PHALCON_INIT_NVAR(merged_joins);
 		array_init_size(merged_joins, 1);
-		phalcon_array_append(&merged_joins, join, PH_SEPARATE);
+		phalcon_array_append(&merged_joins, new_join, PH_SEPARATE);
 	}
 	
 	phalcon_update_property_array_string(this_ptr, SL("_params"), SS("joins"), merged_joins TSRMLS_CC);
@@ -440,8 +448,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, innerJoin){
  */
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, leftJoin){
 
-	zval *model, *conditions = NULL, *alias = NULL, *type, *join, *params;
-	zval *current_joins, *merged_joins = NULL;
+	zval *model, *conditions = NULL, *alias = NULL, *type, *new_join, *params;
+	zval *current_joins, *merged_joins = NULL, *new_join_array = NULL;
 
 	PHALCON_MM_GROW();
 
@@ -458,29 +466,33 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, leftJoin){
 	PHALCON_INIT_VAR(type);
 	ZVAL_STRING(type, "LEFT", 1);
 	
-	PHALCON_INIT_VAR(join);
-	array_init_size(join, 4);
-	phalcon_array_append(&join, model, 0);
-	phalcon_array_append(&join, conditions, 0);
-	phalcon_array_append(&join, alias, 0);
-	phalcon_array_append(&join, type, 0);
+	PHALCON_INIT_VAR(new_join);
+	array_init_size(new_join, 4);
+	phalcon_array_append(&new_join, model, 0);
+	phalcon_array_append(&new_join, conditions, 0);
+	phalcon_array_append(&new_join, alias, 0);
+	phalcon_array_append(&new_join, type, 0);
 	
 	PHALCON_OBS_VAR(params);
 	phalcon_read_property_this(&params, this_ptr, SL("_params"), PH_NOISY TSRMLS_CC);
 	if (phalcon_array_isset_string(params, SS("joins"))) {
-	
+
+		PHALCON_INIT_VAR(new_join_array);
+		array_init_size(new_join_array, 1);
+		phalcon_array_append(&new_join_array, new_join, 0);
+
 		PHALCON_OBS_VAR(current_joins);
 		phalcon_array_fetch_string(&current_joins, params, SL("joins"), PH_NOISY);
 		if (Z_TYPE_P(current_joins) == IS_ARRAY) { 
 			PHALCON_INIT_VAR(merged_joins);
-			phalcon_fast_array_merge(merged_joins, &current_joins, &join TSRMLS_CC);
+			phalcon_fast_array_merge(merged_joins, &current_joins, &new_join_array TSRMLS_CC);
 		} else {
-			PHALCON_CPY_WRT(merged_joins, join);
+			PHALCON_CPY_WRT(merged_joins, new_join_array);
 		}
 	} else {
 		PHALCON_INIT_NVAR(merged_joins);
 		array_init_size(merged_joins, 1);
-		phalcon_array_append(&merged_joins, join, PH_SEPARATE);
+		phalcon_array_append(&merged_joins, new_join, PH_SEPARATE);
 	}
 	
 	phalcon_update_property_array_string(this_ptr, SL("_params"), SS("joins"), merged_joins TSRMLS_CC);
@@ -502,8 +514,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, leftJoin){
  */
 PHP_METHOD(Phalcon_Mvc_Model_Criteria, rightJoin){
 
-	zval *model, *conditions = NULL, *alias = NULL, *type, *join, *params;
-	zval *current_joins, *merged_joins = NULL;
+	zval *model, *conditions = NULL, *alias = NULL, *type, *new_join, *params;
+	zval *current_joins, *merged_joins = NULL, *new_join_array = NULL;
 
 	PHALCON_MM_GROW();
 
@@ -520,29 +532,33 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, rightJoin){
 	PHALCON_INIT_VAR(type);
 	ZVAL_STRING(type, "RIGHT", 1);
 	
-	PHALCON_INIT_VAR(join);
-	array_init_size(join, 4);
-	phalcon_array_append(&join, model, 0);
-	phalcon_array_append(&join, conditions, 0);
-	phalcon_array_append(&join, alias, 0);
-	phalcon_array_append(&join, type, 0);
+	PHALCON_INIT_VAR(new_join);
+	array_init_size(new_join, 4);
+	phalcon_array_append(&new_join, model, 0);
+	phalcon_array_append(&new_join, conditions, 0);
+	phalcon_array_append(&new_join, alias, 0);
+	phalcon_array_append(&new_join, type, 0);
 	
 	PHALCON_OBS_VAR(params);
 	phalcon_read_property_this(&params, this_ptr, SL("_params"), PH_NOISY TSRMLS_CC);
 	if (phalcon_array_isset_string(params, SS("joins"))) {
-	
+
+		PHALCON_INIT_VAR(new_join_array);
+		array_init_size(new_join_array, 1);
+		phalcon_array_append(&new_join_array, new_join, 0);
+
 		PHALCON_OBS_VAR(current_joins);
 		phalcon_array_fetch_string(&current_joins, params, SL("joins"), PH_NOISY);
 		if (Z_TYPE_P(current_joins) == IS_ARRAY) { 
 			PHALCON_INIT_VAR(merged_joins);
-			phalcon_fast_array_merge(merged_joins, &current_joins, &join TSRMLS_CC);
+			phalcon_fast_array_merge(merged_joins, &current_joins, &new_join_array TSRMLS_CC);
 		} else {
-			PHALCON_CPY_WRT(merged_joins, join);
+			PHALCON_CPY_WRT(merged_joins, new_join_array);
 		}
 	} else {
 		PHALCON_INIT_NVAR(merged_joins);
 		array_init_size(merged_joins, 1);
-		phalcon_array_append(&merged_joins, join, PH_SEPARATE);
+		phalcon_array_append(&merged_joins, new_join, PH_SEPARATE);
 	}
 	
 	phalcon_update_property_array_string(this_ptr, SL("_params"), SS("joins"), merged_joins TSRMLS_CC);

--- a/ext/session/adapter.c
+++ b/ext/session/adapter.c
@@ -59,9 +59,14 @@ PHP_METHOD(Phalcon_Session_Adapter, destroy);
 PHP_METHOD(Phalcon_Session_Adapter, __get);
 PHP_METHOD(Phalcon_Session_Adapter, count);
 PHP_METHOD(Phalcon_Session_Adapter, getIterator);
+PHP_METHOD(Phalcon_Session_Adapter, setId);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_session_adapter___construct, 0, 0, 0)
 	ZEND_ARG_INFO(0, options)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_session_adapter_setid, 0, 0, 1)
+	ZEND_ARG_INFO(0, sid)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry phalcon_session_adapter_method_entry[] = {
@@ -87,6 +92,7 @@ static const zend_function_entry phalcon_session_adapter_method_entry[] = {
 	PHP_MALIAS(Phalcon_Session_Adapter, offsetUnset, remove, arginfo_arrayaccess_offsetunset, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Session_Adapter, count, arginfo_countable_count, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Session_Adapter, getIterator, arginfo_iteratoraggregate_getiterator, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Session_Adapter, setId, arginfo_phalcon_session_adapter_setid, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };
 
@@ -678,4 +684,20 @@ PHP_METHOD(Phalcon_Session_Adapter, getIterator)
 	data = phalcon_get_global(SS("_SESSION") TSRMLS_CC);
 	object_init_ex(return_value, spl_ce_ArrayIterator);
 	PHALCON_CALL_METHODW(NULL, return_value, "__construct", data);
+}
+
+/**
+ * Set the current session id
+ *
+ *<code>
+ *	$session->setId($id);
+ *</code>
+ */
+PHP_METHOD(Phalcon_Session_Adapter, setId){
+
+	zval *sid;
+
+	phalcon_fetch_params(0, 1, 0, &sid);
+
+	RETURN_ON_FAILURE(phalcon_set_session_id(sid TSRMLS_CC));
 }


### PR DESCRIPTION
See the discussion here:
http://forum.phalconphp.com/discussion/1479/multiple-joins-in-oo-notation-fail

From what I saw, the problem was that the `current_joins` was merged with the `join` array instead of appended, so it resulted in something like this:

``` php
array(
    //first join
    0 => array(
        'type' => "LEFT",
        'conditions' => "...",
    ),

    //all the following joins
    'type' => "LEFT",
    'conditions' => "...",
)
```

instead of

``` php
array(
    //first join
    0 => array(
        'type' => "LEFT",
        'conditions' => "...",
    ),

    //all the following joins
    1 => array(
        'type' => "LEFT",
        'conditions' => "...",
    ),
)
```

This is my first attempt at editing phalcon code, I have some experience with c code but none with php extension. I didn't tried but i guessed I couldn't edit `current_joins` directly, so phalcon_array_append is out of the question. I don't know how to copy a zval, so to avoid editing too much code I simpy added an array of array that can be merged with `current_joins` or copy-written on `merged_joins`.
