### PR TITLE
Per #2906 had refresh() return the model for fluent interface

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3269,6 +3269,8 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 		if typeof row == "array" {
 			this->assign(row, metaData->getColumnMap(this));
 		}
+
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Tiny fix for #2906 
