### PR TITLE
[2.0.0] Fix asset collection join issue

### DIFF
--- a/phalcon/assets/manager.zep
+++ b/phalcon/assets/manager.zep
@@ -502,7 +502,7 @@ class Manager
 					throw new \Phalcon\Assets\Exception("Resource '". sourcePath. "' does not have a valid target path");
 				}
 
-				if local {
+				if join {
 					/**
 					 * Make sure the target path is not the same source path
 					 */

--- a/tests/unit/Phalcon/Assets/AssetsManagerTest.php
+++ b/tests/unit/Phalcon/Assets/AssetsManagerTest.php
@@ -121,6 +121,35 @@ class AssetsManagerTest extends TBase
     }
 
     /**
+     * outputCss tests
+     */
+    public function testAssetsManagerOutputCssWithoutJoin()
+    {
+        $this->specify(
+            "The output of css collection fails if join is false",
+            function () {
+
+                $this->prepareDI();
+
+                $assets = new PhTAssetsManager();
+                $assets->useImplicitOutput(false);
+                $css = $assets->collection('css');
+
+                $css->addCss(PATH_DATA . 'assets/1198.css');
+                $css->join(false);
+                $output = trim($assets->outputCss());
+
+                $expected = 'assets/1198.css';
+
+                $this->assertContains(
+                    $expected,
+                    $output
+                );
+            }
+        );
+    }
+
+    /**
      * outputCss - implicitOutput tests
      *
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>


### PR DESCRIPTION
Fix an issue that appears after fix for #2997

If assets outputCss or outputJs methods are called and join is false, an error is raised, that target path equals source path.

Also includes a test for this issue.
