### PR TITLE
Fixed Config::merge array values

### DIFF
--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -215,16 +215,22 @@ class Config implements \ArrayAccess, \Countable
 	 */
 	private function _merge(<Config> config, var instance = null) -> <Config>
 	{
-		var key, value;
+		var key, value, number;
 
 		if typeof instance !== "object" {
 			let instance = this;
 		}
 
+		let number = instance->count();
+
 		for key, value in get_object_vars(config) {
 			if isset(instance->{key}) && typeof value === "object" && typeof instance->{key} === "object" {
 				this->_merge(value, instance->{key});
 			} else {
+				if typeof key == "integer" {
+					let key = strval(number);
+					let number++;
+				}
 				let instance->{key} = value;
 			}
 		}

--- a/unit-tests/ConfigTest.php
+++ b/unit-tests/ConfigTest.php
@@ -191,6 +191,52 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
     }
 
+    public function testConfigMergeArray()
+    {
+
+        $conf1 = array(
+            "keys" => array(
+                "scott",
+                "cheetah",
+            ),
+        );
+
+        $conf2 = array(
+            "keys" => array(
+                "peter",
+            ),
+        );
+
+        $config1 = new Phalcon\Config($conf1);
+        $config2 = new Phalcon\Config($conf2);
+        $config1->merge($config2);
+
+        $expected = Phalcon\Config::__set_state(array(
+            'keys' => Phalcon\Config::__set_state(array(
+                '0' => 'scott',
+                '1' => 'cheetah',
+                '2' => 'peter',
+            )),
+        ));
+
+        $this->assertEquals($config1, $expected);
+
+        $config1 = new Phalcon\Config($conf1);
+        $config2 = new Phalcon\Config($conf2);
+        $config2->merge($config1);
+
+        $expected = Phalcon\Config::__set_state(array(
+          'keys' => Phalcon\Config::__set_state(array(
+                '0' => 'peter',
+                '1' => 'scott',
+                '2' => 'cheetah',
+            )),
+        ));
+
+        $this->assertEquals($config2, $expected);
+
+    }
+
     public function testConfigCount()
     {
         $config = new Phalcon\Config(array(


### PR DESCRIPTION
Example Code:

``` php
<?php
namespace Phalcon;

$conf1 = ['keys' => ['scott', 'cheetah']];
$conf2 = ['keys' => ['peter']];

$config = new Config($conf1);
$config->merge(new Config($conf2));

var_dump($config->toArray());
```

Current version output:

```
Warning: Phalcon\Config::_merge(): Property should be string in test.php on line 8
array(1) {
  ["keys"]=>
  array(2) {
    [0]=>
    string(5) "scott"
    [1]=>
    string(7) "cheetah"
  }
}
```

Fixed Config::merge output:

```
array(1) {
  ["keys"]=>
  array(3) {
    [0]=>
    string(5) "scott"
    [1]=>
    string(7) "cheetah"
    [2]=>
    string(5) "peter"
  }
}
```
