### PR TITLE
Phalcon 2 Paginator\Adapter\QueryBuilder fix

### DIFF
--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -239,7 +239,7 @@ class QueryBuilder implements AdapterInterface
 		 */
 		let result = totalQuery->execute(),
 			row = result->getFirst(),
-			rowcount = row->rowcount,
+			rowcount = intval(row->rowcount),
 			totalPages = rowcount / limit;
 
 		let intTotalPages = intval(totalPages);

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -240,13 +240,8 @@ class QueryBuilder implements AdapterInterface
 		let result = totalQuery->execute(),
 			row = result->getFirst(),
 			rowcount = intval(row->rowcount),
-			totalPages = rowcount / limit;
-
-		let intTotalPages = intval(totalPages);
-		if intTotalPages != totalPages {
-			let totalPages = intTotalPages + 1;
-		}
-
+			totalPages = ceil(rowcount / limit);
+			
 		if numberPage < totalPages {
 			let next = numberPage + 1;
 		} else {

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -355,6 +355,9 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->current, 1);
 		$this->assertEquals($page->total_pages, 218);
 
+		$this->assertInternalType('int', $page->total_items);
+		$this->assertInternalType('int', $page->total_pages);
+
 		//Middle page
 		$paginator->setCurrentPage(100);
 
@@ -371,6 +374,9 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->current, 100);
 		$this->assertEquals($page->total_pages, 218);
 
+		$this->assertInternalType('int', $page->total_items);
+		$this->assertInternalType('int', $page->total_pages);
+
 		//Last page
 		$paginator->setCurrentPage(218);
 
@@ -386,6 +392,9 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals($page->current, 218);
 		$this->assertEquals($page->total_pages, 218);
+
+		$this->assertInternalType('int', $page->total_items);
+		$this->assertInternalType('int', $page->total_pages);
 
 		// test of getter/setters of querybuilder adapter
 


### PR DESCRIPTION
Hi

Fixes:
- int type for total items
- fix total pages (limit 100, with 4 in db show 0.04)
- PHP 5.3 BC

Workflow example:

http://phalcon-module.dmtry.me/api/users
http://phalcon-module.dmtry.me/api/users?limit=1
http://phalcon-module.dmtry.me/api/users?limit=2
http://phalcon-module.dmtry.me/api/users?limit=3
http://phalcon-module.dmtry.me/api/users?limit=100

Without patch it works like https://gist.github.com/ovr/43af99f5eca8dd74dca1

Thx

![](http://s.pikabu.ru/post_img/2013/05/17/9/1368796778_1338513910.gif)
