### PR TITLE
Made the request headers return properly per #2294

### DIFF
--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -826,12 +826,22 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 */
 	public function getHeaders() -> array
 	{
-		var headers, key, value;
+		var headers, key, value, parts, pos, part;
 
 		let headers = [];
 		for key, value in _SERVER {
 			if starts_with(key, "HTTP_") {
-				let headers[str_replace("HTTP_", "", key)] = value;
+
+				let key = str_replace("HTTP_", "", key),
+				    parts = explode("_", key),
+				    key = "";
+
+				for pos, part in parts {
+					let parts[pos] = ucfirst(strtolower(part));
+				}
+
+				let key = implode("-", parts),
+					headers[key] = value;
 			}
 		}
 		return headers;

--- a/unit-tests/RequestTest.php
+++ b/unit-tests/RequestTest.php
@@ -352,5 +352,28 @@ class RequestTest extends PHPUnit_Framework_TestCase
 			$this->assertEquals($file->getRealType(), 'image/jpeg');			
 		}
 	}
+
+	public function testIssues2294()
+	{
+		$_SERVER['HTTP_FOO'] = 'Bar';
+		$_SERVER['HTTP_BLA_BLA'] = 'boo';
+		$_SERVER['HTTP_AUTH'] = true;
+
+		$request = new \Phalcon\Http\Request();
+		
+		$oldheaders = $_SERVER;
+		$headers = array();
+
+		foreach($oldheaders as $key => $value) {
+			if (strpos($key, 'HTTP_') === 0) {
+			    $key = explode('_', ltrim($key, 'HTTP_'));
+			    array_walk($key, function(&$k) { $k = ucfirst(strtolower($k)); });
+			    $key = implode('-', $key);
+			    $headers[$key] = $value;
+			}
+		}
+
+		$this->assertEquals($request->getHeaders(), $headers);
+	}
 }
 


### PR DESCRIPTION
From what I could see, the actual headers were being returned, they were just ALL UPPERCASED. So if you had a "Foo-Bar" header according to getallheaders() $request->getHeaders() made it "FOO-BAR". Adjusted accordingly.
