### PR TITLE
Extra } in Formatter::interpolate with numeric index

### DIFF
--- a/ext/logger/formatter.c
+++ b/ext/logger/formatter.c
@@ -120,6 +120,7 @@ PHP_METHOD(Phalcon_Logger_Formatter, interpolate)
 			}
 			else if (HASH_KEY_IS_LONG == type) {
 				str_length = spprintf(&idx, 0, "{%ld}", num_index);
+				str_length++; /* count terminating \0 byte */
 			}
 			else { /* Better safe than sorry */
 				continue;


### PR DESCRIPTION
`\Phalcon\Logger\Formatter::interpolate` leaves a closing } behind when using numeric indices for `context`. That is, the following produces the message `Hello World}`:

```
<?php
$logger = new Phalcon\Logger\Adapter\Stream("php://stdout");
$logger->info("Hello {0}", ['World']);
```

This seems to happen because the return value of `spprintf` does not count the terminating NUL character.
