### PR TITLE
Remove unused variable

### DIFF
--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -169,7 +169,7 @@ class QueryBuilder implements AdapterInterface
 	{
 		var originalBuilder, builder, totalBuilder, totalPages,
 			limit, numberPage, number, query, page, before, items, totalQuery,
-			result, row, rowcount, intTotalPages, next;
+			result, row, rowcount, next;
 
 		let originalBuilder = this->_builder;
 


### PR DESCRIPTION
Find from compilation notice

```
Warning: Variable "intTotalPages" declared but not used in Phalcon\Paginator\Adapter\QueryBuilder::getPaginate in /tmp/cphalcon/phalcon/paginator/adapter/querybuilder.zep on 172 [unused-variable]
```
