### PR TITLE
[2.0.0] Builds status of pull requests

### DIFF
--- a/runTests.sh
+++ b/runTests.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 ZEND_DONT_UNLOAD_MODULES=1 $(phpenv which php) ./unit-tests/ci/phpunit.php --debug -c unit-tests/phpunit.xml --testsuite=stable
+status_phpunit=$?
 
 if [ "$(php -r 'echo substr(PHP_VERSION, 0, 3);')" = "5.3" ];
 then
@@ -9,4 +10,13 @@ then
 else
    $(phpenv which php) codecept.phar build
    ZEND_DONT_UNLOAD_MODULES=1 $(phpenv which php) codecept.phar run
+fi
+status_codeception=$?
+
+if [ ${status_phpunit} != 0 ] ; then
+    exit ${status_phpunit}
+fi
+
+if [ ${status_codeception} != 0 ] ; then
+    exit ${status_codeception}
 fi


### PR DESCRIPTION
I think branch 2.0.0 must be stable, so builds of pull requests must be successful.

Now builds are successful even if tests failed in it.

@phalcon Could you please check build status of pull requests before merge
@akaNightmare 
your pull request #2974 brokes all tests in 5.3 and adds 2 failures in 5.5+ (https://travis-ci.org/phalcon/cphalcon/builds/40434159)
and #2982 adds one new failure in php 5.5+ (https://travis-ci.org/phalcon/cphalcon/jobs/40434388)
