### PR TITLE
[1.3.4 - 2.0.0] Backward compatibility fixes 

### DIFF
--- a/phalcon/cache/backend/xcache.zep
+++ b/phalcon/cache/backend/xcache.zep
@@ -164,10 +164,9 @@ use Phalcon\Cache\Exception;
 		if success {
 			let options = this->_options;
 
-			if !isset options["statsKey"] {
-				throw new Exception("Unexpected inconsistency in options");
-			}
-			let specialKey = options["statsKey"];
+			if !fetch specialKey, this->_options["statsKey"] {
+	                        throw new Exception("Unexpected inconsistency in options");
+        	        }
 
 			/**
 			 * xcache_list() is available only to the administrator (unless XCache was
@@ -225,12 +224,11 @@ use Phalcon\Cache\Exception;
 			let prefixed = "_PHCX" . prefix;
 		}
 
-		let options = this->_options;
+ 		let options = this->_options;
 
-		if !isset options["statsKey"] {
-			throw new Exception("Unexpected inconsistency in options");
+		if !fetch specialKey, this->_options["statsKey"] {
+                	throw new Exception("Unexpected inconsistency in options");
 		}
-		let specialKey = options["statsKey"];
 
 		let retval = [];
 
@@ -240,9 +238,11 @@ use Phalcon\Cache\Exception;
 		*/
 		let keys = xcache_get(specialKey);
 		if typeof keys == "array" {
-			for key in keys {
-				let realKey = substr(key,5,0);
-				let retval[] = realKey;
+			for key, _ in keys {
+				if starts_with(key, prefixed) {
+					let realKey = substr(key, 5);
+					let retval[] = realKey;
+				}
 			}
 		}
 

--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -193,7 +193,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 	 *
 	 * @return Phalcon\Mvc\Model\ManagerInterface
 	 */
-	public function getModelsManager() -> <ManagerInterface>
+	public function getCollectionManager() -> <ManagerInterface>
 	{
 		return this->_modelsManager;
 	}
@@ -1016,7 +1016,7 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 			/**
 			 * Check if the model use implicit ids
 			 */
-			if collection->getModelsManager()->isUsingImplicitObjectIds(collection) {
+			if collection->getCollectionManager()->isUsingImplicitObjectIds(collection) {
 				let mongoId = new \MongoId(id);
 			} else {
 				let mongoId = id;

--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -2271,7 +2271,7 @@ class Compiler implements InjectionAwareInterface
 	 * @param boolean extendsMode
 	 * @return string
 	 */
-	final protected function _compileSource(string! viewCode, boolean extendsMode = false) -> string
+	protected function _compileSource(string! viewCode, boolean extendsMode = false) -> string
 	{
 		var currentPath, intermediate, extended,
 			finalCompilation, blocks, extendedBlocks, name, block,


### PR DESCRIPTION
Changes in methods so that 2.0.0 is more backward compatible with 1.3.4
- Volt _compileSource is no more final
- getModelsManager is renamed getCollectionManager in Mvc/Collection class (changed in 1.3.3)
- fix #3048 bug with queryKeys in Xcache backend
