### PR TITLE
removed the strict type requirement for result param

### DIFF
--- a/phalcon/mvc/model/resultset/complex.zep
+++ b/phalcon/mvc/model/resultset/complex.zep
@@ -44,7 +44,7 @@ class Complex extends Resultset implements ResultsetInterface
 	 * @param Phalcon\Db\ResultInterface result
 	 * @param Phalcon\Cache\BackendInterface cache
 	 */
-	public function __construct(var columnTypes, <ResultInterface> result, <BackendInterface> cache = null)
+	public function __construct(var columnTypes, result, <BackendInterface> cache = null)
 	{
 
 		/**


### PR DESCRIPTION
This fixes the issue with bug https://github.com/phalcon/cphalcon/issues/3098   where empty results would cause exceptions to be thrown since proper type was not being passed to result. 
