### PR TITLE
[2.0.0] #3344 Resultset\Simple::toArray() fails always with fatal error

### DIFF
--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -256,7 +256,7 @@ class Simple extends Resultset
 						/**
 						 * Check if the key is part of the column map
 						 */
-						if fetch renamedKey, columnMap[key] {
+						if !fetch renamedKey, columnMap[key] {
 							throw new Exception("Column '" . key . "' is not part of the column map");
 						}
 


### PR DESCRIPTION
Trying to use Phalcon\Mvc\Model\Resultset/Simple::toArray(true) will always fail with a fatal error:

Column 'xxx' is not part of the column map.
