### PR TITLE
Supported \Phalcon\Db\Index: TYPE for 2.0

### DIFF
--- a/phalcon/db/index.zep
+++ b/phalcon/db/index.zep
@@ -44,15 +44,23 @@ class Index implements \Phalcon\Db\IndexInterface
 	protected _columns { get };
 
 	/**
+	 * Index type
+	 *
+	 * @var string
+	 */
+	protected _type { get };
+
+	/**
 	 * Phalcon\Db\Index constructor
 	 *
 	 * @param string name
 	 * @param array columns
 	 */
-	public function __construct(string! name, array! columns)
+	public function __construct(string! name, array! columns, type=null)
 	{
 		let this->_name = name;
 		let this->_columns = columns;
+		let this->_type = (string) type;
 	}
 
 	/**
@@ -62,7 +70,7 @@ class Index implements \Phalcon\Db\IndexInterface
 	 */
 	public static function __set_state(array! data) -> <\Phalcon\Db\Index>
 	{
-		var indexName, columns;
+		var indexName, columns, type;
 
 		if !fetch indexName, data["_indexName"] {
 			throw new \Phalcon\Db\Exception("_indexName parameter is required");
@@ -72,10 +80,16 @@ class Index implements \Phalcon\Db\IndexInterface
 			throw new \Phalcon\Db\Exception("_columns parameter is required");
 		}
 
+		if isset data["_type"] {
+			let type = data["_type"];
+		} else {
+			let type = "";
+		}
+
 		/**
 		 * Return a Phalcon\Db\Index as part of the returning state
 		 */
-		return new \Phalcon\Db\Index(indexName, columns);
+		return new \Phalcon\Db\Index(indexName, columns, type);
 	}
 
 }

--- a/phalcon/db/indexinterface.zep
+++ b/phalcon/db/indexinterface.zep
@@ -32,8 +32,9 @@ interface IndexInterface
 	 *
 	 * @param string indexName
 	 * @param array columns
+	 * @param string type
 	 */
-	public function __construct(indexName, columns);
+	public function __construct(indexName, columns, type);
 
 	/**
 	 * Gets the index name
@@ -48,6 +49,13 @@ interface IndexInterface
 	 * @return array
 	 */
 	public function getColumns();
+
+	/**
+	 * Gets the index type
+	 *
+	 * @return string
+	 */
+	public function getType();
 
 	/**
 	 * Restore a Phalcon\Db\Index object from export

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -79,6 +79,7 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 			'index1' => new Index("index1", array('column1')),
 			'index2' => new Index("index2", array('column1', 'column2')),
 			'PRIMARY' => new Index("PRIMARY", array('column3')),
+			'index4' => new Index("index4", array('column4'), 'UNIQUE'),
 		);
 	}
 
@@ -201,6 +202,11 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($index3->getName(), 'PRIMARY');
 		$this->assertEquals($index3->getColumns(), array('column3'));
 
+		$index4 = $indexes['index4'];
+		$this->assertEquals($index4->getName(), 'index4');
+		$this->assertEquals($index4->getColumns(), array('column4'));
+		$this->assertEquals($index4->getType(), 'UNIQUE');
+
 	}
 
 	public function testReferences()
@@ -311,6 +317,8 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($dialect->addIndex('table', 'schema', $indexes['index2']), 'ALTER TABLE `schema`.`table` ADD INDEX `index2` (`column1`, `column2`)');
 		$this->assertEquals($dialect->addIndex('table', null, $indexes['PRIMARY']), 'ALTER TABLE `table` ADD INDEX `PRIMARY` (`column3`)');
 		$this->assertEquals($dialect->addIndex('table', 'schema', $indexes['PRIMARY']), 'ALTER TABLE `schema`.`table` ADD INDEX `PRIMARY` (`column3`)');
+		$this->assertEquals($dialect->addIndex('table', null, $indexes['index4']), 'ALTER TABLE `table` ADD UNIQUE INDEX `index4` (`column4`)');
+		$this->assertEquals($dialect->addIndex('table', 'schema', $indexes['index4']), 'ALTER TABLE `schema`.`table` ADD UNIQUE INDEX `index4` (`column4`)');
 
 		//Drop Index
 		$this->assertEquals($dialect->dropIndex('table', null, 'index1'), 'ALTER TABLE `table` DROP INDEX `index1`');


### PR DESCRIPTION
Supported \Phalcon\Db\Index: TYPE for 2.0.

MySQL Only.
