### PR TITLE
Fix #1608 about Phalcon\Mvc\Router\Annotations

### DIFF
--- a/ext/mvc/router/annotations.c
+++ b/ext/mvc/router/annotations.c
@@ -544,7 +544,11 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, processActionAnnotation){
 				PHALCON_INIT_VAR(uri);
 				PHALCON_CONCAT_VV(uri, route_prefix, value);
 			} else {
-				PHALCON_CPY_WRT(uri, route_prefix);
+				if (Z_TYPE_P(route_prefix) != IS_NULL) {
+					PHALCON_CPY_WRT(uri, route_prefix);
+				} else {
+					PHALCON_CPY_WRT(uri, value);
+				}
 			}
 		} else {
 			PHALCON_INIT_NVAR(uri);

--- a/unit-tests/RouterMvcAnnotationsTest.php
+++ b/unit-tests/RouterMvcAnnotationsTest.php
@@ -87,6 +87,19 @@ class ProductsController
 
 }
 
+class MainController
+{
+
+	/**
+	 * @Get("/")
+	 */
+	public function indexAction()
+	{
+
+	}
+
+}
+
 class RouterMvcAnnotationsTest extends PHPUnit_Framework_TestCase
 {
 	public function _getDI()
@@ -105,10 +118,11 @@ class RouterMvcAnnotationsTest extends PHPUnit_Framework_TestCase
 
 		$router->addResource('Robots');
 		$router->addResource('Products');
+		$router->addResource('Main');
 
 		$router->handle();
 
-		$this->assertEquals(count($router->getRoutes()), 7);
+		$this->assertEquals(count($router->getRoutes()), 8);
 
 		$route = $router->getRouteByName('save-robot');
 		$this->assertTrue(is_object($route));
@@ -174,6 +188,13 @@ class RouterMvcAnnotationsTest extends PHPUnit_Framework_TestCase
 				'controller' => 'Robots',
 				'action' => 'deleteRobot',
 				'params' => array('id' => '100')
+			),
+			array(
+				'uri' => '/',
+				'method' => 'GET',
+				'controller' => 'Main',
+				'action' => 'index',
+				'params' => array()
 			),
 		);
 


### PR DESCRIPTION
Makes it possible to define default route with `@Route('/')` annotation
