### PR TITLE
registerDirs with merge fix

### DIFF
--- a/phalcon/loader.zep
+++ b/phalcon/loader.zep
@@ -201,7 +201,7 @@ class Loader implements EventsAwareInterface
 		if merge {
 			let currentDirectories = this->_directories;
 			if typeof currentDirectories == "array" {
-				let mergedDirectories = currentDirectories->merge(directories);
+				let mergedDirectories = array_merge(currentDirectories,directories);
 			} else {
 				let mergedDirectories = directories;
 			}

--- a/unit-tests/LoaderTest.php
+++ b/unit-tests/LoaderTest.php
@@ -81,9 +81,12 @@ class LoaderTest extends PHPUnit_Framework_TestCase
 
 		$loader->registerDirs(array(
 			"unit-tests/vendor/example/dialects", //missing trailing slash
+		));
+
+		$loader->registerDirs(array(
 			"unit-tests/vendor/example/types",
 			"unit-tests/vendor",
-		));
+		), true);
 
 		$loader->register();
 


### PR DESCRIPTION
Fix for: "Uncaught exception 'RuntimeException' with message 'Trying to call method merge on a non-object'" when calling registerDirs with merge.

Test case updated to reflect a merge case.
