### PR TITLE
Closure adjustments for segmentation faults

### DIFF
--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -187,7 +187,9 @@ class Service implements ServiceInterface
 					if typeof parameters == "array" {
 						let instance = call_user_func_array(definition, parameters);
 					} else {
-						let instance = call_user_func(definition);
+						file_put_contents("/tmp/tmp.log", get_class(definition));
+						// let instance = call_user_func(definition);
+						let instance = definition();
 					}
 				} else {
 					let instance = definition;

--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -187,8 +187,6 @@ class Service implements ServiceInterface
 					if typeof parameters == "array" {
 						let instance = call_user_func_array(definition, parameters);
 					} else {
-						file_put_contents("/tmp/tmp.log", get_class(definition));
-						// let instance = call_user_func(definition);
 						let instance = definition();
 					}
 				} else {

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -685,7 +685,7 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
 						/**
 						 * Call the before handler, if it returns false exit
 						 */
-						if call_user_func(before) === false {
+						if before() === false {
 							return false;
 						}
 
@@ -749,7 +749,7 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
 							throw new Exception("One of the 'after' handlers is not callable");
 						}
 
-						let status = call_user_func(after);
+						let status = after();
 					}
 				}
 
@@ -776,7 +776,7 @@ class Micro extends \Phalcon\Di\Injectable implements \ArrayAccess
 				/**
 				 * Call the Not-Found handler
 				 */
-				let returnedValue = call_user_func(notFoundHandler);
+				let returnedValue = call_user_func(notFoundHandler); 
 			}
 
 			/**


### PR DESCRIPTION
Replaced a number of user_call_func() calls for closures and replaced them with {ClosureName}(). This resolved a number of unit-tests that were giving segmentation faults.

See #2914.

Not all of the tests work now, the MicroMvcTest::testMicroNotFound_T169 still seg faults on the NotFoundHandler closure, no matter what I do with it. The only way to have the test pass is to replace the closure with a boolean and not have it execute the closure.
