### PR TITLE
Tests: Add missing close for logger

### DIFF
--- a/tests/unit/Phalcon/Logger/Adapter/TransactionTest.php
+++ b/tests/unit/Phalcon/Logger/Adapter/TransactionTest.php
@@ -45,6 +45,8 @@ class TransactionTest extends FBase
                 $logger = new PhTLoggerAdapterFile($this->logPath . $fileName);
                 $logger->log('Hello');
 
+                $logger->close();
+
                 $contents = file($this->logPath . $fileName);
                 cleanFile($this->logPath, $fileName);
 
@@ -101,6 +103,8 @@ class TransactionTest extends FBase
 
                 $logger = new PhTLoggerAdapterFile($this->logPath . $fileName);
                 $logger->log('Hello');
+
+                $logger->close();
 
                 $contents = file($this->logPath . $fileName);
                 cleanFile($this->logPath, $fileName);


### PR DESCRIPTION
I've done some tests with phalcon and phpci.

If I try to execute the tests, the cleanFile call throws an exception that file is busy.

After closing the logger, everything works fine.
