### PR TITLE
[2.0.0] Fixed type checking for model messages

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2458,7 +2458,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 							/**
 							 * Set the related model
 							 */
-							if typeof record == "object" {
+							if typeof message == "object" {
 								message->setModel(record);
 							}
 
@@ -2644,7 +2644,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 								/**
 								 * Set the related model
 								 */
-								if typeof message != "object" {
+								if typeof message == "object" {
 									message->setModel(record);
 								}
 


### PR DESCRIPTION
With `if typeof message != "object" { ... }`, `message` has to be an object in order to use the `setModel()` method.

With `if typeof record == "object" { ... }`, we know that `record` will be an object because we throw an Exception if it's not on line 2434 and we still need to check that `message` is an object to use the `setModel()` method.
