### PR TITLE
Status is called with null sometimes

### DIFF
--- a/phalcon/mvc/model/query/status.zep
+++ b/phalcon/mvc/model/query/status.zep
@@ -58,7 +58,7 @@ class Status implements StatusInterface
 	 * @param boolean success
 	 * @param Phalcon\Mvc\ModelInterface model
 	 */
-	public function __construct(boolean success, <ModelInterface> model)
+	public function __construct(boolean success, <ModelInterface> model = null)
 	{
 		let this->_success = success,
 			this->_model = model;


### PR DESCRIPTION
Allow null model:
https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/mvc/model/query.zep#L2785

``` php
return new Status(true, null);
```

See https://github.com/phalcon/cphalcon/issues/3069
