### PR TITLE
Removed final keyword from Model constructor

### DIFF
--- a/ext/mvc/model.c
+++ b/ext/mvc/model.c
@@ -229,7 +229,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_model_toarray, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry phalcon_mvc_model_method_entry[] = {
-	PHP_ME(Phalcon_Mvc_Model, __construct, arginfo_phalcon_mvc_model___construct, ZEND_ACC_PUBLIC|ZEND_ACC_FINAL|ZEND_ACC_CTOR)
+	PHP_ME(Phalcon_Mvc_Model, __construct, arginfo_phalcon_mvc_model___construct, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
 	PHP_ME(Phalcon_Mvc_Model, setDI, arginfo_phalcon_di_injectionawareinterface_setdi, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model, getDI, arginfo_phalcon_di_injectionawareinterface_getdi, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model, setEventsManager, NULL, ZEND_ACC_PROTECTED)


### PR DESCRIPTION
When working with unit test frameworks like PHPSpec and PHPUnit, it's impossible to mock/stub entities that inherit from Phalcon\Mvc\Model, since the framework is not able to use it's own constructor into the extended class. When mocking or stubbing, you'll get an error like this:

```
Fatal error: Cannot override final method Phalcon\Mvc\Model::__construct()
```

This is a serious problem for any large project with a serious approach to code quality. I'm sure this causing a lot of problems for other developers and it's a very simple change. There's no reason for the Model constructor to be final.
