### PR TITLE
Updated command-line routing and console, dispatcher

### DIFF
--- a/phalcon/cli/console.zep
+++ b/phalcon/cli/console.zep
@@ -263,19 +263,23 @@ class Console implements \Phalcon\Di\InjectionAwareInterface, \Phalcon\Events\Ev
 		}
 
 		for arg in arguments {
-			if strncmp(arg, "--", 2) == 0 {
-				let pos = strpos(arg, "=");
-				if pos {
-					let opts[trim(substr(arg, 2, pos - 2))] = trim(substr(arg, pos + 1));
+			if typeof arg == "string" {
+				if strncmp(arg, "--", 2) == 0 {
+					let pos = strpos(arg, "=");
+					if pos {
+						let opts[trim(substr(arg, 2, pos - 2))] = trim(substr(arg, pos + 1));
+					} else {
+						let opts[trim(substr(arg, 2))] = true;
+					}
 				} else {
-					let opts[trim(substr(arg, 2))] = true;
+					if strncmp(arg, "-", 1) == 0 {
+						let opts[substr(arg, 1)] = true;
+					} else {
+						let args[] = arg;
+					}
 				}
 			} else {
-				if strncmp(arg, "-", 1) == 0 {
-					let opts[substr(arg, 1)] = true;
-				} else {
-					let args[] = arg;
-				}
+				let args[] = arg;
 			}
 		}
 

--- a/phalcon/cli/console.zep
+++ b/phalcon/cli/console.zep
@@ -258,7 +258,7 @@ class Console implements \Phalcon\Di\InjectionAwareInterface, \Phalcon\Events\Ev
 			throw new \Phalcon\Cli\Console\Exception("Arguments must be an array");
 		}
 
-		if shift {
+		if shift && count(arguments) {
 			array_shift(arguments);
 		}
 

--- a/phalcon/cli/dispatcher.zep
+++ b/phalcon/cli/dispatcher.zep
@@ -52,6 +52,19 @@ class Dispatcher extends \Phalcon\Dispatcher
 
 	protected _defaultAction = "main";
 
+	protected _options;
+
+	/**
+	 * Phalcon\Cli\Dispatcher constructor
+	 *
+	 */
+	public function __construct()
+	{
+		let this->_options = [];
+
+		parent::__construct();
+	}
+
 	/**
 	 * Sets the default task suffix
 	 *
@@ -145,6 +158,26 @@ class Dispatcher extends \Phalcon\Dispatcher
 	public function getActiveTask() -> <\Phalcon\CLI\Task>
 	{
 		return this->_activeHandler;
+	}
+
+	/**
+	 * Set the options to be dispatched
+	 *
+	 * @param array options
+	 */
+	public function setOptions(array options)
+	{
+		let this->_options = options;
+	}
+
+	/**
+	 * Get dispatched options
+	 *
+	 * @return array
+	 */
+	public function getOptions() -> array
+	{
+		return this->_options;
 	}
 
 }

--- a/phalcon/cli/router.zep
+++ b/phalcon/cli/router.zep
@@ -20,6 +20,9 @@
 
 namespace Phalcon\Cli;
 
+use Phalcon\Cli\Router\Route;
+use Phalcon\CLi\Router\Exception;
+
 /**
  * Phalcon\Cli\Router
  *
@@ -52,13 +55,53 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 
 	protected _params;
 
-	protected _defaultModule;
+	protected _defaultModule = null;
 
-	protected _defaultTask;
+	protected _defaultTask = null;
 
-	protected _defaultAction;
+	protected _defaultAction = null;
 
 	protected _defaultParams;
+
+	protected _routes;
+
+	protected _matchedRoute;
+
+	protected _matches;
+
+	protected _wasMatched = false;
+
+	/**
+	 * Phalcon\Cli\Router constructor
+	 *
+	 * @param boolean defaultRoutes
+	 */
+	public function __construct(boolean defaultRoutes = true)
+	{
+		var routes;
+
+		let routes = [];
+		if defaultRoutes === true {
+
+			// Two routes are added by default to match /:task/:action and
+			// /:task/:action/:params
+
+			let routes[] = new Route("#^/([a-zA-Z0-9\\_\\-]+)[/]{0,1}$#", [
+				"task": 1
+			]);
+
+			let routes[] = new Route("#^/([a-zA-Z0-9\\_\\-]+)/([a-zA-Z0-9\\.\\_]+)(/.*)*$#", [
+				"task": 1,
+				"action": 2,
+				"params": 3
+			]);
+		}
+
+		let this->_params = [],
+			this->_defaultParams = [],
+			this->_routes = routes;
+
+	}
 
 	/**
 	 * Sets the dependency injector
@@ -111,16 +154,186 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 	}
 
 	/**
+	 * Sets an array of default paths. If a route is missing a path the router will use the defined here
+	 * This method must not be used to set a 404 route
+	 *
+	 *<code>
+	 * $router->setDefaults(array(
+	 *		'module' => 'common',
+	 *		'action' => 'index'
+	 * ));
+	 *</code>
+	 *
+	 * @param array defaults
+	 * @return Phalcon\Mvc\Router
+	 */
+	public function setDefaults(defaults) -> <Router>
+	{
+		var module, task, action, params;
+
+		if typeof defaults != "array" {
+			throw new Exception("Defaults must be an array");
+		}
+
+		// Set a default module
+		if fetch module, defaults["module"] {
+			let this->_defaultModule = module;
+		}
+
+		// Set a default task
+		if fetch task, defaults["task"] {
+			let this->_defaultTask = task;
+		}
+
+		// Set a default action
+		if fetch action, defaults["action"] {
+			let this->_defaultAction = action;
+		}
+
+		// Set default parameters
+		if fetch params, defaults["params"] {
+			let this->_defaultParams = params;
+		}
+
+		return this;
+	}
+
+	/**
 	 * Handles routing information received from command-line arguments
 	 *
 	 * @param array arguments
 	 */
 	public function handle(arguments=null)
 	{
-		var moduleName, taskName, actionName;
+		var moduleName, taskName, actionName,
+			params, route, parts, pattern, routeFound, matches, paths,
+			beforeMatch, converters, converter, part, position, matchPosition,
+			paramsStr, strParams;
+
+		let routeFound = false,
+			parts = [],
+			params = [],
+			matches = null,
+			this->_wasMatched = false,
+			this->_matchedRoute = null;
 
 		if typeof arguments != "array" {
-			throw new \Phalcon\Cli\Router\Exception("Arguments must be an Array");
+
+			if arguments {
+				for route in reverse this->_routes {
+
+					/**
+					 * If the route has parentheses use preg_match
+					 */
+					let pattern = route->getCompiledPattern();
+
+					if memstr(pattern, "^") {
+						let routeFound = preg_match(pattern, arguments, matches);
+					} else {
+						let routeFound = pattern == arguments;
+					}
+
+					/**
+					 * Check for beforeMatch conditions
+					 */
+					if routeFound {
+
+						let beforeMatch = route->getBeforeMatch();
+						if beforeMatch !== null {
+
+							/**
+							 * Check first if the callback is callable
+							 */
+							if !is_callable(beforeMatch) {
+								throw new Exception("Before-Match callback is not callable in matched route");
+							}
+
+							/**
+							 * Check first if the callback is callable
+							 */
+							let routeFound = call_user_func_array(beforeMatch, [arguments, route, this]);
+						}
+					}
+
+					if routeFound {
+
+						/**
+						 * Start from the default paths
+						 */
+						let paths = route->getPaths(), parts = paths;
+
+						/**
+						 * Check if the matches has variables
+						 */
+						if typeof matches == "array" {
+
+							/**
+							 * Get the route converters if any
+							 */
+							let converters = route->getConverters();
+
+							for part, position in paths {
+
+								if fetch matchPosition, matches[position] {
+
+									/**
+									 * Check if the part has a converter
+									 */
+									if typeof converters == "array" {
+										if fetch converter, converters[part] {
+											let parts[part] = call_user_func_array(converter, [matchPosition]);
+											continue;
+										}
+									}
+
+									/**
+									 * Update the parts if there is no converter
+									 */
+									let parts[part] = matchPosition;
+								} else {
+
+									/**
+									 * Apply the converters anyway
+									 */
+									if typeof converters == "array" {
+										if fetch converter, converters[part] {
+											let parts[part] = call_user_func_array(converter, [position]);
+										}
+									}
+								}
+							}
+
+							/**
+							 * Update the matches generated by preg_match
+							 */
+							let this->_matches = matches;
+						}
+
+						let this->_matchedRoute = route;
+						break;
+					}
+				}
+			}
+
+			/**
+			 * Update the wasMatched property indicating if the route was matched
+			 */
+			if routeFound {
+				let this->_wasMatched = true;
+			} else {
+				let this->_wasMatched = false;
+
+				/**
+				 * The route wasn't found, try to use the not-found paths
+				 */
+				let this->_module = this->_defaultModule,
+					this->_task = this->_defaultTask,
+					this->_action = this->_defaultAction,
+					this->_params = this->_defaultParams;
+				return this;
+			}
+		} else {
+			let parts = arguments;
 		}
 
 		let moduleName = null,
@@ -130,28 +343,70 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		/**
 		 * Check for a module
 		 */
-		if fetch moduleName, arguments["module"] {
-			unset arguments["module"];
+		if fetch moduleName, parts["module"] {
+			unset parts["module"];
+		} else {
+			let moduleName = this->_defaultModule;
 		}
 
 		/**
 		 * Check for a task
 		 */
-		if fetch taskName, arguments["task"] {
-			unset arguments["task"];
+		if fetch taskName, parts["task"] {
+			unset parts["task"];
+		} else {
+			let taskName = this->_defaultTask;
 		}
 
 		/**
 		 * Check for an action
 		 */
-		if fetch actionName, arguments["action"] {
-			unset arguments["action"];
+		if fetch actionName, parts["action"] {
+			unset parts["action"];
+		} else {
+			let actionName = this->_defaultAction;
+		}
+
+		/**
+		 * Check for an parameters
+		 */
+		if fetch paramsStr, parts["params"] {
+			let strParams = substr(paramsStr, 1);
+			if strParams {
+				let params = explode("/", strParams);
+			}
+			unset parts["params"];
+		}
+		if count(params) {
+			let params = array_merge(params, parts);
+		} else {
+			let params = parts;
 		}
 
 		let this->_module = moduleName,
 			this->_task = taskName,
 			this->_action = actionName,
-			this->_params = arguments;
+			this->_params = params;
+	}
+
+	/**
+	 * Adds a route to the router
+	 *
+	 *<code>
+	 * $router->add('/about', 'About::main');
+	 *</code>
+	 *
+	 * @param string pattern
+	 * @param string/array paths
+	 * @return Phalcon\Cli\Router\Route
+	 */
+	public function add(string! pattern, paths = null) -> <Router>
+	{
+		var route;
+
+		let route = new Route(pattern, paths),
+			this->_routes[] = route;
+		return route;
 	}
 
 	/**
@@ -194,4 +449,79 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		return this->_params;
 	}
 
+	/**
+	 * Returns the route that matchs the handled URI
+	 *
+	 * @return Phalcon\Cli\Router\Route
+	 */
+	public function getMatchedRoute() -> <Route>
+	{
+		return this->_matchedRoute;
+	}
+
+	/**
+	 * Returns the sub expressions in the regular expression matched
+	 *
+	 * @return array
+	 */
+	public function getMatches()
+	{
+		return this->_matches;
+	}
+
+	/**
+	 * Checks if the router macthes any of the defined routes
+	 *
+	 * @return bool
+	 */
+	public function wasMatched() -> boolean
+	{
+		return this->_wasMatched;
+	}
+
+	/**
+	 * Returns all the routes defined in the router
+	 *
+	 * @return Phalcon\Cli\Router\Route[]
+	 */
+	public function getRoutes()
+	{
+		return this->_routes;
+	}
+
+	/**
+	 * Returns a route object by its id
+	 *
+	 * @param int id
+	 * @return Phalcon\Cli\Router\Route
+	 */
+	public function getRouteById(var id) -> <Route> | boolean
+	{
+		var route;
+
+		for route in this->_routes {
+			if route->getRouteId() == id {
+				return route;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns a route object by its name
+	 *
+	 * @param string name
+	 * @return Phalcon\Mvc\Router\Route | boolean
+	 */
+	public function getRouteByName(string! name) -> <Route> | boolean
+	{
+		var route;
+
+		for route in this->_routes {
+			if route->getName() == name {
+				return route;
+			}
+		}
+		return false;
+	}
 }

--- a/phalcon/cli/router.zep
+++ b/phalcon/cli/router.zep
@@ -208,7 +208,7 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		var moduleName, taskName, actionName,
 			params, route, parts, pattern, routeFound, matches, paths,
 			beforeMatch, converters, converter, part, position, matchPosition,
-			paramsStr, strParams;
+			strParams;
 
 		let routeFound = false,
 			parts = [],
@@ -372,10 +372,14 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		/**
 		 * Check for an parameters
 		 */
-		if fetch paramsStr, parts["params"] {
-			let strParams = substr(paramsStr, 1);
-			if strParams {
-				let params = explode(Route::getDelimiter(), strParams);
+		if fetch params, parts["params"] {
+			if typeof params != "array" {
+				let strParams = substr((string)params, 1);
+				if strParams {
+					let params = explode(Route::getDelimiter(), strParams);
+				} else {
+					let params = [];
+				}
 			}
 			unset parts["params"];
 		}

--- a/phalcon/cli/router.zep
+++ b/phalcon/cli/router.zep
@@ -372,19 +372,23 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		/**
 		 * Check for an parameters
 		 */
-		if fetch params, parts["params"] {
-			if typeof params != "array" {
-				let strParams = substr((string)params, 1);
-				if strParams {
-					let params = explode(Route::getDelimiter(), strParams);
-				} else {
-					let params = [];
+		if routeFound {
+			if fetch params, parts["params"] {
+				if typeof params != "array" {
+					let strParams = substr((string)params, 1);
+					if strParams {
+						let params = explode(Route::getDelimiter(), strParams);
+					} else {
+						let params = [];
+					}
 				}
+				unset parts["params"];
 			}
-			unset parts["params"];
-		}
-		if count(params) {
-			let params = array_merge(params, parts);
+			if count(params) {
+				let params = array_merge(params, parts);
+			} else {
+				let params = parts;
+			}
 		} else {
 			let params = parts;
 		}
@@ -517,7 +521,7 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 	 * Returns a route object by its name
 	 *
 	 * @param string name
-	 * @return Phalcon\Mvc\Router\Route | boolean
+	 * @return Phalcon\Cli\Router\Route | boolean
 	 */
 	public function getRouteByName(string! name) -> <Route> | boolean
 	{
@@ -530,4 +534,5 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		}
 		return false;
 	}
+
 }

--- a/phalcon/cli/router/route.zep
+++ b/phalcon/cli/router/route.zep
@@ -1,0 +1,535 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Rack Lin <racklin@gmail.com>                                  |
+ +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Cli\Router;
+
+/**
+ * Phalcon\Cli\Router\Route
+ *
+ * This class represents every route added to the router
+ *
+ */
+class Route
+{
+
+	protected _pattern;
+
+	protected _compiledPattern;
+
+	protected _paths;
+
+	protected _converters;
+
+	protected _id;
+
+	protected _name;
+
+	protected _beforeMatch;
+
+	protected static _uniqueId;
+
+	/**
+	 * Phalcon\Cli\Router\Route constructor
+	 *
+	 * @param string pattern
+	 * @param array paths
+	 */
+	public function __construct(string! pattern, paths=null)
+	{
+		var routeId, uniqueId;
+
+		// Configure the route (extract parameters, paths, etc)
+		this->reConfigure(pattern, paths);
+
+		// Get the unique Id from the static member _uniqueId
+		let uniqueId = self::_uniqueId;
+		if uniqueId === null {
+			let uniqueId = 0;
+		}
+
+		// TODO: Add a function that increase static members
+		let routeId = uniqueId,
+			this->_id = routeId,
+			self::_uniqueId = uniqueId + 1;
+	}
+
+	/**
+	 * Replaces placeholders from pattern returning a valid PCRE regular expression
+	 *
+	 * @param string pattern
+	 * @return string
+	 */
+	public function compilePattern(string! pattern)
+	{
+		var idPattern;
+
+		// If a pattern contains ':', maybe there are placeholders to replace
+		if memstr(pattern, ":") {
+
+			// This is a pattern for valid identifiers
+			let idPattern = "/([a-zA-Z0-9\\_\\-]+)";
+
+			// Replace the module part
+			if memstr(pattern, "/:module") {
+				let pattern = str_replace("/:module", idPattern, pattern);
+			}
+
+			// Replace the task placeholder
+			if memstr(pattern, "/:task") {
+				let pattern = str_replace("/:task", idPattern, pattern);
+			}
+
+			// Replace the namespace placeholder
+			if memstr(pattern, "/:namespace") {
+				let pattern = str_replace("/:namespace", idPattern, pattern);
+			}
+
+			// Replace the action placeholder
+			if memstr(pattern, "/:action") {
+				let pattern = str_replace("/:action", idPattern, pattern);
+			}
+
+			// Replace the params placeholder
+			if memstr(pattern, "/:params") {
+				let pattern = str_replace("/:params", "(/.*)*", pattern);
+			}
+
+			// Replace the int placeholder
+			if memstr(pattern, "/:int") {
+				let pattern = str_replace("/:int", "/([0-9]+)", pattern);
+			}
+		}
+
+		// Check if the pattern has parantheses in order to add the regex delimiters
+		if memstr(pattern, "(") {
+			return "#^" . pattern . "$#";
+		}
+
+		// Square brackets are also checked
+		if memstr(pattern, "[") {
+			return "#^" . pattern . "$#";
+		}
+
+		return pattern;
+	}
+
+	/**
+	 * Extracts parameters from a string
+	 *
+	 * @param string pattern
+	 * @return array|boolean
+	 */
+	public function extractNamedParams(string! pattern)
+	{
+
+		char ch;
+		var tmp, matches;
+		boolean notValid;
+		int cursor, cursorVar, marker, bracketCount = 0, parenthesesCount = 0, foundPattern = 0;
+		int intermediate = 0, numberMatches = 0;
+		string route, item, variable, regexp;
+
+		if strlen(pattern) <= 0 {
+			return false;
+		}
+
+		let matches = [],
+		route = "";
+
+		for cursor, ch in pattern {
+
+			if parenthesesCount == 0 {
+				if ch == '{' {
+					if bracketCount == 0 {
+						let marker = cursor + 1,
+							intermediate = 0,
+							notValid = false;
+					}
+					let bracketCount++;
+				} else {
+					if ch == '}' {
+						let bracketCount--;
+						if intermediate > 0 {
+							if bracketCount == 0 {
+
+								let numberMatches++,
+									variable = null,
+									regexp = null,
+									item = (string) substr(pattern, marker, cursor - marker);
+
+								for cursorVar, ch in item {
+
+									if ch == '\0' {
+										break;
+									}
+
+									if cursorVar == 0 && !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')) {
+										let notValid = true;
+										break;
+									}
+
+									if (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <='9') || ch == '-' || ch == '_' || ch ==  ':' {
+										if ch == ':' {
+											let variable = (string) substr(item, 0, cursorVar),
+												regexp = (string) substr(item, cursorVar + 1);
+											break;
+										}
+									} else {
+										let notValid = true;
+										break;
+									}
+
+								}
+
+								if !notValid {
+
+									let tmp = numberMatches;
+
+									if variable && regexp {
+
+										let foundPattern = 0;
+										for ch in regexp {
+											if ch == '\0' {
+												break;
+											}
+											if !foundPattern {
+												if ch == '(' {
+													let foundPattern = 1;
+												}
+											} else {
+												if ch == ')' {
+													let foundPattern = 2;
+													break;
+												}
+											}
+ 										}
+
+										if foundPattern != 2 {
+											let route .= '(',
+												route .= regexp,
+												route .= ')';
+										} else {
+											let route .= regexp;
+										}
+										let matches[variable] = tmp;
+									} else {
+										let route .= "([^/]*)",
+											matches[item] = tmp;
+									}
+								} else {
+									let route .= '{',
+										route .= item,
+										route .= '}';
+								}
+								continue;
+							}
+						}
+					}
+				}
+			}
+
+			if bracketCount == 0 {
+				if ch == '(' {
+					let parenthesesCount++;
+				} else {
+					if ch == ')' {
+						let parenthesesCount--;
+						if parenthesesCount == 0 {
+							let numberMatches++;
+						}
+					}
+				}
+			}
+
+			if bracketCount > 0 {
+				let intermediate++;
+			} else {
+				let route .= ch;
+			}
+		}
+
+		return [route, matches];
+	}
+
+
+	/**
+	 * Reconfigure the route adding a new pattern and a set of paths
+	 *
+	 * @param string pattern
+	 * @param array paths
+	 */
+	public function reConfigure(string! pattern, paths=null)
+	{
+		var moduleName, taskName, actionName,
+			parts, routePaths, realClassName, namespaceName,
+			pcrePattern, compiledPattern, extracted;
+
+		if paths !== null {
+			if typeof paths == "string" {
+
+				let moduleName = null,
+					taskName = null,
+					actionName = null;
+
+				// Explode the short paths using the :: separator
+				let parts = explode("::", paths);
+
+				// Create the array paths dynamically
+				switch count(parts) {
+					case 3:
+						let moduleName = parts[0],
+							taskName = parts[1],
+							actionName = parts[2];
+						break;
+					case 2:
+						let taskName = parts[0],
+							actionName = parts[1];
+						break;
+					case 1:
+						let taskName = parts[0];
+						break;
+				}
+
+				let routePaths = [];
+
+				// Process module name
+				if moduleName !== null {
+					let routePaths["module"] = moduleName;
+				}
+
+				// Process task name
+				if taskName !== null {
+
+					// Check if we need to obtain the namespace
+					if memstr(taskName, "\\") {
+
+						// Extract the real class name from the namespaced class
+						let realClassName = get_class_ns(taskName);
+
+						// Extract the namespace from the namespaced class
+						let namespaceName = get_ns_class(taskName);
+
+						// Update the namespace
+						if namespaceName {
+							let routePaths["namespace"] = namespaceName;
+						}
+					} else {
+						let realClassName = taskName;
+					}
+
+					// Always pass the task to lowercase
+					let routePaths["task"] = uncamelize(realClassName);
+				}
+
+				// Process action name
+				if actionName !== null {
+					let routePaths["action"] = actionName;
+				}
+			} else {
+				let routePaths = paths;
+			}
+		} else {
+			let routePaths = [];
+		}
+
+		if typeof routePaths !== "array" {
+			throw new Exception("The route contains invalid paths");
+		}
+
+		/**
+		 * If the route starts with '#' we assume that it is a regular expression
+		 */
+		if !starts_with(pattern, "#") {
+
+			if memstr(pattern, "{") {
+				/**
+				 * The route has named parameters so we need to extract them
+				 */
+				let extracted = this->extractNamedParams(pattern),
+					pcrePattern = extracted[0],
+					routePaths = array_merge(routePaths, extracted[1]);
+			} else {
+				let pcrePattern = pattern;
+			}
+
+			/**
+			 * Transform the route's pattern to a regular expression
+			 */
+			let compiledPattern = this->compilePattern(pcrePattern);
+		} else {
+			let compiledPattern = pattern;
+		}
+
+		/**
+		 * Update the original pattern
+		 */
+		let this->_pattern = pattern;
+
+		/**
+		 * Update the compiled pattern
+		 */
+		let this->_compiledPattern = compiledPattern;
+
+		/**
+		 * Update the route's paths
+		 */
+		let this->_paths = routePaths;
+	}
+
+	/**
+	 * Returns the route's name
+	 *
+	 * @return string
+	 */
+	public function getName() -> string
+	{
+		return this->_name;
+	}
+
+	/**
+	 * Sets the route's name
+	 *
+	 *<code>
+	 * $router->add('/about', array(
+	 *     'controller' => 'about'
+	 * ))->setName('about');
+	 *</code>
+	 *
+	 * @param string name
+	 * @return Phalcon\Cli\Router\Route
+	 */
+	public function setName(string! name) -> <Route>
+	{
+		let this->_name = name;
+		return this;
+	}
+
+	/**
+	 * Sets a callback that is called if the route is matched.
+	 * The developer can implement any arbitrary conditions here
+	 * If the callback returns false the route is treaded as not matched
+	 *
+	 * @param callback callback
+	 * @return Phalcon\Cli\Router\Route
+	 */
+	public function beforeMatch(var callback) -> <Route>
+	{
+		let this->_beforeMatch = callback;
+		return this;
+	}
+
+	/**
+	 * Returns the 'before match' callback if any
+	 *
+	 * @return mixed
+	 */
+	public function getBeforeMatch()
+	{
+		return this->_beforeMatch;
+	}
+
+	/**
+	 * Returns the route's id
+	 *
+	 * @return string
+	 */
+	public function getRouteId() -> string
+	{
+		return this->_id;
+	}
+
+	/**
+	 * Returns the route's pattern
+	 *
+	 * @return string
+	 */
+	public function getPattern() -> string
+	{
+		return this->_pattern;
+	}
+
+	/**
+	 * Returns the route's compiled pattern
+	 *
+	 * @return string
+	 */
+	public function getCompiledPattern() -> string
+	{
+		return this->_compiledPattern;
+	}
+
+	/**
+	 * Returns the paths
+	 *
+	 * @return array
+	 */
+	public function getPaths()
+	{
+		return this->_paths;
+	}
+
+	/**
+	 * Returns the paths using positions as keys and names as values
+	 *
+	 * @return array
+	 */
+	public function getReversedPaths()
+	{
+		var reversed, path, position;
+
+		let reversed = [];
+		for path, position in this->_paths {
+			let reversed[position] = path;
+		}
+		return reversed;
+	}
+
+	/**
+	 * Adds a converter to perform an additional transformation for certain parameter
+	 *
+	 * @param string name
+	 * @param callable converter
+	 * @return Phalcon\Cli\Router\Route
+	 */
+	public function convert(string! name, converter) -> <Route>
+	{
+		let this->_converters[name] = converter;
+		return this;
+	}
+
+	/**
+	 * Returns the router converter
+	 *
+	 * @return array
+	 */
+	public function getConverters()
+	{
+		return this->_converters;
+	}
+
+	/**
+	 * Resets the internal route id generator
+	 */
+	public static function reset()
+	{
+		let self::_uniqueId = null;
+	}
+
+}

--- a/phalcon/cli/router/route.zep
+++ b/phalcon/cli/router/route.zep
@@ -49,7 +49,7 @@ class Route
 
 	protected static _delimiterPath;
 
-	const DEFAULT_DELIMITER = "/";
+	const DEFAULT_DELIMITER = " ";
 
 	/**
 	 * Phalcon\Cli\Router\Route constructor

--- a/unit-tests/ConsoleCliTest.php
+++ b/unit-tests/ConsoleCliTest.php
@@ -201,4 +201,249 @@ class ConsoleCliTest extends PHPUnit_Framework_TestCase
 		$expected = "beforeExecuteRoute".PHP_EOL."initialize".PHP_EOL;
 		$this->assertEquals($actual, $expected);
 	}
+
+	public function testArgumentArray()
+	{
+		$di = new Phalcon\DI\FactoryDefault\CLI();
+
+		$console = new \Phalcon\CLI\Console();
+		$console->setDI($di);
+		$dispatcher = $console->getDI()->getShared('dispatcher');
+
+		$console->setArgument(array(
+			'php',
+		), false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'main');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'mainAction');
+
+		$console->setArgument(array(
+			'php',
+			'echo'
+		), false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'echo');
+		$this->assertEquals($dispatcher->getActionName(), 'main');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'echoMainAction');
+
+		$console->setArgument(array(
+			'php',
+			'main',
+			'hello'
+		), false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello !');
+
+		$console->setArgument(array(
+			'php',
+			'main',
+			'hello',
+			'World',
+			'######'
+		), false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array('World', '######'));
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World######');
+
+		// testing namespace
+		try {
+			$dispatcher->setDefaultNamespace('Dummy\\');
+			$console->setArgument(array(
+				'php',
+				'main',
+				'hello',
+				'World',
+				'!'
+			), false)->handle();
+			$this->assertEquals($dispatcher->getTaskName(), 'main');
+			$this->assertEquals($dispatcher->getActionName(), 'hello');
+			$this->assertEquals($dispatcher->getParams(), array('World'));
+			$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World!');
+		} catch (Exception $e) {
+			$this->assertEquals($e->getMessage(), 'Dummy\MainTask handler class cannot be loaded');
+		}
+	}
+
+	public function testArgumentNoShift()
+	{
+		$di = new Phalcon\DI\FactoryDefault\CLI();
+
+		$console = new \Phalcon\CLI\Console();
+		$console->setDI($di);
+		$dispatcher = $console->getDI()->getShared('dispatcher');
+
+		$console->setArgument(array(), false, false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'main');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'mainAction');
+
+		$console->setArgument(array(
+			'echo'
+		), false, false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'echo');
+		$this->assertEquals($dispatcher->getActionName(), 'main');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'echoMainAction');
+
+		$console->setArgument(array(
+			'main',
+			'hello'
+		), false, false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello !');
+
+		$console->setArgument(array(
+			'main',
+			'hello',
+			'World',
+			'######'
+		), false, false)->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array('World', '######'));
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World######');
+
+		// testing namespace
+		try {
+			$dispatcher->setDefaultNamespace('Dummy\\');
+			$console->setArgument(array(
+				'main',
+				'hello',
+				'World',
+				'!'
+			), false, false)->handle();
+			$this->assertEquals($dispatcher->getTaskName(), 'main');
+			$this->assertEquals($dispatcher->getActionName(), 'hello');
+			$this->assertEquals($dispatcher->getParams(), array('World'));
+			$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World!');
+		} catch (Exception $e) {
+			$this->assertEquals($e->getMessage(), 'Dummy\MainTask handler class cannot be loaded');
+		}
+	}
+
+	public function testArgumentRouter()
+	{
+		$di = new Phalcon\DI\FactoryDefault\CLI();
+
+		$di->setShared('router', function() {
+			$router = new \Phalcon\Cli\Router(true);
+			return $router;
+		});
+
+		$console = new \Phalcon\CLI\Console();
+		$console->setDI($di);
+		$dispatcher = $console->getDI()->getShared('dispatcher');
+
+		$console->setArgument(array(
+			'php'
+		))->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'main');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'mainAction');
+
+		$console->setArgument(array(
+			'php',
+			'echo'
+		))->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'echo');
+		$this->assertEquals($dispatcher->getActionName(), 'main');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'echoMainAction');
+
+		$console->setArgument(array(
+			'php',
+			'main',
+			'hello'
+		))->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array());
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello !');
+
+		$console->setArgument(array(
+			'php',
+			'main',
+			'hello',
+			'World',
+			'######'
+		))->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array('World', '######'));
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World######');
+
+		// testing namespace
+		try {
+			$dispatcher->setDefaultNamespace('Dummy\\');
+			$console->setArgument(array(
+				'php',
+				'main',
+				'hello',
+				'World',
+				'!'
+			))->handle();
+			$this->assertEquals($dispatcher->getTaskName(), 'main');
+			$this->assertEquals($dispatcher->getActionName(), 'hello');
+			$this->assertEquals($dispatcher->getParams(), array('World'));
+			$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World!');
+		} catch (Exception $e) {
+			$this->assertEquals($e->getMessage(), 'Dummy\MainTask handler class cannot be loaded');
+		}
+
+	}
+
+	public function testArgumentOptions()
+	{
+		$di = new Phalcon\DI\FactoryDefault\CLI();
+
+		$di->setShared('router', function() {
+			$router = new \Phalcon\Cli\Router(true);
+			return $router;
+		});
+
+		$console = new \Phalcon\CLI\Console();
+		$console->setDI($di);
+		$dispatcher = $console->getDI()->getShared('dispatcher');
+
+		$console->setArgument(array(
+			'php',
+			'-opt1',
+			'--option2',
+			'--option3=hoge',
+			'main',
+			'hello',
+			'World',
+			'######'
+		))->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array('World', '######'));
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World######');
+		$this->assertEquals($dispatcher->getOptions(), array('opt1' => true, 'option2' => true, 'option3' => 'hoge'));
+
+		$console->setArgument(array(
+			'php',
+			'main',
+			'-opt1',
+			'hello',
+			'--option2',
+			'World',
+			'--option3=hoge',
+			'######'
+		))->handle();
+		$this->assertEquals($dispatcher->getTaskName(), 'main');
+		$this->assertEquals($dispatcher->getActionName(), 'hello');
+		$this->assertEquals($dispatcher->getParams(), array('World', '######'));
+		$this->assertEquals($dispatcher->getReturnedValue(), 'Hello World######');
+		$this->assertEquals($dispatcher->getOptions(), array('opt1' => true, 'option2' => true, 'option3' => 'hoge'));
+	}
+
 }

--- a/unit-tests/RouterCliTest.php
+++ b/unit-tests/RouterCliTest.php
@@ -124,6 +124,389 @@ class RouterCliTest extends PHPUnit_Framework_TestCase
 				'params' => array()
 			),
 			array(
+				'uri' => ' ',
+				'module' => 'devtools',
+				'task' => 'main',
+				'action' => 'hello',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation index hellao aaadpqñda bbbAdld cc-ccc',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array('hellao', 'aaadpqñda', 'bbbAdld', 'cc-ccc')
+			),
+			array(
+				'uri' => ' documentation index',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation index ',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation index',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation ',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => null,
+				'params' => array()
+			),
+			array(
+				'uri' => 'system admin a edit hellao aaadp',
+				'module' => null,
+				'task' => 'admin',
+				'action' => 'edit',
+				'params' => array('hellao', 'aaadp')
+			),
+			array(
+				'uri' => 'es news',
+				'module' => null,
+				'task' => 'news',
+				'action' => 'index',
+				'params' => array('language' => 'es')
+			),
+			array(
+				'uri' => 'admin posts edit 100',
+				'module' => 'admin',
+				'task' => 'posts',
+				'action' => 'edit',
+				'params' => array('id' => 100)
+			),
+			array(
+				'uri' => 'posts 2010 02 10 title content',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'show',
+				'params' => array('year' => '2010', 'month' => '02', 'day' => '10', 0 => 'title', 1 => 'content')
+			),
+			array(
+				'uri' => 'manual en translate.adapter.txt',
+				'module' => null,
+				'task' => 'manual',
+				'action' => 'show',
+				'params' => array('language' => 'en', 'file' => 'translate.adapter')
+			),
+			array(
+				'uri' => 'named-manual en translate.adapter.txt',
+				'module' => null,
+				'task' => 'manual',
+				'action' => 'show',
+				'params' => array('language' => 'en', 'file' => 'translate.adapter')
+			),
+			array(
+				'uri' => 'posts 1999 s le-nice-title',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'show',
+				'params' => array('year' => '1999', 'title' => 'le-nice-title')
+			),
+			array(
+				'uri' => 'feed fr blog diaporema.json',
+				'module' => null,
+				'task' => 'feed',
+				'action' => 'get',
+				'params' => array('lang' => 'fr', 'blog' => 'diaporema', 'type' => 'json')
+			),
+			array(
+				'uri' => 'posts delete 150',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'delete',
+				'params' => array('id' => '150')
+			),
+			array(
+				'uri' => 'very static route',
+				'module' => null,
+				'task' => 'static',
+				'action' => 'route',
+				'params' => array()
+			),
+		);
+
+		$router = new \Phalcon\CLI\Router();
+
+		$router->add(' ', array(
+			'module' => 'devtools',
+			'task' => 'main',
+			'action' => 'hello',
+		));
+
+		$router->add('system :task a :action :params', array(
+			'task' => 1,
+			'action' => 2,
+			'params' => 3,
+		));
+
+		$router->add('([a-z]{2}) :task', array(
+			'task' => 2,
+			'action' => 'index',
+			'language' => 1
+		));
+
+		$router->add('admin :task :action :int', array(
+			'module' => 'admin',
+			'task' => 1,
+			'action' => 2,
+			'id' => 3
+		));
+
+		$router->add('posts ([0-9]{4}) ([0-9]{2}) ([0-9]{2}) :params', array(
+			'task' => 'posts',
+			'action' => 'show',
+			'year' => 1,
+			'month' => 2,
+			'day' => 3,
+			'params' => 4,
+		));
+
+		$router->add('manual ([a-z]{2}) ([a-z\.]+)\.txt', array(
+			'task' => 'manual',
+			'action' => 'show',
+			'language' => 1,
+			'file' => 2
+		));
+
+		$router->add('named-manual {language:([a-z]{2})} {file:[a-z\.]+}\.txt', array(
+			'task' => 'manual',
+			'action' => 'show',
+		));
+
+		$router->add('very static route', array(
+			'task' => 'static',
+			'action' => 'route'
+		));
+
+		$router->add("feed {lang:[a-z]+} blog {blog:[a-z\-]+}\.{type:[a-z\-]+}", "Feed::get");
+
+		$router->add("posts {year:[0-9]+} s {title:[a-z\-]+}", "Posts::show");
+
+		$router->add("posts delete {id}", "Posts::delete");
+
+		$router->add("show {id:video([0-9]+)} {title:[a-z\-]+}", "Videos::show");
+
+		foreach ($tests as $n => $test) {
+			$this->_runTest($router, $test);
+		}
+
+	}
+
+	public function testRouterParams()
+	{
+
+		$router = new Phalcon\Cli\Router();
+
+		$tests = array(
+			array(
+				'uri' => 'some hattie',
+				'module' => null,
+				'task' => '',
+				'action' => '',
+				'params' => array('name' => 'hattie')
+			),
+			array(
+				'uri' => 'some hattie 100',
+				'module' => null,
+				'task' => '',
+				'action' => '',
+				'params' => array('name' => 'hattie', 'id' => 100)
+			),
+			array(
+				'uri' => 'some hattie 100 2011-01-02',
+				'module' => null,
+				'task' => '',
+				'action' => '',
+				'params' => array('name' => 'hattie', 'id' => 100, 'date' => '2011-01-02')
+			),
+		);
+
+		$router->add('some {name}');
+		$router->add('some {name} {id:[0-9]+}');
+		$router->add('some {name} {id:[0-9]+} {date}');
+
+		foreach ($tests as $n => $test) {
+			$this->_runTest($router, $test);
+		}
+
+	}
+
+	public function testNamedRoutes()
+	{
+
+		Phalcon\Cli\Router\Route::reset();
+
+		$router = new Phalcon\Cli\Router(false);
+
+		$usersFind = $router->add('api users find')->setName('usersFind');
+		$usersAdd = $router->add('api users add')->setName('usersAdd');
+
+		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
+		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
+		$this->assertEquals($usersFind, $router->getRouteById(0));
+
+	}
+
+	public function testConverters()
+	{
+
+		Phalcon\Cli\Router\Route::reset();
+
+		$router = new Phalcon\Cli\Router();
+
+		$router->add('{task:[a-z\-]+} {action:[a-z\-]+} this-is-a-country')
+		->convert('task', function($task){
+			return str_replace('-', '', $task);
+		})
+		->convert('action', function($action){
+			return str_replace('-', '', $action);
+		});
+
+		$router->add('([A-Z]+) ([0-9]+)', array(
+			'task' => 1,
+			'action' => 'default',
+			'id' => 2,
+		))
+		->convert('task', function($task) {
+			return strtolower($task);
+		})
+		->convert('action', function($action) {
+			if ($action == 'default') {
+				return 'index';
+			}
+			return $action;
+		})
+		->convert('id', function($id) {
+			return strrev($id);
+		});
+
+		$routes = array(
+			'some-controller my-action-name this-is-a-country' => array(
+				'task' => 'somecontroller',
+				'action' => 'myactionname',
+				'params' => array('this-is-a-country')
+			),
+			'BINARY 1101' => array(
+				'task' => 'binary',
+				'action' => 'index',
+				'params' => array(1011)
+			)
+		);
+
+		foreach ($routes as $route => $paths) {
+			$router->handle($route);
+			$this->assertTrue($router->wasMatched());
+			$this->assertEquals($paths['task'], $router->getTaskName());
+			$this->assertEquals($paths['action'], $router->getActionName());
+		}
+
+	}
+
+	public function testShortPaths()
+	{
+		Phalcon\Cli\Router\Route::reset();
+
+		$router = new Phalcon\Cli\Router(false);
+
+		$route = $router->add("route0", "Feed");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => 'feed'
+		));
+
+		$route = $router->add("route1", "Feed::get");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => 'feed',
+			'action' => 'get',
+		));
+
+		$route = $router->add("route2", "News::Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'module' => 'News',
+			'task' => 'posts',
+			'action' => 'show',
+		));
+
+		$route = $router->add("route3", "MyApp\\Tasks\\Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'namespace' => 'MyApp\\Tasks',
+			'task' => 'posts',
+			'action' => 'show',
+		));
+
+		$route = $router->add("route3", "MyApp\\Tasks\\::show");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => '',
+			'action' => 'show',
+		));
+
+		$route = $router->add("route3", "News::MyApp\\Tasks\\Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'module' => 'News',
+			'namespace' => 'MyApp\\Tasks',
+			'task' => 'posts',
+			'action' => 'show',
+		));
+
+		$route = $router->add("route3", "\\Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => 'posts',
+			'action' => 'show',
+		));
+	}
+
+	public function testBeforeMatch()
+	{
+		Phalcon\Cli\Router\Route::reset();
+
+		$trace = 0;
+
+		$router = new Phalcon\Cli\Router(false);
+
+		$router
+			->add('static route')
+			->beforeMatch(function() use (&$trace) {
+				$trace++;
+				return false;
+			});
+
+		$router
+			->add('static route2')
+			->beforeMatch(function() use (&$trace) {
+				$trace++;
+				return true;
+			});
+
+		$router->handle();
+		$this->assertFalse($router->wasMatched());
+
+		$router->handle('static route');
+		$this->assertFalse($router->wasMatched());
+
+		$router->handle('static route2');
+		$this->assertTrue($router->wasMatched());
+
+		$this->assertEquals($trace, 2);
+	}
+
+	public function testDelimiter()
+	{
+		Phalcon\Cli\Router\Route::reset();
+		Phalcon\Cli\Router\Route::delimiter('/');
+
+		$tests = array(
+			array(
 				'uri' => '/',
 				'module' => 'devtools',
 				'task' => 'main',
@@ -290,389 +673,6 @@ class RouterCliTest extends PHPUnit_Framework_TestCase
 		$router->add("/posts/delete/{id}", "Posts::delete");
 
 		$router->add("/show/{id:video([0-9]+)}/{title:[a-z\-]+}", "Videos::show");
-
-		foreach ($tests as $n => $test) {
-			$this->_runTest($router, $test);
-		}
-
-	}
-
-	public function testRouterParams()
-	{
-
-		$router = new Phalcon\Cli\Router();
-
-		$tests = array(
-			array(
-				'uri' => '/some/hattie',
-				'module' => null,
-				'task' => '',
-				'action' => '',
-				'params' => array('name' => 'hattie')
-			),
-			array(
-				'uri' => '/some/hattie/100',
-				'module' => null,
-				'task' => '',
-				'action' => '',
-				'params' => array('name' => 'hattie', 'id' => 100)
-			),
-			array(
-				'uri' => '/some/hattie/100/2011-01-02',
-				'module' => null,
-				'task' => '',
-				'action' => '',
-				'params' => array('name' => 'hattie', 'id' => 100, 'date' => '2011-01-02')
-			),
-		);
-
-		$router->add('/some/{name}');
-		$router->add('/some/{name}/{id:[0-9]+}');
-		$router->add('/some/{name}/{id:[0-9]+}/{date}');
-
-		foreach ($tests as $n => $test) {
-			$this->_runTest($router, $test);
-		}
-
-	}
-
-	public function testNamedRoutes()
-	{
-
-		Phalcon\Cli\Router\Route::reset();
-
-		$router = new Phalcon\Cli\Router(false);
-
-		$usersFind = $router->add('/api/users/find')->setName('usersFind');
-		$usersAdd = $router->add('/api/users/add')->setName('usersAdd');
-
-		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
-		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
-		$this->assertEquals($usersFind, $router->getRouteById(0));
-
-	}
-
-	public function testConverters()
-	{
-
-		Phalcon\Cli\Router\Route::reset();
-
-		$router = new Phalcon\Cli\Router();
-
-		$router->add('/{task:[a-z\-]+}/{action:[a-z\-]+}/this-is-a-country')
-		->convert('task', function($task){
-			return str_replace('-', '', $task);
-		})
-		->convert('action', function($action){
-			return str_replace('-', '', $action);
-		});
-
-		$router->add('/([A-Z]+)/([0-9]+)', array(
-			'task' => 1,
-			'action' => 'default',
-			'id' => 2,
-		))
-		->convert('task', function($task) {
-			return strtolower($task);
-		})
-		->convert('action', function($action) {
-			if ($action == 'default') {
-				return 'index';
-			}
-			return $action;
-		})
-		->convert('id', function($id) {
-			return strrev($id);
-		});
-
-		$routes = array(
-			'/some-controller/my-action-name/this-is-a-country' => array(
-				'task' => 'somecontroller',
-				'action' => 'myactionname',
-				'params' => array('this-is-a-country')
-			),
-			'/BINARY/1101' => array(
-				'task' => 'binary',
-				'action' => 'index',
-				'params' => array(1011)
-			)
-		);
-
-		foreach ($routes as $route => $paths) {
-			$router->handle($route);
-			$this->assertTrue($router->wasMatched());
-			$this->assertEquals($paths['task'], $router->getTaskName());
-			$this->assertEquals($paths['action'], $router->getActionName());
-		}
-
-	}
-
-	public function testShortPaths()
-	{
-		Phalcon\Cli\Router\Route::reset();
-
-		$router = new Phalcon\Cli\Router(false);
-
-		$route = $router->add("/route0", "Feed");
-		$this->assertEquals($route->getPaths(), array(
-			'task' => 'feed'
-		));
-
-		$route = $router->add("/route1", "Feed::get");
-		$this->assertEquals($route->getPaths(), array(
-			'task' => 'feed',
-			'action' => 'get',
-		));
-
-		$route = $router->add("/route2", "News::Posts::show");
-		$this->assertEquals($route->getPaths(), array(
-			'module' => 'News',
-			'task' => 'posts',
-			'action' => 'show',
-		));
-
-		$route = $router->add("/route3", "MyApp\\Tasks\\Posts::show");
-		$this->assertEquals($route->getPaths(), array(
-			'namespace' => 'MyApp\\Tasks',
-			'task' => 'posts',
-			'action' => 'show',
-		));
-
-		$route = $router->add("/route3", "MyApp\\Tasks\\::show");
-		$this->assertEquals($route->getPaths(), array(
-			'task' => '',
-			'action' => 'show',
-		));
-
-		$route = $router->add("/route3", "News::MyApp\\Tasks\\Posts::show");
-		$this->assertEquals($route->getPaths(), array(
-			'module' => 'News',
-			'namespace' => 'MyApp\\Tasks',
-			'task' => 'posts',
-			'action' => 'show',
-		));
-
-		$route = $router->add("/route3", "\\Posts::show");
-		$this->assertEquals($route->getPaths(), array(
-			'task' => 'posts',
-			'action' => 'show',
-		));
-	}
-
-	public function testBeforeMatch()
-	{
-		Phalcon\Cli\Router\Route::reset();
-
-		$trace = 0;
-
-		$router = new Phalcon\Cli\Router(false);
-
-		$router
-			->add('/static/route')
-			->beforeMatch(function() use (&$trace) {
-				$trace++;
-				return false;
-			});
-
-		$router
-			->add('/static/route2')
-			->beforeMatch(function() use (&$trace) {
-				$trace++;
-				return true;
-			});
-
-		$router->handle();
-		$this->assertFalse($router->wasMatched());
-
-		$router->handle('/static/route');
-		$this->assertFalse($router->wasMatched());
-
-		$router->handle('/static/route2');
-		$this->assertTrue($router->wasMatched());
-
-		$this->assertEquals($trace, 2);
-	}
-
-	public function testDelimiter()
-	{
-		Phalcon\Cli\Router\Route::reset();
-		Phalcon\Cli\Router\Route::delimiter(' ');
-
-		$tests = array(
-			array(
-				'uri' => '',
-				'module' => 'devtools',
-				'task' => 'main',
-				'action' => 'hello',
-				'params' => array()
-			),
-			array(
-				'uri' => 'documentation index hellao aaadpqñda bbbAdld cc-ccc',
-				'module' => null,
-				'task' => 'documentation',
-				'action' => 'index',
-				'params' => array('hellao', 'aaadpqñda', 'bbbAdld', 'cc-ccc')
-			),
-			array(
-				'uri' => 'documentation index ',
-				'module' => null,
-				'task' => 'documentation',
-				'action' => 'index',
-				'params' => array()
-			),
-			array(
-				'uri' => 'documentation index',
-				'module' => null,
-				'task' => 'documentation',
-				'action' => 'index',
-				'params' => array()
-			),
-			array(
-				'uri' => ' documentation index',
-				'module' => null,
-				'task' => 'documentation',
-				'action' => 'index',
-				'params' => array()
-			),
-			array(
-				'uri' => 'documentation',
-				'module' => null,
-				'task' => 'documentation',
-				'action' => null,
-				'params' => array()
-			),
-			array(
-				'uri' => 'system admin a edit hellao aaadp',
-				'module' => null,
-				'task' => 'admin',
-				'action' => 'edit',
-				'params' => array('hellao', 'aaadp')
-			),
-			array(
-				'uri' => 'es news',
-				'module' => null,
-				'task' => 'news',
-				'action' => 'index',
-				'params' => array('language' => 'es')
-			),
-			array(
-				'uri' => 'admin posts edit 100',
-				'module' => 'admin',
-				'task' => 'posts',
-				'action' => 'edit',
-				'params' => array('id' => 100)
-			),
-			array(
-				'uri' => 'posts 2010 02 10 title content',
-				'module' => null,
-				'task' => 'posts',
-				'action' => 'show',
-				'params' => array('year' => '2010', 'month' => '02', 'day' => '10', 0 => 'title', 1 => 'content')
-			),
-			array(
-				'uri' => 'manual en translate.adapter.txt',
-				'module' => null,
-				'task' => 'manual',
-				'action' => 'show',
-				'params' => array('language' => 'en', 'file' => 'translate.adapter')
-			),
-			array(
-				'uri' => 'named-manual en translate.adapter.txt',
-				'module' => null,
-				'task' => 'manual',
-				'action' => 'show',
-				'params' => array('language' => 'en', 'file' => 'translate.adapter')
-			),
-			array(
-				'uri' => 'posts 1999 s le-nice-title',
-				'module' => null,
-				'task' => 'posts',
-				'action' => 'show',
-				'params' => array('year' => '1999', 'title' => 'le-nice-title')
-			),
-			array(
-				'uri' => 'feed fr blog diaporema.json',
-				'module' => null,
-				'task' => 'feed',
-				'action' => 'get',
-				'params' => array('lang' => 'fr', 'blog' => 'diaporema', 'type' => 'json')
-			),
-			array(
-				'uri' => 'posts delete 150',
-				'module' => null,
-				'task' => 'posts',
-				'action' => 'delete',
-				'params' => array('id' => '150')
-			),
-			array(
-				'uri' => 'very static route',
-				'module' => null,
-				'task' => 'static',
-				'action' => 'route',
-				'params' => array()
-			),
-		);
-
-		$router = new \Phalcon\CLI\Router();
-
-		$router->add('', array(
-			'module' => 'devtools',
-			'task' => 'main',
-			'action' => 'hello',
-		));
-
-		$router->add('system :task a :action :params', array(
-			'task' => 1,
-			'action' => 2,
-			'params' => 3,
-		));
-
-		$router->add('([a-z]{2}) :task', array(
-			'task' => 2,
-			'action' => 'index',
-			'language' => 1
-		));
-
-		$router->add('admin :task :action :int', array(
-			'module' => 'admin',
-			'task' => 1,
-			'action' => 2,
-			'id' => 3
-		));
-
-		$router->add('posts ([0-9]{4}) ([0-9]{2}) ([0-9]{2}) :params', array(
-			'task' => 'posts',
-			'action' => 'show',
-			'year' => 1,
-			'month' => 2,
-			'day' => 3,
-			'params' => 4,
-		));
-
-		$router->add('manual ([a-z]{2}) ([a-z\.]+)\.txt', array(
-			'task' => 'manual',
-			'action' => 'show',
-			'language' => 1,
-			'file' => 2
-		));
-
-		$router->add('named-manual {language:([a-z]{2})} {file:[a-z\.]+}\.txt', array(
-			'task' => 'manual',
-			'action' => 'show',
-		));
-
-		$router->add('very static route', array(
-			'task' => 'static',
-			'action' => 'route'
-		));
-
-		$router->add("feed {lang:[a-z]+} blog {blog:[a-z\-]+}\.{type:[a-z\-]+}", "Feed::get");
-
-		$router->add("posts {year:[0-9]+} s {title:[a-z\-]+}", "Posts::show");
-
-		$router->add("posts delete {id}", "Posts::delete");
-
-		$router->add("show {id:video([0-9]+)} {title:[a-z\-]+}", "Videos::show");
 
 		foreach ($tests as $n => $test) {
 			$this->_runTest($router, $test);

--- a/unit-tests/RouterCliTest.php
+++ b/unit-tests/RouterCliTest.php
@@ -102,4 +102,395 @@ class RouterCliTest extends PHPUnit_Framework_TestCase
 
 	}
 
+	private function _runTest($router, $test)
+	{
+		$router->handle($test['uri']);
+		$this->assertEquals($router->getModuleName(), $test['module'], "Testing " . $test['uri']);
+		$this->assertEquals($router->getTaskName(), $test['task'], "Testing " . $test['uri']);
+		$this->assertEquals($router->getActionName(), $test['action'], "Testing " . $test['uri']);
+		$this->assertEquals($router->getParams(), $test['params'], "Testing " . $test['uri']);
+	}
+
+	public function testRouter()
+	{
+		Phalcon\Cli\Router\Route::reset();
+
+		$tests = array(
+			array(
+				'uri' => '',
+				'module' => null,
+				'task' => null,
+				'action' => null,
+				'params' => array()
+			),
+			array(
+				'uri' => '/',
+				'module' => 'devtools',
+				'task' => 'main',
+				'action' => 'hello',
+				'params' => array()
+			),
+			array(
+				'uri' => '/documentation/index/hellao/aaadpqñda/bbbAdld/cc-ccc',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array('hellao', 'aaadpqñda', 'bbbAdld', 'cc-ccc')
+			),
+			array(
+				'uri' => '/documentation/index/',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => '/documentation/index',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => '/documentation/',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => null,
+				'params' => array()
+			),
+			array(
+				'uri' => '/system/admin/a/edit/hellao/aaadp',
+				'module' => null,
+				'task' => 'admin',
+				'action' => 'edit',
+				'params' => array('hellao', 'aaadp')
+			),
+			array(
+				'uri' => '/es/news',
+				'module' => null,
+				'task' => 'news',
+				'action' => 'index',
+				'params' => array('language' => 'es')
+			),
+			array(
+				'uri' => '/admin/posts/edit/100',
+				'module' => 'admin',
+				'task' => 'posts',
+				'action' => 'edit',
+				'params' => array('id' => 100)
+			),
+			array(
+				'uri' => '/posts/2010/02/10/title/content',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'show',
+				'params' => array('year' => '2010', 'month' => '02', 'day' => '10', 0 => 'title', 1 => 'content')
+			),
+			array(
+				'uri' => '/manual/en/translate.adapter.txt',
+				'module' => null,
+				'task' => 'manual',
+				'action' => 'show',
+				'params' => array('language' => 'en', 'file' => 'translate.adapter')
+			),
+			array(
+				'uri' => '/named-manual/en/translate.adapter.txt',
+				'module' => null,
+				'task' => 'manual',
+				'action' => 'show',
+				'params' => array('language' => 'en', 'file' => 'translate.adapter')
+			),
+			array(
+				'uri' => '/posts/1999/s/le-nice-title',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'show',
+				'params' => array('year' => '1999', 'title' => 'le-nice-title')
+			),
+			array(
+				'uri' => '/feed/fr/blog/diaporema.json',
+				'module' => null,
+				'task' => 'feed',
+				'action' => 'get',
+				'params' => array('lang' => 'fr', 'blog' => 'diaporema', 'type' => 'json')
+			),
+			array(
+				'uri' => '/posts/delete/150',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'delete',
+				'params' => array('id' => '150')
+			),
+			array(
+				'uri' => '/very/static/route',
+				'module' => null,
+				'task' => 'static',
+				'action' => 'route',
+				'params' => array()
+			),
+		);
+
+		$router = new \Phalcon\CLI\Router();
+
+		$router->add('/', array(
+			'module' => 'devtools',
+			'task' => 'main',
+			'action' => 'hello',
+		));
+
+		$router->add('/system/:task/a/:action/:params', array(
+			'task' => 1,
+			'action' => 2,
+			'params' => 3,
+		));
+
+		$router->add('/([a-z]{2})/:task', array(
+			'task' => 2,
+			'action' => 'index',
+			'language' => 1
+		));
+
+		$router->add('/admin/:task/:action/:int', array(
+			'module' => 'admin',
+			'task' => 1,
+			'action' => 2,
+			'id' => 3
+		));
+
+		$router->add('/posts/([0-9]{4})/([0-9]{2})/([0-9]{2})/:params', array(
+			'task' => 'posts',
+			'action' => 'show',
+			'year' => 1,
+			'month' => 2,
+			'day' => 3,
+			'params' => 4,
+		));
+
+		$router->add('/manual/([a-z]{2})/([a-z\.]+)\.txt', array(
+			'task' => 'manual',
+			'action' => 'show',
+			'language' => 1,
+			'file' => 2
+		));
+
+		$router->add('/named-manual/{language:([a-z]{2})}/{file:[a-z\.]+}\.txt', array(
+			'task' => 'manual',
+			'action' => 'show',
+		));
+
+		$router->add('/very/static/route', array(
+			'task' => 'static',
+			'action' => 'route'
+		));
+
+		$router->add("/feed/{lang:[a-z]+}/blog/{blog:[a-z\-]+}\.{type:[a-z\-]+}", "Feed::get");
+
+		$router->add("/posts/{year:[0-9]+}/s/{title:[a-z\-]+}", "Posts::show");
+
+		$router->add("/posts/delete/{id}", "Posts::delete");
+
+		$router->add("/show/{id:video([0-9]+)}/{title:[a-z\-]+}", "Videos::show");
+
+		foreach ($tests as $n => $test) {
+			$this->_runTest($router, $test);
+		}
+
+	}
+
+	public function testRouterParams()
+	{
+
+		$router = new Phalcon\Cli\Router();
+
+		$tests = array(
+			array(
+				'uri' => '/some/hattie',
+				'module' => null,
+				'task' => '',
+				'action' => '',
+				'params' => array('name' => 'hattie')
+			),
+			array(
+				'uri' => '/some/hattie/100',
+				'module' => null,
+				'task' => '',
+				'action' => '',
+				'params' => array('name' => 'hattie', 'id' => 100)
+			),
+			array(
+				'uri' => '/some/hattie/100/2011-01-02',
+				'module' => null,
+				'task' => '',
+				'action' => '',
+				'params' => array('name' => 'hattie', 'id' => 100, 'date' => '2011-01-02')
+			),
+		);
+
+		$router->add('/some/{name}');
+		$router->add('/some/{name}/{id:[0-9]+}');
+		$router->add('/some/{name}/{id:[0-9]+}/{date}');
+
+		foreach ($tests as $n => $test) {
+			$this->_runTest($router, $test);
+		}
+
+	}
+
+	public function testNamedRoutes()
+	{
+
+		Phalcon\Cli\Router\Route::reset();
+
+		$router = new Phalcon\Cli\Router(false);
+
+		$usersFind = $router->add('/api/users/find')->setName('usersFind');
+		$usersAdd = $router->add('/api/users/add')->setName('usersAdd');
+
+		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
+		$this->assertEquals($usersAdd, $router->getRouteByName('usersAdd'));
+		$this->assertEquals($usersFind, $router->getRouteById(0));
+
+	}
+
+	public function testConverters()
+	{
+
+		Phalcon\Cli\Router\Route::reset();
+
+		$router = new Phalcon\Cli\Router();
+
+		$router->add('/{task:[a-z\-]+}/{action:[a-z\-]+}/this-is-a-country')
+		->convert('task', function($task){
+			return str_replace('-', '', $task);
+		})
+		->convert('action', function($action){
+			return str_replace('-', '', $action);
+		});
+
+		$router->add('/([A-Z]+)/([0-9]+)', array(
+			'task' => 1,
+			'action' => 'default',
+			'id' => 2,
+		))
+		->convert('task', function($task) {
+			return strtolower($task);
+		})
+		->convert('action', function($action) {
+			if ($action == 'default') {
+				return 'index';
+			}
+			return $action;
+		})
+		->convert('id', function($id) {
+			return strrev($id);
+		});
+
+		$routes = array(
+			'/some-controller/my-action-name/this-is-a-country' => array(
+				'task' => 'somecontroller',
+				'action' => 'myactionname',
+				'params' => array('this-is-a-country')
+			),
+			'/BINARY/1101' => array(
+				'task' => 'binary',
+				'action' => 'index',
+				'params' => array(1011)
+			)
+		);
+
+		foreach ($routes as $route => $paths) {
+			$router->handle($route);
+			$this->assertTrue($router->wasMatched());
+			$this->assertEquals($paths['task'], $router->getTaskName());
+			$this->assertEquals($paths['action'], $router->getActionName());
+		}
+
+	}
+
+	public function testShortPaths()
+	{
+		Phalcon\Cli\Router\Route::reset();
+
+		$router = new Phalcon\Cli\Router(false);
+
+		$route = $router->add("/route0", "Feed");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => 'feed'
+		));
+
+		$route = $router->add("/route1", "Feed::get");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => 'feed',
+			'action' => 'get',
+		));
+
+		$route = $router->add("/route2", "News::Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'module' => 'News',
+			'task' => 'posts',
+			'action' => 'show',
+		));
+
+		$route = $router->add("/route3", "MyApp\\Tasks\\Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'namespace' => 'MyApp\\Tasks',
+			'task' => 'posts',
+			'action' => 'show',
+		));
+
+		$route = $router->add("/route3", "MyApp\\Tasks\\::show");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => '',
+			'action' => 'show',
+		));
+
+		$route = $router->add("/route3", "News::MyApp\\Tasks\\Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'module' => 'News',
+			'namespace' => 'MyApp\\Tasks',
+			'task' => 'posts',
+			'action' => 'show',
+		));
+
+		$route = $router->add("/route3", "\\Posts::show");
+		$this->assertEquals($route->getPaths(), array(
+			'task' => 'posts',
+			'action' => 'show',
+		));
+	}
+
+	public function testBeforeMatch()
+	{
+		Phalcon\Cli\Router\Route::reset();
+
+		$trace = 0;
+
+		$router = new Phalcon\Cli\Router(false);
+
+		$router
+			->add('/static/route')
+			->beforeMatch(function() use (&$trace) {
+				$trace++;
+				return false;
+			});
+
+		$router
+			->add('/static/route2')
+			->beforeMatch(function() use (&$trace) {
+				$trace++;
+				return true;
+			});
+
+		$router->handle('');
+		$this->assertFalse($router->wasMatched());
+
+		$router->handle('/static/route');
+		$this->assertFalse($router->wasMatched());
+
+		$router->handle('/static/route2');
+		$this->assertTrue($router->wasMatched());
+
+		$this->assertEquals($trace, 2);
+	}
+
 }

--- a/unit-tests/RouterCliTest.php
+++ b/unit-tests/RouterCliTest.php
@@ -481,7 +481,7 @@ class RouterCliTest extends PHPUnit_Framework_TestCase
 				return true;
 			});
 
-		$router->handle('');
+		$router->handle();
 		$this->assertFalse($router->wasMatched());
 
 		$router->handle('/static/route');
@@ -491,6 +491,193 @@ class RouterCliTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($router->wasMatched());
 
 		$this->assertEquals($trace, 2);
+	}
+
+	public function testDelimiter()
+	{
+		Phalcon\Cli\Router\Route::reset();
+		Phalcon\Cli\Router\Route::delimiter(' ');
+
+		$tests = array(
+			array(
+				'uri' => '',
+				'module' => 'devtools',
+				'task' => 'main',
+				'action' => 'hello',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation index hellao aaadpqñda bbbAdld cc-ccc',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array('hellao', 'aaadpqñda', 'bbbAdld', 'cc-ccc')
+			),
+			array(
+				'uri' => 'documentation index ',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation index',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => ' documentation index',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => 'index',
+				'params' => array()
+			),
+			array(
+				'uri' => 'documentation',
+				'module' => null,
+				'task' => 'documentation',
+				'action' => null,
+				'params' => array()
+			),
+			array(
+				'uri' => 'system admin a edit hellao aaadp',
+				'module' => null,
+				'task' => 'admin',
+				'action' => 'edit',
+				'params' => array('hellao', 'aaadp')
+			),
+			array(
+				'uri' => 'es news',
+				'module' => null,
+				'task' => 'news',
+				'action' => 'index',
+				'params' => array('language' => 'es')
+			),
+			array(
+				'uri' => 'admin posts edit 100',
+				'module' => 'admin',
+				'task' => 'posts',
+				'action' => 'edit',
+				'params' => array('id' => 100)
+			),
+			array(
+				'uri' => 'posts 2010 02 10 title content',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'show',
+				'params' => array('year' => '2010', 'month' => '02', 'day' => '10', 0 => 'title', 1 => 'content')
+			),
+			array(
+				'uri' => 'manual en translate.adapter.txt',
+				'module' => null,
+				'task' => 'manual',
+				'action' => 'show',
+				'params' => array('language' => 'en', 'file' => 'translate.adapter')
+			),
+			array(
+				'uri' => 'named-manual en translate.adapter.txt',
+				'module' => null,
+				'task' => 'manual',
+				'action' => 'show',
+				'params' => array('language' => 'en', 'file' => 'translate.adapter')
+			),
+			array(
+				'uri' => 'posts 1999 s le-nice-title',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'show',
+				'params' => array('year' => '1999', 'title' => 'le-nice-title')
+			),
+			array(
+				'uri' => 'feed fr blog diaporema.json',
+				'module' => null,
+				'task' => 'feed',
+				'action' => 'get',
+				'params' => array('lang' => 'fr', 'blog' => 'diaporema', 'type' => 'json')
+			),
+			array(
+				'uri' => 'posts delete 150',
+				'module' => null,
+				'task' => 'posts',
+				'action' => 'delete',
+				'params' => array('id' => '150')
+			),
+			array(
+				'uri' => 'very static route',
+				'module' => null,
+				'task' => 'static',
+				'action' => 'route',
+				'params' => array()
+			),
+		);
+
+		$router = new \Phalcon\CLI\Router();
+
+		$router->add('', array(
+			'module' => 'devtools',
+			'task' => 'main',
+			'action' => 'hello',
+		));
+
+		$router->add('system :task a :action :params', array(
+			'task' => 1,
+			'action' => 2,
+			'params' => 3,
+		));
+
+		$router->add('([a-z]{2}) :task', array(
+			'task' => 2,
+			'action' => 'index',
+			'language' => 1
+		));
+
+		$router->add('admin :task :action :int', array(
+			'module' => 'admin',
+			'task' => 1,
+			'action' => 2,
+			'id' => 3
+		));
+
+		$router->add('posts ([0-9]{4}) ([0-9]{2}) ([0-9]{2}) :params', array(
+			'task' => 'posts',
+			'action' => 'show',
+			'year' => 1,
+			'month' => 2,
+			'day' => 3,
+			'params' => 4,
+		));
+
+		$router->add('manual ([a-z]{2}) ([a-z\.]+)\.txt', array(
+			'task' => 'manual',
+			'action' => 'show',
+			'language' => 1,
+			'file' => 2
+		));
+
+		$router->add('named-manual {language:([a-z]{2})} {file:[a-z\.]+}\.txt', array(
+			'task' => 'manual',
+			'action' => 'show',
+		));
+
+		$router->add('very static route', array(
+			'task' => 'static',
+			'action' => 'route'
+		));
+
+		$router->add("feed {lang:[a-z]+} blog {blog:[a-z\-]+}\.{type:[a-z\-]+}", "Feed::get");
+
+		$router->add("posts {year:[0-9]+} s {title:[a-z\-]+}", "Posts::show");
+
+		$router->add("posts delete {id}", "Posts::delete");
+
+		$router->add("show {id:video([0-9]+)} {title:[a-z\-]+}", "Videos::show");
+
+		foreach ($tests as $n => $test) {
+			$this->_runTest($router, $test);
+		}
+
 	}
 
 }


### PR DESCRIPTION
- updated to Phalcon\Cli\Router (Phalcon\Mvc\ Router like.)
- parse the argument at Phalcon\Cli\Console::setArgument.
- get/set the option of the argument (-opt, --opt, --opt=OPT) at Phalcon\Cli\Dispatcher::setOptions, getOptions

sample code: https://gist.github.com/kjdev/956c7837d7fd50c45f12
