### PR TITLE
Removes redundant check

### DIFF
--- a/ext/mvc/micro.c
+++ b/ext/mvc/micro.c
@@ -1064,13 +1064,15 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle){
 	if (Z_TYPE_P(returned_value) == IS_OBJECT) {
 		int returned_response = instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC);
 
-		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
-		
-		if (returned_response && PHALCON_IS_FALSE(returned_response_sent)) {
-			/** 
-			 * Automatically send the responses
-			 */
-			PHALCON_CALL_METHOD(NULL, returned_value, "send");
+		if (returned_response) {
+			PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
+			
+			if (PHALCON_IS_FALSE(returned_response_sent)) {
+				/** 
+				 * Automatically send the responses
+				 */
+				PHALCON_CALL_METHOD(NULL, returned_value, "send");
+			}
 		}
 	}
 	

--- a/ext/mvc/micro.c
+++ b/ext/mvc/micro.c
@@ -1062,10 +1062,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle){
 	 * Check if the returned object is already a response
 	 */
 	if (Z_TYPE_P(returned_value) == IS_OBJECT) {
-		int returned_response =
-				(Z_TYPE_P(returned_value) == IS_OBJECT)
-			 && (instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC))
-		;
+		int returned_response = instanceof_function_ex(Z_OBJCE_P(returned_value), phalcon_http_responseinterface_ce, 1 TSRMLS_CC);
 
 		PHALCON_CALL_METHOD(&returned_response_sent, returned_value, "issent");
 		


### PR DESCRIPTION
Another commit will be made to ensure that issent() is only called when returned_response evaluates to true.

Also want to make sure that unit tests pass with this commit...
