### PR TITLE
Adjusted the Config to behave like the 1.3.* series' Config

### DIFF
--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -54,35 +54,16 @@ class Config implements \ArrayAccess, \Countable
 	 */
 	public function __construct(array! arrayConfig = null)
 	{
-		var key, value, subKey, subValue;
-		boolean hasNumericKey;
+		var key, value;
 
 		for key, value in arrayConfig {
-			/**
-			 * Phalcon\Config does not support numeric keys as properties
-			 */
-			 // todo: add support numeric keys as properties
-			if typeof key !== "string" {
-				throw new Exception("Only string keys are allowed as configuration properties");
-			}
 
-			if typeof value === "array" {
-				let hasNumericKey = false;
-				for subKey, subValue in value {
-					if typeof subKey === "int" {
-						let hasNumericKey = true;
-						break;
-					}
-				}
-				if hasNumericKey {
-					let this->{key} = value;
-				} else {
-					let this->{key} = new self(value);
-				}
+			let key = strval(key);
+			if (typeof value === "array") {
+				let this->{key} = new self(value);
 			} else {
 				let this->{key} = value;
 			}
-
 		}
 	}
 

--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -59,7 +59,7 @@ class Config implements \ArrayAccess, \Countable
 		for key, value in arrayConfig {
 
 			let key = strval(key);
-			if (typeof value === "array") {
+			if typeof value === "array" {
 				let this->{key} = new self(value);
 			} else {
 				let this->{key} = value;

--- a/unit-tests/ConfigTest.php
+++ b/unit-tests/ConfigTest.php
@@ -263,4 +263,16 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         ));
         $this->assertTrue($this->_compareConfig($this->_config, $config));
     }
+
+    public function testNumericConfig()
+    {
+		$config = new \Phalcon\Config(["abc"]);
+		$this->assertEquals($config->{0}, "abc");
+    }
+
+    public function testChildArrayToConfigObject()
+    {
+		$config = new \Phalcon\Config(['childsettings' => ['A', 'B', 'C']]);
+		$this->assertInstanceOf('Phalcon\Config', $config->childsettings);
+    }
 }


### PR DESCRIPTION
See #2988 for information. The result now is:

```
$c = new \Phalcon\Config(['test' => 'toto', 2 => 'abc', 'test2' => ['A', 'B', 'C']]);

var_dump($c);
var_dump($c->{2});
var_dump($c->test2->toArray());
```

```
object(Phalcon\Config)#1 (3) {
  ["test"]=>
  string(4) "toto"
  ["2"]=>
  string(3) "abc"
  ["test2"]=>
  object(Phalcon\Config)#2 (3) {
    ["0"]=>
    string(1) "A"
    ["1"]=>
    string(1) "B"
    ["2"]=>
    string(1) "C"
  }
}
string(3) "abc"
array(3) {
  [0]=>
  string(1) "A"
  [1]=>
  string(1) "B"
  [2]=>
  string(1) "C"
}
```
