### PR TITLE
[2.0.0] Fix fatal error on rendering empty asset collection

### DIFF
--- a/phalcon/assets/collection.zep
+++ b/phalcon/assets/collection.zep
@@ -31,15 +31,15 @@ class Collection implements \Countable, \Iterator
 
 	protected _local = true { get };
 
-	protected _resources { get };
+	protected _resources = [] { get };
 
-	protected _codes { get };
+	protected _codes = [] { get };
 
 	protected _position { get };
 
-	protected _filters { get };
+	protected _filters = [] { get };
 
-	protected _attributes { get };
+	protected _attributes = [] { get };
 
 	protected _join = true { get };
 


### PR DESCRIPTION
The `_collection` property in `Phalcon\Assets\Manager` is null by default, and
implicitly becomes an array when `Phalcon\Assets\Manager::add` is called. This
causes a fatal error when for example `outputJs()` or `outputCss()` is called
without adding resources, which is a normal use case.

```
Fatal error: Uncaught exception 'Exception' with message 'The argument is not initialized or iterable()' in phalcon/assets/manager.zep:693
```
