### PR TITLE
Fix pagination nativeArray test-unit failed

### DIFF
--- a/phalcon/paginator/adapter/nativearray.zep
+++ b/phalcon/paginator/adapter/nativearray.zep
@@ -117,7 +117,7 @@ class NativeArray implements \Phalcon\Paginator\AdapterInterface
 
 		let page = new \stdClass(),
 			number = count(items),
-			roundedTotal = number / show,
+			roundedTotal = number / floatval(show),
 			totalPages = (int) roundedTotal;
 
 		/**


### PR DESCRIPTION
1) PaginatorTest::testArrayPaginator_t445
Failed asserting that 2 matches expected 1.

/home/vagrant/cphalcon-2.x.x/unit-tests/PaginatorTest.php:204

Bug : Divide by an integer return an integer.
Fix : Add floatval on denominator to return a float

use test-unit "PaginatorTest" to check fix
