### PR TITLE
Dont call cleanBuildDirectories if phalcon not loaded

### DIFF
--- a/build/_resource/Phalcon/Build/Generator/Optimized.php
+++ b/build/_resource/Phalcon/Build/Generator/Optimized.php
@@ -193,14 +193,13 @@ class Generator_Optimized
     {
         echo 'Generating builds, optimized for 32-bit and 64-bit platforms... ';
 
-        $this->cleanBuildDirectories();
-
         if (!extension_loaded('phalcon')) {
             echo "SKIPPED - Phalcon extension is required to be already loaded in PHP\n";
             // You need to compile safe Phalcon extension, enable it in PHP, and then you can compile optimized version
             return;
         }
 
+        $this->cleanBuildDirectories();
         $this->copyFilesFromSourceBuildDir();
         $this->copyAndOptimizePhalconC();
 


### PR DESCRIPTION
I don't know if my change is correct or not, but currently, you clean the "build" files, then test if phalcon is not loaded you exit without create the build files.
