### PR TITLE
[2.0.0] Disambiguifiy Between' and StringLength' documentation regarding inclusivity

### DIFF
--- a/ext/phalcon/validation/validator/between.zep.c
+++ b/ext/phalcon/validation/validator/between.zep.c
@@ -42,6 +42,8 @@
  * Phalcon\Validation\Validator\Between
  *
  * Validates that a value is between a range of two values
+ * Validates that a value is between an inclusive range of two values.
+ * For a value x, the test is passed if minimum<=x<=maximum.
  *
  *<code>
  *use Phalcon\Validation\Validator\Between;

--- a/ext/phalcon/validation/validator/stringlength.zep.c
+++ b/ext/phalcon/validation/validator/stringlength.zep.c
@@ -43,6 +43,8 @@
  * Phalcon\Validation\Validator\StringLength
  *
  * Validates that a string has the specified maximum and minimum constraints
+ * The test is passed if for a string's length L, min<=L<=max, i.e. L must
+ * be at least min, and at most max.
  *
  *<code>
  *use Phalcon\Validation\Validator\StringLength as StringLength;

--- a/phalcon/validation/validator/between.zep
+++ b/phalcon/validation/validator/between.zep
@@ -22,7 +22,8 @@ namespace Phalcon\Validation\Validator;
 /**
  * Phalcon\Validation\Validator\Between
  *
- * Validates that a value is between a range of two values
+ * Validates that a value is between an inclusive range of two values.
+ * For a value x, the test is passed if minimum<=x<=maximum.
  *
  *<code>
  *use Phalcon\Validation\Validator\Between;

--- a/phalcon/validation/validator/stringlength.zep
+++ b/phalcon/validation/validator/stringlength.zep
@@ -23,6 +23,8 @@ namespace Phalcon\Validation\Validator;
  * Phalcon\Validation\Validator\StringLength
  *
  * Validates that a string has the specified maximum and minimum constraints
+ * The test is passed if for a string's length L, min<=L<=max, i.e. L must
+ * be at least min, and at most max.
  *
  *<code>
  *use Phalcon\Validation\Validator\StringLength as StringLength;


### PR DESCRIPTION
This clarifies whether Between and StringLength do inclusive checks.
