### PR TITLE
Fix valid function for the first call

### DIFF
--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -175,9 +175,10 @@ abstract class Resultset
 				}
 
 				if typeof rows == "array" {
-					reset(rows);
-					for i in range(0, position) {
+					let i = 0;
+					while i < position {
 						next(rows);
+						let i++;
 					}
 				}
 			}

--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -108,6 +108,7 @@ class Simple extends \Phalcon\Mvc\Model\Resultset
 				let result = this->_result;
 				if typeof result == "object" {
 					let this->_rows = result->fetchAll();
+					let rows = this->_rows;
 				}
 			}
 


### PR DESCRIPTION
commit 5c9bf86,

Problem : the function valid respond false the first time when the fetchAll must be done.

Solution : set directly rows field after the fetch.

Example to reproduce :
#1 Create table

CREATE TABLE IF NOT EXISTS `user` (
  `user_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `email` varchar(70) CHARACTER SET utf8 NOT NULL,
  `password` char(32) CHARACTER SET utf8 NOT NULL,
  PRIMARY KEY (`user_id`),
  UNIQUE KEY `email_password` (`email`,`password`)
) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=3 ;

INSERT INTO `user` (`user_id`, `email`, `password`) VALUES
(1, 'example1@gmail.com', 'pass1'),
(2, 'example2@test.com', 'pass2');
#2 (use scaffold of phalcon-devtool)

phalcon scaffold --table-name user
#3 Search all result (juste enter in http://127.0.0.1/user/index page

or check like this :
$users = User::find();
while ($users->valid() !== false) {
    echo "user : " . $users->current()->email . '<br />';
}

commit 8af3f1e,

Fix resultSet->seek function. replace range by while loop because range(0, 0) do one loop and apply next function.
