### PR TITLE
Update libmemcached.zep

### DIFF
--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -68,8 +68,12 @@ class Libmemcached extends \Phalcon\Session\Adapter implements \Phalcon\Session\
 			throw new \Phalcon\Session\Exception("No servers given in options");
 		}
 
+		let servers = options["servers"];
+
 		if !isset options["client"] {
 			let client = NULL;
+		} else {
+			let client = options["client"];
 		}
 
 		if fetch lifetime, options["lifetime"] {
@@ -80,6 +84,8 @@ class Libmemcached extends \Phalcon\Session\Adapter implements \Phalcon\Session\
 
 		if !fetch prefix, options["prefix"] {
 			let prefix = NULL;
+		} else {
+			let prefix = options["prefix"];
 		}
 
 		let this->_libmemcached = new \Phalcon\Cache\Backend\Libmemcached(


### PR DESCRIPTION
Zephir\CompilerException: Variable 'servers' cannot be read because it's not initialized in /home/ikhrustalev/Desktop/work/cphalcon/phalcon/session/adapter/libmemcached.zep on line 87

```
   ["servers": servers, "client": client, "prefix": prefix]
----------------------^
```
