### PR TITLE
switch headers + avoid duplicate definition

### DIFF
--- a/build/_resource/config/phalcon_c_priority_files.php
+++ b/build/_resource/config/phalcon_c_priority_files.php
@@ -3,8 +3,8 @@
 
 return array(
     // Header files
-    'assets/filters/jsminifier.h',
-    'assets/filters/cssminifier.h',
+    'assets/filters/nojsminifier.h',
+    'assets/filters/nocssminifier.h',
     'mvc/model/query/parser.h',
     'mvc/model/query/scanner.h',
     'mvc/model/query/phql.h',

--- a/build/_resource/config/phalcon_c_skip_files.php
+++ b/build/_resource/config/phalcon_c_skip_files.php
@@ -11,4 +11,6 @@ return array(
     'annotations/base.c',
     'mvc/model/query/base.c',
     'mvc/view/engine/volt/base.c',
+    'assets/filters/jsminifier.h',
+    'assets/filters/cssminifier.h',
 );

--- a/ext/assets/filters/cssminifier.c
+++ b/ext/assets/filters/cssminifier.c
@@ -36,9 +36,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#ifdef PHALCON_NON_FREE
-
 #include "php_phalcon.h"
+
+#ifdef PHALCON_NON_FREE
 
 #include <ext/standard/php_smart_str.h>
 

--- a/ext/assets/filters/jsminifier.c
+++ b/ext/assets/filters/jsminifier.c
@@ -24,9 +24,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-#ifdef PHALCON_NON_FREE
-
 #include "php_phalcon.h"
+
+#ifdef PHALCON_NON_FREE
 
 #include <ext/standard/php_smart_str.h>
 

--- a/ext/assets/filters/nocssminifier.c
+++ b/ext/assets/filters/nocssminifier.c
@@ -17,9 +17,9 @@
 
 /* placeholder for non-free csssminifier.c */
 
-#ifndef PHALCON_NON_FREE
-
 #include "php_phalcon.h"
+
+#ifndef PHALCON_NON_FREE
 
 #include "assets/filters/nocssminifier.h"
 #include "assets/exception.h"

--- a/ext/assets/filters/nojsminifier.c
+++ b/ext/assets/filters/nojsminifier.c
@@ -17,9 +17,9 @@
 
 /* placeholder for non-free jsminifier.c */
 
-#ifndef PHALCON_NON_FREE
-
 #include "php_phalcon.h"
+
+#ifndef PHALCON_NON_FREE
 
 #include "assets/filters/nojsminifier.h"
 #include "assets/exception.h"


### PR DESCRIPTION
First I apologize to have broken gen-build... still don't really understand why this step is required... condtional buildtime option should be enough...

as 379c258 and d9ded2a are mostly enough to allow "100% free" build, this minor change allow

1/ to avoid both headers to be included in big phalcon.c

2/ allow to gen-build + build when non-free file are drop, as this step is mandatory for downstream distribution where non-free sources cannot even be part of the source.

See an exemple how this can be done for phalcon
https://github.com/remicollet/remirepo/blob/master/php/php-phalcon/strip.sh

P.S. perhaps you can even drop the js(css)minifier.h, and keep only one, without the "Douglas Crockford Fucking License"... (as this function prototype is obviously from Phalcon project not, from D.C.) but I don't want to touch any non-free source code.
