### PR TITLE
[1.3.4] Fix #2815, #2855, #2874

### DIFF
--- a/ext/cache/backend/apc.c
+++ b/ext/cache/backend/apc.c
@@ -211,7 +211,8 @@ PHP_METHOD(Phalcon_Cache_Backend_Apc, save){
 	}
 	
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 	

--- a/ext/cache/backend/file.c
+++ b/ext/cache/backend/file.c
@@ -301,7 +301,8 @@ PHP_METHOD(Phalcon_Cache_Backend_File, save){
 	}
 
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 

--- a/ext/cache/backend/libmemcached.c
+++ b/ext/cache/backend/libmemcached.c
@@ -384,7 +384,7 @@ PHP_METHOD(Phalcon_Cache_Backend_Libmemcached, save){
 
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
 
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 

--- a/ext/cache/backend/memcache.c
+++ b/ext/cache/backend/memcache.c
@@ -358,7 +358,7 @@ PHP_METHOD(Phalcon_Cache_Backend_Memcache, save){
 	
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
 
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 	

--- a/ext/cache/backend/memory.c
+++ b/ext/cache/backend/memory.c
@@ -176,7 +176,7 @@ PHP_METHOD(Phalcon_Cache_Backend_Memory, save){
 
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
 
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 

--- a/ext/cache/backend/mongo.c
+++ b/ext/cache/backend/mongo.c
@@ -373,7 +373,7 @@ PHP_METHOD(Phalcon_Cache_Backend_Mongo, save){
 	
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
 
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 

--- a/ext/cache/backend/xcache.c
+++ b/ext/cache/backend/xcache.c
@@ -237,7 +237,8 @@ PHP_METHOD(Phalcon_Cache_Backend_Xcache, save){
 	}
 	
 	PHALCON_CALL_METHOD(&is_buffering, frontend, "isbuffering");
-	if (!stop_buffer || PHALCON_IS_TRUE(stop_buffer)) {
+
+	if (!stop_buffer || Z_TYPE_P(stop_buffer) == IS_NULL || PHALCON_IS_TRUE(stop_buffer)) {
 		PHALCON_CALL_METHOD(NULL, frontend, "stop");
 	}
 	

--- a/ext/dispatcher.c
+++ b/ext/dispatcher.c
@@ -690,6 +690,21 @@ PHP_METHOD(Phalcon_Dispatcher, dispatch){
 		}
 
 		/**
+		 * Update local variable handler_name and action_name if had been change after event: dispatch:beforeDispatch
+		 */
+		handler_name = phalcon_fetch_nproperty_this(this_ptr, SL("_handlerName"), PH_NOISY TSRMLS_CC);
+		if (!zend_is_true(handler_name)) {
+			handler_name = phalcon_fetch_nproperty_this(this_ptr, SL("_defaultHandler"), PH_NOISY TSRMLS_CC);
+			phalcon_update_property_this(this_ptr, SL("_handlerName"), handler_name TSRMLS_CC);
+		}
+		
+		action_name = phalcon_fetch_nproperty_this(this_ptr, SL("_actionName"), PH_NOISY TSRMLS_CC);
+		if (!zend_is_true(action_name)) {
+			action_name = phalcon_fetch_nproperty_this(this_ptr, SL("_defaultAction"), PH_NOISY TSRMLS_CC);
+			phalcon_update_property_this(this_ptr, SL("_actionName"), action_name TSRMLS_CC);
+		}
+
+		/**
 		 * We don't camelize the classes if they are in namespaces
 		 */
 		if (!phalcon_memnstr_str(handler_name, SL("\\"))) {

--- a/ext/mvc/view.c
+++ b/ext/mvc/view.c
@@ -1014,6 +1014,8 @@ PHP_METHOD(Phalcon_Mvc_View, _engineRender){
 			ZVAL_FALSE(not_exists);
 
 			if (Z_TYPE_P(events_manager) == IS_OBJECT) {
+				phalcon_update_property_this(this_ptr, SL("_activeRenderPath"), view_engine_path TSRMLS_CC);
+
 				PHALCON_INIT_NVAR(event_name);
 				ZVAL_STRING(event_name, "view:afterRenderView", 1);
 				PHALCON_CALL_METHOD(NULL, events_manager, "fire", event_name, this_ptr);


### PR DESCRIPTION
Fix #2815 It is now possible to change the controller or action name in event handler for event: "dispatch:beforeDispatch"

Fix #2855 Correct value of variable _activeRenderPath in event handler 'view:afterRenderView'

Fix #2874 fixed.
