### PR TITLE
[2.0.0] Fix addForeignKey() method on Phalcon\Db\Dialect\MySQL

### DIFF
--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -374,12 +374,12 @@ class MySQL extends Dialect //implements Phalcon\Db\DialectInterface
 		}
 
 		if schemaName {
-			let sql = "ALTER TABLE `" . schemaName . "`.`" . tableName . "` ADD FOREIGN KEY ";
+			let sql = "ALTER TABLE `" . schemaName . "`.`" . tableName . "` ADD CONSTRAINT ";
 		} else {
-			let sql = "ALTER TABLE `" . tableName . "` ADD FOREIGN KEY ";
+			let sql = "ALTER TABLE `" . tableName . "` ADD CONSTRAINT ";
 		}
 
-		let sql .= "`" . reference->getName() . "`(" . this->getColumnList(reference->getColumns()) . ") REFERENCES ";
+		let sql .= "`" . reference->getName() . "` FOREIGN KEY (" . this->getColumnList(reference->getColumns()) . ") REFERENCES ";
 
 		/**
 		 * Add the schema


### PR DESCRIPTION
Thix fix allows to name the constraint explicitly (the name wasn't taken into consideration with the old syntax)
