### PR TITLE
[2.0.0] Update asset manager code written to depend on null property defaults of Collection

### DIFF
--- a/phalcon/assets/manager.zep
+++ b/phalcon/assets/manager.zep
@@ -372,7 +372,7 @@ class Manager
 		/**
 		 * Prepare options if the collection must be filtered
 		 */
-		if typeof filters == "array" {
+		if count(filters) {
 
 			let options = this->_options;
 
@@ -462,7 +462,7 @@ class Manager
 			/**
 			 * If the collection must not be joined we must print a HTML for each one
 			 */
-			if typeof filters == "array" {
+			if count(filters) {
 				if local {
 
 					/**
@@ -690,7 +690,7 @@ class Manager
 			}
 		}
 
-		if typeof filters == "array" {
+		if count(filters) {
 
 			if join == true {
 


### PR DESCRIPTION
Didn't pick this error up before submitting my change in #2997, sorry. There was code in the assets manager that depended on a `typeof` check and started running because the property default is now an array. Changed this to use `count()` instead.

As a side note, it looks like there's quite a few places in the code where null would be returned instead of an array as indicated by the doc comment, because the code is written with lazy array allocation. What's the preference? In PHP user-land, I'd expect to get an array back if a method indicates it returns an array of something.
