### PR TITLE
Update PHPDoc

### DIFF
--- a/phalcon/mvc/model/behavior.zep
+++ b/phalcon/mvc/model/behavior.zep
@@ -44,6 +44,7 @@ abstract class Behavior
 	 * Checks whether the behavior must take action on certain event
 	 *
 	 * @param string eventName
+	 * @return boolean
 	 */
 	protected function mustTakeAction(string! eventName)
 	{


### PR DESCRIPTION
Added missed PHPDoc `@return`.

IDE without `@return` gives a warning when checking for the return value:

``` php
class FooBehavior extends \Phalcon\Mvc\Model\Behavior implements \Phalcon\Mvc\Model\BehaviorInterface
{
    public function notify($eventType, \Phalcon\Mvc\ModelInterface $model)
    {
        // WARNING HERE
        if (!$this->mustTakeAction($eventType)) { 
           //
        }
    }
}
```
