### PR TITLE
travis fast-finish builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ after_failure:
  - sudo apt-get -qq install gdb
  - ./unit-tests/ci/after_failure.sh
 
+matrix:
+  fast_finish: true
+
 notifications:
   email:
     - andres@phalconphp.com

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Current Build Status
 
 Phalcon Framework is built under the Travis CI service. Every commit pushed to this repository will queue a build into the continuous integration service and will run all PHPUnit tests to ensure that everything is going well and the project is stable. The current build status is:
 
-[![Build Status](https://secure.travis-ci.org/phalcon/cphalcon.png?branch=master)](http://travis-ci.org/phalcon/cphalcon)
+[![Build Status](https://travis-ci.org/phalcon/cphalcon.png?branch=master)](http://travis-ci.org/phalcon/cphalcon)
 
 Meet the Incubator
 -----------


### PR DESCRIPTION
For a while, Travis CI has supported allowed failures in your build
matrix - jobs that are allowed to fail, without affecting the status of
the entire build.

However, even if some of the items in your build matrix are allowed failures, Travis CI will still wait for them to finish before marking the build as finished. Even if all of the other jobs are done, Travis CI won't mark the build as finished until the allowed failures are done, despite the fact that allowed failures won't ultimately affect the status of the build.
- [Fast-Finish Builds with Allowed Failures](http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/)
- [Rows That are Allowed To Fail](http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail)
