### PR TITLE
Ignore "value" attribute in TextArea.

### DIFF
--- a/ext/tag.c
+++ b/ext/tag.c
@@ -1430,6 +1430,10 @@ PHP_METHOD(Phalcon_Tag, textArea){
 
 	PHALCON_CALL_SELF(&content, "getvalue", id, params);
 
+	if (phalcon_array_isset_string(params, SS("value"))) {
+		phalcon_array_unset_string(&params, SS("value"), 0);
+	}
+
 	PHALCON_OBS_VAR(escaper);
 	phalcon_tag_get_escaper(&escaper, params TSRMLS_CC);
 	if (EG(exception)) {


### PR DESCRIPTION
Ignoring "value" attrib when Phalcon renders textareas.
