### PR TITLE
Phalcon\Db\Column type can be specified in a string

### DIFF
--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -148,9 +148,23 @@ class Column implements \Phalcon\Db\ColumnInterface
 	/**
 	 * Column data type
 	 *
-	 * @var int
+	 * @var int|string
 	 */
 	protected _type { get };
+
+	/**
+	 * Column data type reference
+	 *
+	 * @var int
+	 */
+	protected _typeReference { get };
+
+	/**
+	 * Column data type values
+	 *
+	 * @var array|string
+	 */
+	protected _typeValues { get };
 
 	/**
 	 * The column have some numeric type?
@@ -230,7 +244,8 @@ class Column implements \Phalcon\Db\ColumnInterface
 	public function __construct(string! name, var definition)
 	{
 		var type, notNull, primary, size, scale, dunsigned, first,
-			after, bindType, isNumeric, autoIncrement, defaultValue;
+			after, bindType, isNumeric, autoIncrement, defaultValue,
+			typeReference, typeValues;
 
 		let this->_name = name;
 
@@ -241,6 +256,16 @@ class Column implements \Phalcon\Db\ColumnInterface
 			let this->_type = type;
 		} else {
 			throw new Exception("Column type is required");
+		}
+
+		if fetch typeReference, definition["typeReference"] {
+			let this->_typeReference = typeReference;
+		} else {
+			let this->_typeReference = -1;
+		}
+
+		if fetch typeValues, definition["typeValues"] {
+			let this->_typeValues = typeValues;
 		}
 
 		/**
@@ -421,7 +446,8 @@ class Column implements \Phalcon\Db\ColumnInterface
 	{
 		var definition, columnType, notNull, size, dunsigned, after,
 			isNumeric, first, bindType, primary, columnName, scale,
-			defaultValue, autoIncrement;
+			defaultValue, autoIncrement,
+			columnTypeReference, columnTypeValues;
 
 		if !fetch columnName, data["_columnName"] {
 			if !fetch columnName, data["_name"] {
@@ -433,6 +459,16 @@ class Column implements \Phalcon\Db\ColumnInterface
 
 		if fetch columnType,  data["_type"] {
 			let definition["type"] = columnType;
+		}
+
+		if fetch columnTypeReference,  data["_typeReference"] {
+			let definition["typeReference"] = columnTypeReference;
+		} else {
+			let definition["typeReference"] = -1;
+		}
+
+		if fetch columnTypeValues,  data["_typeValues"] {
+			let definition["typeValeus"] = columnTypeValues;
 		}
 
 		if fetch notNull, data["_notNull"] {

--- a/phalcon/db/columninterface.zep
+++ b/phalcon/db/columninterface.zep
@@ -57,6 +57,20 @@ interface ColumnInterface
 	public function getType();
 
 	/**
+	 * Returns column type reference
+	 *
+	 * @return int
+	 */
+	public function getTypeReference();
+
+	/**
+	 * Returns column type values
+	 *
+	 * @return int
+	 */
+	public function getTypeValues();
+
+	/**
 	 * Returns column size
 	 *
 	 * @return int

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -176,7 +176,7 @@ class MySQL extends \Phalcon\Db\Dialect //implements Phalcon\Db\DialectInterface
 
 		let defaultValue = column->getDefault();
 		if ! empty defaultValue {
-			let sql .= " DEFAULT \"" . defaultValue . "\"";
+			let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
 		}
 
 		if column->isNotNull() {
@@ -220,7 +220,7 @@ class MySQL extends \Phalcon\Db\Dialect //implements Phalcon\Db\DialectInterface
 
 		let defaultValue = column->getDefault();
 		if ! empty defaultValue {
-			let sql .= " DEFAULT \"" . defaultValue . "\"";
+			let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
 		}
 
 		if column->isNotNull() {
@@ -515,7 +515,7 @@ class MySQL extends \Phalcon\Db\Dialect //implements Phalcon\Db\DialectInterface
 			 */
 			let defaultValue = column->getDefault();
 			if ! empty defaultValue {
-				let columnLine .= " DEFAULT \"" . defaultValue . "\"";
+				let columnLine .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
 			}
 
 			/**

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -42,7 +42,7 @@ class Postgresql extends Dialect implements DialectInterface
 	 */
 	public function getColumnDefinition(column) -> string
 	{
- 		var size, columnType, columnSql;
+		var size, columnType, columnSql, typeValues;
 
 		if typeof column != "object" {
 			throw new Exception("Column definition must be an object compatible with Phalcon\\Db\\ColumnInterface");
@@ -50,37 +50,79 @@ class Postgresql extends Dialect implements DialectInterface
 
 		let size = column->getSize();
 		let columnType = column->getType();
+		let columnSql = "";
+		if typeof columnType == "string" {
+			let columnSql .= columnType;
+			let columnType = column->getTypeReference();
+		}
 
 		switch columnType {
 			case 0:
-				let columnSql = "INT";
+				if empty columnSql {
+					let columnSql .= "INT";
+				}
 				break;
 			case 1:
-				let columnSql = "DATE";
+				if empty columnSql {
+					let columnSql .= "DATE";
+				}
 				break;
 			case 2:
-				let columnSql = "CHARACTER VARYING(" . size . ")";
+				if empty columnSql {
+					let columnSql .= "CHARACTER VARYING";
+				}
+				let columnSql .= "(" . size . ")";
 				break;
 			case 3:
-				let columnSql = "NUMERIC(" . size . "," . column->getScale() . ")";
+				if empty columnSql {
+					let columnSql .= "NUMERIC";
+				}
+				let columnSql .= "(" . size . "," . column->getScale() . ")";
 				break;
 			case 4:
-				let columnSql = "TIMESTAMP";
+				if empty columnSql {
+					let columnSql .= "TIMESTAMP";
+				}
 				break;
 			case 5:
-				let columnSql = "CHARACTER(" . size . ")";
+				if empty columnSql {
+					let columnSql .= "CHARACTER";
+				}
+				let columnSql .= "(" . size . ")";
 				break;
 			case 6:
-				let columnSql = "TEXT";
+				if empty columnSql {
+					let columnSql .= "TEXT";
+				}
 				break;
 			case 7:
-				let columnSql = "FLOAT";
+				if empty columnSql {
+					let columnSql .= "FLOAT";
+				}
 				break;
 			case 8:
-				let columnSql = "SMALLINT(1)";
+				if empty columnSql {
+					let columnSql .= "SMALLINT(1)";
+				}
 				break;
 			default:
-				throw new Exception("Unrecognized PostgreSQL data type");
+				if empty columnSql {
+					throw new Exception("Unrecognized PostgreSQL data type");
+				}
+
+				let typeValues = column->getTypeValues();
+				if !empty typeValues {
+					if typeof typeValues == "array" {
+						var value, valueSql;
+						let valueSql = "";
+						for value in typeValues {
+							let valueSql .= "\"" . addcslashes(value, "\"") . "\", ";
+						}
+						let columnSql .= "(" . substr(valueSql, 0, -2) . ")";
+					} else {
+						let columnSql .= "(\"" . addcslashes(typeValues, "\"") . "\")";
+					}
+				}
 		}
 
 		return columnSql;

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -45,48 +45,91 @@ class Sqlite extends Dialect implements DialectInterface
 	 */
 	public function getColumnDefinition(<\Phalcon\Db\ColumnInterface> column) -> string
 	{
-		var columnSql;
+		var columnSql, type, typeValues;
 
 		if typeof column != "object" {
 			throw new Exception("Column definition must be an object compatible with Phalcon\\Db\\ColumnInterface");
 		}
 
-		switch column->getType() {
+		let columnSql = "";
+
+		let type = column->getType();
+		if typeof type == "string" {
+			let columnSql .= type;
+			let type = column->getTypeReference();
+		}
+
+		switch type {
 
 			case Column::TYPE_INTEGER:
-				let columnSql = "INT";
+				if empty columnSql {
+					let columnSql .= "INT";
+				}
 				break;
 
 			case Column::TYPE_DATE:
-				let columnSql = "DATE";
+				if empty columnSql {
+					let columnSql .= "DATE";
+				}
 				break;
 
 			case Column::TYPE_VARCHAR:
-				let columnSql = "VARCHAR(" . column->getSize() . ")";
+				if empty columnSql {
+					let columnSql .= "VARCHAR";
+				}
+				let columnSql .= "(" . column->getSize() . ")";
 				break;
 
 			case Column::TYPE_DECIMAL:
-				let columnSql = "NUMERIC(" . column->getSize() . "," . column->getScale() . ")";
+				if empty columnSql {
+					let columnSql .= "NUMERIC";
+				}
+				let columnSql .= "(" . column->getSize() . "," . column->getScale() . ")";
 				break;
 
 			case Column::TYPE_DATETIME:
-				let columnSql = "TIMESTAMP";
+				if empty columnSql {
+					let columnSql .= "TIMESTAMP";
+				}
 				break;
 
 			case Column::TYPE_CHAR:
-				let columnSql = "CHARACTER(" . column->getSize() . ")";
+				if empty columnSql {
+					let columnSql .= "CHARACTER";
+				}
+				let columnSql .= "(" . column->getSize() . ")";
 				break;
 
 			case Column::TYPE_TEXT:
-				let columnSql = "TEXT";
+				if empty columnSql {
+					let columnSql .= "TEXT";
+				}
 				break;
 
 			case Column::TYPE_FLOAT:
-				let columnSql = "FLOAT";
+				if empty columnSql {
+					let columnSql .= "FLOAT";
+				}
 				break;
 
 			default:
-				throw new Exception("Unrecognized SQLite data type");
+				if empty columnSql {
+					throw new Exception("Unrecognized SQLite data type");
+				}
+
+				let typeValues = column->getTypeValues();
+				if !empty typeValues {
+					if typeof typeValues == "array" {
+						var value, valueSql;
+						let valueSql = "";
+						for value in typeValues {
+							let valueSql .= "\"" . addcslashes(value, "\"") . "\", ";
+						}
+						let columnSql .= "(" . substr(valueSql, 0, -2) . ")";
+					} else {
+						let columnSql .= "(\"" . addcslashes(typeValues, "\"") . "\")";
+					}
+				}
 		}
 
 		return columnSql;

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -160,7 +160,7 @@ class Sqlite extends Dialect implements DialectInterface
 
 		let defaultValue = column->getDefault();
 		if ! empty defaultValue {
-			let sql .= " DEFAULT \"" . defaultValue . "\"";
+			let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
 		}
 
 		if column->isNotNull() {


### PR DESCRIPTION
type processing is the same as TYPE_INTEGER (typeReference()).
type name is a `BIGINT` instead of `INT`.

``` php
new \Phalcon\Db\Column(
    'name', array(
        'type' => 'BIGINT',
        'typeReference' => \Phalcon\Db\Column::TYPE_INTEGER,
        'size' => 20,
        'unsigned' => true,
        'notNull' => false
    )
```

type name is `ENUM`.
specify the set value in typeValues().

``` php
new \Phalcon\Db\Column(
    'name', array(
        'type' => 'ENUM',
        'typeValues' => array('A', 'B', 'C'),
        'notNull' => true,
        'default' => 'A'
    )
```
