### PR TITLE
Restoring builds on php5.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ services:
   - redis-server
 
 before_install:
+ - composer --prefer-source install
+ - composer require phalcon/zephir:dev-master
  - ./unit-tests/ci/install_prereqs.sh
  - ./unit-tests/ci/setup_dbs.sh
 
-install:
- - composer --prefer-source install
- - composer require phalcon/zephir:dev-master
+#install:
+# - composer --prefer-source install
+# - composer require phalcon/zephir:dev-master
 
 before_script:
  - git submodule --quiet update --init --recursive

--- a/unit-tests/ci/install_prereqs.sh
+++ b/unit-tests/ci/install_prereqs.sh
@@ -19,5 +19,6 @@ phpenv config-add "$DIR/memcache.ini"
 phpenv config-rm xdebug.ini
 
 composer self-update
+composer --version
 
 wait

--- a/unit-tests/ci/install_prereqs.sh
+++ b/unit-tests/ci/install_prereqs.sh
@@ -18,6 +18,3 @@ CFLAGS="-O2 -g3 -fno-strict-aliasing" pecl install igbinary < /dev/null &
 phpenv config-add "$DIR/memcache.ini"
 phpenv config-rm xdebug.ini
 wait
-
-composer self-update
-composer --version

--- a/unit-tests/ci/install_prereqs.sh
+++ b/unit-tests/ci/install_prereqs.sh
@@ -17,8 +17,7 @@ CFLAGS="-O2 -g3 -fno-strict-aliasing" pecl install igbinary < /dev/null &
 
 phpenv config-add "$DIR/memcache.ini"
 phpenv config-rm xdebug.ini
+wait
 
 composer self-update
 composer --version
-
-wait

--- a/unit-tests/ci/install_prereqs.sh
+++ b/unit-tests/ci/install_prereqs.sh
@@ -17,4 +17,7 @@ CFLAGS="-O2 -g3 -fno-strict-aliasing" pecl install igbinary < /dev/null &
 
 phpenv config-add "$DIR/memcache.ini"
 phpenv config-rm xdebug.ini
+
+composer self-update
+
 wait


### PR DESCRIPTION
Temporary run composer before installing prereqs

https://github.com/composer/composer/issues/3405
