### PR TITLE
Fix innerJoin() comment

### DIFF
--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -185,13 +185,11 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	 *	$criteria->innerJoin('Robots');
 	 *	$criteria->innerJoin('Robots', 'r.id = RobotsParts.robots_id');
 	 *	$criteria->innerJoin('Robots', 'r.id = RobotsParts.robots_id', 'r');
-	 *	$criteria->innerJoin('Robots', 'r.id = RobotsParts.robots_id', 'r', 'LEFT');
 	 *</code>
 	 *
 	 * @param string model
 	 * @param string conditions
 	 * @param string alias
-	 * @param string type
 	 * @return Phalcon\Mvc\Model\Criteria
 	 */
 	public function innerJoin(string! model, conditions = null, alias = null) -> <Criteria>


### PR DESCRIPTION
`innerJoin('Robots', 'r.id = RobotsParts.robots_id', 'r', 'LEFT');` does not work, because `innerJoin()` means `join()` with 4th param `'INNER'`.
