### PR TITLE
[2.0.0] Fix broken ACL inheritance

### DIFF
--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -358,7 +358,7 @@ class Memory extends Adapter
 	 * @param string access
 	 * @param string action
 	 */
-	private function _allowOrDeny(var roleName, var resourceName, var access, var action)
+	protected function _allowOrDeny(var roleName, var resourceName, var access, var action)
 	{
 		var defaultAccess, accessList, accessName, accessKey, accessKeyAll, internalAccess;
 
@@ -456,10 +456,10 @@ class Memory extends Adapter
 		var tmp;
 
 		if roleName != "*" {
-			return this->_allowordeny(roleName, resourceName, access, \Phalcon\Acl::ALLOW);
+			return this->_allowOrDeny(roleName, resourceName, access, \Phalcon\Acl::ALLOW);
 		} else {
 			for roleName, tmp in this->_rolesNames {
-				this->_allowordeny(roleName, resourceName, access, \Phalcon\Acl::ALLOW);
+				this->_allowOrDeny(roleName, resourceName, access, \Phalcon\Acl::ALLOW);
 			}
 		}
 	}

--- a/tests/unit/Phalcon/Acl/Adapter/Memory/ACLMemoryTest.php
+++ b/tests/unit/Phalcon/Acl/Adapter/Memory/ACLMemoryTest.php
@@ -24,7 +24,7 @@
 namespace Phalcon\Tests\unit\Phalcon\Acl;
 
 use \Phalcon\Acl as PhAcl;
-use \Phalcon\Acl\Adapter\Memory as PhTAclMem;
+use \PhalconTest\Acl\Adapter\Memory as PhTAclMem;
 
 use \PhalconTest\Acl\Role as PhTAclRole;
 use \PhalconTest\Acl\Resource as PhTAclResource;


### PR DESCRIPTION
Problem:
If you inherit the acl memory adapter and call inside your class $this->allow(...) then following exception will thrown.

_ErrorException: Invalid callback PhalconTest\Acl\Adapter\Memory::_allowordeny, cannot access private method PhalconTest\Acl\Adapter\Memory::_allowOrDeny()_

This pull request is a quick fix. I think the real issue appears in compilation from zephir to c.
