### PR TITLE
[2.0.0] Forms: Fix entity binding before validation

### DIFF
--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -293,6 +293,8 @@ class Form extends Injectable implements \Countable, \Iterator
 		 */
 		if typeof entity == "object" {
 			this->bind(data, entity);
+		} elseif typeof this->_entity == "object" {
+			this->bind(data, this->_entity);
 		}
 
 		/**


### PR DESCRIPTION
If entity is not passed to isValid method but previously set via constructor we should bind this one.

Now it's additionally possible:

``` php
$robot = Robots::findFirst();
$form = new Form($robot);

// works because we use for entity binding the model which is passed to constructor
if ($form->isValid($_POST)) { 
    $robot->save();
}
```
