### PR TITLE
[2.0.0] ACL constants are now integers

### DIFF
--- a/phalcon/acl.zep
+++ b/phalcon/acl.zep
@@ -65,8 +65,8 @@ namespace Phalcon;
 abstract class Acl
 {
 
-	const ALLOW = true;
+	const ALLOW = 1;
 
-	const DENY = false;
+	const DENY = 0;
 
 }

--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -516,9 +516,9 @@ class Memory extends Adapter
 	  * @param  string roleName
 	  * @param  string resourceName
 	  * @param  string access
-	  * @return int|boolean
+	  * @return boolean
 	  */
-	public function isAllowed(var roleName, var resourceName, var access) -> int|boolean
+	public function isAllowed(var roleName, var resourceName, var access) -> boolean
 	{
 		var eventsManager, accessList, accessKey,
 			haveAccess = null, roleInherits, inheritedRole, rolesNames,
@@ -541,7 +541,7 @@ class Memory extends Adapter
 		 */
 		let rolesNames = this->_rolesNames;
 		if !isset rolesNames[roleName] {
-			return this->_defaultAccess;
+			return (this->_defaultAccess == \Phalcon\Acl::ALLOW);
 		}
 
 		let accessKey = roleName . "!" . resourceName . "!" . access;
@@ -639,10 +639,10 @@ class Memory extends Adapter
 		}
 
 		if haveAccess == null {
-			return 0;
+			return false;
 		}
 
-		return haveAccess;
+		return (haveAccess == \Phalcon\Acl::ALLOW);
 	}
 
 	/**


### PR DESCRIPTION
The ACL constants were previously booleans and threw a warning:

```
Warning: Passing possible incorrect type for parameter: Phalcon\Acl\Adapter\Memory::setDefaultAction(defaultAccess), passing: bool, expecting: int in ... on ... [possible-wrong-parameter]
```

\Phalcon\Acl\Adapter\Memory::isAllowed() now also returns only boolean values instead of possibly returning the ACL constants.
