### PR TITLE
[2.0.0] Problem to restore a Phalcon\Db\Index object from export. Method __set_st...

### DIFF
--- a/phalcon/db/index.zep
+++ b/phalcon/db/index.zep
@@ -75,8 +75,8 @@ class Index implements IndexInterface
 	{
 		var indexName, columns, type;
 
-		if !fetch indexName, data["_indexName"] {
-			throw new Exception("_indexName parameter is required");
+		if !fetch indexName, data["_name"] {
+			throw new Exception("_name parameter is required");
 		}
 
 		if !fetch columns, data["_columns"] {


### PR DESCRIPTION
Problem to restore a Phalcon\Db\Index object from export. Method __set_state requires _indexName instead _name parameter.
