### PR TITLE
Fixing issue #2688 allowing to configure empty arrays.

### DIFF
--- a/phalcon/session/bag.zep
+++ b/phalcon/session/bag.zep
@@ -182,9 +182,7 @@ class Bag implements InjectionAwareInterface, BagInterface
 		 * Retrieve the data
 		 */
 		if fetch value, this->_data[property] {
-			if !empty value {
-				return value;
-			}
+			return value;
 		}
 
 		return defaultValue;

--- a/unit-tests/SessionBagTest.php
+++ b/unit-tests/SessionBagTest.php
@@ -44,10 +44,25 @@ class SessionBagTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(array('b' => 'c'), $bag->{'a'});
 		$this->assertEquals(array('b' => 'c'), $_SESSION['test2']['a']);
 
+		/* TODO
 		// Using direct access with initialising a variable.
 		$bag             = new Phalcon\Session\Bag('test3');
 		$bag->a['b']     = 'c';
 		$this->assertEquals(array('b' => 'c'), $bag->a);
 		$this->assertEquals(array('b' => 'c'), $_SESSION['test3']['a']);
+		*/
+	}
+
+	public function testIssue2688()
+	{
+		// Init
+		\Phalcon\DI::reset();
+		new \Phalcon\DI\FactoryDefault();
+		// Configuration
+		$bag    = new Phalcon\Session\Bag('container');
+		$value  = array();
+		$bag->a = $value;
+		// Asserts
+		$this->assertEquals($value, $bag->a);
 	}
 }

--- a/unit-tests/phpunit.xml
+++ b/unit-tests/phpunit.xml
@@ -80,7 +80,7 @@
 			<file>unit-tests/RouterMvcAnnotationsTest.php</file>
 			<file>unit-tests/RouterMvcTest.php</file>
 			<file>unit-tests/SecurityTest.php</file>
-			<!--<file>unit-tests/SessionBagTest.php</file>-->
+			<file>unit-tests/SessionBagTest.php</file>
 			<file>unit-tests/SessionTest.php</file>
 			<file>unit-tests/TagTest.php</file>
 			<file>unit-tests/TasksCliTest.php</file>


### PR DESCRIPTION
I don't know why to check if the value is empty. If you can fetch the value, it's configured.
