### PR TITLE
[2.0.0] Model/Validator/Url: Comparison fix

### DIFF
--- a/phalcon/mvc/model/validator/url.zep
+++ b/phalcon/mvc/model/validator/url.zep
@@ -62,7 +62,7 @@ class Url extends Validator implements ValidatorInterface
 		var field, value, message;
 
 		let field = this->getOption("field");
-		if typeof field == "string" {
+		if typeof field != "string" {
 			throw new Exception("Field name must be a string");
 		}
 


### PR DESCRIPTION
If using validator of type url you get an error, because the comparison is wrong here 

```
typeof field == "string"  => throw Exception ("Field name must be a string")
```

It is fixed to 

```
typeof field != "string"
```
