### PR TITLE
Allow APC Adapter to use specific key and TTL

### DIFF
--- a/phalcon/annotations/adapter/apc.zep
+++ b/phalcon/annotations/adapter/apc.zep
@@ -35,6 +35,29 @@ use Phalcon\Annotations\Reflection;
 class Apc extends Adapter implements AdapterInterface
 {
 
+	protected _prefix = "";
+
+	protected _ttl = 172800;
+
+	/**
+	 * Phalcon\Annotations\Adapter\Apc constructor
+	 *
+	 * @param array options
+	 */
+	public function __construct(options = null)
+	{
+		var prefix, ttl;
+
+		if typeof options == "array" {
+			if fetch prefix, options["prefix"] {
+				let this->_prefix = prefix;
+			}
+			if fetch ttl, options["lifetime"] {
+				let this->_ttl = ttl;
+			}
+		}
+	}
+
 	/**
 	 * Reads parsed annotations from APC
 	 *
@@ -43,17 +66,17 @@ class Apc extends Adapter implements AdapterInterface
 	 */
 	public function read(string! key) -> <Reflection> | boolean
 	{
-		return apc_fetch(strtolower("_PHAN" . key));
+		return apc_fetch(strtolower("_PHAN" . this->_prefix . key));
 	}
 
 	/**
 	 * Writes parsed annotations to APC
 	 *
- 	 * @param string key
+	 * @param string key
 	 * @param Phalcon\Annotations\Reflection data
 	 */
 	public function write(string! key, <Reflection> data)
 	{
-		return apc_store(strtolower("_PHAN" . key), data);
+		return apc_store(strtolower("_PHAN" . this->_prefix . key), data, this->_ttl);
 	}
 }


### PR DESCRIPTION
Along with other APC adapters (metadata, cache\backend), the use of prefix and TTL would allow cache purge without purging all APC cache.
