### PR TITLE
Fix «in» operator because of strpos «0» answer

### DIFF
--- a/phalcon/mvc/view/engine/volt.zep
+++ b/phalcon/mvc/view/engine/volt.zep
@@ -176,9 +176,9 @@ class Volt extends Engine implements EngineInterface
 
 		if typeof haystack == "string" {
 			if function_exists("mb_strpos") {
-				return mb_strpos(haystack, needle);
+				return mb_strpos(haystack, needle) !== false;
 			}
-			return strpos(haystack, needle);
+			return strpos(haystack, needle) !== false;
 		}
 
 		throw new Exception("Invalid haystack");


### PR DESCRIPTION
strpos returns 0 if the needle is found at position 0. So the test should be made against «false», and not return the position of the string, which won't work for examples like 'test' in 'test1234'.
