### PR TITLE
[2.0.0] Improve Sqlite support

### DIFF
--- a/ext/phalcon/db/adapter/pdo/sqlite.zep.c
+++ b/ext/phalcon/db/adapter/pdo/sqlite.zep.c
@@ -121,13 +121,13 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, connect) {
  */
 PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 
-	zephir_fcall_cache_entry *_22 = NULL;
-	zephir_nts_static zephir_fcall_cache_entry *_12 = NULL, *_17 = NULL, *_20 = NULL;
-	zend_bool _8;
+	zephir_fcall_cache_entry *_23 = NULL;
+	zephir_nts_static zephir_fcall_cache_entry *_13 = NULL, *_18 = NULL, *_21 = NULL;
+	zend_bool _11;
 	HashTable *_5;
 	HashPosition _4;
 	int ZEPHIR_LAST_CALL_STATUS;
-	zval *table_param = NULL, *schema_param = NULL, *columns, *columnType = NULL, *field = NULL, *definition = NULL, *oldColumn = NULL, *sizePattern, *matches = NULL, *matchOne = NULL, *matchTwo = NULL, *columnName, *_0 = NULL, *_1, *_2 = NULL, *_3 = NULL, **_6, *_7 = NULL, *_9 = NULL, *_10, *_11 = NULL, *_13 = NULL, *_14, *_15, _16 = zval_used_for_init, *_18, *_19 = NULL, *_21 = NULL;
+	zval *table_param = NULL, *schema_param = NULL, *columns, *columnType = NULL, *field = NULL, *definition = NULL, *oldColumn = NULL, *sizePattern, *matches = NULL, *matchOne = NULL, *matchTwo = NULL, *columnName, *_0 = NULL, *_1, *_2 = NULL, *_3 = NULL, **_6, *_7, *_8 = NULL, *_9 = NULL, *_10, *_12 = NULL, *_14 = NULL, *_15, *_16, _17 = zval_used_for_init, *_19, *_20 = NULL, *_22 = NULL;
 	zval *table = NULL, *schema = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -155,7 +155,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 	ZVAL_LONG(_3, 3);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "fetchall", NULL, _2, _3);
 	zephir_check_call_status();
-	zephir_is_iterable(_0, &_5, &_4, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 284);
+	zephir_is_iterable(_0, &_5, &_4, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 276);
 	for (
 	  ; zephir_hash_get_current_data_ex(_5, (void**) &_6, &_4) == SUCCESS
 	  ; zephir_hash_move_forward_ex(_5, &_4)
@@ -164,28 +164,25 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 		ZEPHIR_INIT_NVAR(definition);
 		array_init_size(definition, 2);
 		add_assoc_long_ex(definition, SS("bindType"), 2);
-		ZEPHIR_OBS_NVAR(columnType);
-		zephir_array_fetch_long(&columnType, field, 2, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 112 TSRMLS_CC);
+		ZEPHIR_INIT_NVAR(columnType);
+		zephir_array_fetch_long(&_7, field, 2, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 112 TSRMLS_CC);
+		zephir_fast_strtolower(columnType, _7);
 		while (1) {
 			if (zephir_memnstr_str(columnType, SL("tinyint(1)"), "phalcon/db/adapter/pdo/sqlite.zep", 119)) {
 				ZEPHIR_INIT_NVAR(_3);
 				ZVAL_LONG(_3, 8);
 				zephir_array_update_string(&definition, SL("type"), &_3, PH_COPY | PH_SEPARATE);
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 5);
-				zephir_array_update_string(&definition, SL("bindType"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 5);
+				zephir_array_update_string(&definition, SL("bindType"), &_8, PH_COPY | PH_SEPARATE);
 				ZEPHIR_INIT_NVAR(columnType);
 				ZVAL_STRING(columnType, "boolean", 1);
 				break;
 			}
-			_8 = zephir_memnstr_str(columnType, SL("int"), "phalcon/db/adapter/pdo/sqlite.zep", 129);
-			if (!(_8)) {
-				_8 = zephir_memnstr_str(columnType, SL("INT"), "phalcon/db/adapter/pdo/sqlite.zep", 129);
-			}
-			if (_8) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 0);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+			if (zephir_memnstr_str(columnType, SL("int"), "phalcon/db/adapter/pdo/sqlite.zep", 129)) {
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 0);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				zephir_array_update_string(&definition, SL("isNumeric"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 				ZEPHIR_INIT_NVAR(_9);
 				ZVAL_LONG(_9, 1);
@@ -197,27 +194,31 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("varchar"), "phalcon/db/adapter/pdo/sqlite.zep", 144)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 2);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 2);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("date"), "phalcon/db/adapter/pdo/sqlite.zep", 152)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 1);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 1);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("timestamp"), "phalcon/db/adapter/pdo/sqlite.zep", 160)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 1);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 1);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				break;
 			}
-			if (zephir_memnstr_str(columnType, SL("decimal"), "phalcon/db/adapter/pdo/sqlite.zep", 168)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 3);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+			_11 = zephir_memnstr_str(columnType, SL("numeric"), "phalcon/db/adapter/pdo/sqlite.zep", 168);
+			if (!(_11)) {
+				_11 = zephir_memnstr_str(columnType, SL("decimal"), "phalcon/db/adapter/pdo/sqlite.zep", 168);
+			}
+			if (_11) {
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 3);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				zephir_array_update_string(&definition, SL("isNumeric"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 				ZEPHIR_INIT_NVAR(_9);
 				ZVAL_LONG(_9, 32);
@@ -225,52 +226,46 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("char"), "phalcon/db/adapter/pdo/sqlite.zep", 178)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 5);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 5);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("datetime"), "phalcon/db/adapter/pdo/sqlite.zep", 186)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 4);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 4);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("text"), "phalcon/db/adapter/pdo/sqlite.zep", 194)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 6);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 6);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				break;
 			}
 			if (zephir_memnstr_str(columnType, SL("float"), "phalcon/db/adapter/pdo/sqlite.zep", 202)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 7);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+				ZEPHIR_INIT_NVAR(_8);
+				ZVAL_LONG(_8, 7);
+				zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 				zephir_array_update_string(&definition, SL("isNumeric"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 				ZEPHIR_INIT_NVAR(_9);
 				ZVAL_LONG(_9, 3);
 				zephir_array_update_string(&definition, SL("bindType"), &_9, PH_COPY | PH_SEPARATE);
 				break;
 			}
-			if (zephir_memnstr_str(columnType, SL("enum"), "phalcon/db/adapter/pdo/sqlite.zep", 212)) {
-				ZEPHIR_INIT_NVAR(_7);
-				ZVAL_LONG(_7, 5);
-				zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
-				break;
-			}
-			ZEPHIR_INIT_NVAR(_7);
-			ZVAL_LONG(_7, 2);
-			zephir_array_update_string(&definition, SL("type"), &_7, PH_COPY | PH_SEPARATE);
+			ZEPHIR_INIT_NVAR(_8);
+			ZVAL_LONG(_8, 2);
+			zephir_array_update_string(&definition, SL("type"), &_8, PH_COPY | PH_SEPARATE);
 			break;
 		}
-		if (zephir_memnstr_str(columnType, SL("("), "phalcon/db/adapter/pdo/sqlite.zep", 227)) {
+		if (zephir_memnstr_str(columnType, SL("("), "phalcon/db/adapter/pdo/sqlite.zep", 219)) {
 			ZEPHIR_INIT_NVAR(matches);
 			ZVAL_NULL(matches);
 			Z_SET_ISREF_P(matches);
-			ZEPHIR_CALL_FUNCTION(&_11, "preg_match", &_12, sizePattern, columnType, matches);
+			ZEPHIR_CALL_FUNCTION(&_12, "preg_match", &_13, sizePattern, columnType, matches);
 			Z_UNSET_ISREF_P(matches);
 			zephir_check_call_status();
-			if (zephir_is_true(_11)) {
+			if (zephir_is_true(_12)) {
 				ZEPHIR_OBS_NVAR(matchOne);
 				if (zephir_array_isset_long_fetch(&matchOne, matches, 1, 0 TSRMLS_CC)) {
 					ZEPHIR_INIT_NVAR(_9);
@@ -279,13 +274,13 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 				}
 				ZEPHIR_OBS_NVAR(matchTwo);
 				if (zephir_array_isset_long_fetch(&matchTwo, matches, 2, 0 TSRMLS_CC)) {
-					ZEPHIR_INIT_NVAR(_13);
-					ZVAL_LONG(_13, zephir_get_intval(matchTwo));
-					zephir_array_update_string(&definition, SL("scale"), &_13, PH_COPY | PH_SEPARATE);
+					ZEPHIR_INIT_NVAR(_14);
+					ZVAL_LONG(_14, zephir_get_intval(matchTwo));
+					zephir_array_update_string(&definition, SL("scale"), &_14, PH_COPY | PH_SEPARATE);
 				}
 			}
 		}
-		if (zephir_memnstr_str(columnType, SL("unsigned"), "phalcon/db/adapter/pdo/sqlite.zep", 242)) {
+		if (zephir_memnstr_str(columnType, SL("unsigned"), "phalcon/db/adapter/pdo/sqlite.zep", 234)) {
 			zephir_array_update_string(&definition, SL("unsigned"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 		}
 		if (Z_TYPE_P(oldColumn) == IS_NULL) {
@@ -293,37 +288,37 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns) {
 		} else {
 			zephir_array_update_string(&definition, SL("after"), &oldColumn, PH_COPY | PH_SEPARATE);
 		}
-		zephir_array_fetch_long(&_10, field, 5, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 258 TSRMLS_CC);
+		zephir_array_fetch_long(&_10, field, 5, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 250 TSRMLS_CC);
 		if (zephir_is_true(_10)) {
 			zephir_array_update_string(&definition, SL("primary"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 		}
-		zephir_array_fetch_long(&_14, field, 3, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 265 TSRMLS_CC);
-		if (zephir_is_true(_14)) {
+		zephir_array_fetch_long(&_15, field, 3, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 257 TSRMLS_CC);
+		if (zephir_is_true(_15)) {
 			zephir_array_update_string(&definition, SL("notNull"), &ZEPHIR_GLOBAL(global_true), PH_COPY | PH_SEPARATE);
 		}
-		zephir_array_fetch_long(&_15, field, 4, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 272 TSRMLS_CC);
-		ZEPHIR_SINIT_NVAR(_16);
-		ZVAL_STRING(&_16, "null", 0);
-		ZEPHIR_CALL_FUNCTION(&_11, "strcasecmp", &_17, _15, &_16);
+		zephir_array_fetch_long(&_16, field, 4, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 264 TSRMLS_CC);
+		ZEPHIR_SINIT_NVAR(_17);
+		ZVAL_STRING(&_17, "null", 0);
+		ZEPHIR_CALL_FUNCTION(&_12, "strcasecmp", &_18, _16, &_17);
 		zephir_check_call_status();
-		if (!ZEPHIR_IS_LONG(_11, 0)) {
-			zephir_array_fetch_long(&_18, field, 4, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 273 TSRMLS_CC);
-			ZEPHIR_INIT_NVAR(_7);
-			ZVAL_STRING(_7, "/^'|'$/", 0);
+		if (!ZEPHIR_IS_LONG(_12, 0)) {
+			zephir_array_fetch_long(&_19, field, 4, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 265 TSRMLS_CC);
+			ZEPHIR_INIT_NVAR(_8);
+			ZVAL_STRING(_8, "/^'|'$/", 0);
 			ZEPHIR_INIT_NVAR(_9);
 			ZVAL_STRING(_9, "", 0);
-			ZEPHIR_CALL_FUNCTION(&_19, "preg_replace", &_20, _7, _9, _18);
-			zephir_check_temp_parameter(_7);
+			ZEPHIR_CALL_FUNCTION(&_20, "preg_replace", &_21, _8, _9, _19);
+			zephir_check_temp_parameter(_8);
 			zephir_check_temp_parameter(_9);
 			zephir_check_call_status();
-			zephir_array_update_string(&definition, SL("default"), &_19, PH_COPY | PH_SEPARATE);
+			zephir_array_update_string(&definition, SL("default"), &_20, PH_COPY | PH_SEPARATE);
 		}
-		zephir_array_fetch_long(&columnName, field, 1, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 279 TSRMLS_CC);
-		ZEPHIR_INIT_LNVAR(_21);
-		object_init_ex(_21, phalcon_db_column_ce);
-		ZEPHIR_CALL_METHOD(NULL, _21, "__construct", &_22, columnName, definition);
+		zephir_array_fetch_long(&columnName, field, 1, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 271 TSRMLS_CC);
+		ZEPHIR_INIT_LNVAR(_22);
+		object_init_ex(_22, phalcon_db_column_ce);
+		ZEPHIR_CALL_METHOD(NULL, _22, "__construct", &_23, columnName, definition);
 		zephir_check_call_status();
-		zephir_array_append(&columns, _21, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 280);
+		zephir_array_append(&columns, _22, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 272);
 		ZEPHIR_CPY_WRT(oldColumn, columnName);
 	}
 	RETURN_CCTOR(columns);
@@ -362,20 +357,20 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes) {
 	ZVAL_LONG(_3, 3);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "fetchall", NULL, _2, _3);
 	zephir_check_call_status();
-	zephir_is_iterable(_0, &_5, &_4, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 316);
+	zephir_is_iterable(_0, &_5, &_4, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 308);
 	for (
 	  ; zephir_hash_get_current_data_ex(_5, (void**) &_6, &_4) == SUCCESS
 	  ; zephir_hash_move_forward_ex(_5, &_4)
 	) {
 		ZEPHIR_GET_HVALUE(index, _6);
 		ZEPHIR_OBS_NVAR(keyName);
-		zephir_array_fetch_long(&keyName, index, 1, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 302 TSRMLS_CC);
+		zephir_array_fetch_long(&keyName, index, 1, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 294 TSRMLS_CC);
 		if (!(zephir_array_isset(indexes, keyName))) {
 			ZEPHIR_INIT_NVAR(columns);
 			array_init(columns);
 		} else {
 			ZEPHIR_OBS_NVAR(columns);
-			zephir_array_fetch(&columns, indexes, keyName, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 306 TSRMLS_CC);
+			zephir_array_fetch(&columns, indexes, keyName, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 298 TSRMLS_CC);
 		}
 		_8 = zephir_fetch_nproperty_this(this_ptr, SL("_dialect"), PH_NOISY_CC);
 		ZEPHIR_CALL_METHOD(&_9, _8, "describeindex", NULL, keyName);
@@ -384,20 +379,20 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes) {
 		ZVAL_LONG(_3, 3);
 		ZEPHIR_CALL_METHOD(&_7, this_ptr, "fetchall", &_10, _9, _3);
 		zephir_check_call_status();
-		zephir_is_iterable(_7, &_12, &_11, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 313);
+		zephir_is_iterable(_7, &_12, &_11, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 305);
 		for (
 		  ; zephir_hash_get_current_data_ex(_12, (void**) &_13, &_11) == SUCCESS
 		  ; zephir_hash_move_forward_ex(_12, &_11)
 		) {
 			ZEPHIR_GET_HVALUE(describe_index, _13);
-			zephir_array_fetch_long(&_14, describe_index, 2, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 310 TSRMLS_CC);
-			zephir_array_append(&columns, _14, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 310);
+			zephir_array_fetch_long(&_14, describe_index, 2, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 302 TSRMLS_CC);
+			zephir_array_append(&columns, _14, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 302);
 		}
 		zephir_array_update_zval(&indexes, keyName, &columns, PH_COPY | PH_SEPARATE);
 	}
 	ZEPHIR_INIT_VAR(indexObjects);
 	array_init(indexObjects);
-	zephir_is_iterable(indexes, &_16, &_15, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 321);
+	zephir_is_iterable(indexes, &_16, &_15, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 313);
 	for (
 	  ; zephir_hash_get_current_data_ex(_16, (void**) &_17, &_15) == SUCCESS
 	  ; zephir_hash_move_forward_ex(_16, &_15)
@@ -447,7 +442,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeReferences) {
 	ZVAL_LONG(_3, 3);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "fetchall", NULL, _2, _3);
 	zephir_check_call_status();
-	zephir_is_iterable(_0, &_5, &_4, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 366);
+	zephir_is_iterable(_0, &_5, &_4, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 358);
 	for (
 	  ; zephir_hash_get_current_data_ex(_5, (void**) &_6, &_4) == SUCCESS
 	  ; zephir_hash_move_forward_ex(_5, &_4)
@@ -460,29 +455,29 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeReferences) {
 			ZEPHIR_INIT_NVAR(referencedSchema);
 			ZVAL_NULL(referencedSchema);
 			ZEPHIR_OBS_NVAR(referencedTable);
-			zephir_array_fetch_long(&referencedTable, reference, 2, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 345 TSRMLS_CC);
+			zephir_array_fetch_long(&referencedTable, reference, 2, PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 337 TSRMLS_CC);
 			ZEPHIR_INIT_NVAR(columns);
 			array_init(columns);
 			ZEPHIR_INIT_NVAR(referencedColumns);
 			array_init(referencedColumns);
 		} else {
-			zephir_array_fetch(&_7, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 349 TSRMLS_CC);
+			zephir_array_fetch(&_7, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 341 TSRMLS_CC);
 			ZEPHIR_OBS_NVAR(referencedSchema);
-			zephir_array_fetch_string(&referencedSchema, _7, SL("referencedSchema"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 349 TSRMLS_CC);
-			zephir_array_fetch(&_8, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 350 TSRMLS_CC);
+			zephir_array_fetch_string(&referencedSchema, _7, SL("referencedSchema"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 341 TSRMLS_CC);
+			zephir_array_fetch(&_8, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 342 TSRMLS_CC);
 			ZEPHIR_OBS_NVAR(referencedTable);
-			zephir_array_fetch_string(&referencedTable, _8, SL("referencedTable"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 350 TSRMLS_CC);
-			zephir_array_fetch(&_9, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 351 TSRMLS_CC);
+			zephir_array_fetch_string(&referencedTable, _8, SL("referencedTable"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 342 TSRMLS_CC);
+			zephir_array_fetch(&_9, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 343 TSRMLS_CC);
 			ZEPHIR_OBS_NVAR(columns);
-			zephir_array_fetch_string(&columns, _9, SL("columns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 351 TSRMLS_CC);
-			zephir_array_fetch(&_10, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 352 TSRMLS_CC);
+			zephir_array_fetch_string(&columns, _9, SL("columns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 343 TSRMLS_CC);
+			zephir_array_fetch(&_10, references, constraintName, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 344 TSRMLS_CC);
 			ZEPHIR_OBS_NVAR(referencedColumns);
-			zephir_array_fetch_string(&referencedColumns, _10, SL("referencedColumns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 352 TSRMLS_CC);
+			zephir_array_fetch_string(&referencedColumns, _10, SL("referencedColumns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 344 TSRMLS_CC);
 		}
-		zephir_array_fetch_long(&_7, reference, 3, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 355 TSRMLS_CC);
-		zephir_array_append(&columns, _7, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 355);
-		zephir_array_fetch_long(&_8, reference, 4, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 356 TSRMLS_CC);
-		zephir_array_append(&referencedColumns, _8, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 356);
+		zephir_array_fetch_long(&_7, reference, 3, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 347 TSRMLS_CC);
+		zephir_array_append(&columns, _7, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 347);
+		zephir_array_fetch_long(&_8, reference, 4, PH_NOISY | PH_READONLY, "phalcon/db/adapter/pdo/sqlite.zep", 348 TSRMLS_CC);
+		zephir_array_append(&referencedColumns, _8, PH_SEPARATE, "phalcon/db/adapter/pdo/sqlite.zep", 348);
 		ZEPHIR_INIT_NVAR(_11);
 		array_init_size(_11, 6);
 		zephir_array_update_string(&_11, SL("referencedSchema"), &referencedSchema, PH_COPY | PH_SEPARATE);
@@ -493,7 +488,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeReferences) {
 	}
 	ZEPHIR_INIT_VAR(referenceObjects);
 	array_init(referenceObjects);
-	zephir_is_iterable(references, &_13, &_12, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 376);
+	zephir_is_iterable(references, &_13, &_12, 0, 0, "phalcon/db/adapter/pdo/sqlite.zep", 368);
 	for (
 	  ; zephir_hash_get_current_data_ex(_13, (void**) &_14, &_12) == SUCCESS
 	  ; zephir_hash_move_forward_ex(_13, &_12)
@@ -505,16 +500,16 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeReferences) {
 		ZEPHIR_INIT_NVAR(_11);
 		array_init_size(_11, 6);
 		ZEPHIR_OBS_NVAR(_16);
-		zephir_array_fetch_string(&_16, arrayReference, SL("referencedSchema"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 369 TSRMLS_CC);
+		zephir_array_fetch_string(&_16, arrayReference, SL("referencedSchema"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 361 TSRMLS_CC);
 		zephir_array_update_string(&_11, SL("referencedSchema"), &_16, PH_COPY | PH_SEPARATE);
 		ZEPHIR_OBS_NVAR(_16);
-		zephir_array_fetch_string(&_16, arrayReference, SL("referencedTable"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 370 TSRMLS_CC);
+		zephir_array_fetch_string(&_16, arrayReference, SL("referencedTable"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 362 TSRMLS_CC);
 		zephir_array_update_string(&_11, SL("referencedTable"), &_16, PH_COPY | PH_SEPARATE);
 		ZEPHIR_OBS_NVAR(_16);
-		zephir_array_fetch_string(&_16, arrayReference, SL("columns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 371 TSRMLS_CC);
+		zephir_array_fetch_string(&_16, arrayReference, SL("columns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 363 TSRMLS_CC);
 		zephir_array_update_string(&_11, SL("columns"), &_16, PH_COPY | PH_SEPARATE);
 		ZEPHIR_OBS_NVAR(_16);
-		zephir_array_fetch_string(&_16, arrayReference, SL("referencedColumns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 373 TSRMLS_CC);
+		zephir_array_fetch_string(&_16, arrayReference, SL("referencedColumns"), PH_NOISY, "phalcon/db/adapter/pdo/sqlite.zep", 365 TSRMLS_CC);
 		zephir_array_update_string(&_11, SL("referencedColumns"), &_16, PH_COPY | PH_SEPARATE);
 		ZEPHIR_CALL_METHOD(NULL, _15, "__construct", &_17, name, _11);
 		zephir_check_call_status();

--- a/ext/phalcon/db/dialect/sqlite.zep.c
+++ b/ext/phalcon/db/dialect/sqlite.zep.c
@@ -738,14 +738,14 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, _getTableOptions) {
  */
 PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 
-	zend_bool _9, _16;
-	zephir_nts_static zephir_fcall_cache_entry *_7 = NULL, *_14 = NULL;
-	zephir_fcall_cache_entry *_5 = NULL;
+	zend_bool _11;
+	zephir_fcall_cache_entry *_8 = NULL, *_17 = NULL;
+	HashTable *_4, *_14, *_20;
+	HashPosition _3, _13, _19;
 	int ZEPHIR_LAST_CALL_STATUS;
-	HashTable *_1, *_12, *_18;
-	HashPosition _0, _11, _17;
+	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL, *_16 = NULL;
 	zval *definition = NULL;
-	zval *tableName_param = NULL, *schemaName_param = NULL, *definition_param = NULL, *temporary = NULL, *options, *table, *createLines, *columns = NULL, *column = NULL, *indexes, *index = NULL, *reference = NULL, *references, *indexName = NULL, *indexSql = NULL, *sql, *columnLine = NULL, *indexType = NULL, *referenceSql = NULL, *onDelete = NULL, *onUpdate = NULL, *defaultValue = NULL, *indexLines, *autocolumn = NULL, *escapeChar, **_2, *_3 = NULL, *_4 = NULL, *_6 = NULL, *_8 = NULL, *_10 = NULL, **_13, *_15 = NULL, **_19, *_20 = NULL, *_21 = NULL, *_22 = NULL, *_23, *_24;
+	zval *tableName_param = NULL, *schemaName_param = NULL, *definition_param = NULL, *temporary = NULL, *options, *table, *createLines, *columns = NULL, *column = NULL, *indexes, *index = NULL, *reference = NULL, *references, *indexName = NULL, *sql = NULL, *columnLine = NULL, *indexType = NULL, *referenceSql = NULL, *onDelete = NULL, *onUpdate = NULL, *defaultValue = NULL, *indexLines, *autocolumn = NULL, *escapeChar, *_0 = NULL, *_2 = NULL, **_5, *_6 = NULL, *_7 = NULL, *_9 = NULL, *_10 = NULL, *_12 = NULL, **_15, *_18 = NULL, **_21, *_22 = NULL, *_23 = NULL, *_24, *_25, *_26;
 	zval *tableName = NULL, *schemaName = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -762,6 +762,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 		ZEPHIR_INIT_VAR(tableName);
 		ZVAL_EMPTY_STRING(tableName);
 	}
+	ZEPHIR_SEPARATE_PARAM(tableName);
 	if (unlikely(Z_TYPE_P(schemaName_param) != IS_STRING && Z_TYPE_P(schemaName_param) != IS_NULL)) {
 		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'schemaName' must be a string") TSRMLS_CC);
 		RETURN_MM_NULL();
@@ -773,6 +774,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 		ZEPHIR_INIT_VAR(schemaName);
 		ZVAL_EMPTY_STRING(schemaName);
 	}
+	ZEPHIR_SEPARATE_PARAM(schemaName);
 	if (unlikely(Z_TYPE_P(definition_param) != IS_ARRAY)) {
 		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'definition' must be an array") TSRMLS_CC);
 		RETURN_MM_NULL();
@@ -791,6 +793,12 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 	zephir_read_property_this(&escapeChar, this_ptr, SL("_escapeChar"), PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(autocolumn);
 	ZVAL_NULL(autocolumn);
+	ZEPHIR_CALL_FUNCTION(&_0, "addcslashes", &_1, schemaName, escapeChar);
+	zephir_check_call_status();
+	zephir_get_strval(schemaName, _0);
+	ZEPHIR_CALL_FUNCTION(&_2, "addcslashes", &_1, tableName, escapeChar);
+	zephir_check_call_status();
+	zephir_get_strval(tableName, _2);
 	ZEPHIR_INIT_VAR(table);
 	if (schemaName && Z_STRLEN_P(schemaName)) {
 		ZEPHIR_CONCAT_VVVSVVV(table, escapeChar, schemaName, escapeChar, ".", escapeChar, tableName, escapeChar);
@@ -812,77 +820,78 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 	}
 	ZEPHIR_INIT_VAR(createLines);
 	array_init(createLines);
-	zephir_is_iterable(columns, &_1, &_0, 0, 0, "phalcon/db/dialect/sqlite.zep", 402);
+	zephir_is_iterable(columns, &_4, &_3, 0, 0, "phalcon/db/dialect/sqlite.zep", 405);
 	for (
-	  ; zephir_hash_get_current_data_ex(_1, (void**) &_2, &_0) == SUCCESS
-	  ; zephir_hash_move_forward_ex(_1, &_0)
+	  ; zephir_hash_get_current_data_ex(_4, (void**) &_5, &_3) == SUCCESS
+	  ; zephir_hash_move_forward_ex(_4, &_3)
 	) {
-		ZEPHIR_GET_HVALUE(column, _2);
-		ZEPHIR_CALL_METHOD(&_3, column, "getname",  NULL);
+		ZEPHIR_GET_HVALUE(column, _5);
+		ZEPHIR_CALL_METHOD(&_6, column, "getname",  NULL);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_4, this_ptr, "getcolumndefinition", &_5, column);
+		ZEPHIR_CALL_METHOD(&_7, this_ptr, "getcolumndefinition", &_8, column);
 		zephir_check_call_status();
 		ZEPHIR_INIT_NVAR(columnLine);
-		ZEPHIR_CONCAT_VVVSV(columnLine, escapeChar, _3, escapeChar, " ", _4);
+		ZEPHIR_CONCAT_VVVSV(columnLine, escapeChar, _6, escapeChar, " ", _7);
 		ZEPHIR_CALL_METHOD(&defaultValue, column, "getdefault",  NULL);
 		zephir_check_call_status();
 		if (!(ZEPHIR_IS_EMPTY(defaultValue))) {
-			ZEPHIR_CALL_FUNCTION(&_6, "addcslashes", &_7, defaultValue, escapeChar);
+			ZEPHIR_CALL_FUNCTION(&_9, "addcslashes", &_1, defaultValue, escapeChar);
 			zephir_check_call_status();
-			ZEPHIR_INIT_LNVAR(_8);
-			ZEPHIR_CONCAT_SVVV(_8, " DEFAULT ", escapeChar, _6, escapeChar);
-			zephir_concat_self(&columnLine, _8 TSRMLS_CC);
+			ZEPHIR_INIT_LNVAR(_10);
+			ZEPHIR_CONCAT_SVVV(_10, " DEFAULT ", escapeChar, _9, escapeChar);
+			zephir_concat_self(&columnLine, _10 TSRMLS_CC);
 		}
-		ZEPHIR_CALL_METHOD(&_6, column, "isnotnull",  NULL);
+		ZEPHIR_CALL_METHOD(&_9, column, "isnotnull",  NULL);
 		zephir_check_call_status();
-		if (zephir_is_true(_6)) {
+		if (zephir_is_true(_9)) {
 			zephir_concat_self_str(&columnLine, SL(" NOT NULL") TSRMLS_CC);
 		}
-		ZEPHIR_CALL_METHOD(&_6, column, "isprimary",  NULL);
+		ZEPHIR_CALL_METHOD(&_9, column, "isprimary",  NULL);
 		zephir_check_call_status();
-		_9 = zephir_is_true(_6);
-		if (!(_9)) {
-			ZEPHIR_CALL_METHOD(&_10, column, "isautoincrement",  NULL);
+		_11 = zephir_is_true(_9);
+		if (!(_11)) {
+			ZEPHIR_CALL_METHOD(&_12, column, "isautoincrement",  NULL);
 			zephir_check_call_status();
-			_9 = zephir_is_true(_10);
+			_11 = zephir_is_true(_12);
 		}
-		if (_9) {
+		if (_11) {
 			zephir_concat_self_str(&columnLine, SL(" PRIMARY KEY") TSRMLS_CC);
 		}
-		ZEPHIR_CALL_METHOD(&_6, column, "isautoincrement",  NULL);
+		ZEPHIR_CALL_METHOD(&_9, column, "isautoincrement",  NULL);
 		zephir_check_call_status();
-		if (zephir_is_true(_6)) {
+		if (zephir_is_true(_9)) {
 			zephir_concat_self_str(&columnLine, SL(" AUTOINCREMENT") TSRMLS_CC);
 			ZEPHIR_CALL_METHOD(&autocolumn, column, "getname",  NULL);
 			zephir_check_call_status();
 		}
-		zephir_array_append(&createLines, columnLine, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 396);
+		zephir_array_append(&createLines, columnLine, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 399);
 	}
 	ZEPHIR_INIT_VAR(indexLines);
 	array_init(indexLines);
 	ZEPHIR_OBS_VAR(indexes);
 	if (zephir_array_isset_string_fetch(&indexes, definition, SS("indexes"), 0 TSRMLS_CC)) {
-		zephir_is_iterable(indexes, &_12, &_11, 0, 0, "phalcon/db/dialect/sqlite.zep", 452);
+		zephir_is_iterable(indexes, &_14, &_13, 0, 0, "phalcon/db/dialect/sqlite.zep", 442);
 		for (
-		  ; zephir_hash_get_current_data_ex(_12, (void**) &_13, &_11) == SUCCESS
-		  ; zephir_hash_move_forward_ex(_12, &_11)
+		  ; zephir_hash_get_current_data_ex(_14, (void**) &_15, &_13) == SUCCESS
+		  ; zephir_hash_move_forward_ex(_14, &_13)
 		) {
-			ZEPHIR_GET_HVALUE(index, _13);
+			ZEPHIR_GET_HVALUE(index, _15);
 			ZEPHIR_CALL_METHOD(&indexName, index, "getname",  NULL);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&indexType, index, "gettype",  NULL);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&columns, index, "getcolumns",  NULL);
 			zephir_check_call_status();
-			_9 = ZEPHIR_IS_STRING(indexName, "PRIMARY");
-			if (_9) {
-				_9 = ZEPHIR_IS_EMPTY(autocolumn);
+			_11 = ZEPHIR_IS_STRING(indexName, "PRIMARY");
+			if (_11) {
+				_11 = ZEPHIR_IS_EMPTY(autocolumn);
 			}
-			if (_9) {
-				ZEPHIR_CALL_METHOD(&_3, this_ptr, "getcolumnlist", &_14, columns);
+			if (_11) {
+				ZEPHIR_CALL_METHOD(&_6, this_ptr, "getcolumnlist", &_16, columns);
 				zephir_check_call_status();
-				ZEPHIR_INIT_NVAR(indexSql);
-				ZEPHIR_CONCAT_SVS(indexSql, "PRIMARY KEY (", _3, ")");
+				ZEPHIR_INIT_LNVAR(_10);
+				ZEPHIR_CONCAT_SVS(_10, "PRIMARY KEY (", _6, ")");
+				zephir_array_append(&createLines, _10, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 419);
 			} else {
 				if (ZEPHIR_IS_STRING(indexName, "PRIMARY")) {
 					if (zephir_fast_count_int(columns TSRMLS_CC) == 1) {
@@ -893,90 +902,70 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 					ZEPHIR_INIT_NVAR(indexType);
 					ZVAL_STRING(indexType, "UNIQUE", 1);
 				}
-				ZEPHIR_INIT_NVAR(indexSql);
 				if (ZEPHIR_IS_EMPTY(indexType)) {
-					ZVAL_STRING(indexSql, "CREATE INDEX ", 1);
+					ZEPHIR_CALL_METHOD(&_7, this_ptr, "addindex", &_17, tableName, schemaName, index);
+					zephir_check_call_status();
+					zephir_array_append(&indexLines, _7, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 436);
 				} else {
-					ZVAL_STRING(indexSql, "CONSTRAINT ", 1);
+					ZEPHIR_CALL_METHOD(&_9, this_ptr, "getcolumnlist", &_16, columns);
+					zephir_check_call_status();
+					ZEPHIR_INIT_LNVAR(_18);
+					ZEPHIR_CONCAT_SVVVSVSVS(_18, "CONSTRAINT ", escapeChar, indexName, escapeChar, " ", indexType, " (", _9, ")");
+					zephir_array_append(&createLines, _18, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 438);
 				}
-				ZEPHIR_INIT_LNVAR(_8);
-				ZEPHIR_CONCAT_VVVS(_8, escapeChar, indexName, escapeChar, " ");
-				zephir_concat_self(&indexSql, _8 TSRMLS_CC);
-				if (ZEPHIR_IS_EMPTY(indexType)) {
-					ZEPHIR_INIT_LNVAR(_15);
-					ZEPHIR_CONCAT_SV(_15, "ON ", table);
-					zephir_concat_self(&indexSql, _15 TSRMLS_CC);
-				} else {
-					zephir_concat_self(&indexSql, indexType TSRMLS_CC);
-				}
-				ZEPHIR_CALL_METHOD(&_6, index, "getcolumns",  NULL);
-				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&_4, this_ptr, "getcolumnlist", &_14, _6);
-				zephir_check_call_status();
-				ZEPHIR_INIT_LNVAR(_15);
-				ZEPHIR_CONCAT_SVS(_15, "(", _4, ")");
-				zephir_concat_self(&indexSql, _15 TSRMLS_CC);
-			}
-			_16 = ZEPHIR_IS_EMPTY(indexType);
-			if (_16) {
-				_16 = !ZEPHIR_IS_STRING(indexName, "PRIMARY");
-			}
-			if (_16) {
-				zephir_array_append(&indexLines, indexSql, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 447);
-			} else {
-				zephir_array_append(&createLines, indexSql, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 449);
 			}
 		}
 	}
 	ZEPHIR_OBS_VAR(references);
 	if (zephir_array_isset_string_fetch(&references, definition, SS("references"), 0 TSRMLS_CC)) {
-		zephir_is_iterable(references, &_18, &_17, 0, 0, "phalcon/db/dialect/sqlite.zep", 474);
+		zephir_is_iterable(references, &_20, &_19, 0, 0, "phalcon/db/dialect/sqlite.zep", 464);
 		for (
-		  ; zephir_hash_get_current_data_ex(_18, (void**) &_19, &_17) == SUCCESS
-		  ; zephir_hash_move_forward_ex(_18, &_17)
+		  ; zephir_hash_get_current_data_ex(_20, (void**) &_21, &_19) == SUCCESS
+		  ; zephir_hash_move_forward_ex(_20, &_19)
 		) {
-			ZEPHIR_GET_HVALUE(reference, _19);
-			ZEPHIR_CALL_METHOD(&_3, reference, "getname",  NULL);
+			ZEPHIR_GET_HVALUE(reference, _21);
+			ZEPHIR_CALL_METHOD(&_6, reference, "getname",  NULL);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_6, reference, "getcolumns",  NULL);
+			ZEPHIR_CALL_METHOD(&_9, reference, "getcolumns",  NULL);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_4, this_ptr, "getcolumnlist", &_14, _6);
+			ZEPHIR_CALL_METHOD(&_7, this_ptr, "getcolumnlist", &_16, _9);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_10, reference, "getreferencedtable",  NULL);
+			ZEPHIR_CALL_METHOD(&_12, reference, "getreferencedtable",  NULL);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_21, reference, "getreferencedcolumns",  NULL);
+			ZEPHIR_CALL_METHOD(&_23, reference, "getreferencedcolumns",  NULL);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_20, this_ptr, "getcolumnlist", &_14, _21);
+			ZEPHIR_CALL_METHOD(&_22, this_ptr, "getcolumnlist", &_16, _23);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(referenceSql);
-			ZEPHIR_CONCAT_SVVVSVSSVVVSVS(referenceSql, "CONSTRAINT ", escapeChar, _3, escapeChar, " FOREIGN KEY (", _4, ")", " REFERENCES ", escapeChar, _10, escapeChar, "(", _20, ")");
+			ZEPHIR_CONCAT_SVVVSVSSVVVSVS(referenceSql, "CONSTRAINT ", escapeChar, _6, escapeChar, " FOREIGN KEY (", _7, ")", " REFERENCES ", escapeChar, _12, escapeChar, "(", _22, ")");
 			ZEPHIR_CALL_METHOD(&onDelete, reference, "getondelete",  NULL);
 			zephir_check_call_status();
 			if (!(ZEPHIR_IS_EMPTY(onDelete))) {
-				ZEPHIR_INIT_LNVAR(_8);
-				ZEPHIR_CONCAT_SV(_8, " ON DELETE ", onDelete);
-				zephir_concat_self(&referenceSql, _8 TSRMLS_CC);
+				ZEPHIR_INIT_LNVAR(_10);
+				ZEPHIR_CONCAT_SV(_10, " ON DELETE ", onDelete);
+				zephir_concat_self(&referenceSql, _10 TSRMLS_CC);
 			}
 			ZEPHIR_CALL_METHOD(&onUpdate, reference, "getonupdate",  NULL);
 			zephir_check_call_status();
 			if (!(ZEPHIR_IS_EMPTY(onUpdate))) {
-				ZEPHIR_INIT_LNVAR(_22);
-				ZEPHIR_CONCAT_SV(_22, " ON UPDATE ", onUpdate);
-				zephir_concat_self(&referenceSql, _22 TSRMLS_CC);
+				ZEPHIR_INIT_LNVAR(_18);
+				ZEPHIR_CONCAT_SV(_18, " ON UPDATE ", onUpdate);
+				zephir_concat_self(&referenceSql, _18 TSRMLS_CC);
 			}
-			zephir_array_append(&createLines, referenceSql, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 472);
+			zephir_array_append(&createLines, referenceSql, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 462);
 		}
 	}
-	ZEPHIR_INIT_VAR(_23);
-	zephir_fast_join_str(_23, SL(",\n\t"), createLines TSRMLS_CC);
-	ZEPHIR_INIT_LNVAR(_8);
-	ZEPHIR_CONCAT_VS(_8, _23, "\n)");
-	zephir_concat_self(&sql, _8 TSRMLS_CC);
+	ZEPHIR_INIT_VAR(_24);
+	zephir_fast_join_str(_24, SL(",\n\t"), createLines TSRMLS_CC);
+	ZEPHIR_INIT_LNVAR(_10);
+	ZEPHIR_CONCAT_VS(_10, _24, "\n)");
+	zephir_concat_self(&sql, _10 TSRMLS_CC);
 	if (zephir_fast_count_int(indexLines TSRMLS_CC)) {
-		ZEPHIR_INIT_VAR(_24);
-		zephir_fast_join_str(_24, SL(";\n"), indexLines TSRMLS_CC);
-		ZEPHIR_INIT_BNVAR(sql);
-		ZEPHIR_CONCAT_SVSVSVS(sql, "SAVEPOINT create", tableName, ";\n", _24, ";\nRELEASE create", tableName, ";\n");
+		ZEPHIR_INIT_VAR(_25);
+		zephir_fast_join_str(_25, SL(";\n"), indexLines TSRMLS_CC);
+		ZEPHIR_INIT_VAR(_26);
+		ZEPHIR_CONCAT_SVSVSVSVS(_26, "SAVEPOINT create", tableName, ";\n", sql, ";\n", _25, ";\nRELEASE create", tableName, ";");
+		ZEPHIR_CPY_WRT(sql, _26);
 	}
 	if (zephir_array_isset_string(definition, SS("options"))) {
 	}
@@ -1086,7 +1075,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createView) {
 
 	ZEPHIR_OBS_VAR(viewSql);
 	if (!(zephir_array_isset_string_fetch(&viewSql, definition, SS("sql"), 0 TSRMLS_CC))) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "The index 'sql' is required in the definition array", "phalcon/db/dialect/sqlite.zep", 529);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "The index 'sql' is required in the definition array", "phalcon/db/dialect/sqlite.zep", 519);
 		return;
 	}
 	if (schemaName && Z_STRLEN_P(schemaName)) {

--- a/ext/phalcon/db/dialect/sqlite.zep.c
+++ b/ext/phalcon/db/dialect/sqlite.zep.c
@@ -83,7 +83,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, getColumnDefinition) {
 		return;
 	}
 	if (Z_TYPE_P(column) != IS_OBJECT) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Column definition must be an object compatible with Phalcon\\\\Db\\\\ColumnInterface", "phalcon/db/dialect/sqlite.zep", 51);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Column definition must be an object compatible with Phalcon\\\\Db\\\\ColumnInterface", "phalcon/db/dialect/sqlite.zep", 52);
 		return;
 	}
 	ZEPHIR_INIT_VAR(columnSql);
@@ -162,7 +162,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, getColumnDefinition) {
 			break;
 		}
 		if (ZEPHIR_IS_EMPTY(columnSql)) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Unrecognized SQLite data type", "phalcon/db/dialect/sqlite.zep", 117);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Unrecognized SQLite data type", "phalcon/db/dialect/sqlite.zep", 118);
 			return;
 		}
 		ZEPHIR_CALL_METHOD(&typeValues, column, "gettypevalues",  NULL);
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, getColumnDefinition) {
 			if (Z_TYPE_P(typeValues) == IS_ARRAY) {
 				ZEPHIR_INIT_VAR(valueSql);
 				ZVAL_STRING(valueSql, "", 1);
-				zephir_is_iterable(typeValues, &_4, &_3, 0, 0, "phalcon/db/dialect/sqlite.zep", 128);
+				zephir_is_iterable(typeValues, &_4, &_3, 0, 0, "phalcon/db/dialect/sqlite.zep", 129);
 				for (
 				  ; zephir_hash_get_current_data_ex(_4, (void**) &_5, &_3) == SUCCESS
 				  ; zephir_hash_move_forward_ex(_4, &_3)
@@ -256,7 +256,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, addColumn) {
 		return;
 	}
 	if (Z_TYPE_P(column) != IS_OBJECT) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Column definition must be an object compatible with Phalcon\\\\Db\\\\ColumnInterface", "phalcon/db/dialect/sqlite.zep", 150);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Column definition must be an object compatible with Phalcon\\\\Db\\\\ColumnInterface", "phalcon/db/dialect/sqlite.zep", 151);
 		return;
 	}
 	ZEPHIR_INIT_VAR(sql);
@@ -345,7 +345,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, modifyColumn) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(spl_ce_InvalidArgumentException, "Parameter 'column' must be an instance of 'Phalcon\\\\Db\\\\ColumnInterface'", "", 0);
 		return;
 	}
-	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Altering a DB column is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 187);
+	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Altering a DB column is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 188);
 	return;
 
 }
@@ -391,7 +391,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, dropColumn) {
 	zephir_get_strval(columnName, columnName_param);
 
 
-	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Dropping DB column is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 200);
+	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Dropping DB column is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 201);
 	return;
 
 }
@@ -443,7 +443,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, addIndex) {
 		return;
 	}
 	if (Z_TYPE_P(index) != IS_OBJECT) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Index parameter must be an object compatible with Phalcon\\\\Db\\\\IndexInterface", "phalcon/db/dialect/sqlite.zep", 216);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Index parameter must be an object compatible with Phalcon\\\\Db\\\\IndexInterface", "phalcon/db/dialect/sqlite.zep", 217);
 		return;
 	}
 	ZEPHIR_CALL_METHOD(&indexType, index, "gettype",  NULL);
@@ -567,7 +567,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, addPrimaryKey) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(spl_ce_InvalidArgumentException, "Parameter 'index' must be an instance of 'Phalcon\\\\Db\\\\IndexInterface'", "", 0);
 		return;
 	}
-	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Adding a primary key after table has been created is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 266);
+	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Adding a primary key after table has been created is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 267);
 	return;
 
 }
@@ -611,7 +611,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, dropPrimaryKey) {
 	}
 
 
-	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Removing a primary key after table has been created is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 278);
+	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Removing a primary key after table has been created is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 279);
 	return;
 
 }
@@ -660,7 +660,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, addForeignKey) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(spl_ce_InvalidArgumentException, "Parameter 'reference' must be an instance of 'Phalcon\\\\Db\\\\ReferenceInterface'", "", 0);
 		return;
 	}
-	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Adding a foreign key constraint to an existing table is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 291);
+	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Adding a foreign key constraint to an existing table is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 292);
 	return;
 
 }
@@ -705,7 +705,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, dropForeignKey) {
 	}
 
 
-	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Dropping a foreign key constraint is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 304);
+	ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "Dropping a foreign key constraint is not supported by SQLite", "phalcon/db/dialect/sqlite.zep", 305);
 	return;
 
 }
@@ -739,13 +739,13 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, _getTableOptions) {
 PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 
 	zend_bool _11;
-	zephir_fcall_cache_entry *_8 = NULL, *_17 = NULL;
-	HashTable *_4, *_14, *_20;
-	HashPosition _3, _13, _19;
+	zephir_fcall_cache_entry *_8 = NULL, *_18 = NULL, *_19 = NULL;
+	HashTable *_4, *_14, *_21;
+	HashPosition _3, _13, _20;
 	int ZEPHIR_LAST_CALL_STATUS;
 	zephir_nts_static zephir_fcall_cache_entry *_1 = NULL, *_16 = NULL;
 	zval *definition = NULL;
-	zval *tableName_param = NULL, *schemaName_param = NULL, *definition_param = NULL, *temporary = NULL, *options, *table, *createLines, *columns = NULL, *column = NULL, *indexes, *index = NULL, *reference = NULL, *references, *indexName = NULL, *sql = NULL, *columnLine = NULL, *indexType = NULL, *referenceSql = NULL, *onDelete = NULL, *onUpdate = NULL, *defaultValue = NULL, *indexLines, *autocolumn = NULL, *escapeChar, *_0 = NULL, *_2 = NULL, **_5, *_6 = NULL, *_7 = NULL, *_9 = NULL, *_10 = NULL, *_12 = NULL, **_15, *_18 = NULL, **_21, *_22 = NULL, *_23 = NULL, *_24, *_25, *_26;
+	zval *tableName_param = NULL, *schemaName_param = NULL, *definition_param = NULL, *temporary = NULL, *options, *table, *createLines, *columns = NULL, *column = NULL, *indexes, *index = NULL, *reference = NULL, *references, *indexName = NULL, *sql = NULL, *columnLine = NULL, *indexType = NULL, *referenceSql = NULL, *onDelete = NULL, *onUpdate = NULL, *defaultValue = NULL, *indexLines, *autocolumn = NULL, *escapeChar, *_0 = NULL, *_2 = NULL, **_5, *_6 = NULL, *_7 = NULL, *_9 = NULL, *_10 = NULL, *_12 = NULL, **_15, *_17 = NULL, **_22, *_23 = NULL, *_24 = NULL, *_25 = NULL, *_26;
 	zval *tableName = NULL, *schemaName = NULL;
 
 	ZEPHIR_MM_GROW();
@@ -786,7 +786,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 
 	ZEPHIR_OBS_VAR(columns);
 	if (!(zephir_array_isset_string_fetch(&columns, definition, SS("columns"), 0 TSRMLS_CC))) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "The index 'columns' is required in the definition array", "phalcon/db/dialect/sqlite.zep", 335);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "The index 'columns' is required in the definition array", "phalcon/db/dialect/sqlite.zep", 336);
 		return;
 	}
 	ZEPHIR_OBS_VAR(escapeChar);
@@ -820,7 +820,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 	}
 	ZEPHIR_INIT_VAR(createLines);
 	array_init(createLines);
-	zephir_is_iterable(columns, &_4, &_3, 0, 0, "phalcon/db/dialect/sqlite.zep", 405);
+	zephir_is_iterable(columns, &_4, &_3, 0, 0, "phalcon/db/dialect/sqlite.zep", 406);
 	for (
 	  ; zephir_hash_get_current_data_ex(_4, (void**) &_5, &_3) == SUCCESS
 	  ; zephir_hash_move_forward_ex(_4, &_3)
@@ -864,13 +864,13 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 			ZEPHIR_CALL_METHOD(&autocolumn, column, "getname",  NULL);
 			zephir_check_call_status();
 		}
-		zephir_array_append(&createLines, columnLine, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 399);
+		zephir_array_append(&createLines, columnLine, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 400);
 	}
 	ZEPHIR_INIT_VAR(indexLines);
 	array_init(indexLines);
 	ZEPHIR_OBS_VAR(indexes);
 	if (zephir_array_isset_string_fetch(&indexes, definition, SS("indexes"), 0 TSRMLS_CC)) {
-		zephir_is_iterable(indexes, &_14, &_13, 0, 0, "phalcon/db/dialect/sqlite.zep", 442);
+		zephir_is_iterable(indexes, &_14, &_13, 0, 0, "phalcon/db/dialect/sqlite.zep", 443);
 		for (
 		  ; zephir_hash_get_current_data_ex(_14, (void**) &_15, &_13) == SUCCESS
 		  ; zephir_hash_move_forward_ex(_14, &_13)
@@ -891,7 +891,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 				zephir_check_call_status();
 				ZEPHIR_INIT_LNVAR(_10);
 				ZEPHIR_CONCAT_SVS(_10, "PRIMARY KEY (", _6, ")");
-				zephir_array_append(&createLines, _10, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 419);
+				zephir_array_append(&createLines, _10, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 420);
 			} else {
 				if (ZEPHIR_IS_STRING(indexName, "PRIMARY")) {
 					if (zephir_fast_count_int(columns TSRMLS_CC) == 1) {
@@ -899,31 +899,28 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 							continue;
 						}
 					}
-					ZEPHIR_INIT_NVAR(indexType);
-					ZVAL_STRING(indexType, "UNIQUE", 1);
-				}
-				if (ZEPHIR_IS_EMPTY(indexType)) {
-					ZEPHIR_CALL_METHOD(&_7, this_ptr, "addindex", &_17, tableName, schemaName, index);
+					ZEPHIR_INIT_NVAR(index);
+					object_init_ex(index, phalcon_db_index_ce);
+					ZEPHIR_INIT_NVAR(_17);
+					ZVAL_STRING(_17, "UNIQUE", 0);
+					ZEPHIR_CALL_METHOD(NULL, index, "__construct", &_18, indexName, columns, _17);
+					zephir_check_temp_parameter(_17);
 					zephir_check_call_status();
-					zephir_array_append(&indexLines, _7, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 436);
-				} else {
-					ZEPHIR_CALL_METHOD(&_9, this_ptr, "getcolumnlist", &_16, columns);
-					zephir_check_call_status();
-					ZEPHIR_INIT_LNVAR(_18);
-					ZEPHIR_CONCAT_SVVVSVSVS(_18, "CONSTRAINT ", escapeChar, indexName, escapeChar, " ", indexType, " (", _9, ")");
-					zephir_array_append(&createLines, _18, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 438);
 				}
+				ZEPHIR_CALL_METHOD(&_7, this_ptr, "addindex", &_19, tableName, schemaName, index);
+				zephir_check_call_status();
+				zephir_array_append(&indexLines, _7, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 440);
 			}
 		}
 	}
 	ZEPHIR_OBS_VAR(references);
 	if (zephir_array_isset_string_fetch(&references, definition, SS("references"), 0 TSRMLS_CC)) {
-		zephir_is_iterable(references, &_20, &_19, 0, 0, "phalcon/db/dialect/sqlite.zep", 464);
+		zephir_is_iterable(references, &_21, &_20, 0, 0, "phalcon/db/dialect/sqlite.zep", 465);
 		for (
-		  ; zephir_hash_get_current_data_ex(_20, (void**) &_21, &_19) == SUCCESS
-		  ; zephir_hash_move_forward_ex(_20, &_19)
+		  ; zephir_hash_get_current_data_ex(_21, (void**) &_22, &_20) == SUCCESS
+		  ; zephir_hash_move_forward_ex(_21, &_20)
 		) {
-			ZEPHIR_GET_HVALUE(reference, _21);
+			ZEPHIR_GET_HVALUE(reference, _22);
 			ZEPHIR_CALL_METHOD(&_6, reference, "getname",  NULL);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&_9, reference, "getcolumns",  NULL);
@@ -932,12 +929,12 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&_12, reference, "getreferencedtable",  NULL);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_23, reference, "getreferencedcolumns",  NULL);
+			ZEPHIR_CALL_METHOD(&_24, reference, "getreferencedcolumns",  NULL);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_22, this_ptr, "getcolumnlist", &_16, _23);
+			ZEPHIR_CALL_METHOD(&_23, this_ptr, "getcolumnlist", &_16, _24);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(referenceSql);
-			ZEPHIR_CONCAT_SVVVSVSSVVVSVS(referenceSql, "CONSTRAINT ", escapeChar, _6, escapeChar, " FOREIGN KEY (", _7, ")", " REFERENCES ", escapeChar, _12, escapeChar, "(", _22, ")");
+			ZEPHIR_CONCAT_SVVVSVSSVVVSVS(referenceSql, "CONSTRAINT ", escapeChar, _6, escapeChar, " FOREIGN KEY (", _7, ")", " REFERENCES ", escapeChar, _12, escapeChar, "(", _23, ")");
 			ZEPHIR_CALL_METHOD(&onDelete, reference, "getondelete",  NULL);
 			zephir_check_call_status();
 			if (!(ZEPHIR_IS_EMPTY(onDelete))) {
@@ -948,24 +945,24 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable) {
 			ZEPHIR_CALL_METHOD(&onUpdate, reference, "getonupdate",  NULL);
 			zephir_check_call_status();
 			if (!(ZEPHIR_IS_EMPTY(onUpdate))) {
-				ZEPHIR_INIT_LNVAR(_18);
-				ZEPHIR_CONCAT_SV(_18, " ON UPDATE ", onUpdate);
-				zephir_concat_self(&referenceSql, _18 TSRMLS_CC);
+				ZEPHIR_INIT_LNVAR(_25);
+				ZEPHIR_CONCAT_SV(_25, " ON UPDATE ", onUpdate);
+				zephir_concat_self(&referenceSql, _25 TSRMLS_CC);
 			}
-			zephir_array_append(&createLines, referenceSql, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 462);
+			zephir_array_append(&createLines, referenceSql, PH_SEPARATE, "phalcon/db/dialect/sqlite.zep", 463);
 		}
 	}
-	ZEPHIR_INIT_VAR(_24);
-	zephir_fast_join_str(_24, SL(",\n\t"), createLines TSRMLS_CC);
+	ZEPHIR_INIT_NVAR(_17);
+	zephir_fast_join_str(_17, SL(",\n\t"), createLines TSRMLS_CC);
 	ZEPHIR_INIT_LNVAR(_10);
-	ZEPHIR_CONCAT_VS(_10, _24, "\n)");
+	ZEPHIR_CONCAT_VS(_10, _17, "\n)");
 	zephir_concat_self(&sql, _10 TSRMLS_CC);
 	if (zephir_fast_count_int(indexLines TSRMLS_CC)) {
-		ZEPHIR_INIT_VAR(_25);
-		zephir_fast_join_str(_25, SL(";\n"), indexLines TSRMLS_CC);
 		ZEPHIR_INIT_VAR(_26);
-		ZEPHIR_CONCAT_SVSVSVSVS(_26, "SAVEPOINT create", tableName, ";\n", sql, ";\n", _25, ";\nRELEASE create", tableName, ";");
-		ZEPHIR_CPY_WRT(sql, _26);
+		zephir_fast_join_str(_26, SL(";\n"), indexLines TSRMLS_CC);
+		ZEPHIR_INIT_LNVAR(_25);
+		ZEPHIR_CONCAT_SVSVSVSVS(_25, "SAVEPOINT create", tableName, ";\n", sql, ";\n", _26, ";\nRELEASE create", tableName, ";");
+		ZEPHIR_CPY_WRT(sql, _25);
 	}
 	if (zephir_array_isset_string(definition, SS("options"))) {
 	}
@@ -1075,7 +1072,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createView) {
 
 	ZEPHIR_OBS_VAR(viewSql);
 	if (!(zephir_array_isset_string_fetch(&viewSql, definition, SS("sql"), 0 TSRMLS_CC))) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "The index 'sql' is required in the definition array", "phalcon/db/dialect/sqlite.zep", 519);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exception_ce, "The index 'sql' is required in the definition array", "phalcon/db/dialect/sqlite.zep", 520);
 		return;
 	}
 	if (schemaName && Z_STRLEN_P(schemaName)) {

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -109,7 +109,7 @@ class Sqlite extends \Phalcon\Db\Adapter\Pdo implements AdapterInterface
 			/**
 			 * By checking every column type we convert it to a Phalcon\Db\Column
 			 */
-			let columnType = field[2];
+			let columnType = strtolower(field[2]);
 
 			loop {
 
@@ -126,7 +126,7 @@ class Sqlite extends \Phalcon\Db\Adapter\Pdo implements AdapterInterface
 				/**
 				 * Smallint/Bigint/Integers/Int are int
 				 */
-				if memstr(columnType, "int") || memstr(columnType, "INT") {
+				if memstr(columnType, "int") {
 
 					let definition["type"] = Column::TYPE_INTEGER,
 						definition["isNumeric"] = true,
@@ -163,9 +163,9 @@ class Sqlite extends \Phalcon\Db\Adapter\Pdo implements AdapterInterface
 				}
 
 				/**
-				 * Decimals are floats
+				 * Numeric are decimals
 				 */
-				if memstr(columnType, "decimal") {
+				if memstr(columnType, "numeric") || memstr(columnType, "decimal") {
 					let definition["type"] = Column::TYPE_DECIMAL,
 						definition["isNumeric"] = true,
 						definition["bindType"] = Column::BIND_PARAM_DECIMAL;
@@ -203,14 +203,6 @@ class Sqlite extends \Phalcon\Db\Adapter\Pdo implements AdapterInterface
 					let definition["type"] = Column::TYPE_FLOAT,
 						definition["isNumeric"] = true,
 						definition["bindType"] = Column::TYPE_DECIMAL;
-					break;
-				}
-
-				/**
-				 * Enum are treated as char
-				 */
-				if memstr(columnType, "enum") {
-					let definition["type"] = Column::TYPE_CHAR;
 					break;
 				}
 

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -23,6 +23,7 @@ namespace Phalcon\Db\Dialect;
 
 use Phalcon\Db\Column;
 use Phalcon\Db\Exception;
+use Phalcon\Db\Index;
 use Phalcon\Db\IndexInterface;
 use Phalcon\Db\Dialect;
 use Phalcon\Db\DialectInterface;
@@ -419,7 +420,7 @@ class Sqlite extends Dialect implements DialectInterface
 					let createLines[] = "PRIMARY KEY (" . this->getColumnList(columns) . ")";
 				} else {
 					/**
-					 * Make a unique index key when there already an autoincrement column
+					 * Make a unique index key if there is already an autoincrement column
 					 */
 					if indexName == "PRIMARY" {
 						if count(columns) == 1 {
@@ -430,13 +431,13 @@ class Sqlite extends Dialect implements DialectInterface
 								continue;
 							}
 						}
-						let indexType = "UNIQUE";
+						let index = new Index(indexName, columns, "UNIQUE");
 					}
-					if empty indexType {
-						let indexLines[] = this->addIndex(tableName, schemaName, index);
-					} else {
-						let createLines[] = "CONSTRAINT " . escapeChar . indexName . escapeChar . " " . indexType . " (" . this->getColumnList(columns) . ")";
-					}
+					/**
+					 * Table constraints are not considered indexes
+					 * So create an actual index instead
+					 */
+					let indexLines[] = this->addIndex(tableName, schemaName, index);
 				}
 			}
 		}

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -807,6 +807,37 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 		$describeIndexes = $connection->describeIndexes('robots_parts', 'main');
 		$this->assertEquals($describeIndexes, $expectedIndexes);
 
+		// Unique and multi-column indexes
+		$expectedIndexes = array(
+			'personas_estado_2' => Phalcon\Db\Index::__set_state(array(
+				'_indexName' => 'personas_estado_2',
+				'_columns' => array('estado', 'nombres')
+			)),
+			'personas_ciudad_id' => Phalcon\Db\Index::__set_state(array(
+				'_indexName' => 'personas_ciudad_id',
+				'_columns' => array('ciudad_id')
+			)),
+			'personas_unique_idx' => Phalcon\Db\Index::__set_state(array(
+				'_indexName' => 'personas_unique_idx',
+				'_columns' => array('nombres', 'telefono', 'email', 'creado_at'),
+				'_type' => 'UNIQUE'
+			)),
+			'personas_estado' => Phalcon\Db\Index::__set_state(array(
+				'_indexName' => 'personas_estado',
+				'_columns' => array('estado')
+			)),
+			'PRIMARY' => Phalcon\Db\Index::__set_state(array(
+				'_indexName' => 'PRIMARY',
+				'_columns' => array('cedula')
+			)),
+		);
+
+		$describeIndexes = $connection->describeIndexes('personas');
+		$this->assertEquals($describeIndexes, $expectedIndexes);
+
+		$describeIndexes = $connection->describeIndexes('personas', 'main');
+		$this->assertEquals($describeIndexes, $expectedIndexes);
+
 		//References
 		$expectedReferences = array(
 		   'foreign_key_0' => Phalcon\Db\Reference::__set_state(array(

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -765,9 +765,8 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 			7 => 'prueba',
 			8 => 'robots',
 			9 => 'robots_parts',
-			10 => 'sqlite_sequence',
-			11 => 'subscriptores',
-			12 => 'tipo_documento',
+			10 => 'subscriptores',
+			11 => 'tipo_documento',
 		);
 
 		$tables = $connection->listTables();

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -822,9 +822,9 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$expected .= "CREATE TABLE \"table\" (\n";
 		$expected .= "\t\"column13\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,\n";
 		$expected .= "\t\"column1\" VARCHAR(10),\n";
-		$expected .= "\t\"column2\" INTEGER,\n";
-		$expected .= "\tCONSTRAINT \"PRIMARY\" UNIQUE (\"column13\", \"column1\")\n";
+		$expected .= "\t\"column2\" INTEGER\n";
 		$expected .= ");\n";
+		$expected .= "CREATE UNIQUE INDEX \"PRIMARY\" ON \"table\" (\"column13\", \"column1\");\n";
 		$expected .= "CREATE INDEX \"index2\" ON \"table\" (\"column1\", \"column2\");\n";
 		$expected .= "RELEASE createtable;";
 		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -562,7 +562,7 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 
 	}
 
-	public function testSQLiteDialect()
+	public function testSqliteDialect()
 	{
 
 		$dialect = new \Phalcon\Db\Dialect\Sqlite();
@@ -574,7 +574,7 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 
 		//Column definitions
 		$this->assertEquals($dialect->getColumnDefinition($columns['column1']), 'VARCHAR(10)');
-		$this->assertEquals($dialect->getColumnDefinition($columns['column2']), 'INT');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column2']), 'INTEGER');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column3']), 'NUMERIC(10,2)');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column4']), 'CHARACTER(100)');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column5']), 'DATE');
@@ -582,13 +582,13 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($dialect->getColumnDefinition($columns['column7']), 'TEXT');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column8']), 'FLOAT');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column9']), 'VARCHAR(10)');
-		$this->assertEquals($dialect->getColumnDefinition($columns['column10']), 'INT');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column10']), 'INTEGER');
 
 		//Add Columns
 		$this->assertEquals($dialect->addColumn('table', null,     $columns['column1']), 'ALTER TABLE "table" ADD COLUMN "column1" VARCHAR(10)');
 		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column1']), 'ALTER TABLE "schema"."table" ADD COLUMN "column1" VARCHAR(10)');
-		$this->assertEquals($dialect->addColumn('table', null,     $columns['column2']), 'ALTER TABLE "table" ADD COLUMN "column2" INT');
-		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column2']), 'ALTER TABLE "schema"."table" ADD COLUMN "column2" INT');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column2']), 'ALTER TABLE "table" ADD COLUMN "column2" INTEGER');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column2']), 'ALTER TABLE "schema"."table" ADD COLUMN "column2" INTEGER');
 		$this->assertEquals($dialect->addColumn('table', null,     $columns['column3']), 'ALTER TABLE "table" ADD COLUMN "column3" NUMERIC(10,2) NOT NULL');
 		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column3']), 'ALTER TABLE "schema"."table" ADD COLUMN "column3" NUMERIC(10,2) NOT NULL');
 		$this->assertEquals($dialect->addColumn('table', null,     $columns['column4']), 'ALTER TABLE "table" ADD COLUMN "column4" CHARACTER(100) NOT NULL');
@@ -603,8 +603,8 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column8']), 'ALTER TABLE "schema"."table" ADD COLUMN "column8" FLOAT NOT NULL');
 		$this->assertEquals($dialect->addColumn('table', null,     $columns['column9']), 'ALTER TABLE "table" ADD COLUMN "column9" VARCHAR(10) DEFAULT "column9"');
 		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column9']), 'ALTER TABLE "schema"."table" ADD COLUMN "column9" VARCHAR(10) DEFAULT "column9"');
-		$this->assertEquals($dialect->addColumn('table', null,     $columns['column10']), 'ALTER TABLE "table" ADD COLUMN "column10" INT DEFAULT "10"');
-		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column10']), 'ALTER TABLE "schema"."table" ADD COLUMN "column10" INT DEFAULT "10"');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column10']), 'ALTER TABLE "table" ADD COLUMN "column10" INTEGER DEFAULT "10"');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column10']), 'ALTER TABLE "schema"."table" ADD COLUMN "column10" INTEGER DEFAULT "10"');
 
 		//Modify Columns
 		try {
@@ -692,7 +692,63 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		}
 
 		//Create tables
-		// Not implemented yet
+		$definition = array(
+			'columns' => array(
+				$columns['column1'],
+				$columns['column2'],
+			)
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	\"column1\" VARCHAR(10),\n";
+		$expected .= "	\"column2\" INTEGER\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
+
+		$definition = array(
+			'columns' => array(
+				$columns['column2'],
+				$columns['column3'],
+				$columns['column1'],
+			),
+			'indexes' => array(
+				$indexes['PRIMARY']
+			)
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	\"column2\" INTEGER,\n";
+		$expected .= "	\"column3\" NUMERIC(10,2) NOT NULL,\n";
+		$expected .= "	\"column1\" VARCHAR(10),\n";
+		$expected .= "	PRIMARY KEY (\"column3\")\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
+
+		$definition['references'] = array(
+			$references['fk3']
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	\"column2\" INTEGER,\n";
+		$expected .= "	\"column3\" NUMERIC(10,2) NOT NULL,\n";
+		$expected .= "	\"column1\" VARCHAR(10),\n";
+		$expected .= "	PRIMARY KEY (\"column3\"),\n";
+		$expected .= "	CONSTRAINT \"fk3\" FOREIGN KEY (\"column1\") REFERENCES \"ref_table\"(\"column2\") ON DELETE CASCADE\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
+
+		$definition = array(
+			'columns' => array(
+				$columns['column9'],
+				$columns['column10'],
+			)
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	\"column9\" VARCHAR(10) DEFAULT \"column9\",\n";
+		$expected .= "	\"column10\" INTEGER DEFAULT \"10\"\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
 	}
 
 	public function testViews()

--- a/unit-tests/schemas/sqlite/phalcon_test.sql
+++ b/unit-tests/schemas/sqlite/phalcon_test.sql
@@ -63,6 +63,8 @@ CREATE TABLE `personas` (
   `estado` character(1) NOT NULL,
   PRIMARY KEY (`cedula`)
 );
+CREATE UNIQUE INDEX personas_unique_idx ON personas (`nombres`, `telefono`, `email`, `creado_at`);
+
 INSERT INTO "personas" VALUES('1',3,'HUANG ZHENGQUIN','191821112','CRA 25 CALLE 100','@yahoo.es','2011-02-03',127591,'2011-05-18',6930,'I');
 INSERT INTO "personas" VALUES('100',1,'USME FERNANDEZ JUAN GUILLERMO','191821112','CRA 25 CALLE 100','@hotmail.es','2011-02-03',128662,'2010-04-15',439480,'A');
 INSERT INTO "personas" VALUES('1003',8,'SINMON PEREZ','191821112','CRA 25 CALLE 100','@terra.com.co','2011-02-03',127591,'2011-08-25',468610,'A');


### PR DESCRIPTION
createTable support, column type and index fixes, pseudo composite primary key support, improved unit tests.

SQLite PRAGMA queries do not provide all the information necessary for a robust implementations of adapter->describeIndexes or other such functions.

I think a simple schema parser (SELECT sql FROM sqlite_master WHERE tbl_name = ?) is necessary.  I'm happy to write it if the team is interested.
