### PR TITLE
[2.0.0] HTTP Request:  Fixes and adjustments

### DIFF
--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -952,7 +952,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 * @return mixed
 	 */
 	public function getContentType()
-    {
+	{
 		var contentType;
 
 		if fetch contentType, _SERVER["CONTENT_TYPE"] {


### PR DESCRIPTION
We have done some adjustments and fixes.

1)
Method **getJsonRawBody** extended with boolean parameter to have a possibility to return a associative array instead of object. It's compatible with 1.3.x code.

2) 
Method **_getQualityHeader** refactored to fix poor mapped header parts and whitespacing. Now its possible to catch parts like that _"text/html;level=1; q=0.5"_ (http://tools.ietf.org/html/rfc7231#page-38). It's compatible with 1.3.x code. 

3) 
Added a new method **getContentType** to get request content type. This method includes also the content type bugfix for php version 5.5.8 (https://bugs.php.net/bug.php?id=66606)

4) 
Method **isSoapRequested** refactored with new content type function. It's compatible with 1.3.x code.

5) 
Added a new test for content type, extend old tests because of refactoring **_getQualityHeader** and fix **isSoapRequested** test
