### PR TITLE
return `Group` Object when `Validation#beforeValidation()` returns `false`

### DIFF
--- a/build/32bits/phalcon.c
+++ b/build/32bits/phalcon.c
@@ -22776,7 +22776,7 @@ static PHP_METHOD(Phalcon_Validation, validate){
 	if (phalcon_method_quick_exists_ex(this_ptr, SS("beforevalidation"), 4025473891UL TSRMLS_CC) == SUCCESS) {
 		PHALCON_CALL_METHOD(&status, this_ptr, "beforevalidation", data, entity, messages);
 		if (PHALCON_IS_FALSE(status)) {
-			RETURN_CCTOR(status);
+			RETURN_CCTOR(messages);
 		}
 	}
 	

--- a/build/64bits/phalcon.c
+++ b/build/64bits/phalcon.c
@@ -22776,7 +22776,7 @@ static PHP_METHOD(Phalcon_Validation, validate){
 	if (phalcon_method_quick_exists_ex(this_ptr, SS("beforevalidation"), 2568167555410680675UL TSRMLS_CC) == SUCCESS) {
 		PHALCON_CALL_METHOD(&status, this_ptr, "beforevalidation", data, entity, messages);
 		if (PHALCON_IS_FALSE(status)) {
-			RETURN_CCTOR(status);
+			RETURN_CCTOR(messages);
 		}
 	}
 	

--- a/ext/validation.c
+++ b/ext/validation.c
@@ -263,7 +263,7 @@ PHP_METHOD(Phalcon_Validation, validate){
 	if (phalcon_method_exists_ex(this_ptr, SS("beforevalidation") TSRMLS_CC) == SUCCESS) {
 		PHALCON_CALL_METHOD(&status, this_ptr, "beforevalidation", data, entity, messages);
 		if (PHALCON_IS_FALSE(status)) {
-			RETURN_CCTOR(status);
+			RETURN_CCTOR(messages);
 		}
 	}
 	


### PR DESCRIPTION
[Document](http://docs.phalconphp.com/en/latest/api/Phalcon_Validation.html#methods)  and [2.0's code](https://github.com/phalcon/cphalcon/blob/6915f4d55bebe02dcfd93cd10bc7d2ebdce86132/phalcon/validation.zep#L99) returns messages, that is `Phalcon\Validation\Message\Group`'s object.

![screenshot 2014-07-15 21 04 57](https://cloud.githubusercontent.com/assets/366888/3584403/6a9d701e-0c18-11e4-9276-12f4077d443f.png)

But 1.3.2 returns `false` (`beforeValidation()`'s return value) in following code.

http://docs.phalconphp.com/en/latest/reference/validation.html#validation-events

``` php
<?php

use Phalcon\Validation;
use Phalcon\Validation\Message;

class MyValidation extends Validation
{
    public function beforeValidation($data, $entity, $messages)
    {
        $messages->appendMessage(new Message('hoge', 'hoge', 'hoge'));
        return false;
    }
...
```

in controller

``` php
<?php

class IndexAction extends ControllerBase
{
    public function validateAction()
    {
        $validation = new MyValidation();
        $validation->add('hoge', new PresenceOf());
        $messages = $validation->validate($post);
        var_dump($messages);
        $this->view->disable();
        return false;
    }
...
```

```
$ curl http://localhost/index/validate -X POST -d "hoge="
bool(false)
```

it should be following result?

```
$ curl http://localhost/index/validate -X POST -d "hoge="
object(Phalcon\Validation\Message\Group)#51 (2) {
  ["_position":protected]=>
  NULL
  ["_messages":protected]=>
  array(1) {
    [0]=>
    object(Phalcon\Validation\Message)#52 (4) {
      ["_type":protected]=>
      string(4) "hoge"
      ["_message":protected]=>
      string(4) "hoge"
      ["_field":protected]=>
      string(4) "hoge"
      ["_code":protected]=>
      int(0)
    }
  }
}
```
