### PR TITLE
Fix bug about Phalcon\Http\Request::getHeaders

### DIFF
--- a/ext/http/request.c
+++ b/ext/http/request.c
@@ -1736,7 +1736,7 @@ PHP_METHOD(Phalcon_Http_Request, getHeaders){
 
 			MAKE_STD_ZVAL(header);
 			ZVAL_STRINGL(header, Z_STRVAL(key) + 5, Z_STRLEN(key) - 5, 1);
-			phalcon_array_update_zval(&return_value, header, *hd, 0);
+			phalcon_array_update_zval(&return_value, header, *hd, PH_COPY);
 		}
 	}
 }


### PR DESCRIPTION
``` shell
php -S localhost:8080 -t .
PHP 5.4.32 Development Server started at Tue Oct 28 15:50:43 2014
Listening on http://localhost:8080
Document root is /www/public/test/manicure_test_1/public
Press Ctrl-C to quit.
[Tue Oct 28 15:51:15 2014]  Script:  '/www/public/api.php'
/cphalcon/ext/http/request.c(1739) :  Freeing 0x032C0B30 (5 bytes), script=/www/public/api.php
Last leak repeated 6 times
[Tue Oct 28 15:51:15 2014]  Script:  '/www/public/api.php'
/cphalcon/ext/http/request.c(1738) :  Freeing 0x032C3FA8 (32 bytes), script=/www/public/api.php
Last leak repeated 6 times
```
