### PR TITLE
[1.3.5] [minor] Bad return type in getPaginate() for all Paginator\Adapter's

### DIFF
--- a/ext/paginator/adapter/model.c
+++ b/ext/paginator/adapter/model.c
@@ -108,7 +108,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_Model, setCurrentPage){
 /**
  * Returns a slice of the resultset to show in the pagination
  *
- * @return stdClass
+ * @return \stdClass
  */
 PHP_METHOD(Phalcon_Paginator_Adapter_Model, getPaginate){
 

--- a/ext/paginator/adapter/nativearray.c
+++ b/ext/paginator/adapter/nativearray.c
@@ -135,7 +135,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_NativeArray, setCurrentPage){
 /**
  * Returns a slice of the resultset to show in the pagination
  *
- * @return stdClass
+ * @return \stdClass
  */
 PHP_METHOD(Phalcon_Paginator_Adapter_NativeArray, getPaginate){
 

--- a/ext/paginator/adapter/querybuilder.c
+++ b/ext/paginator/adapter/querybuilder.c
@@ -229,7 +229,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, getQueryBuilder){
 /**
  * Returns a slice of the resultset to show in the pagination
  *
- * @return stdClass
+ * @return \stdClass
  */
 PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, getPaginate){
 

--- a/ext/paginator/adapterinterface.c
+++ b/ext/paginator/adapterinterface.c
@@ -49,6 +49,6 @@ PHALCON_DOC_METHOD(Phalcon_Paginator_AdapterInterface, setCurrentPage);
 /**
  * Returns a slice of the resultset to show in the pagination
  *
- * @return stdClass
+ * @return \stdClass
  */
 PHALCON_DOC_METHOD(Phalcon_Paginator_AdapterInterface, getPaginate);


### PR DESCRIPTION
The stubs are declared with `stdClass` as return type, which expands in their namespace to be `Phalcon\Paginator\Adapter\stdClass`, which in turn does not exist.
Quick fix to change it to `\stdClass`.
