### PR TITLE
[1.3.2] Fix wrong issent() call on non Response objects

### DIFF
--- a/build/32bits/phalcon.c
+++ b/build/32bits/phalcon.c
@@ -58745,9 +58745,13 @@ static PHP_METHOD(Phalcon_Mvc_Micro, handle){
 			 && (instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC))
 		;
 
-		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
+		if (!returned_response) {
+			RETURN_CCTOR(returned_value);
+		}
+
+		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "isSent");
 		
-		if (returned_response && PHALCON_IS_FALSE(returned_response_sent)) {
+		if (PHALCON_IS_FALSE(returned_response_sent)) {
 			PHALCON_CALL_METHOD(NULL, returned_value, "send");
 		}
 	}

--- a/build/64bits/phalcon.c
+++ b/build/64bits/phalcon.c
@@ -58745,9 +58745,13 @@ static PHP_METHOD(Phalcon_Mvc_Micro, handle){
 			 && (instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC))
 		;
 
-		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
+		if (!returned_response) {
+			RETURN_CCTOR(returned_value);
+		}
+
+		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "isSent");
 		
-		if (returned_response && PHALCON_IS_FALSE(returned_response_sent)) {
+		if (PHALCON_IS_FALSE(returned_response_sent)) {
 			PHALCON_CALL_METHOD(NULL, returned_value, "send");
 		}
 	}

--- a/build/safe/phalcon.c
+++ b/build/safe/phalcon.c
@@ -58745,9 +58745,13 @@ static PHP_METHOD(Phalcon_Mvc_Micro, handle){
 			 && (instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC))
 		;
 
-		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
+		if (!returned_response) {
+			RETURN_CCTOR(returned_value);
+		}
+
+		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "isSent");
 		
-		if (returned_response && PHALCON_IS_FALSE(returned_response_sent)) {
+		if (PHALCON_IS_FALSE(returned_response_sent)) {
 			PHALCON_CALL_METHOD(NULL, returned_value, "send");
 		}
 	}

--- a/ext/mvc/micro.c
+++ b/ext/mvc/micro.c
@@ -1067,9 +1067,13 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle){
 			 && (instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC))
 		;
 
-		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
+		if (!returned_response) {
+			RETURN_CCTOR(returned_value);
+		}
+
+		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "isSent");
 		
-		if (returned_response && PHALCON_IS_FALSE(returned_response_sent)) {
+		if (PHALCON_IS_FALSE(returned_response_sent)) {
 			/** 
 			 * Automatically send the responses
 			 */


### PR DESCRIPTION
Can happens that `isSent()` method is called on non `ResponseInterface` compatible objects.
Another way to avoid this is to add `isSent()` method to `ResponseInterface`.
