### PR TITLE
Fix default value for checkboxes/radios

### DIFF
--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -524,8 +524,6 @@ class Tag
 			let params = parameters;
 		}
 
-		let value = null;
-
 		if !isset params[0] {
 			let params[0] = params["id"];
 		}
@@ -549,30 +547,28 @@ class Tag
 			}
 		}
 
-		let value = self::getValue(id, params);
-
 		/**
 		 * Automatically check inputs
 		 */
-		if fetch currentValue, params["value"] {
-			if value && currentValue == value {
-				let params["checked"] = "checked";
-			}
-		} else {
-			/**
-			* Evaluate the value in POST
-			*/
-			if value {
-				let params["checked"] = "checked";
-			}
+                if isset self::_displayValues[params["name"]] {
+                        let value = self::_displayValues[params["name"]];
+                } else {
+                        if !fetch value, params["value"] {
+                                let value = null;
+                        }
+                }
 
-			/**
-			* Update the value anyways
-			*/
-			let params["value"] = value;
-		}
+                if !fetch currentValue, params["value"] {
+                        if !fetch currentValue, _POST[params["name"]] {
+                                let currentValue = value;
+                        }
+                }
+                if currentValue == value {
+                        let params["checked"] = "checked";
+                }
 
-		let params["type"] = type,
+                let params["value"] = value,
+			params["type"] = type,
 			code = self::renderAttributes("<input", params);
 
 		/**


### PR DESCRIPTION
Fix https://github.com/phalcon/cphalcon/issues/3058
- don't use the value from «default» if there's no value in params['value'] or _POST
- find out what the real default value is: use the _displayValues[](setDefault function), or if it's not set, use the value from params['value'] or _POST
- once the real default value is found, just test it against the real current value

=> this should not break any script that didn't use the setDefault() function so far. But that will define what the «value» attribute should be: it doesn't depend on the field's value, as in «input type=text», it's a fixed value. If the value is the same as the default one, then the checked attribute is «checked».

I think the big issue there is that there's no difference between the value of the checkbox and the value of the parameter. For example, if I have to code it in PHP (don't mind the HTML injections!):
`<input type="text" value="<?php echo $value ?>"/>`
but:
`<input type="radio" value="X" <?php if ($value === 'X') echo ' checked="checked"' ?>/>`
=> in the radio type, the value belongs to the input, not to the object ($value).
