### PR TITLE
[2.0.0] fix key typo error of Column definition

### DIFF
--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -469,7 +469,7 @@ class Column implements ColumnInterface
 		}
 
 		if fetch columnTypeValues,  data["_typeValues"] {
-			let definition["typeValeus"] = columnTypeValues;
+			let definition["typeValues"] = columnTypeValues;
 		}
 
 		if fetch notNull, data["_notNull"] {


### PR DESCRIPTION
Fix an error when defining typeValues of a column.
