### PR TITLE
getSqlExpression() should not be final

### DIFF
--- a/phalcon/db/dialect.zep
+++ b/phalcon/db/dialect.zep
@@ -112,7 +112,7 @@ abstract class Dialect
 	 * @param string escapeChar
 	 * @return string
 	 */
-	public final function getSqlExpression(array! expression, var escapeChar = null) -> string
+	public function getSqlExpression(array! expression, var escapeChar = null) -> string
 	{
 		var type, domain, operator, left, right, name, sqlItems,
 			escapedName, sqlArguments, arguments, argument, item;


### PR DESCRIPTION
If we need to extend the dialect, we have to overload the getSqlExpression(). See https://github.com/phalcon/cphalcon/issues/2952 and http://forum.phalconphp.com/discussion/1748/date-sub-interval-mysql
