### PR TITLE
[2.0.0] Bad field is settled in related[] array.

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4134,7 +4134,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 			for key, item in value {
 				if typeof item == "object" {
 					if item instanceof \Phalcon\Mvc\ModelInterface {
-						let related[] = value;
+						let related[] = item;
 					}
 				} else {
 					let lowerKey = strtolower(key),


### PR DESCRIPTION
when you set a relationship items (hasMany), you add all available items
in related field.

An error has been done, each time you add value (and not item) in
related array.
