### PR TITLE
[2.0.0] fixed return null at Phalcon\Mvc\Model\Resultset:toArray() when the resu...

### DIFF
--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -228,6 +228,8 @@ class Simple extends Resultset
 					 * Update the row count
 					 */
 					let this->_count = count(records);
+				} else {
+					let records = [];
 				}
 			}
 		}


### PR DESCRIPTION
fixed return null at Phalcon\Mvc\Model\Resultset:toArray() when the result is empty.
