### PR TITLE
[2.0.0] Image crop bug

### DIFF
--- a/phalcon/image/adapter.zep
+++ b/phalcon/image/adapter.zep
@@ -185,7 +185,7 @@ abstract class Adapter
  	 */
 	public function crop(int width, int height, int offset_x = null, int offset_y = null) -> <Adapter>
 	{
-		if !offset_x {
+		if is_null(offset_x) {
 			let offset_x = ((this->_width - width) / 2);
 		} else {
 			if offset_x < 0 {
@@ -197,7 +197,7 @@ abstract class Adapter
 			}
 		}
 
-		if !offset_y {
+		if is_null(offset_y) {
 			let offset_y = ((this->_height - height) / 2);
 		} else {
 			if offset_y < 0 {


### PR DESCRIPTION
0 can be a desired value for offsets, e.g. if you want to crop from top of the image

``` php
$image->crop(150, 193, null, 0); //crop horizontally center, vertically top 
```

It was OK in 1.3:
https://github.com/phalcon/cphalcon/blob/1.3.4/ext/image/adapter.c#L429
