### PR TITLE
[2.0.0] Implemented new unit tests for Redis and Added ability to specify many keys in delete() method of Redis backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_script:
  - ./vendor/bin/zephir generate
  - (cd ext; export CFLAGS="-g3 -O1 -std=gnu90 -Wall -DZEPHIR_RELEASE=1"; phpize && ./configure --enable-phalcon && make --silent -j4 && sudo make --silent install && phpenv config-add ../unit-tests/ci/phalcon.ini)
  - ulimit -c unlimited || true
+ - phpenv config-add ./unit-tests/ci/redis.ini
 
 script:
  - ./runTests.sh

--- a/unit-tests/CacheTest.php
+++ b/unit-tests/CacheTest.php
@@ -203,6 +203,192 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		));
 	}
 
+	protected function _prepareRedis()
+	{
+
+		if (!extension_loaded('redis')) {
+			$this->markTestSkipped('Warning: redis extension is not loaded');
+			return false;
+		}
+
+		$redis = new Redis();
+		$redis->connect('127.0.0.1', 6379);
+		//$redis->flushDB();
+		return $redis;
+	}
+
+	public function testRedisIncrement()
+	{
+		$redis = $this->_prepareRedis();
+		if (!$redis) {
+			return false;
+		}
+
+		$frontCache = new Phalcon\Cache\Frontend\Data(array('lifetime' => 20));
+		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
+			'host' => 'localhost',
+			'port' => 6379,
+//			 'auth' => 'foobared',
+//			 'persistent' => false
+		));
+		$cache->delete('increment');
+
+		$cache->save('increment', 1);
+		$this->assertEquals(2, $cache->increment('increment'));
+		$this->assertEquals(4, $cache->increment('increment', 2));
+		$this->assertEquals(14, $cache->increment('increment', 10));
+	}
+
+	public function testRedisDecrement()
+	{
+		$ready = $this->_prepareRedis();
+		if (!$ready) {
+			return false;
+		}
+
+		$frontCache = new Phalcon\Cache\Frontend\Data(array('lifetime' => 20));
+		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
+			'host' => 'localhost',
+			'port' => 6379
+		));
+		$cache->delete('decrement');
+
+		$cache->save('decrement', 100);
+		$this->assertEquals(99, $cache->decrement('decrement'));
+		$this->assertEquals(97, $cache->decrement('decrement', 2));
+		$this->assertEquals(87, $cache->decrement('decrement', 10));
+	}
+
+	public function testOutputRedisCache()
+	{
+
+		$redis = $this->_prepareRedis();
+		if (!$redis) {
+			return false;
+		}
+
+		$redis->delete('_PHCRtest-output');
+
+		$time = date('H:i:s');
+
+		$frontCache = new Phalcon\Cache\Frontend\Output(array('lifetime' => 60));
+		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
+			'host' => 'localhost',
+			'port' => 6379
+		));
+
+		ob_start();
+
+		//First time cache
+		$content = $cache->start('test-output');
+		if ($content !== null) {
+			$this->assertTrue(false);
+		}
+
+		echo $time;
+
+		$cache->save(null, null, null, false);
+
+		$obContent = ob_get_contents();
+		ob_end_clean();
+
+		$this->assertEquals($time, $obContent);
+		$this->assertEquals($time, $redis->get('_PHCRtest-output'));
+
+		//Expect same cache
+		$content = $cache->start('test-output');
+		if ($content === null) {
+			$this->assertTrue(false);
+		}
+
+		$this->assertEquals($content, $obContent);
+		$this->assertEquals($content, $redis->get('_PHCRtest-output'));
+
+		//Query keys
+		$keys = $cache->queryKeys();
+		sort($keys);
+		$this->assertEquals($keys, array(
+			'decrement',
+			'increment',
+			'test-output',
+		));
+
+		//Delete entry from cache
+		$this->assertEquals(1,$cache->delete('test-output'));
+	}
+
+	public function testDataRedisCache()
+	{
+		$redis = $this->_prepareRedis();
+		if (!$redis) {
+			return false;
+		}
+
+//		$redis->delete('test-data');
+
+		$frontCache = new Phalcon\Cache\Frontend\Data();
+		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
+			'host' => 'localhost',
+			'port' => 6379
+		));
+
+		$data = array(1, 2, 3, 4, 5);
+
+		$cache->save('test-data', $data);
+
+		$cachedContent = $cache->get('test-data');
+		$this->assertEquals($cachedContent, $data);
+
+		$cache->save('test-data', "sure, nothing interesting");
+
+		$cachedContent = $cache->get('test-data');
+		$this->assertEquals($cachedContent, "sure, nothing interesting");
+
+		$this->assertEquals(1,$cache->delete('test-data'));
+
+		$cache->save('a', 1);
+		$cache->save('long-key', 'long-val');
+		$cache->save('bcd', 3);
+		$keys = $cache->queryKeys();
+		sort($keys);
+		$this->assertEquals($keys, array('a', 'bcd', 'decrement', 'increment', 'long-key'));
+		$this->assertEquals($cache->get('long-key'), 'long-val');
+
+		$this->assertEquals(1, $cache->delete('a'));
+		$this->assertEquals(1, $cache->delete('long-key'));
+		$this->assertEquals(1, $cache->delete('bcd'));
+
+		$cache->save('a', 1,120);
+		$cache->save('long-key', 'long-val',120);
+		$cache->save('bcd', 3,120);
+		$this->assertEquals(3, $cache->delete(array('a','long-key','bcd')));
+	}
+
+
+	public function testCacheRedisFlush()
+	{
+		$redis = $this->_prepareRedis();
+		if (!$redis) {
+			return false;
+		}
+
+		$frontCache = new Phalcon\Cache\Frontend\Data();
+		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
+			'host' => 'localhost',
+			'port' => 6379
+		));
+
+		$cache->save('data', "1");
+		$cache->save('data2', "2");
+
+		$this->assertTrue($cache->exists('data'));
+		$this->assertTrue($cache->exists('data2'));
+
+		$this->assertTrue($cache->flush());
+
+		$this->assertFalse($cache->exists('data'));
+		$this->assertFalse($cache->exists('data2'));
+	}
 
 	/*public function testMemoryCache()
 	{
@@ -1407,186 +1593,5 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$this->assertFalse($cache->exists('data'));
 		$this->assertFalse($cache->exists('data2'));
 	}
-
-	protected function _prepareRedis()
-	{
-
-		if (!extension_loaded('redis')) {
-			$this->markTestSkipped('Warning: redis extension is not loaded');
-			return false;
-		}
-
-		$redis = new Redis();
-		$redis->connect('127.0.0.1', 6379);
-		//$redis->flushDB();
-		return $redis;
-	}
-
-	public function xtestRedisIncrement()
-	{
-		$redis = $this->_prepareRedis();
-		if (!$redis) {
-			return false;
-		}
-
-		$frontCache = new Phalcon\Cache\Frontend\Data(array('lifetime' => 20));
-		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
-			'host' => 'localhost',
-			'port' => 6379,
-			// 'auth' => 'foobared',
-			// 'persistent' => false
-		));
-		$cache->delete('increment');
-
-		$cache->save('increment', 1);
-		$this->assertEquals(2, $cache->increment('increment'));
-		$this->assertEquals(4, $cache->increment('increment', 2));
-		$this->assertEquals(14, $cache->increment('increment', 10));
-	}
-
-	public function xtestRedisDecrement()
-	{
-		$ready = $this->_prepareRedis();
-		if (!$ready) {
-			return false;
-		}
-
-		$frontCache = new Phalcon\Cache\Frontend\Data(array('lifetime' => 20));
-		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
-			'host' => 'localhost',
-			'port' => 6379
-		));
-		$cache->delete('decrement');
-
-		$cache->save('decrement', 100);
-		$this->assertEquals(99, $cache->decrement('decrement'));
-		$this->assertEquals(97, $cache->decrement('decrement', 2));
-		$this->assertEquals(87, $cache->decrement('decrement', 10));
-	}
-
-	public function xtestOutputRedisCache()
-	{
-
-		$redis = $this->_prepareRedis();
-		if (!$redis) {
-			return false;
-		}
-
-		$redis->delete('_PHCRtest-output');
-
-		$time = date('H:i:s');
-
-		$frontCache = new Phalcon\Cache\Frontend\Output(array('lifetime' => 2));
-		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
-			'host' => 'localhost',
-			'port' => 6379
-		));
-
-		ob_start();
-
-		//First time cache
-		$content = $cache->start('test-output');
-		if ($content !== null) {
-			$this->assertTrue(false);
-		}
-
-		echo $time;
-
-		$cache->save(null, null, null, true);
-
-		$obContent = ob_get_contents();
-		ob_end_clean();
-
-		$this->assertEquals($time, $obContent);
-		$this->assertEquals($time, $redis->get('_PHCRtest-output'));
-
-		//Expect same cache
-		$content = $cache->start('test-output');
-		if ($content === null) {
-			$this->assertTrue(false);
-		}
-
-		$this->assertEquals($content, $obContent);
-		$this->assertEquals($content, $redis->get('_PHCRtest-output'));
-
-		//Query keys
-		$keys = $cache->queryKeys();
-		$this->assertEquals($keys, array(
-			0 => 'test-output',
-			1 => 'decrement',
-			2 => 'increment'
-		));
-
-		//Delete entry from cache
-		$this->assertTrue($cache->delete('test-output'));
-	}
-
-	public function xtestDataRedisCache()
-	{
-		$redis = $this->_prepareRedis();
-		if (!$redis) {
-			return false;
-		}
-
-		$redis->delete('test-data');
-
-		$frontCache = new Phalcon\Cache\Frontend\Data();
-		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
-			'host' => 'localhost',
-			'port' => 6379
-		));
-
-		$data = array(1, 2, 3, 4, 5);
-
-		$cache->save('test-data', $data);
-
-		$cachedContent = $cache->get('test-data');
-		$this->assertEquals($cachedContent, $data);
-
-		$cache->save('test-data', "sure, nothing interesting");
-
-		$cachedContent = $cache->get('test-data');
-		$this->assertEquals($cachedContent, "sure, nothing interesting");
-
-		$this->assertTrue($cache->delete('test-data'));
-
-		$cache->save('a', 1);
-		$cache->save('long-key', 'long-val');
-		$cache->save('bcd', 3);
-		$keys = $cache->queryKeys();
-		sort($keys);
-		$this->assertEquals($keys, array('a', 'bcd', 'decrement', 'increment', 'long-key'));
-		$this->assertEquals($cache->queryKeys('long'), array('long-key'));
-
-		$this->assertTrue($cache->delete('a'));
-		$this->assertTrue($cache->delete('long-key'));
-		$this->assertTrue($cache->delete('bcd'));
-	}
-
-	public function xtestCacheRedisFlush()
-	{
-		$frontCache = new Phalcon\Cache\Frontend\Data(array('lifetime' => 10));
-
-		$redis = $this->_prepareRedis();
-		if (!$redis) {
-			return false;
-		}
-
-		$frontCache = new Phalcon\Cache\Frontend\Data();
-		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
-			'host' => 'localhost',
-			'port' => 6379
-		));
-
-		$cache->save('data', "1");
-		$cache->save('data2', "2");
-
-		$this->assertTrue($cache->exists('data'));
-		$this->assertTrue($cache->exists('data2'));
-
-		$this->assertTrue($cache->flush());
-
-		$this->assertFalse($cache->exists('data'));
-		$this->assertFalse($cache->exists('data2'));
-	}*/
+*/
 }

--- a/unit-tests/ci/redis.ini
+++ b/unit-tests/ci/redis.ini
@@ -1,0 +1,1 @@
+extension=redis.so


### PR DESCRIPTION
Hello,

With this PR, it's now possible to add several keys at the same time in delete method of Redis backend.
This method implement native functionnality of [phpredis driver](https://github.com/phpredis/phpredis#del-delete)

``` php
        $frontCache = new Phalcon\Cache\Frontend\Data(array('lifetime' => 20));
        $cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
            'host' => 'localhost',
            'port' => 6379
        ));
        $cache->save('key1', 'value1');
        $cache->save('key2', 'value2');
        $cache->save('key3', 'value3');
        $cache->delete(array('key1','key2','key3'));
```

Delete method return now Long Number of keys deleted.

Thanks
