### PR TITLE
suport merge method for Phalcon\Config

### DIFF
--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -237,12 +237,8 @@ class Config implements \ArrayAccess, \Countable
 		}
 
 		for key, value in get_object_vars(config) {
-			if isset(instance->{key}) {
-				if typeof value === "object" && typeof instance->{key} === "object" {
-					this->_merge(value, instance->{key});
-				} else {
-					let instance->{key} = value;
-				}
+			if isset(instance->{key}) && typeof value === "object" && typeof instance->{key} === "object" {
+				this->_merge(value, instance->{key});
 			} else {
 				let instance->{key} = value;
 			}

--- a/phalcon/config/adapter/ini.zep
+++ b/phalcon/config/adapter/ini.zep
@@ -89,7 +89,7 @@ class Ini extends Config
 	 * Build multidimensional array from string
 	 *
 	 * <code>
-	 * $this->_buildArrayFromString('path.hello.world', 'value for last key');
+	 * $this->_parseIniString('path.hello.world', 'value for last key');
 	 * // result
 	 * [
 	 *      'path' => [

--- a/phalcon/config/adapter/ini.zep
+++ b/phalcon/config/adapter/ini.zep
@@ -90,6 +90,7 @@ class Ini extends Config
 	 *
 	 * <code>
 	 * $this->_parseIniString('path.hello.world', 'value for last key');
+	 *
 	 * // result
 	 * [
 	 *      'path' => [

--- a/phalcon/config/adapter/ini.zep
+++ b/phalcon/config/adapter/ini.zep
@@ -14,6 +14,7 @@
  +------------------------------------------------------------------------+
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Ivan Zubok <chi_no@ukr.net>                                   |
  +------------------------------------------------------------------------+
  */
 
@@ -22,6 +23,35 @@ namespace Phalcon\Config\Adapter;
 use Phalcon\Config;
 use Phalcon\Config\Exception;
 
+/**
+ * Phalcon\Config\Adapter\Ini
+ *
+ * Reads ini files and converts them to Phalcon\Config objects.
+ *
+ * Given the next configuration file:
+ *
+ *<code>
+ * [database]
+ * adapter = Mysql
+ * host = localhost
+ * username = scott
+ * password = cheetah
+ * dbname = test_db
+ *
+ * [phalcon]
+ * controllersDir = "../app/controllers/"
+ * modelsDir = "../app/models/"
+ * viewsDir = "../app/views/"
+ * </code>
+ *
+ * You can read it as follows:
+ *
+ *<code>
+ * $config = new Phalcon\Config\Adapter\Ini("path/config.ini");
+ * echo $config->phalcon->controllersDir;
+ * echo $config->database->username;
+ *</code>
+ */
 class Ini extends Config
 {
 
@@ -32,26 +62,62 @@ class Ini extends Config
 	 */
 	public function __construct(string! filePath)
 	{
-		var config, iniConfig, section, directives, directiveParts, key, value;
+		var iniConfig;
 
-		let config = [];
-
-		let iniConfig = parse_ini_file($filePath, true);
+		let iniConfig = parse_ini_file(filePath, true);
 		if iniConfig === false {
 			throw new Exception("Configuration file " . basename(filePath) . " can't be loaded");
 		}
 
+		var config, section, sections, directives, path, lastValue;
+
+		let config = [];
+
 		for section, directives in iniConfig {
-			for key, value in directives {
-				if memstr(key, ".") {
-					let directiveParts = explode(".", key);
-					let config[section][directiveParts[0]][directiveParts[1]] = value;
-				} else {
-					let config[section][key] = value;
-				}
+			let sections = [];
+			for path, lastValue in directives {
+				let sections[] = this->_parseIniString(path, lastValue);
 			}
+
+			let config[section] = call_user_func_array("array_merge_recursive", sections);
 		}
 
 		parent::__construct(config);
+	}
+
+	/**
+	 * Build multidimensional array from string
+	 *
+	 * <code>
+	 * $this->_buildArrayFromString('path.hello.world', 'value for last key');
+	 * // result
+	 * [
+	 *      'path' => [
+	 *          'hello' => [
+	 *              'world' => 'value for last key',
+	 *          ],
+	 *      ],
+	 * ];
+	 * </code>
+	 * @param string path
+	 * @param mixed value
+	 *
+	 * @return array parsed path
+	 */
+	private function _parseIniString(string! path, var value) -> array
+	{
+		var pos;
+		let pos = strpos(path, ".");
+
+		if pos === false {
+			return [path: value];
+		}
+
+		var key;
+
+		let key = substr(path, 0, pos);
+		let path = substr(path, pos + 1);
+
+		return [key: this->_parseIniString(path, value)];
 	}
 }

--- a/phalcon/config/adapter/json.zep
+++ b/phalcon/config/adapter/json.zep
@@ -21,6 +21,25 @@ namespace Phalcon\Config\Adapter;
 
 use Phalcon\Config;
 
+/**
+ * Phalcon\Config\Adapter\Json
+ *
+ * Reads JSON files and converts them to Phalcon\Config objects.
+ *
+ * Given the following configuration file:
+ *
+ *<code>
+ * {"phalcon":{"baseuri":"\/phalcon\/"},"models":{"metadata":"memory"}}
+ *</code>
+ *
+ * You can read it as follows:
+ *
+ *<code>
+ * $config = new Phalcon\Config\Adapter\Json("path/config.json");
+ * echo $config->phalcon->baseuri;
+ * echo $config->models->metadata;
+ *</code>
+ */
 class Json extends Config
 {
 

--- a/phalcon/config/adapter/php.zep
+++ b/phalcon/config/adapter/php.zep
@@ -21,6 +21,39 @@ namespace Phalcon\Config\Adapter;
 
 use Phalcon\Config;
 
+/**
+ * Phalcon\Config\Adapter\Php
+ *
+ * Reads php files and converts them to Phalcon\Config objects.
+ *
+ * Given the next configuration file:
+ *
+ *<code>
+ *<?php
+ *return array(
+ * 'database' => array(
+ *     'adapter' => 'Mysql',
+ *     'host' => 'localhost',
+ *     'username' => 'scott',
+ *     'password' => 'cheetah',
+ *     'dbname' => 'test_db'
+ * ),
+ *
+ * phalcon' => array(
+ *    'controllersDir' => '../app/controllers/',
+ *    'modelsDir' => '../app/models/',
+ *    'viewsDir' => '../app/views/'
+ *));
+ *</code>
+ *
+ * You can read it as follows:
+ *
+ *<code>
+ * $config = new Phalcon\Config\Adapter\Php("path/config.php");
+ * echo $config->phalcon->controllersDir;
+ * echo $config->database->username;
+ *</code>
+ */
 class Php extends Config
 {
 

--- a/phalcon/config/adapter/yaml.zep
+++ b/phalcon/config/adapter/yaml.zep
@@ -22,33 +22,58 @@ namespace Phalcon\Config\Adapter;
 use Phalcon\Config;
 use Phalcon\Config\Exception;
 
+/**
+ * Phalcon\Config\Adapter\Yaml
+ *
+ * Reads JSON files and converts them to Phalcon\Config objects.
+ *
+ * Given the following configuration file:
+ *
+ *<code>
+ * phalcon
+ *   baseuri: /phalcon/
+ * models:
+ *   metadata: memory
+ *</code>
+ *
+ * You can read it as follows:
+ *
+ *<code>
+ * $config = new Phalcon\Config\Adapter\Yaml("path/config.yaml");
+ * echo $config->phalcon->baseuri;
+ * echo $config->models->metadata;
+ *</code>
+ *
+ */
 class Yaml extends Config
 {
 
-    /**
-     * Phalcon\Config\Adapter\Yaml constructor
-     *
-     * @param  string                    $filePath
-     * @param  array                     $callbacks
-     * @throws \Phalcon\Config\Exception
-     */
-    public function __construct(string! filePath, array! callbacks = null)
-    {
-        if (!extension_loaded("yaml")) {
-            throw new Exception("Yaml extension not loaded");
-        }
-        var yamlConfig;
-        int ndocs = 0;
-        if callbacks != null {
-            let yamlConfig = yaml_parse_file(filePath, 0, ndocs, callbacks);
-        } else {
-            let yamlConfig = yaml_parse_file(filePath);
-        }
-        if yamlConfig === false {
-            throw new Exception("Configuration file " . basename(filePath) . " can't be loaded");
-        }
+	/**
+	 * Phalcon\Config\Adapter\Yaml constructor
+	 *
+	 * @param  string                    $filePath
+	 * @param  array                     $callbacks
+	 * @throws \Phalcon\Config\Exception
+	 */
+	public function __construct(string! filePath, array! callbacks = null)
+	{
+		if !extension_loaded("yaml") {
+			throw new Exception("Yaml extension not loaded");
+		}
+		var yamlConfig;
+		int ndocs = 0;
 
-        parent::__construct(yamlConfig);
-    }
+		if callbacks !== null {
+			let yamlConfig = yaml_parse_file(filePath, 0, ndocs, callbacks);
+		} else {
+			let yamlConfig = yaml_parse_file(filePath);
+		}
+
+		if yamlConfig === false {
+			throw new Exception("Configuration file " . basename(filePath) . " can't be loaded");
+		}
+
+		parent::__construct(yamlConfig);
+	}
 
 }

--- a/unit-tests/ConfigTest.php
+++ b/unit-tests/ConfigTest.php
@@ -150,7 +150,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 				"host"     => "localhost",
 				"username" => "peter",
 				"options" => array(
-					"case" => "lower"
+					"case" => "lower",
+//					PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
 				),
 				"alternatives" => array(
 					"primary" => "swedish",
@@ -180,6 +181,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 				)),
 				'options' => Phalcon\Config::__set_state(array(
 					'case' => 'lower',
+					// todo: add support numeric keys as properties
+//					(string)PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
 				)),
 			)),
 		));
@@ -190,14 +193,12 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     public function testConfigCount()
     {
+		$config = new Phalcon\Config(array(
+			 "controllersDir" => "../x/y/z",
+			 "modelsDir" => "../x/y/z",
+		 ));
 
-        $config = new Phalcon\Config(array(
-                                         "controllersDir" => "../x/y/z",
-                                         "modelsDir" => "../x/y/z",
-                                     ));
-
-
-        $this->assertEquals(2, count($config));
+		$this->assertEquals(2, count($config));
 
     }
 

--- a/unit-tests/phpunit.xml
+++ b/unit-tests/phpunit.xml
@@ -22,7 +22,7 @@
 			<!--<file>unit-tests/CollectionsEventsTest.php</file>-->
 			<!--<file>unit-tests/CollectionsSerializeTest.php</file>-->
 			<!--<file>unit-tests/CollectionsTest.php</file>-->
-			<!--<file>unit-tests/ConfigTest.php</file>-->
+			<file>unit-tests/ConfigTest.php</file>
 			<file>unit-tests/ConsoleCliTest.php</file>
 			<file>unit-tests/ControllersTest.php</file>
 			<file>unit-tests/CryptTest.php</file>


### PR DESCRIPTION
general code was:
`if typeof instance !== "object"` -> `if !(instance instanceof self)` and
`if typeof value === "object" && typeof instance->{key} === "object"` had the same situation, but in the iteration Zephir throws some exception like
`Phalcon\self does not exist`, please pay attention to this case, thanx

Also config can have numerical keys as properties (example `PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8'`), why do u exclude numerical type?
