### PR TITLE
add --without-non-free build option to disable non-free minifiers

### DIFF
--- a/ext/assets/filters/cssmin.c
+++ b/ext/assets/filters/cssmin.c
@@ -18,7 +18,11 @@
 */
 
 #include "assets/filters/cssmin.h"
+#ifdef PHALCON_NON_FREE
 #include "assets/filters/cssminifier.h"
+#else
+#include "assets/filters/nocssminifier.h"
+#endif
 #include "assets/filterinterface.h"
 
 #include "kernel/main.h"

--- a/ext/assets/filters/jsmin.c
+++ b/ext/assets/filters/jsmin.c
@@ -18,7 +18,11 @@
 */
 
 #include "assets/filters/jsmin.h"
+#ifdef PHALCON_NON_FREE
 #include "assets/filters/jsminifier.h"
+#else
+#include "assets/filters/nojsminifier.h"
+#endif
 #include "assets/filterinterface.h"
 
 #include "kernel/main.h"

--- a/ext/assets/filters/nocssminifier.c
+++ b/ext/assets/filters/nocssminifier.c
@@ -1,0 +1,31 @@
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Remi Collet <remi@famillecollet.com>                          |
+  +------------------------------------------------------------------------+
+*/
+
+/* placeholder for non-free csssminifier.c */
+
+
+#include "php_phalcon.h"
+
+#include "assets/filters/nocssminifier.h"
+#include "assets/exception.h"
+#include "kernel/exception.h"
+
+int phalcon_cssmin(zval *return_value, zval *style TSRMLS_DC) {
+
+	PHALCON_THROW_EXCEPTION_STRW(phalcon_assets_exception_ce, "Non-free csssminifier not available");
+	return FAILURE;
+}

--- a/ext/assets/filters/nocssminifier.h
+++ b/ext/assets/filters/nocssminifier.h
@@ -1,0 +1,27 @@
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Remi Collet <remi@famillecollet.com>                          |
+  +------------------------------------------------------------------------+
+*/
+
+/* placeholder for non-free csssminifier.h */
+
+#ifndef PHALCON_ASSETS_FILTERS_CSSMINIFIER_H
+#define PHALCON_ASSETS_FILTERS_CSSMINIFIER_H
+
+#include <Zend/zend.h>
+
+int phalcon_cssmin(zval *return_value, zval *style TSRMLS_DC);
+
+#endif /* PHALCON_ASSETS_FILTERS_CSSMINIFIER_H */

--- a/ext/assets/filters/nojsminifier.c
+++ b/ext/assets/filters/nojsminifier.c
@@ -1,0 +1,31 @@
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Remi Collet <remi@famillecollet.com>                          |
+  +------------------------------------------------------------------------+
+*/
+
+/* placeholder for non-free jsminifier.c */
+
+
+#include "php_phalcon.h"
+
+#include "assets/filters/nojsminifier.h"
+#include "assets/exception.h"
+#include "kernel/exception.h"
+
+int phalcon_jsmin(zval *return_value, zval *script TSRMLS_DC) {
+
+	PHALCON_THROW_EXCEPTION_STRW(phalcon_assets_exception_ce, "Non-free jsminifier not available");
+	return FAILURE;
+}

--- a/ext/assets/filters/nojsminifier.h
+++ b/ext/assets/filters/nojsminifier.h
@@ -1,0 +1,27 @@
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Remi Collet <remi@famillecollet.com>                          |
+  +------------------------------------------------------------------------+
+*/
+
+/* placeholder for non-free jsminifier.h */
+
+#ifndef PHALCON_ASSETS_FILTERS_JSMINIFIER_H
+#define PHALCON_ASSETS_FILTERS_JSMINIFIER_H
+
+#include <Zend/zend.h>
+
+int phalcon_jsmin(zval *return_value, zval *script TSRMLS_DC);
+
+#endif /* PHALCON_ASSETS_FILTERS_JSMINIFIER_H */

--- a/ext/config.m4
+++ b/ext/config.m4
@@ -1,4 +1,5 @@
 PHP_ARG_ENABLE(phalcon, whether to enable phalcon framework, [ --enable-phalcon   Enable phalcon framework])
+PHP_ARG_WITH(non-free, wheter to enable non-free css and js minifier, [ --without-non-free Disable non-free minifiers], yes, no)
 
 if test "$PHP_PHALCON" = "yes"; then
 	AC_DEFINE(HAVE_PHALCON, 1, [Whether you have Phalcon Framework])
@@ -340,8 +341,6 @@ validation/validator/inclusionin.c \
 validation/validator/stringlength.c \
 validation/validator/url.c \
 validation/validator.c \
-assets/filters/jsminifier.c \
-assets/filters/cssminifier.c \
 mvc/model/query/parser.c \
 mvc/model/query/scanner.c \
 mvc/view/engine/volt/parser.c \
@@ -363,6 +362,16 @@ psr/log/loggertrait.c \
 psr/log/loglevel.c \
 psr/log/nulllogger.c \
 registry.c"
+
+	AC_MSG_CHECKING([Include non-free minifiers])
+	if test "$PHP_NON_FREE" = "yes"; then
+		phalcon_sources="$phalcon_sources assets/filters/jsminifier.c assets/filters/cssminifier.c "
+		AC_DEFINE([PHALCON_NON_FREE], [1], [Whether non-free minifiers are available])
+		AC_MSG_RESULT([yes, css and js])
+	else
+		phalcon_sources="$phalcon_sources assets/filters/nojsminifier.c assets/filters/nocssminifier.c "
+		AC_MSG_RESULT([no])
+	fi
 
 	PHP_NEW_EXTENSION(phalcon, $phalcon_sources, $ext_shared)
 	PHP_ADD_EXTENSION_DEP([phalcon], [spl])


### PR DESCRIPTION
Douglas Crockford code is non-free (per FSF definition) as liberty #0 is not granted (restriction).

This is a blocker to include this framework in any downstream distributions which strictly respect the free License (Fedora, Debian, ...). See: https://fedoraproject.org/wiki/Licensing:Main?rd=Licensing#SoftwareLicenses  (search for JSON.org)

So this patch, which is noop with standard build, allow to build using --without-non-free option and disable those filters.
