### PR TITLE
Fixed multiple log params, the message and type params position changed.

### DIFF
--- a/ext/phalcon/logger/multiple.zep.c
+++ b/ext/phalcon/logger/multiple.zep.c
@@ -168,7 +168,7 @@ PHP_METHOD(Phalcon_Logger_Multiple, log) {
 			ZEPHIR_GET_HVALUE(logger, _2);
 			ZEPHIR_INIT_NVAR(_3);
 			ZVAL_LONG(_3, type);
-			ZEPHIR_CALL_METHOD(NULL, logger, "log", NULL, message, _3);
+			ZEPHIR_CALL_METHOD(NULL, logger, "log", NULL, _3, message);
 			zephir_check_call_status();
 		}
 	}

--- a/phalcon/logger/multiple.zep
+++ b/phalcon/logger/multiple.zep
@@ -75,7 +75,7 @@ class Multiple
 		let loggers = this->_loggers;
 		if typeof loggers == "array" {
 			for logger in loggers {
-				logger->log(message, type);
+				logger->log(type, message);
 			}
 		}
 	}

--- a/unit-tests/LoggerTest.php
+++ b/unit-tests/LoggerTest.php
@@ -64,15 +64,29 @@ class LoggerTest extends PHPUnit_Framework_TestCase
     $logger = new \Phalcon\Logger\Multiple();
     $logger->push(new \Phalcon\Logger\Adapter\File($logfile1));
     $logger->push(new \Phalcon\Logger\Adapter\File($logfile2));
+    $logger->setFormatter(new \Phalcon\Logger\Formatter\Json());
 		$logger->log('This is a message');
 		$logger->log("This is an error", \Phalcon\Logger::ERROR);
 		$logger->error("This is another error");
 
+    $loggerType = array('DEBUG', 'ERROR', 'ERROR');
+    $loggerMessage = array('This is a message', 'This is an error', 'This is another error');
+
     $lines = file($logfile1);
     $this->assertEquals(count($lines), 3);
+    foreach($lines as $key => $line) {
+      $line = json_decode($line, true);
+      $this->assertEquals($line['type'], $loggerType[$key]);
+      $this->assertEquals($line['message'], $loggerMessage[$key]);
+    }
 
     unset($lines);
     $lines = file($logfile2);
     $this->assertEquals(count($lines), 3);
+    foreach($lines as $key => $line) {
+      $line = json_decode($line, true);
+      $this->assertEquals($line['type'], $loggerType[$key]);
+      $this->assertEquals($line['message'], $loggerMessage[$key]);
+    }
   }
 }


### PR DESCRIPTION
Cause the Adapter log function implement PSR-3 in `adapter.zep` line 259,

```
public function log($level, $message = null, array $content = array())
```

And there is the conditions in line 272,

```
if message === null {
```

BUT the `multiple.zep`, line 78 use the old way,

```
logger->log(message, type);
```

When I use the multiple to log something,

```
$logger = new \Phalcon\Logger\Multiple();
$logger->push(new \Phalcon\Logger\Adapter\File('/tmp/file.log');
$logger->log("This is a message");
$logger->log("This is a message", \Phalcon\Logger::ERROR);
```

And the `file.log` is wrong,

```
[Wed, 10 Sep 14 15:13:54 +0800][EMERGENCY] 7
[Wed, 10 Sep 14 15:13:54 +0800][EMERGENCY] 3
```

it should be,

```
logger->log(type, message);
```

And the `file.log` is good like this,

```
[Wed, 10 Sep 14 16:13:07 +0800][DEBUG] This is a message
[Wed, 10 Sep 14 16:13:07 +0800][ERROR] This is a message
```

Also I update the unit-tests to test the logger "type" and "message" must be match.
