### PR TITLE
[2.0.0] Fix Warning when Zephir compiles the file

### DIFF
--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -427,10 +427,10 @@ abstract class Pdo extends Adapter
 	 */
 	public function convertBoundParams(string! sql, array params = []) -> array
 	{
-		var boundSql, placeHolders, queryParams, bindPattern, matches,
+		var boundSql, placeHolders, bindPattern, matches,
 			setOrder, placeMatch, value;
 
-		let queryParams = [], placeHolders = [],
+		let placeHolders = [],
 			bindPattern = "/\\?([0-9]+)|:([a-zA-Z0-9_]+):/",
 			matches = null, setOrder = 2;
 


### PR DESCRIPTION
Warning: Variable "queryParams" assigned but not used in Phalcon\Db\Adapter\Pdo::convertBoundParams in /usr/local/src/cphalcon/phalcon/db/adapter/pdo.zep on 433 [unused-variable]

```
      let queryParams = [], placeHolders = [],
    ----------------------^
```
