### PR TITLE
[2.0.0] Model/Validator/Presenceof: Empty filter fix

### DIFF
--- a/phalcon/mvc/model/validator/presenceof.zep
+++ b/phalcon/mvc/model/validator/presenceof.zep
@@ -71,7 +71,7 @@ class PresenceOf extends Validator implements ValidatorInterface
 		 * A value is null when it is identical to null or a empty string
 		 */
 		let value = record->readAttribute(field);
-		if empty value {
+		if is_null(value) || (is_string(value) && !strlen(value)) {
 
 			/**
 			 * Check if the developer has defined a custom message


### PR DESCRIPTION
Presenceof validator use function named empty to check a passed value. 
Unfortunately, this function filters values like false and 0 (zero) as well.

Back to the roots v. 1.x:
A value is null when it is identical to null or a empty string.
