### PR TITLE
Allow to override the default statsKey

### DIFF
--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -64,7 +64,7 @@ class Libmemcached extends Adapter implements AdapterInterface
 	 */
 	public function __construct(options = null)
 	{
-		var servers, client, lifetime, prefix;
+		var servers, client, lifetime, prefix, statsKey;
 
 		if typeof options != "array" {
 			throw new Exception("The options must be an array");
@@ -94,9 +94,15 @@ class Libmemcached extends Adapter implements AdapterInterface
 			let prefix = options["prefix"];
 		}
 
+		if !fetch statsKey, options["statsKey"] {
+			let statsKey = NULL;
+		} else {
+			let statsKey = options["statsKey"];
+		}
+
 		let this->_libmemcached = new Libmemcached(
 			new FrontendData(["lifetime": this->_lifetime]),
-			["servers": servers, "client": client, "prefix": prefix]
+			["servers": servers, "client": client, "prefix": prefix, "statsKey": statsKey]
 		);
 
 		session_set_save_handler(


### PR DESCRIPTION
Please just confirm the fact that «isset» in https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/cache/backend/libmemcached.zep#L86 will treat «null» as «not set» (PHP-like, but I don't know in Zephir).

This is to fix the same issue as https://github.com/phalcon/cphalcon/pull/3183, but in the session handler part.
