### PR TITLE
[2.0.0] getTokenKey : add default value as in 1.3 and documentation

### DIFF
--- a/phalcon/security.zep
+++ b/phalcon/security.zep
@@ -179,7 +179,7 @@ class Security implements \Phalcon\Di\InjectionAwareInterface
 	 * @param int numberBytes
 	 * @return string
 	 */
-	public function getTokenKey(int numberBytes) -> string
+	public function getTokenKey(int numberBytes=null) -> string
 	{
 		var safeBytes, dependencyInjector, session;
 


### PR DESCRIPTION
the current version of getTokenKey requires a length parameter but it was not the case in 1.3 and the rest of the function handles a null value as expected.
