### PR TITLE
Fix #3050 - PresenceOf validator doesn't work with string '0'

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -1930,7 +1930,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 							 */
 							if typeof value != "object" {
 								if !isset dataTypeNumeric[field] {
-									if empty value {
+									if value == "" {
 										let isNull = true;
 									}
 								} else {


### PR DESCRIPTION
``` zephir
if empty "0" 
```

return true which is (as far as i can see) a bug.

This fix the validator (unless zephir empty operator has to be fixed) 
