### PR TITLE
[2.0.0] Binding arrays

### DIFF
--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -127,6 +127,25 @@ class Column implements ColumnInterface
 	 */
 	const BIND_PARAM_DECIMAL = 32;
 
+    /**
+     * Represents an array of ints to be expanded by SQL parsing.
+     *
+     * @var integer
+     */
+    const BIND_PARAM_INT_ARRAY = 101;
+    /**
+     * Represents an array of strings to be expanded by SQL parsing.
+     *
+     * @var integer
+     */
+    const BIND_PARAM_STR_ARRAY = 102;
+    /**
+     * Offset by which BIND_PARAM_* constants are detected as arrays of the param type.
+     *
+     * @var integer
+     */
+    const BIND_ARRAY_PARAM_OFFSET = 100;
+
 	/**
 	 * Skip binding by type
 	 */

--- a/phalcon/db/utils/sqlparser.zep
+++ b/phalcon/db/utils/sqlparser.zep
@@ -49,7 +49,7 @@ class SQLParser
 	 *
 	 * @return array
 	 */
-	static public function getPlaceholderPositions(string statement, boolean isPositional = true)
+	public static function getPlaceholderPositions(string statement, boolean isPositional = true)
 	{
 		var matches = null, fragment, placeholder, paramMap = [];
 		string match, token;
@@ -85,7 +85,7 @@ class SQLParser
 	 *
 	 * @throws Exception
 	 */
-	static public function expandListParameters(string query, var params, var types)
+	public static function expandListParameters(string query, var params, var types)
 	{
 		var arrayPositions = [], isPositional, bindIndex = -1, name, paramOffset,
 			queryOffset, needle, needlePos, typesOrd, paramsOrd, paramPos, count,

--- a/phalcon/db/utils/sqlparser.zep
+++ b/phalcon/db/utils/sqlparser.zep
@@ -2,18 +2,45 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | This source file is port of the file of Doctrine DBAL project, which   |
+ | licensed under the MIT license (see below).                            |
  |                                                                        |
  | If you did not receive a copy of the license and are unable to         |
  | obtain it through the world-wide-web, please send an email             |
  | to license@phalconphp.com so we can send you a copy immediately.       |
  +------------------------------------------------------------------------+
- | Authors: Doctrine DBAL Team                                            |
+ | Authors: Benjamin Eberlei <kontakt@beberlei.de>                        |
+ |          Doctrine DBAL Team                                            |
  |          Vladimir Khramov <quant13@gmail.com>                          |
  +------------------------------------------------------------------------+
+
+
+ Doctrine 2 License (MIT)
+
+ Copyright (c) 2006-2012 Doctrine Project
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this software and associated documentation files (the "Software"), to deal in
+ the Software without restriction, including without limitation the rights to
+ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ of the Software, and to permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
  */
 
 namespace Phalcon\Db\Utils;

--- a/phalcon/db/utils/sqlparser.zep
+++ b/phalcon/db/utils/sqlparser.zep
@@ -1,0 +1,260 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Doctrine DBAL Team                                            |
+ |          Vladimir Khramov <quant13@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Utils;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\Column;
+
+/**
+ * Phalcon\Db\Utils\SQLParser
+ *
+ * Utility class that parses sql statements with regard to types and parameters.
+ * Port of class SQLParserUtils of Doctrine DBAL.
+ */
+class SQLParser
+{
+	const POSITIONAL_TOKEN = "\\?";
+	const NAMED_TOKEN = "(?<!:):[a-zA-Z0-9_]+";
+
+	// Quote characters within string literals can be preceded by a backslash.
+	const ESCAPED_SINGLE_QUOTED_TEXT   = "'(?:[^'\\\\]|\\\\'?)*'";
+	const ESCAPED_DOUBLE_QUOTED_TEXT   = "\"(?:[^\"\\\\]|\\\\\"?)*\"";
+	const ESCAPED_BACKTICK_QUOTED_TEXT = "`(?:[^`\\\\]|\\\\`?)*`";
+	const ESCAPED_BRACKET_QUOTED_TEXT  = "\\[(?:[^\\]])*\\]"; //"
+
+	/**
+	 * Gets an array of the placeholders in an sql statements as keys and their positions in the query string.
+	 *
+	 * Returns an integer => integer pair (indexed from zero) for a positional statement
+	 * and a string => int[] pair for a named statement.
+	 *
+	 * @param string  statement
+	 * @param boolean isPositional
+	 *
+	 * @return array
+	 */
+	static public function getPlaceholderPositions(string statement, boolean isPositional = true)
+	{
+		var matches = null, fragment, placeholder, paramMap = [];
+		string match, token;
+		int pos;
+
+		let match = isPositional ? "?" : ":";
+		if (strpos(statement, match) === false) {
+			return [];
+		}
+		let token = isPositional ? self::POSITIONAL_TOKEN : self::NAMED_TOKEN;
+		for fragment in self::getUnquotedStatementFragments(statement) {
+			preg_match_all("/" . token . "/", fragment[0], matches, PREG_OFFSET_CAPTURE);
+			for placeholder in matches[0] {
+				if isPositional {
+					let paramMap[] = placeholder[1] + fragment[1];
+				} else {
+					let pos = placeholder[1] + fragment[1];
+					let paramMap[pos] = substr(placeholder[0], 1, strlen(placeholder[0]));
+				}
+			}
+		}
+		return paramMap;
+	}
+
+	/**
+	 * For a positional query this method can rewrite the sql statement with regard to array parameters.
+	 *
+	 * @param string query  The SQL query to execute.
+	 * @param array  params The parameters to bind to the query.
+	 * @param array  types  The types the previous parameters are in.
+	 *
+	 * @return array
+	 *
+	 * @throws Exception
+	 */
+	static public function expandListParameters(string query, var params, var types)
+	{
+		var arrayPositions = [], isPositional, bindIndex = -1, name, paramOffset,
+			queryOffset, needle, needlePos, typesOrd, paramsOrd, paramPos, count,
+			paramsExpanded, typesExpanded, typesForExpand, expandStr,
+			pos, paramName, paramLen, value, val, param, processTypes;
+
+		let processTypes = typeof types == "array" && count(types);
+		let isPositional = is_int(key(params));
+
+		if (isPositional) {
+			ksort(params);
+			if processTypes {
+				ksort(types);
+			}
+		}
+
+		for name, param in params {
+			let bindIndex = bindIndex+1;
+
+			if typeof param != "array" {
+				continue;
+			}
+
+			if (isPositional) {
+				let name = bindIndex;
+			}
+
+			let arrayPositions[name] = false;
+		}
+
+		if empty arrayPositions {
+			return [query, params, types];
+		}
+
+		let paramPos = self::getPlaceholderPositions(query, isPositional);
+
+		if (isPositional) {
+			let paramOffset = 0;
+			let queryOffset = 0;
+			let paramsExpanded = array_values(params);
+			if processTypes {
+				let typesExpanded = array_values(types);
+			}
+
+			for needle, needlePos in paramPos {
+				if !isset arrayPositions[needle] {
+					continue;
+				}
+
+				let needle = needle + paramOffset;
+				let needlePos = needlePos + queryOffset;
+				let count = count(paramsExpanded[needle]);
+
+				let paramsExpanded = array_merge(
+					array_slice(paramsExpanded, 0, needle),
+					paramsExpanded[needle],
+					array_slice(paramsExpanded, needle + 1)
+				);
+
+				if processTypes {
+					let typesForExpand = count ? array_fill(0, count, typesExpanded[needle] - Column::BIND_ARRAY_PARAM_OFFSET) : [];
+					let typesExpanded = array_merge(
+						array_slice(typesExpanded, 0, needle),
+						typesForExpand,
+						array_slice(typesExpanded, needle + 1)
+					);
+				}
+
+				let expandStr = count ? implode(", ", array_fill(0, count, "?")) : "NULL";
+				let query = substr(query, 0, needlePos) . expandStr . substr(query, needlePos + 1);
+
+				let paramOffset = paramOffset + (count - 1); // Grows larger by number of parameters minus the replaced needle.
+				let queryOffset = queryOffset + (strlen(expandStr) - 1);
+			}
+
+			return [query, paramsExpanded, processTypes ? typesExpanded : types];
+		}
+
+		let queryOffset = 0;
+		let typesOrd = [];
+		let paramsOrd = [];
+
+		for pos, paramName in paramPos {
+			let paramLen = strlen(paramName) + 1;
+			let value = static::extractParam(paramName, params, true);
+
+			if !isset arrayPositions[paramName] && !isset arrayPositions[":" . paramName] {
+				let pos = pos + queryOffset;
+				let queryOffset = queryOffset - (paramLen - 1);
+				let paramsOrd[] = value;
+				if processTypes {
+					let typesOrd[] = static::extractParam(paramName, types, false, Column::BIND_PARAM_STR);
+				}
+				let query = substr(query, 0, pos) . "?" . substr(query, (pos + paramLen));
+
+				continue;
+			}
+
+			let count = count(value);
+			let expandStr = count > 0 ? implode(", ", array_fill(0, count, "?")) : "NULL";
+
+			for val in value {
+				let paramsOrd[] = val;
+				if processTypes {
+					let typesOrd[]  = static::extractParam(paramName, types, false) - Column::BIND_ARRAY_PARAM_OFFSET;
+				}
+			}
+
+			let pos = pos + queryOffset;
+			let queryOffset = queryOffset + (strlen(expandStr) - paramLen);
+			let query = substr(query, 0, pos) . expandStr . substr(query, (pos + paramLen));
+		}
+
+		return [query, paramsOrd, processTypes ? typesOrd : types];
+	}
+
+	/**
+	 * Slice the SQL statement around pairs of quotes and
+	 * return string fragments of SQL outside of quoted literals.
+	 * Each fragment is captured as a 2-element array:
+	 *
+	 * 0 => matched fragment string,
+	 * 1 => offset of fragment in $statement
+	 *
+	 * @param string statement
+	 * @return array
+	 */
+	static private function getUnquotedStatementFragments(string statement)
+	{
+		var fragments = null;
+		string literal;
+
+		let literal = self::ESCAPED_SINGLE_QUOTED_TEXT . "|" .
+					  self::ESCAPED_DOUBLE_QUOTED_TEXT . "|" .
+					  self::ESCAPED_BACKTICK_QUOTED_TEXT . "|" .
+					  self::ESCAPED_BRACKET_QUOTED_TEXT;
+		preg_match_all("/([^'\"`\[]+)(?:" . literal . ")?/s", statement, fragments, PREG_OFFSET_CAPTURE);//"
+
+		return fragments[1];
+	}
+
+	/**
+	 * @param string paramName      The name of the parameter (without a colon in front)
+	 * @param array  paramsOrTypes  A hash of parameters or types
+	 * @param bool   isParam
+	 * @param mixed  defaultValue   An optional default value. If omitted, an exception is thrown
+	 *
+	 * @throws Exception
+	 * @return mixed
+	 */
+	static private function extractParam(string paramName, array paramsOrTypes, bool isParam, var defaultValue = null)
+	{
+		if (array_key_exists(paramName, paramsOrTypes)) {
+			return paramsOrTypes[paramName];
+		}
+
+		// Hash keys can be prefixed with a colon for compatibility
+		if (array_key_exists(":" . paramName, paramsOrTypes)) {
+			return paramsOrTypes[":" . paramName];
+		}
+
+		if (null !== defaultValue) {
+			return defaultValue;
+		}
+
+		if (isParam) {
+			throw new Exception("Missing param '" . paramName . "'");
+		}
+
+		throw new Exception("Missing type '" . paramName . "'");
+	}
+}

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3885,7 +3885,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	public static function __callStatic(string method, arguments = null)
 	{
 		var extraMethod, type, modelName, value, model,
-			attributes, field, extraMethodFirst, metaData;
+			attributes, field, extraMethodFirst, metaData, conditions;
 
 		let extraMethod = null;
 
@@ -3969,8 +3969,13 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 		/**
 		 * Execute the query
 		 */
+		if is_array(value) {
+			let conditions = field . " in (?0)";
+		} else {
+			let conditions = field . " = ?0";
+		}
 		return {modelName}::{type}([
-			"conditions": field . " = ?0",
+			"conditions": conditions,
 			"bind"      : [value]
 		]);
 	}

--- a/tests/unit/Phalcon/Db/Utils/SQLParserTest.php
+++ b/tests/unit/Phalcon/Db/Utils/SQLParserTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/**
+ * SQLParserTest.php
+ * \Phalcon\Db\Utils\SQLParser
+ *
+ * Tests the \Phalcon\Db\Utils\SQLParser component
+ * Port to Phalcon of tests for class SQLParserUtils of Doctrine DBAL.
+ *
+ * Phalcon Framework
+ *
+ * @copyright (c) 2011-2014 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Doctrine DBAL Team
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+
+namespace Phalcon\Tests\unit\Phalcon\Db\Utils;
+
+use \Phalcon\Db\Utils\SQLParser;
+use \Phalcon\Db\Column;
+use \Phalcon\Tests\unit\Phalcon\_Helper\TestsBase as TBase;
+
+class SQLParserTest extends TBase
+{
+    public function dataGetPlaceholderPositions()
+    {
+        return array(
+            // none
+            array('SELECT * FROM Foo', true, array()),
+            array('SELECT * FROM Foo', false, array()),
+
+            // Positionals
+            array('SELECT ?', true, array(7)),
+            array('SELECT * FROM Foo WHERE bar IN (?, ?, ?)', true, array(32, 35, 38)),
+            array('SELECT ? FROM ?', true, array(7, 14)),
+            array('SELECT "?" FROM foo', true, array()),
+            array("SELECT '?' FROM foo", true, array()),
+            array("SELECT `?` FROM foo", true, array()), // Ticket DBAL-552
+            array("SELECT [?] FROM foo", true, array()),
+            array("SELECT 'Doctrine\DBAL?' FROM foo", true, array()), // Ticket DBAL-558
+            array('SELECT "Doctrine\DBAL?" FROM foo', true, array()), // Ticket DBAL-558
+            array('SELECT `Doctrine\DBAL?` FROM foo', true, array()), // Ticket DBAL-558
+            array('SELECT [Doctrine\DBAL?] FROM foo', true, array()), // Ticket DBAL-558
+            array('SELECT "?" FROM foo WHERE bar = ?', true, array(32)),
+            array("SELECT '?' FROM foo WHERE bar = ?", true, array(32)),
+            array("SELECT `?` FROM foo WHERE bar = ?", true, array(32)), // Ticket DBAL-552
+            array("SELECT [?] FROM foo WHERE bar = ?", true, array(32)),
+            array("SELECT 'Doctrine\DBAL?' FROM foo WHERE bar = ?", true, array(45)), // Ticket DBAL-558
+            array('SELECT "Doctrine\DBAL?" FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
+            array('SELECT `Doctrine\DBAL?` FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
+            array('SELECT [Doctrine\DBAL?] FROM foo WHERE bar = ?', true, array(45)), // Ticket DBAL-558
+            array(
+<<<'SQLDATA'
+SELECT * FROM foo WHERE bar = 'it\'s a trap? \\' OR bar = ?
+AND baz = "\"quote\" me on it? \\" OR baz = ?
+SQLDATA
+            , true, array(58, 104)
+            ),
+            array('SELECT * FROM foo WHERE foo = ? AND bar = ?', true, array(1 => 42, 0 => 30)), // explicit keys
+
+            // named
+            array('SELECT :foo FROM :bar', false, array(7 => 'foo', 17 => 'bar')),
+            array('SELECT * FROM Foo WHERE bar IN (:name1, :name2)', false, array(32 => 'name1', 40 => 'name2')),
+            array('SELECT ":foo" FROM Foo WHERE bar IN (:name1, :name2)', false, array(37 => 'name1', 45 => 'name2')),
+            array("SELECT ':foo' FROM Foo WHERE bar IN (:name1, :name2)", false, array(37 => 'name1', 45 => 'name2')),
+            array('SELECT :foo_id', false, array(7 => 'foo_id')), // Ticket DBAL-231
+            array('SELECT @rank := 1', false, array()), // Ticket DBAL-398
+            array('SELECT @rank := 1 AS rank, :foo AS foo FROM :bar', false, array(27 => 'foo', 44 => 'bar')), // Ticket DBAL-398
+            array('SELECT * FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(30 => 'start_date', 52 =>  'start_date')), // Ticket GH-113
+            array('SELECT foo::date as date FROM Foo WHERE bar > :start_date AND baz > :start_date', false, array(46 => 'start_date', 68 =>  'start_date')), // Ticket GH-259
+            array('SELECT `d.ns:col_name` FROM my_table d WHERE `d.date` >= :param1', false, array(57 => 'param1')), // Ticket DBAL-552
+            array('SELECT [d.ns:col_name] FROM my_table d WHERE [d.date] >= :param1', false, array(57 => 'param1')), // Ticket DBAL-552
+        );
+    }
+
+    /**
+     * @dataProvider dataGetPlaceholderPositions
+     */
+    public function testGetPlaceholderPositions($query, $isPositional, $expectedParamPos)
+    {
+        $actualParamPos = SQLParser::getPlaceholderPositions($query, $isPositional);
+        $this->assertEquals($expectedParamPos, $actualParamPos);
+    }
+
+    public function dataExpandListParameters()
+    {
+        return array(
+            // Positional: Very simple with one needle
+            array(
+                "SELECT * FROM Foo WHERE foo IN (?)",
+                array(array(1, 2, 3)),
+                array(Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?)',
+                array(1, 2, 3),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Positional: One non-list before d one after list-needle
+            array(
+                "SELECT * FROM Foo WHERE foo = ? AND bar IN (?)",
+                array("string", array(1, 2, 3)),
+                array(Column::BIND_PARAM_STR, Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo = ? AND bar IN (?, ?, ?)',
+                array("string", 1, 2, 3),
+                array(Column::BIND_PARAM_STR, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Positional: One non-list after list-needle
+            array(
+                "SELECT * FROM Foo WHERE bar IN (?) AND baz = ?",
+                array(array(1, 2, 3), "foo"),
+                array(Column::BIND_PARAM_INT_ARRAY, Column::BIND_PARAM_STR),
+                'SELECT * FROM Foo WHERE bar IN (?, ?, ?) AND baz = ?',
+                array(1, 2, 3, "foo"),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR)
+            ),
+            // Positional: One non-list before and one after list-needle
+            array(
+                "SELECT * FROM Foo WHERE foo = ? AND bar IN (?) AND baz = ?",
+                array(1, array(1, 2, 3), 4),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT_ARRAY, Column::BIND_PARAM_INT),
+                'SELECT * FROM Foo WHERE foo = ? AND bar IN (?, ?, ?) AND baz = ?',
+                array(1, 1, 2, 3, 4),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Positional: Two lists
+            array(
+                "SELECT * FROM Foo WHERE foo IN (?, ?)",
+                array(array(1, 2, 3), array(4, 5)),
+                array(Column::BIND_PARAM_INT_ARRAY, Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?, ?, ?)',
+                array(1, 2, 3, 4, 5),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Positional: Empty "integer" array DDC-1978
+            array(
+                "SELECT * FROM Foo WHERE foo IN (?)",
+                array(array()),
+                array(Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (NULL)',
+                array(),
+                array()
+            ),
+            // Positional: Empty "str" array DDC-1978
+            array(
+                "SELECT * FROM Foo WHERE foo IN (?)",
+                array(array()),
+                array(Column::BIND_PARAM_STR_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (NULL)',
+                array(),
+                array()
+            ),
+            // Positional: explicit keys for params and types
+            array(
+                "SELECT * FROM Foo WHERE foo = ? AND bar = ? AND baz = ?",
+                array(1 => 'bar', 2 => 'baz', 0 => 1),
+                array(2 => Column::BIND_PARAM_STR, 1 => Column::BIND_PARAM_STR),
+                'SELECT * FROM Foo WHERE foo = ? AND bar = ? AND baz = ?',
+                array(1 => 'bar', 0 => 1, 2 => 'baz'),
+                array(1 => Column::BIND_PARAM_STR, 2 => Column::BIND_PARAM_STR)
+            ),
+            // Positional: explicit keys for array params and array types
+            array(
+                "SELECT * FROM Foo WHERE foo IN (?) AND bar IN (?) AND baz = ?",
+                array(1 => array('bar1', 'bar2'), 2 => true, 0 => array(1, 2, 3)),
+                array(2 => Column::BIND_PARAM_BOOL, 1 => Column::BIND_PARAM_STR_ARRAY, 0 => Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?) AND bar IN (?, ?) AND baz = ?',
+                array(1, 2, 3, 'bar1', 'bar2', true),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR, Column::BIND_PARAM_STR, Column::BIND_PARAM_BOOL)
+            ),
+            // Positional starts from 1: One non-list before and one after list-needle
+            array(
+                "SELECT * FROM Foo WHERE foo = ? AND bar IN (?) AND baz = ? AND foo IN (?)",
+                array(1 => 1, 2 => array(1, 2, 3), 3 => 4, 4 => array(5, 6)),
+                array(1 => Column::BIND_PARAM_INT, 2 => Column::BIND_PARAM_INT_ARRAY, 3 => Column::BIND_PARAM_INT, 4 => Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo = ? AND bar IN (?, ?, ?) AND baz = ? AND foo IN (?, ?)',
+                array(1, 1, 2, 3, 4, 5, 6),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            //  Named parameters : Very simple with one needle
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo)",
+                array('foo'=>array(1, 2, 3)),
+                array('foo'=>Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?)',
+                array(1, 2, 3),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Named parameters: One non-list before d one after list-needle
+            array(
+                "SELECT * FROM Foo WHERE foo = :foo AND bar IN (:bar)",
+                array('foo'=>"string", 'bar'=>array(1, 2, 3)),
+                array('foo'=>Column::BIND_PARAM_STR, 'bar'=>Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo = ? AND bar IN (?, ?, ?)',
+                array("string", 1, 2, 3),
+                array(Column::BIND_PARAM_STR, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Named parameters: One non-list after list-needle
+            array(
+                "SELECT * FROM Foo WHERE bar IN (:bar) AND baz = :baz",
+                array('bar'=>array(1, 2, 3), 'baz'=>"foo"),
+                array('bar'=>Column::BIND_PARAM_INT_ARRAY, 'baz'=>Column::BIND_PARAM_STR),
+                'SELECT * FROM Foo WHERE bar IN (?, ?, ?) AND baz = ?',
+                array(1, 2, 3, "foo"),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR)
+            ),
+            // Named parameters: One non-list before and one after list-needle
+            array(
+                "SELECT * FROM Foo WHERE foo = :foo AND bar IN (:bar) AND baz = :baz",
+                array('bar'=>array(1, 2, 3),'foo'=>1, 'baz'=>4),
+                array('bar'=>Column::BIND_PARAM_INT_ARRAY, 'foo'=>Column::BIND_PARAM_INT, 'baz'=>Column::BIND_PARAM_INT),
+                'SELECT * FROM Foo WHERE foo = ? AND bar IN (?, ?, ?) AND baz = ?',
+                array(1, 1, 2, 3, 4),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            // Named parameters: Two lists
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:a, :b)",
+                array('b'=>array(4, 5),'a'=>array(1, 2, 3)),
+                array('a'=>Column::BIND_PARAM_INT_ARRAY, 'b'=>Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?, ?, ?)',
+                array(1, 2, 3, 4, 5),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+            //  Named parameters : With the same name arg
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:arg) AND NOT bar IN (:arg)",
+                array('arg'=>array(1, 2, 3)),
+                array('arg'=>Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?, ?) AND NOT bar IN (?, ?, ?)',
+                array(1, 2, 3, 1, 2, 3),
+                array(Column::BIND_PARAM_INT,Column::BIND_PARAM_INT, Column::BIND_PARAM_INT,Column::BIND_PARAM_INT,Column::BIND_PARAM_INT, Column::BIND_PARAM_INT)
+            ),
+
+            //  Named parameters : Empty "integer" array DDC-1978
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo)",
+                array('foo'=>array()),
+                array('foo'=>Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (NULL)',
+                array(),
+                array()
+            ),
+            //  Named parameters : Two empty "str" array DDC-1978
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar IN (:bar)",
+                array('foo'=>array(), 'bar'=>array()),
+                array('foo'=>Column::BIND_PARAM_STR_ARRAY, 'bar'=>Column::BIND_PARAM_STR_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (NULL) OR bar IN (NULL)',
+                array(),
+                array()
+            ),
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar = :bar OR baz = :baz",
+                array('foo' => array(1, 2), 'bar' => 'bar', 'baz' => 'baz'),
+                array('foo' => Column::BIND_PARAM_INT_ARRAY, 'baz' => 'string'),
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar = ? OR baz = ?',
+                array(1, 2, 'bar', 'baz'),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR, 'string')
+            ),
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar = :bar",
+                array('foo' => array(1, 2), 'bar' => 'bar'),
+                array('foo' => Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar = ?',
+                array(1, 2, 'bar'),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR)
+            ),
+            // Params/types with colons
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar = :bar",
+                array(':foo' => array(1, 2), ':bar' => 'bar'),
+                array('foo' => Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar = ?',
+                array(1, 2, 'bar'),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR)
+            ),
+            array(
+                "SELECT * FROM Foo WHERE foo IN (:foo) OR bar = :bar",
+                array('foo' => array(1, 2), 'bar' => 'bar'),
+                array(':foo' => Column::BIND_PARAM_INT_ARRAY),
+                'SELECT * FROM Foo WHERE foo IN (?, ?) OR bar = ?',
+                array(1, 2, 'bar'),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_INT, Column::BIND_PARAM_STR)
+            ),
+            // DBAL-522 - null valued parameters are not considered
+            array(
+                'INSERT INTO Foo (foo, bar) values (?, ?)',
+                array(1, null),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_NULL),
+                'INSERT INTO Foo (foo, bar) values (?, ?)',
+                array(1, null),
+                array(Column::BIND_PARAM_INT, Column::BIND_PARAM_NULL)
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider dataExpandListParameters
+     */
+    public function testExpandListParameters($q, $p, $t, $expectedQuery, $expectedParams, $expectedTypes)
+    {
+        list($query, $params, $types) = SQLParser::expandListParameters($q, $p, $t);
+
+        $this->assertEquals($expectedQuery, $query, "Query was not rewritten correctly.");
+        $this->assertEquals($expectedParams, $params, "Params dont match");
+        $this->assertEquals($expectedTypes, $types, "Types dont match");
+    }
+}

--- a/tests/unit/Phalcon/Db/Utils/SQLParserTest.php
+++ b/tests/unit/Phalcon/Db/Utils/SQLParserTest.php
@@ -9,16 +9,42 @@
  *
  * Phalcon Framework
  *
- * @copyright (c) 2011-2014 Phalcon Team
+ * @copyright (c) 2011-2015 Phalcon Team
  * @link      http://www.phalconphp.com
- * @author    Doctrine DBAL Team
+ * @author    Doctrine DBAL Team, Vladimir Khramov <quant13@gmail.com>
  *
  * The contents of this file are subject to the New BSD License that is
  * bundled with this package in the file docs/LICENSE.txt
  *
+ * This source file is based on the file of Doctrine DBAL project, which
+ * licensed under the MIT license (see below).
+ *
  * If you did not receive a copy of the license and are unable to obtain it
  * through the world-wide-web, please send an email to license@phalconphp.com
  * so that we can send you a copy immediately.
+ *
+ *
+ * Doctrine 2 License (MIT)
+ *
+ * Copyright (c) 2006-2012 Doctrine Project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
  */
 
 

--- a/unit-tests/DbBindTest.php
+++ b/unit-tests/DbBindTest.php
@@ -20,6 +20,7 @@
 */
 
 use Phalcon\Db\Column as DbColumn;
+use Phalcon\Db as Db;
 
 class DbBindTest extends PHPUnit_Framework_TestCase
 {
@@ -39,6 +40,7 @@ class DbBindTest extends PHPUnit_Framework_TestCase
 		//$this->_executeRawBindTestsMysql($connection);
 		$this->_executeConvertBindTests($connection);
 		$this->_executeBindByTypeTests($connection);
+		$this->_executeBindArrayTests($connection);
 	}
 
 	public function testDbBindPostgresql()
@@ -55,6 +57,7 @@ class DbBindTest extends PHPUnit_Framework_TestCase
 		//$this->_executeRawBindTests($connection);
 		//$this->_executeRawBindTestsPostgresql($connection);
 		$this->_executeBindByTypeTests($connection);
+		$this->_executeBindArrayTests($connection);
 	}
 
 	public function testDbBindSqlite()
@@ -71,6 +74,7 @@ class DbBindTest extends PHPUnit_Framework_TestCase
 		//$this->_executeRawBindTests($connection);
 		//$this->_executeRawBindTestsSqlite($connection);
 		$this->_executeBindByTypeTests($connection);
+		$this->_executeBindArrayTests($connection);
 	}
 
 	/*protected function _executeRawBindTests($connection)
@@ -232,6 +236,106 @@ class DbBindTest extends PHPUnit_Framework_TestCase
 		);
 		$this->assertTrue($success);
 
+	}
+
+	protected function _executeBindArrayTests($connection)
+	{
+		//with int bindings
+		$robots = $connection->fetchAll(
+			'select * from robots where id in (?) order by id',
+			Db::FETCH_ASSOC,
+			array(array(1, 2, 3)),
+			array(DbColumn::BIND_PARAM_INT_ARRAY)
+		);
+		$this->assertEquals(3, count($robots));
+		$this->assertEquals('Robotina', $robots[0]['name']);
+		$this->assertEquals('Astro Boy', $robots[1]['name']);
+		$this->assertEquals('Terminator', $robots[2]['name']);
+
+		//with string bindings
+		$robots = $connection->fetchAll(
+			'select * from robots where name in (?) order by id',
+			Db::FETCH_ASSOC,
+			array(array('Robotina', 'Astro Boy', 'Terminator')),
+			array(DbColumn::BIND_PARAM_STR_ARRAY)
+		);
+		$this->assertEquals(3, count($robots));
+		$this->assertEquals(1, $robots[0]['id']);
+		$this->assertEquals(2, $robots[1]['id']);
+		$this->assertEquals(3, $robots[2]['id']);
+
+		//int params without param types
+		$robots = $connection->fetchAll(
+			'select * from robots where id in (?) order by id',
+			Db::FETCH_ASSOC,
+			array(array(1, 2, 3))
+		);
+		$this->assertEquals(3, count($robots));
+		$this->assertEquals('Robotina', $robots[0]['name']);
+		$this->assertEquals('Astro Boy', $robots[1]['name']);
+		$this->assertEquals('Terminator', $robots[2]['name']);
+
+		//string params without param types
+		$robots = $connection->fetchAll(
+			'select * from robots where name in (?) order by id',
+			Db::FETCH_ASSOC,
+			array(array('Robotina', 'Astro Boy', 'Terminator'))
+		);
+		$this->assertEquals(3, count($robots));
+		$this->assertEquals(1, $robots[0]['id']);
+		$this->assertEquals(2, $robots[1]['id']);
+		$this->assertEquals(3, $robots[2]['id']);
+
+		//fetch one
+		$robot = $connection->fetchOne(
+			'select * from robots where id in (?) order by id limit 1',
+			Db::FETCH_ASSOC,
+			array(array(1, 2, 3)),
+			array(DbColumn::BIND_PARAM_INT_ARRAY)
+		);
+		$this->assertEquals('Robotina', $robot['name']);
+
+		$robot = $connection->fetchOne(
+			'select * from robots where id in (?) order by id limit 1',
+			Db::FETCH_ASSOC,
+			array(array(1, 2, 3))
+		);
+		$this->assertEquals('Robotina', $robot['name']);
+
+		//named param
+		$robots = $connection->fetchAll(
+			'select * from robots where id in (:ids) order by id',
+			Db::FETCH_ASSOC,
+			array('ids' => array(1, 2, 3))
+		);
+		$this->assertEquals(3, count($robots));
+		$this->assertEquals('Robotina', $robots[0]['name']);
+		$this->assertEquals('Astro Boy', $robots[1]['name']);
+		$this->assertEquals('Terminator', $robots[2]['name']);
+
+		//todo updateAsDict
+
+		//deleting
+		$connection->delete('robots', "name like 'name%'");
+		$connection->insertAsDict('robots',array('id' => $connection->getDefaultIdValue(), 'year' => 1,'type' => 'mechanical','name' => 'name1'));
+		$connection->insertAsDict('robots',array('id' => $connection->getDefaultIdValue(), 'year' => 2,'type' => 'mechanical','name' => 'name2'));
+		$connection->insertAsDict('robots',array('id' => $connection->getDefaultIdValue(), 'year' => 3,'type' => 'mechanical','name' => 'name3'));
+		$connection->insertAsDict('robots',array('id' => $connection->getDefaultIdValue(), 'year' => 4,'type' => 'mechanical','name' => 'name4'));
+		$robots = $connection->fetchAll('select * from robots');
+		$this->assertEquals(7, count($robots));
+
+		$connection->delete(
+			'robots',
+			'name in (?)',
+			array(array('name1','name2')),
+			array(DbColumn::BIND_PARAM_STR_ARRAY)
+		);
+		$robots = $connection->fetchAll('select * from robots');
+		$this->assertEquals(5, count($robots));
+
+		$connection->delete('robots', 'name in (?)', array(array('name3','name4')));
+		$robots = $connection->fetchAll('select * from robots');
+		$this->assertEquals(3, count($robots));
 	}
 
 }

--- a/unit-tests/ModelsFindersTest.php
+++ b/unit-tests/ModelsFindersTest.php
@@ -92,6 +92,17 @@ class ModelsFindersTest extends PHPUnit_Framework_TestCase
 
 		$number = Robots::countByType('mechanical');
 		$this->assertEquals($number, 2);
+
+		$robot = Robots::findFirstById(array(1));
+		$this->assertEquals($robot->id, 1);
+
+		$robots = Robots::findById(array(1,2));
+		$this->assertEquals(count($robots), 2);
+		$this->assertEquals($robots[0]->id, 1);
+		$this->assertEquals($robots[1]->id, 2);
+
+		$number = Robots::countById(array(1,2));
+		$this->assertEquals($number, 2);
 	}
 
 	protected function _executeTestsRenamed($di)
@@ -110,6 +121,17 @@ class ModelsFindersTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($robots[0]->code, 1);
 
 		$number = Robotters::countByTheType('mechanical');
+		$this->assertEquals($number, 2);
+
+		$robot = Robotters::findFirstByCode(array(1));
+		$this->assertEquals($robot->code, 1);
+
+		$robots = Robotters::findByCode(array(1,2));
+		$this->assertEquals(count($robots), 2);
+		$this->assertEquals($robots[0]->code, 1);
+		$this->assertEquals($robots[1]->code, 2);
+
+		$number = Robotters::countByCode(array(1,2));
 		$this->assertEquals($number, 2);
 	}
 

--- a/unit-tests/ModelsQueryExecuteTest.php
+++ b/unit-tests/ModelsQueryExecuteTest.php
@@ -236,6 +236,26 @@ class ModelsQueryExecuteTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(isset($result[0]->nextId));
 		$this->assertEquals($result[0]->nextId, 2);
 
+		$result = $manager->executeQuery(
+			'SELECT Robots.id+1 AS nextId FROM Robots WHERE id in (?0) order by id',
+			array(array(1,2,3))
+		);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Resultset\Simple', $result);
+		$this->assertEquals(count($result), 3);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Row', $result[0]);
+		$this->assertTrue(isset($result[0]->nextId));
+		$this->assertEquals($result[0]->nextId, 2);
+
+		$result = $manager->executeQuery(
+			'SELECT Robots.id+1 AS nextId FROM Robots WHERE id in (:ids:) order by id',
+			array('ids' => array(2,3))
+		);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Resultset\Simple', $result);
+		$this->assertEquals(count($result), 2);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Row', $result[0]);
+		$this->assertTrue(isset($result[0]->nextId));
+		$this->assertEquals($result[0]->nextId, 3);
+
 		$result = $manager->executeQuery('SELECT Robots.id+1 AS nextId FROM Robots WHERE id = "1"');
 		$this->assertInstanceOf('Phalcon\Mvc\Model\Resultset\Simple', $result);
 		$this->assertEquals(count($result), 1);
@@ -504,6 +524,26 @@ class ModelsQueryExecuteTest extends PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('Phalcon\Mvc\Model\Row', $result[0]);
 		$this->assertTrue(isset($result[0]->nextId));
 		$this->assertEquals($result[0]->nextId, 2);
+
+		$result = $manager->executeQuery(
+			'SELECT Robotters.code+1 AS nextId FROM Robotters WHERE code in (?0) order by code',
+			array(array(1,2,3))
+		);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Resultset\Simple', $result);
+		$this->assertEquals(count($result), 3);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Row', $result[0]);
+		$this->assertTrue(isset($result[0]->nextId));
+		$this->assertEquals($result[0]->nextId, 2);
+
+		$result = $manager->executeQuery(
+			'SELECT Robotters.code+1 AS nextId FROM Robotters WHERE code in (:ids:) order by code',
+			array('ids' => array(2,3))
+		);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Resultset\Simple', $result);
+		$this->assertEquals(count($result), 2);
+		$this->assertInstanceOf('Phalcon\Mvc\Model\Row', $result[0]);
+		$this->assertTrue(isset($result[0]->nextId));
+		$this->assertEquals($result[0]->nextId, 3);
 
 		$result = $manager->executeQuery('SELECT Robotters.code+1 AS nextId FROM Robotters WHERE code = "1"');
 		$this->assertInstanceOf('Phalcon\Mvc\Model\Resultset\Simple', $result);

--- a/unit-tests/ModelsTest.php
+++ b/unit-tests/ModelsTest.php
@@ -19,6 +19,7 @@
 */
 
 use Phalcon\Mvc\Model\Message as ModelMessage;
+use Phalcon\Db\Column;
 
 class Issue_1534 extends \Phalcon\Mvc\Model
 {
@@ -359,6 +360,57 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 			$number++;
 		}
 		$this->assertEquals($number, 20);
+
+        //find with in
+        $persons = Robots::find(array(
+            "id in (:ids:)",
+            'bind' => array('ids' => array(1, 2, 3)),
+            'bindTypes' => array('ids' => Column::BIND_PARAM_INT_ARRAY),
+            'order' => 'id'
+        ));
+        $this->assertEquals(3, count($persons));
+        $this->assertEquals('Robotina', $persons[0]->name);
+        $this->assertEquals('Astro Boy', $persons[1]->name);
+        $this->assertEquals('Terminator', $persons[2]->name);
+
+        $persons = Robots::find(array(
+            "id in (:ids:)",
+            'bind' => array('ids' => array(1, 2, 3)),
+            'order' => 'id'
+        ));
+        $this->assertEquals(3, count($persons));
+        $this->assertEquals('Robotina', $persons[0]->name);
+        $this->assertEquals('Astro Boy', $persons[1]->name);
+        $this->assertEquals('Terminator', $persons[2]->name);
+
+        $persons = Robots::find(array(
+            "id in (?0)",
+            'bind' => array(array(1, 2, 3)),
+            'order' => 'id'
+        ));
+        $this->assertEquals(3, count($persons));
+        $this->assertEquals('Robotina', $persons[0]->name);
+        $this->assertEquals('Astro Boy', $persons[1]->name);
+        $this->assertEquals('Terminator', $persons[2]->name);
+
+        $person = Robots::findFirst(array(
+            "name in (?0)",
+            'bind' => array(array('Robotina', 'Astro Boy', 'Terminator')),
+            'order' => 'name'
+        ));
+        $this->assertEquals('Astro Boy', $person->name);
+        $this->assertEquals(2, $person->id);
+
+        $persons = Robots::find(array(
+            "name in (?0)",
+            'bind' => array(array('Robotina', 'Astro Boy', 'hack\'\ " \' or 1')),
+            'order' => 'name'
+        ));
+        $this->assertEquals(2, count($persons));
+        $this->assertEquals('Astro Boy', $persons[0]->name);
+        $this->assertEquals('Robotina', $persons[1]->name);
+
+
 
 		$persona = new Personas($di);
 		$persona->cedula = 'CELL' . mt_rand(0, 999999);

--- a/unit-tests/schemas/postgresql/phalcon_test.sql
+++ b/unit-tests/schemas/postgresql/phalcon_test.sql
@@ -192,7 +192,7 @@ ALTER SEQUENCE robots_id_seq OWNED BY robots.id;
 -- Name: robots_id_seq; Type: SEQUENCE SET; Schema: public; Owner: postgres
 --
 
-SELECT pg_catalog.setval('robots_id_seq', 1, false);
+SELECT pg_catalog.setval('robots_id_seq', 4, false);
 
 
 --


### PR DESCRIPTION
Related #2934

Port of Doctrine DBAL SQLParserUtils

Usage:

```
$songs = $connection->fetchAll(
        'select * from songs where name in (?) order by id',
        Db::FETCH_ASSOC,
        array(array('Born to Die', 'Off to Races', 'Blue Jeans'))
    );

    $connection->delete(
        'songs',
        'name in (?)',
        array(array('name1','name2'))
    );

    $persons = Robots::find(array(
        "id in (:ids:)",
        'bind' => array('ids' => array(1, 2, 3)),
        'bindTypes' => array('ids' => Column::BIND_PARAM_INT_ARRAY)
    ));

    $persons = Robots::find(array(
        "id in (?0)",
        'bind' => array(array(1, 2, 3))
    ));

    $persons = Robots::findById(array(1, 2, 3));
```

Original class is under MIT licence. In which form I must write copyright notices in ported files?
Now I write default template for such files:
https://github.com/quantum13/cphalcon/blob/bind_array/phalcon/db/utils/sqlparser.zep
https://github.com/quantum13/cphalcon/blob/bind_array/tests/unit/Phalcon/Db/Utils/SQLParserTest.php
