### PR TITLE
[fixes #2658] Oracle Model::find() not working

### DIFF
--- a/build/32bits/phalcon.c
+++ b/build/32bits/phalcon.c
@@ -43577,6 +43577,8 @@ static PHP_METHOD(Phalcon_Db_Dialect_Oracle, select){
 		ZVAL_STRING(sql, "SELECT ", 1);
 	}
 
+	PHALCON_SCONCAT_VSV(sql, columns_sql, " FROM ", tables_sql);
+
 	if (phalcon_array_isset_quick_string(definition, SS("joins"), 120974824UL)) {
 
 		PHALCON_OBS_VAR(joins);

--- a/build/64bits/phalcon.c
+++ b/build/64bits/phalcon.c
@@ -43577,6 +43577,8 @@ static PHP_METHOD(Phalcon_Db_Dialect_Oracle, select){
 		ZVAL_STRING(sql, "SELECT ", 1);
 	}
 
+	PHALCON_SCONCAT_VSV(sql, columns_sql, " FROM ", tables_sql);
+
 	if (phalcon_array_isset_quick_string(definition, SS("joins"), 6953673027048UL)) {
 
 		PHALCON_OBS_VAR(joins);

--- a/build/safe/phalcon.c
+++ b/build/safe/phalcon.c
@@ -43577,6 +43577,8 @@ static PHP_METHOD(Phalcon_Db_Dialect_Oracle, select){
 		ZVAL_STRING(sql, "SELECT ", 1);
 	}
 
+    PHALCON_SCONCAT_VSV(sql, columns_sql, " FROM ", tables_sql);
+
 	if (phalcon_array_isset_string(definition, SS("joins"))) {
 
 		PHALCON_OBS_VAR(joins);

--- a/ext/db/dialect/oracle.c
+++ b/ext/db/dialect/oracle.c
@@ -988,6 +988,8 @@ PHP_METHOD(Phalcon_Db_Dialect_Oracle, select){
 		ZVAL_STRING(sql, "SELECT ", 1);
 	}
 
+	PHALCON_SCONCAT_VSV(sql, columns_sql, " FROM ", tables_sql);
+
 	/**
 	 * Check for joins
 	 */


### PR DESCRIPTION
Phalcon generated invalid SQL query for Oracle (missing column names) when using Model::find() method.
