### PR TITLE
[NFR] Phalcon\Tag class extension by closure 

### DIFF
--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -618,6 +618,15 @@ class Compiler implements InjectionAwareInterface
 			}
 
 			/**
+			 * Check if it's a function in Phalcon\Tag
+			 */
+			if method_exists(className, "hasFunction") {
+				if {className}::hasFunction(method) {
+					return "$this->tag->" . method . "(" . arguments . ")";
+				}
+			}
+
+			/**
 			 * The function doesn't exist throw an exception
 			 */
 			throw new Exception("Undefined function '" . name . "' in " . expr["file"] . " on line " . expr["line"]);

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  +------------------------------------------------------------------------+
+*/
+
+class TagTest extends PHPUnit_Framework_TestCase
+{
+	public function testFunctions()
+	{
+		$this->assertFalse(Phalcon\Tag::hasFunction('lower'));
+		$this->assertFalse(Phalcon\Tag::hasFunction('sum'));
+
+		$this->assertTrue(Phalcon\Tag::addFunction('lower', function($str){
+			return strtolower($str);
+		}));
+
+		$this->assertTrue(Phalcon\Tag::addFunction('sum', function($a, $b){
+			return $a + $b;
+		}));
+
+		$this->assertTrue(Phalcon\Tag::hasFunction('lower'));
+		$this->assertTrue(Phalcon\Tag::hasFunction('sum'));
+
+		$this->assertEquals(Phalcon\Tag::lower('TEST'), 'test');
+		$this->assertEquals(Phalcon\Tag::sum(1, 3), '4');
+	}
+}

--- a/unit-tests/ViewEnginesVoltTest.php
+++ b/unit-tests/ViewEnginesVoltTest.php
@@ -1354,4 +1354,16 @@ Clearly, the song is: <?php echo $this->getContent(); ?>.
 
 		$this->assertEquals($view->getContent(), 'Length Array: 4Length Object: 4Length String: 5Length No String: 4Slice Array: 1,2,3,4Slice Array: 2,3Slice Array: 1,2,3Slice Object: 2,3,4Slice Object: 2Slice Object: 1Slice String: helSlice String: elSlice String: lloSlice No String: 123Slice No String: 23Slice No String: 34');
 	}
+
+	public function testVoltTagFunctions()
+	{
+		Phalcon\Tag::addFunction('shuffle', function($str){
+			return str_shuffle($str);
+		});
+
+		$volt = new Compiler();
+
+		$compilation = $volt->compileString('{{ shuffle("hello") }}');
+		$this->assertEquals($compilation, '<?php echo $this->tag->shuffle(\'hello\'); ?>');
+	}
 }


### PR DESCRIPTION
Added Phalcon\Tag::addFunction() and hasFunction() and calls from Volt Compiler.

``` php
Phalcon\Tag::addFunction('shuffle', function($str){
    return str_shuffle($str);
});

$volt = new Phalcon\Mvc\View\Engine\Volt\Compiler();
$compilation = $volt->compileString('{{ shuffle("hello") }}');
// compilation: <?php echo $this->tag->shuffle('hello'); ?>
```
