### PR TITLE
[2.0.0] ORM enhancement

### DIFF
--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -446,7 +446,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 				/**
 				 * Assign the values to the base object
 				 */
-				return self::cloneResult(base, document);
+				return static::cloneResult(base, document);
 			}
 			return false;
 		}
@@ -460,7 +460,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 			/**
 			 * Assign the values to the base object
 			 */
-			let collections[] = self::cloneResult(base, document);
+			let collections[] = static::cloneResult(base, document);
 		}
 
 		return collections;
@@ -1026,7 +1026,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 			let mongoId = id;
 		}
 
-		return self::findFirst([["_id": mongoId]]);
+		return static::findFirst([["_id": mongoId]]);
 	}
 
 	/**
@@ -1072,7 +1072,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 
 		let connection = collection->getConnection();
 
-		return self::_getResultset(parameters, collection, connection, true);
+		return static::_getResultset(parameters, collection, connection, true);
 	}
 
 	/**
@@ -1125,7 +1125,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 
 		let className = get_called_class();
 		let collection = new {className}();
-		return self::_getResultset(parameters, collection, collection->getConnection(), false);
+		return static::_getResultset(parameters, collection, collection->getConnection(), false);
 	}
 
 	/**
@@ -1154,7 +1154,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 
 		let connection = collection->getConnection();
 
-		return self::_getGroupResultset(parameters, collection, connection);
+		return static::_getGroupResultset(parameters, collection, connection);
 	}
 
 	/**

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -751,7 +751,9 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	 */
 	public static function find(var parameters = null) -> <ResultsetInterface>
 	{
-		var params, builder, query, bindParams, bindTypes, cache, resultset, hydration;
+		var params, builder, query, bindParams, bindTypes, cache, resultset, hydration, dependencyInjector, manager;
+		let dependencyInjector = \Phalcon\Di::getDefault();
+		let manager = <ManagerInterface> dependencyInjector->getShared("modelsManager");
 
 		if typeof parameters != "array" {
 			let params = [];
@@ -765,7 +767,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 		/**
 		 * Builds a query with the passed parameters
 		 */
-		let builder = new Builder(params);
+		let builder = manager->createBuilder(params);
 		builder->from(get_called_class());
 
 		let query = builder->getQuery(),
@@ -827,7 +829,9 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	 */
 	public static function findFirst(parameters = null) -> <Model>
 	{
-		var params, builder, query, bindParams, bindTypes, cache;
+		var params, builder, query, bindParams, bindTypes, cache, dependencyInjector, manager;
+		let dependencyInjector = \Phalcon\Di::getDefault();
+		let manager = <ManagerInterface> dependencyInjector->getShared("modelsManager");
 
 		if typeof parameters != "array" {
 			let params = [];
@@ -841,7 +845,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 		/**
 		 * Builds a query with the passed parameters
 		 */
-		let builder = new Builder(params);
+		let builder = manager->createBuilder(params);
 		builder->from(get_called_class());
 
 		/**
@@ -1061,7 +1065,9 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	{
 		var params, distinctColumn, groupColumn, columns,
 			bindParams, bindTypes, resultset, cache, firstRow, groupColumns,
-			builder, query;
+			builder, query, dependencyInjector, manager;
+		let dependencyInjector = \Phalcon\Di::getDefault();
+		let manager = <ManagerInterface> dependencyInjector->getShared("modelsManager");
 
 		if typeof parameters != "array" {
 			let params = [];
@@ -1092,7 +1098,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 		/**
 		 * Builds a query with the passed parameters
 		 */
-		let builder = new Builder(params);
+		let builder = manager->createBuilder(params);
 		builder->columns(columns);
 		builder->from(get_called_class());
 

--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -96,7 +96,7 @@ class Simple extends Resultset
 	 */
 	public function valid() -> boolean
 	{
-		var result, row, rows, hydrateMode, columnMap, activeRow;
+		var result, row, rows, hydrateMode, columnMap, activeRow, modelName;
 
 		if this->_type {
 
@@ -149,7 +149,11 @@ class Simple extends Resultset
 			 * Set records as dirty state PERSISTENT by default
 			 * Performs the standard hydration based on objects
 			 */
-			let activeRow = Model::cloneResultMap(
+			let modelName = "Phalcon\\Mvc\\Model";
+			if this->_model instanceof \Phalcon\Mvc\Model {
+				let modelName = get_class(this->_model);
+			}
+			let activeRow = {modelName}::cloneResultMap(
 				this->_model,
 				row,
 				columnMap,
@@ -212,8 +216,8 @@ class Simple extends Resultset
 					let activeRow = this->_activeRow;
 
 					/**
-				 	 * Check if we need to re-execute the query
-				 	 */
+					 * Check if we need to re-execute the query
+					 */
 					if activeRow !== null {
 						result->execute();
 					}


### PR DESCRIPTION
ORM enhancements : 
- Replace new builder by models manager createBuilder call on model queries
- Late state binding on hydration (cloneResultMap call) to be able to override class creation (refs #2786) - also done here for 1.3.3 : link to #2789 

With this we can override the instantiation of an object to mimic Doctrine inheritance (http://the-phpjs-ldc.rgou.net/symfony1/more-with-symfony/en/09-Doctrine-Form-Inheritance.markdown)

``` php
/**
     * Assigns values to a model inherited class from an array returning a new model.
     *
     * @param \Phalcon\Mvc\Model $base          object to hydrate
     * @param array              $data          data to use for hydration
     * @param array              $columnMap     column mapping
     * @param int                $dirtyState    object state
     * @param boolean            $keepSnapshots keep snapshot
     *
     * @return \Phalcon\Mvc\Model
     */
    public static function cloneResultMap(
        $base,
        $data,
        $columnMap,
        $dirtyState = null,
        $keepSnapshots = null
    ) {
        if (isset($data['columnUsedForTableInheritance'])) {
            $class = '\Ournamespace\Models\\' . $data['columnUsedForTableInheritance'];
            if (class_exists($class)) {
                $base = new $class();
            }
        }
        return parent::cloneResultMap(
            $base,
            $data,
            $columnMap,
            $dirtyState,
            $keepSnapshots
        );
    }
```
