### PR TITLE
Handle the case when _messages is empty in getMessages() and parameter b...

### DIFF
--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -399,10 +399,11 @@ class Form extends \Phalcon\Di\Injectable implements \Countable, \Iterator
 		}
 
 		let group = new \Phalcon\Validation\Message\Group();
-		for element, elementMessages in messages {
-			group->appendMessages(elementMessages);
+		if typeof messages == "array" {
+			for element, elementMessages in messages {
+				group->appendMessages(elementMessages);
+			}
 		}
-
 		return group;
 	}
 


### PR DESCRIPTION
...yItemName is false to return an empty messageGroup instead of throwing an exception saying "messages is not iterable".

In phalcon 1.3 the case was cleanly handled.
