### PR TITLE
Backward compatibility : Remove final from Volt compiler _compileSource

### DIFF
--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -2271,7 +2271,7 @@ class Compiler implements InjectionAwareInterface
 	 * @param boolean extendsMode
 	 * @return string
 	 */
-	final protected function _compileSource(string! viewCode, boolean extendsMode = false) -> string
+	protected function _compileSource(string! viewCode, boolean extendsMode = false) -> string
 	{
 		var currentPath, intermediate, extended,
 			finalCompilation, blocks, extendedBlocks, name, block,


### PR DESCRIPTION
In 1.3.4, _compileSource was not final and could be overrided.
