### PR TITLE
[2.0.0] Add __isset magic method to view for view params

### DIFF
--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -1442,7 +1442,7 @@ class View extends Injectable implements ViewInterface
      * @param string key
      * @return boolean
      */
-    public function __isset(string! key)
+    public function __isset(string! key) -> boolean
     {
         return isset(this->_viewParams[key]);
     }

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -1432,4 +1432,18 @@ class View extends Injectable implements ViewInterface
 		return this->_disabled;
 	}
 
+    /**
+     * Magic method to retrieve if a variable is set in the view
+     *
+     *<code>
+     *  echo isset($this->view->products);
+     *</code>
+     *
+     * @param string key
+     * @return boolean
+     */
+    public function __isset(string! key)
+    {
+        return isset(this->_viewParams[key]);
+    }
 }

--- a/unit-tests/ViewTest.php
+++ b/unit-tests/ViewTest.php
@@ -305,6 +305,21 @@ class ViewTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($content, '<html>Hey, this is a partial, also le-this</html>' . PHP_EOL);
 	}
 
+	/**
+	 * @covers \Phalcon\Mvc\View::__isset
+	 */
+	public function testViewParamIsset()
+	{
+		$view = new View();
+
+		$view->setViewsDir('unit-tests/views/');
+		$view->set_param = 'something';
+		
+		$content = $view->getRender('test16', 'index');
+
+		$this->assertEquals($content, 'true' . PHP_EOL);
+	}
+
 	protected function _getViewDisabled($level=null)
 	{
 		$view = new View();

--- a/unit-tests/views/test16/index.phtml
+++ b/unit-tests/views/test16/index.phtml
@@ -1,0 +1,1 @@
+<?php echo isset($this->getView()->set_param); ?>


### PR DESCRIPTION
Adds the magic isset method the the view object so that view params can be checked with isset().

ie:
echo isset($this->view->products);
