### PR TITLE
[2.0.0] Updated Memcached client option to optional

### DIFF
--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -112,11 +112,13 @@ class Libmemcached extends Backend implements BackendInterface
 			throw new Exception("Cannot connect to Memcached server");
 		}
 
-		let client = options["client"];
-		if typeof client == "array" {
-			memcache->setOptions(client);
-		} else {
-			throw new Exception("Client options must be instance of array");
+		if isset options["client"] {
+			let client = options["client"];
+			if typeof client == "array" {
+				memcache->setOptions(client);
+			} else {
+				throw new Exception("Client options must be instance of array");
+			}
 		}
 
 		let this->_memcache = memcache;


### PR DESCRIPTION
unit-tests/CacheTest.php(libmemcached) becomes Segmentaion Fault.

It seems there is no client set to option of test. 

If you are not a required option than to add a client option to test has been fixed.
