### PR TITLE
Add magic method to session adapter

### DIFF
--- a/phalcon/session/adapter.zep
+++ b/phalcon/session/adapter.zep
@@ -208,4 +208,43 @@ abstract class Adapter
 		return session_destroy();
 	}
 
+	/**
+	 * Alias: Gets a session variable from an application context
+	 *
+	 * @param string index
+	 * @return mixed
+	 */
+	public function __get(string index)
+	{
+		return this->get(index);
+	}
+
+	/**
+	 * Alias: Sets a session variable in an application context
+	 *
+	 * @param string index
+	 * @param string value
+	 */
+	public function __set(string index, value)
+	{
+		return this->set(index, value);
+	}
+
+	/**
+	 * Alias: Check whether a session variable is set in an application context
+	 *
+	 * @param string index
+	 */
+	public function __isset(string index) -> boolean
+	{
+		return this->has(index);
+	}
+
+	/**
+	 * Alias: Removes a session variable from an application context
+	 */
+	public function __unset(string index)
+	{
+		return this->remove(index);
+	}
 }

--- a/unit-tests/SessionTest.php
+++ b/unit-tests/SessionTest.php
@@ -21,6 +21,32 @@
 class SessionTest extends PHPUnit_Framework_TestCase
 {
 
+	protected $stack = array();
+
+	protected function setUp()
+	{
+
+		$this->stack = array(
+			'save_handler' => ini_get('session.save_handler'),
+			'save_path' => ini_get('session.save_path'),
+			'serialize_handler' => ini_get('session.serialize_handler'),
+		);
+
+	}
+
+	protected function tearDown()
+	{
+
+		if (session_status() != PHP_SESSION_DISABLED) {
+			session_write_close();
+		}
+
+		foreach ($this->stack as $key => $val) {
+			@ini_set($key, $val);
+		}
+
+	}
+
 	public function testSessionFiles()
 	{
 
@@ -40,6 +66,109 @@ class SessionTest extends PHPUnit_Framework_TestCase
 		// Automatically deleted after reading
 		$this->assertEquals($session->get('some', NULL, TRUE), 'value');
 		$this->assertFalse($session->has('some'));
+	}
+
+	public function testSessionFilesWrite()
+	{
+
+		$session_path =  __DIR__ . '/cache';
+		ini_set('session.save_handler', 'files');
+		ini_set('session.save_path', $session_path);
+		ini_set('session.serialize_handler', 'php');
+
+		// Write
+		$session = new Phalcon\Session\Adapter\Files();
+		$session->start();
+		@session_start();
+
+		$session->set('some', 'write-value');
+
+		$this->assertEquals($session->get('some'), 'write-value');
+		$this->assertTrue($session->has('some'));
+
+		$session_id = $session->getId();
+		$this->assertNotEmpty($session_id);
+
+		session_write_close();
+		unset($session);
+
+		// Check session file
+		$session_file = $session_path . '/sess_' . $session_id;
+		$this->assertTrue(is_file($session_file));
+		$this->assertNotEmpty(@file_get_contents($session_file));
+
+		// Read
+		$session = new Phalcon\Session\Adapter\Files();
+		$session->start();
+		@session_start();
+
+		$session->setId($session_id);
+
+		$this->assertTrue($session->has('some'));
+		$this->assertEquals($session->get('some'), 'write-value');
+
+		$session->remove('some');
+		$this->assertFalse($session->has('some'));
+
+		@session_write_close();
+		unset($session);
+
+		// Check session file
+		$this->assertTrue(is_file($session_file));
+		$this->assertEmpty(@file_get_contents($session_file));
+		@unlink($session_file);
+
+	}
+
+	public function testSessionFilesWriteMagicMethods()
+	{
+
+		$session_path =  __DIR__ . '/cache';
+		ini_set('session.save_handler', 'files');
+		ini_set('session.save_path', $session_path);
+		ini_set('session.serialize_handler', 'php');
+
+		// Write
+		$session = new Phalcon\Session\Adapter\Files();
+		$session->start();
+		@session_start();
+
+		$session->some = 'write-magic-value';
+
+		$this->assertEquals($session->some, 'write-magic-value');
+		$this->assertTrue(isset($session->some));
+
+		$session_id = $session->getId();
+
+		@session_write_close();
+		unset($session);
+
+		// Check session file
+		$session_file = $session_path . '/sess_' . $session_id;
+		$this->assertTrue(is_file($session_file));
+		$this->assertNotEmpty(@file_get_contents($session_file));
+
+		// Read
+		$session = new Phalcon\Session\Adapter\Files();
+		$session->start();
+		@session_start();
+
+		$session->setId($session_id);
+
+		$this->assertTrue(isset($session->some));
+		$this->assertEquals($session->some, 'write-magic-value');
+
+		unset($session->some);
+		$this->assertFalse(isset($session->some));
+
+		@session_write_close();
+		unset($session);
+
+		// Check session file
+		$this->assertTrue(is_file($session_file));
+		$this->assertEmpty(@file_get_contents($session_file));
+		@unlink($session_file);
+
 	}
 
 }


### PR DESCRIPTION
Not found alias function of magic methods.

``` php
$session = new Phalcon\Session\Adapter\Files();
$session->some = 'value'; // Not saved
```
