### PR TITLE
[2.0.0] Add MySQL Boolean column definition

### DIFF
--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -128,6 +128,12 @@ class MySQL extends \Phalcon\Db\Dialect //implements Phalcon\Db\DialectInterface
 				}
 				break;
 
+			case Column::TYPE_BOOLEAN:
+				if empty columnSql {
+					let columnSql .= "TINYINT(1)";
+				}
+				break;
+
 			default:
 				if empty columnSql {
 					throw new Exception("Unrecognized MySQL data type");


### PR DESCRIPTION
This PR adds definition for a BOOLEAN type column which is compatible with branch 1.3.x
