### PR TITLE
[2.0.0] form default value fix

### DIFF
--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -474,18 +474,7 @@ abstract class Element
 		 */
 		let form = this->_form;
 		if typeof form == "object" {
-
-			/**
-			 * Check if the tag has a default value
-			 */
-			if !\Phalcon\Tag::hasValue(name) {
-
-				/**
-				 * Gets the possible value for the widget
-				 */
-				let value = form->getValue(name);
-			}
-
+			let value = form->getValue(name);
 		}
 
 		/**

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -475,6 +475,9 @@ abstract class Element
 		let form = this->_form;
 		if typeof form == "object" {
 			let value = form->getValue(name);
+			if typeof value == "null" && \Phalcon\Tag::hasValue(name) {
+				let value = \Phalcon\Tag::getValue(name);
+			}
 		}
 
 		/**

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -623,6 +623,11 @@ class Form extends Injectable implements \Countable, \Iterator
 				return value;
 			}
 		}
+		
+		let method = "get" . name;
+		if method_exists(this, method) {
+			return this->{method}();
+		}
 
 		return null;
 	}


### PR DESCRIPTION
Form was not calling self getters, fixed it so that adding csrf to the form would not cause problems.

csrf, if set as default for element would cause it to update everytime a new instance is created.

now it will use getCsrf().
