### PR TITLE
Fixing a typo

### DIFF
--- a/phalcon/http/request/file.zep
+++ b/phalcon/http/request/file.zep
@@ -1,4 +1,3 @@
-
 /*
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
@@ -141,7 +140,7 @@ class File implements \Phalcon\Http\Request\FileInterface
         }
 
         let mime = finfo_file(finfo, this->_tmp);
-        fclose(finfo);
+        finfo_close(finfo);
 
         return mime;
 	}


### PR DESCRIPTION
Fixing a typo when closing the Mime type check resource.
