### PR TITLE
disambiguify whether it's an inclusive check

### DIFF
--- a/ext/validation/validator/stringlength.c
+++ b/ext/validation/validator/stringlength.c
@@ -37,7 +37,9 @@
 /**
  * Phalcon\Validation\Validator\StringLength
  *
- * Validates that a string has the specified maximum and minimum constraints
+ * Validates that a string has the specified maximum and minimum constraints.
+ * The test is passed if for a string's length l, min<=l<=max, i.e. l must
+ * be at least min, and at most max.
  *
  *<code>
  *use Phalcon\Validation\Validator\StringLength as StringLength;


### PR DESCRIPTION
Previously it was not clear from the documentation or C-sourcecode whether it is "longer-than" or "at least"; same for max.
