### PR TITLE
[1.3.3][BUG] Fix MSVC11 build error

### DIFF
--- a/ext/translate/adapter/gettext.c
+++ b/ext/translate/adapter/gettext.c
@@ -45,13 +45,14 @@ static zend_object_handlers phalcon_translate_adapter_gettext_object_handlers;
 static zval* phalcon_translate_adapter_gettext_read_dimension(zval *object, zval *offset, int type TSRMLS_DC)
 {
 	zval *translation = NULL, *params[1];
+	uint32_t result;
 
 	if (!is_phalcon_class(Z_OBJCE_P(object))) {
 		return zend_get_std_object_handlers()->read_dimension(object, offset, type TSRMLS_CC);
 	}
 
 	params[0] = offset;
-	uint32_t result = phalcon_call_func_aparams(&translation, SL("gettext"), 1, params TSRMLS_CC);
+	result = phalcon_call_func_aparams(&translation, SL("gettext"), 1, params TSRMLS_CC);
 
 	if (result) {
 		MAKE_STD_ZVAL(translation);
@@ -64,13 +65,14 @@ static zval* phalcon_translate_adapter_gettext_read_dimension(zval *object, zval
 static int phalcon_translate_adapter_gettext_has_dimension(zval *object, zval *offset, int check_empty TSRMLS_DC)
 {
 	zval *translation = NULL, *params[1];
+	uint32_t result;
 
 	if (!is_phalcon_class(Z_OBJCE_P(object))) {
 		return zend_get_std_object_handlers()->has_dimension(object, offset, check_empty TSRMLS_CC);
 	}
 
 	params[0] = offset;
-	uint32_t result = phalcon_call_func_aparams(&translation, SL("gettext"), 1, params TSRMLS_CC);
+	result = phalcon_call_func_aparams(&translation, SL("gettext"), 1, params TSRMLS_CC);
 
 	if (result) {
 		return 0;


### PR DESCRIPTION
This PR fixes the following MSVC compilation issue:

```
ext\phalcon\phalcon.c(108557) : error C2275: 'uint32_t' : illegal use of this type as an expression
        .\win32/php_stdint.h(85) : see declaration of 'uint32_t'
ext\phalcon\phalcon.c(108576) : error C2275: 'uint32_t' : illegal use of this type as an expression
        .\win32/php_stdint.h(85) : see declaration of 'uint32_t'
```
