### PR TITLE
[2.0.0] - Implement functions for phpunit tests

### DIFF
--- a/phalcon/http/request/file.zep
+++ b/phalcon/http/request/file.zep
@@ -65,18 +65,14 @@ class File implements \Phalcon\Http\Request\FileInterface
 	 *
 	 * @param array file
 	 */
-	public function __construct(var file, key=null)
+	public function __construct(array! file, key = null)
 	{
 		var name, tempName, size, type, error;
-
-		if typeof file != "array" {
-			throw new \Phalcon\Http\Request\Exception("Phalcon\\Http\\Request\\File requires a valid uploaded file");
-		}
 
 		if fetch name, file["name"] {
 			let this->_name = name;
 
-			if constant(PATHINFO_EXTENSION) {
+			if defined(PATHINFO_EXTENSION) {
 				let this->_extension = pathinfo(name, PATHINFO_EXTENSION);
 			}
 		}

--- a/phalcon/http/request/fileinterface.zep
+++ b/phalcon/http/request/fileinterface.zep
@@ -33,7 +33,7 @@ interface FileInterface
 	 *
 	 * @param array file
 	 */
-	public function __construct(file);
+	public function __construct(array! file, key = null);
 
 	/**
 	 * Returns the file size of the uploaded file

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -111,6 +111,13 @@ class QueryBuilder implements \Phalcon\Paginator\AdapterInterface
 		return this->_page;
 	}
 	
+	/**
+	 * Set current rows limit
+	 *
+	 * @param int $limit
+	 *
+	 * @return Phalcon\Paginator\Adapter\QueryBuilder $this Fluent interface
+	 */
 	public function setLimit(int limitRows) -> <QueryBuilder>
 	{
 		let this->_limitRows = limitRows;
@@ -118,11 +125,23 @@ class QueryBuilder implements \Phalcon\Paginator\AdapterInterface
 		return this;
 	}
 	
+	/**
+	 * Get current rows limit
+	 *
+	 * @return int $limit
+	 */
 	public function getLimit() -> int
 	{
 		return this->_limitRows;
 	}
 	
+	/**
+	 * Set query builder object
+	 *
+	 * @param Phalcon\Mvc\Model\Query\BuilderInterface $builder
+	 *
+	 * @return Phalcon\Paginator\Adapter\QueryBuilder $this Fluent interface
+	 */
 	public function setQueryBuilder(<Builder> builder) -> <QueryBuilder>
 	{
 		let this->_builder = builder;
@@ -130,6 +149,11 @@ class QueryBuilder implements \Phalcon\Paginator\AdapterInterface
 		return this;
 	}
 	
+	/**
+	 * Get query builder object
+	 *
+	 * @return Phalcon\Mvc\Model\Query\BuilderInterface $builder
+	 */
 	public function getQueryBuilder() -> <Builder>
 	{
 		return this->_builder;

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -19,6 +19,7 @@
 
 namespace Phalcon\Paginator\Adapter;
 
+use Phalcon\Mvc\Model\Query\Builder;
 use Phalcon\Paginator\Exception;
 
 /**
@@ -100,6 +101,40 @@ class QueryBuilder implements \Phalcon\Paginator\AdapterInterface
 		return this;
 	}
 
+	/**
+	 * Get the current page number
+	 *
+	 * @return int page
+	 */
+	public function getCurrentPage () -> int
+	{
+		return this->_page;
+	}
+	
+	public function setLimit(int limitRows) -> <QueryBuilder>
+	{
+		let this->_limitRows = limitRows;
+		
+		return this;
+	}
+	
+	public function getLimit() -> int
+	{
+		return this->_limitRows;
+	}
+	
+	public function setQueryBuilder(<Builder> builder) -> <QueryBuilder>
+	{
+		let this->_builder = builder;
+		
+		return this;
+	}
+	
+	public function getQueryBuilder() -> <Builder>
+	{
+		return this->_builder;
+	}
+	
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 *

--- a/unit-tests/phpunit.xml
+++ b/unit-tests/phpunit.xml
@@ -73,8 +73,8 @@
 			<!--<file>unit-tests/ModelsSnapshotsTest.php</file>-->
 			<file>unit-tests/ModelsTransactionsTest.php</file>
 			<file>unit-tests/ModelsValidatorsTest.php</file>
-			<!--<file>unit-tests/PaginatorTest.php</file>-->
-			<!--<file>unit-tests/RequestTest.php</file>-->
+			<file>unit-tests/PaginatorTest.php</file>
+			<file>unit-tests/RequestTest.php</file>
 			<file>unit-tests/ResponseTest.php</file>
 			<file>unit-tests/RouterCliTest.php</file>
 			<file>unit-tests/RouterMvcAnnotationsTest.php</file>


### PR DESCRIPTION
2 first commits:
I have implemented all functions of \Phalcon\Paginator\Adapter\queryBuilder (and added comments - same as branch 1.x).

Now you can activate paginator test in phpunit.xml.

third commit:
Please do a big check for the third commit, I have rewrite the function \Phalcon\Http\request->getUploadedFiles(boolean)

Now all phpunit tests work (requestTest.php)

Fourth commit: Fix memcache set function call parameters
    before: memcache->set(lastKey, cachedContent, tt1);
    after: memcache->set(lastKey, cachedContent, 0, tt1);
php manual: http://php.net/manual/en/memcache.set.php 
