### PR TITLE
Corrected buffer stop for output-frontend in backends: libmemcache and redis

### DIFF
--- a/phalcon/cache/backend/file.zep
+++ b/phalcon/cache/backend/file.zep
@@ -214,11 +214,11 @@ class File extends \Phalcon\Cache\Backend implements \Phalcon\Cache\BackendInter
 
 		let isBuffering = frontend->isBuffering();
 
-		if stopBuffer == true {
+		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if isBuffering {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 

--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -248,11 +248,11 @@ class Libmemcached extends Backend implements BackendInterface
 
 		let isBuffering = frontend->isBuffering();
 
-		if !stopBuffer {
+		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if isBuffering == true {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -243,11 +243,11 @@ class Memcache extends Backend implements BackendInterface
 
 		let isBuffering = frontend->isBuffering();
 
-		if stopBuffer == true {
+		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if isBuffering == true {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 

--- a/phalcon/cache/backend/memory.zep
+++ b/phalcon/cache/backend/memory.zep
@@ -108,11 +108,13 @@ class Memory extends Backend implements BackendInterface
 		let preparedContent = frontend->beforeStore(cachedContent),
 			this->_data[lastKey] = preparedContent;
 
+		let isBuffering = frontend->isBuffering();
+
 		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if frontend->isBuffering() === true {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 

--- a/phalcon/cache/backend/memory.zep
+++ b/phalcon/cache/backend/memory.zep
@@ -85,7 +85,7 @@ class Memory extends Backend implements BackendInterface
 	 */
 	public function save(var keyName = null, var content = null, lifetime = null, stopBuffer = true) -> void
 	{
-		var lastKey, frontend, cachedContent, preparedContent;
+		var lastKey, frontend, cachedContent, preparedContent, isBuffering;
 
 		if keyName === null {
 			let lastKey = this->_lastKey;

--- a/phalcon/cache/backend/mongo.zep
+++ b/phalcon/cache/backend/mongo.zep
@@ -247,11 +247,11 @@ class Mongo extends Backend implements BackendInterface
 
 		let isBuffering = frontend->isBuffering();
 
-		if stopBuffer == true {
+		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if isBuffering == true {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -242,11 +242,11 @@ class Redis extends \Phalcon\Cache\Backend implements \Phalcon\Cache\BackendInte
 
 		let isBuffering = frontend->isBuffering();
 
-		if !stopBuffer {
+		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if isBuffering == true {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 

--- a/phalcon/cache/backend/xcache.zep
+++ b/phalcon/cache/backend/xcache.zep
@@ -151,11 +151,11 @@ use Phalcon\Cache\Exception;
 
 		let isBuffering = frontend->isBuffering();
 
-		if !stopBuffer {
+		if stopBuffer === true {
 			frontend->stop();
 		}
 
-		if isBuffering == true {
+		if isBuffering === true {
 			echo cachedContent;
 		}
 


### PR DESCRIPTION
Cache backends redis and libmemcached do not stop the frontend buffer on save. Cacheable content in viewCache ouput-cache is displayed twice.

Replaced "if !stopBuffer true {" with "if stopBuffer === true {" as implemented in apc-cache-backend. Also isBuffering() in memory-backend must occur before stop() is called.
