### PR TITLE
[NFR] Added Phalcon\Mvc\View\Engine\Compiler

### DIFF
--- a/phalcon/mvc/view/engine/compiler.zep
+++ b/phalcon/mvc/view/engine/compiler.zep
@@ -1,0 +1,336 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Mvc\View\Engine;
+
+use Phalcon\Mvc\View\Engine;
+use Phalcon\Mvc\View\EngineInterface;
+use Phalcon\Mvc\View\Exception;
+
+/**
+ * Phalcon\Mvc\View\Engine\Compiler
+ */
+class Compiler extends Engine implements EngineInterface
+{
+
+	protected _options;
+
+	protected _compiledTemplatePath;
+
+	/**
+	 * Set Volt's options
+	 *
+	 * @param array options
+	 */
+	public function setOptions(array! options)
+	{
+		let this->_options = options;
+	}
+
+	/**
+	 * Return Volt's options
+	 *
+	 * @return array
+	 */
+	public function getOptions()
+	{
+		return this->_options;
+	}
+
+	/**
+	 * Compiles a source code returning a PHP plain version
+	 *
+	 * @param string  viewCode
+	 * @return string
+	 */
+	protected function _compileSource(string! viewCode) -> string
+	{
+		var options, compiledSource;
+
+		let options = this->_options;
+
+		if typeof options == "array" {
+
+			/**
+			 * This makes that templates will be compiled source
+			 */
+			if isset options["compiledSource"] {
+				let compiledSource = options["compiledSource"];
+
+				if is_callable(compiledSource) {
+					return call_user_func_array(compiledSource, [viewCode]);
+				}
+			}
+
+		}
+
+		throw new Exception("compileSource must be a string or closure");
+	}
+
+	/**
+	 * Compiles a template into a file forcing the destination path
+	 *
+	 * @param string path
+	 * @param string compiledPath
+	 * @return string
+	 */
+	public function compileFile(string! path, string! compiledPath)
+	{
+		var viewCode, compilation;
+
+		if path == compiledPath {
+			throw new Exception("Template path and compilation template path cannot be the same");
+		}
+
+		/**
+		 * Check if the template does exist
+		 */
+		if !file_exists(path) {
+			throw new Exception("Template file " . path . " does not exist");
+		}
+
+		/**
+		 * Always use file_get_contents instead of read the file directly, this respect the open_basedir directive
+		 */
+		let viewCode = file_get_contents(path);
+		if viewCode === false {
+			throw new Exception("Template file " . path . " could not be opened");
+		}
+
+		let compilation = this->_compileSource(viewCode);
+
+		/**
+		 * Always use file_put_contents to write files instead of write the file directly, this respect the open_basedir directive
+		 */
+		if file_put_contents(compiledPath, compilation) === false {
+			throw new Exception("Compile directory can't be written");
+		}
+
+		return compilation;
+	}
+
+	/**
+	 * Compiles a template
+	 *
+	 * @param string templatePath
+	 * @return string
+	 */
+	public function compile(string !templatePath)
+	{
+		var stat, compileAlways, prefix, compiledPath, compiledSeparator,
+			compiledExtension, compilation, options, realCompiledPath,
+			compiledTemplatePath, templateSepPath;
+
+		let stat = true;
+		let compileAlways = false;
+		let compiledPath = "";
+		let prefix = null;
+		let compiledSeparator = "%%";
+		let compiledExtension = ".php";
+		let compilation = null;
+
+		let options = this->_options;
+		if typeof options == "array" {
+
+			/**
+			 * This makes that templates will be compiled always
+			 */
+			if isset options["compileAlways"] {
+				let compileAlways = options["compileAlways"];
+				if typeof compileAlways != "boolean" {
+					throw new Exception("compileAlways must be a bool value");
+				}
+			}
+
+			/**
+			 * Prefix is prepended to the template name
+			 */
+			if isset options["prefix"] {
+				let prefix = options["prefix"];
+				if typeof prefix != "string" {
+					throw new Exception("prefix must be a string");
+				}
+			}
+
+			/**
+			 * Compiled path is a directory where the compiled templates will be located
+			 */
+			if isset options["compiledPath"] {
+				let compiledPath = options["compiledPath"];
+				if typeof compiledPath != "string" {
+					if typeof compiledPath != "object" {
+						throw new Exception("compiledPath must be a string or a closure");
+					}
+				}
+			}
+
+			/**
+			 * There is no compiled separator by default
+			 */
+			if isset options["compiledSeparator"] {
+				let compiledSeparator = options["compiledSeparator"];
+				if typeof compiledSeparator != "string" {
+					throw new Exception("compiledSeparator must be a string");
+				}
+			}
+
+			/**
+			 * By default the compile extension is .php
+			 */
+			if isset options["compiledExtension"] {
+				let compiledExtension = options["compiledExtension"];
+				if typeof compiledExtension != "string" {
+					throw new Exception("compiledExtension must be a string");
+				}
+			}
+
+			/**
+			 * Stat option assumes the compilation of the file
+			 */
+			if isset options["stat"] {
+				let stat = options["stat"];
+			}
+		}
+
+		/**
+		 * Check if there is a compiled path
+		 */
+		if typeof compiledPath == "string" {
+
+			/**
+			 * Calculate the template realpath's
+			 */
+			if !empty compiledPath {
+				/**
+				 * Create the virtual path replacing the directory separator by the compiled separator
+				 */
+				let templateSepPath = prepare_virtual_path(realpath(templatePath), compiledSeparator);
+			} else {
+				let templateSepPath = templatePath;
+			}
+
+			let compiledTemplatePath = compiledPath . prefix . templateSepPath . compiledExtension;
+
+		} else {
+
+			/**
+			 * A closure can dynamically compile the path
+			 */
+			if typeof compiledPath == "object" {
+
+				if compiledPath instanceof \Closure {
+
+					let compiledTemplatePath = call_user_func_array(compiledPath, [templatePath, options]);
+
+					/**
+					 * The closure must return a valid path
+					 */
+					if typeof compiledTemplatePath != "string" {
+						throw new Exception("compiledPath closure didn't return a valid string");
+					}
+				} else {
+					throw new Exception("compiledPath must be a string or a closure");
+				}
+			}
+		}
+
+		/**
+		 * Use the real path to avoid collisions
+		 */
+		let realCompiledPath = compiledTemplatePath;
+
+		if compileAlways {
+
+			/**
+			 * Compile always must be used only in the development stage
+			 */
+			let compilation = this->compileFile(templatePath, realCompiledPath);
+		} else {
+			if stat === true {
+				if file_exists(compiledTemplatePath) {
+
+					/**
+					 * Compare modification timestamps to check if the file needs to be recompiled
+					 */
+					if compare_mtime(templatePath, realCompiledPath) {
+						let compilation = this->compileFile(templatePath, realCompiledPath);
+					}
+
+				} else {
+
+					/**
+					 * The file doesn't exist so we compile the php version for the first time
+					 */
+					let compilation = this->compileFile(templatePath, realCompiledPath);
+				}
+			} else {
+
+				/**
+				 * Stat is off but the compiled file doesn't exist
+				 */
+				if !file_exists(realCompiledPath) {
+					throw new Exception("Compiled template file " . realCompiledPath . " does not exist");
+				}
+
+			}
+		}
+
+		let this->_compiledTemplatePath = realCompiledPath;
+
+		return compilation;
+	}
+
+	/**
+	 * Renders a view using the template engine
+	 *
+	 * @param string  $templatePath
+	 * @param array   $params
+	 * @param boolean $mustClean
+	 */
+	public function render(string! templatePath, var params, boolean mustClean = false)
+	{
+		var key, value;
+
+		if mustClean {
+			ob_clean();
+		}
+
+		/**
+		 * The compilation process is done
+		 */
+		this->compile(templatePath);
+
+		/**
+		 * Export the variables the current symbol table
+		 */
+		if typeof params == "array" {
+			for key, value in params {
+				let {key} = value;
+			}
+		}
+
+		require this->_compiledTemplatePath;
+
+		if mustClean {
+			this->_view->setContent(ob_get_contents());
+			//ob_clean();
+		}
+	}
+
+}

--- a/unit-tests/ViewEnginesCompilerTest.php
+++ b/unit-tests/ViewEnginesCompilerTest.php
@@ -18,6 +18,7 @@
   +------------------------------------------------------------------------+
 */
 
+if (!function_exists('phalcon_prepare_virtual_path')) {
 function phalcon_prepare_virtual_path($path, $separator) {
 	$virtual_str = '';
 
@@ -42,6 +43,7 @@ function phalcon_prepare_virtual_path($path, $separator) {
 	}
 
 	return $virtual_str;
+}
 }
 
 class ViewEnginesCompilerTest extends PHPUnit_Framework_TestCase

--- a/unit-tests/ViewEnginesCompilerTest.php
+++ b/unit-tests/ViewEnginesCompilerTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+  +------------------------------------------------------------------------+
+  | Phalcon Framework                                                      |
+  +------------------------------------------------------------------------+
+  | Copyright (c) 2011-2014 Phalcon Team (http://www.phalconphp.com)       |
+  +------------------------------------------------------------------------+
+  | This source file is subject to the New BSD License that is bundled     |
+  | with this package in the file docs/LICENSE.txt.                        |
+  |                                                                        |
+  | If you did not receive a copy of the license and are unable to         |
+  | obtain it through the world-wide-web, please send an email             |
+  | to license@phalconphp.com so we can send you a copy immediately.       |
+  +------------------------------------------------------------------------+
+  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+  +------------------------------------------------------------------------+
+*/
+
+function phalcon_prepare_virtual_path($path, $separator) {
+	$virtual_str = '';
+
+	if (!is_string($path) || !is_string($separator)) {
+		if (is_string($path)) {
+			return $path;
+		} else {
+			return "";
+		}
+	}
+
+	for ($i = 0; $i < strlen($path); $i++) {
+		$ch = $path[$i];
+		if ($ch == '\0') {
+			break;
+		}
+		if ($ch == '/' || $ch == '\\' || $ch == ':') {
+			$virtual_str .= $separator;
+		} else {
+			$virtual_str .= strtolower($ch);
+		}
+	}
+
+	return $virtual_str;
+}
+
+class ViewEnginesCompilerTest extends PHPUnit_Framework_TestCase
+{
+	public function testCompilerFile()
+	{
+		@unlink('unit-tests/views/test17/index.compiler.php');
+
+		$di = new Phalcon\DI();
+		$view = new Phalcon\Mvc\View();
+
+		$compiler = new Phalcon\Mvc\View\Engine\Compiler($view, $di);
+
+		$compiler->setOptions(array(
+			"compiledSource" => function($viewCode) {
+				preg_match_all('|\${[a-z]+}|', $viewCode, $matches);
+				foreach ($matches as $value) {
+					$viewCode = str_replace($value[0], '<?php echo $' . substr($value[0], 2, -1). '; ?>', $viewCode);
+				}
+				return $viewCode;
+			}
+		));
+
+		//Simple file
+		$compiler->compileFile('unit-tests/views/test17/index.compiler', 'unit-tests/views/test17/index.compiler.php');
+
+		$compilation = file_get_contents('unit-tests/views/test17/index.compiler.php');
+		$this->assertEquals($compilation, 'Hello <?php echo $song; ?>!'."\n");
+	}
+
+	public function testCompilerFileOptions()
+	{
+		@unlink('unit-tests/views/test17/index.compiler.php');
+		@unlink('unit-tests/cache/unit-tests.views.test17.index.compiler.compiled');
+
+		$di = new Phalcon\DI();
+		$view = new Phalcon\Mvc\View();
+
+		$compiler = new Phalcon\Mvc\View\Engine\Compiler($view, $di);
+
+		$compiler->setOptions(array(
+			"compiledPath" => "unit-tests/cache/",
+			"compiledSeparator" => ".",
+			"compiledExtension" => ".compiled",
+			"compiledSource" => function($viewCode) {
+				preg_match_all('|\${[a-z]+}|', $viewCode, $matches);
+				foreach ($matches as $value) {
+					$viewCode = str_replace($value[0], '<?php echo $' . substr($value[0], 2, -1). '; ?>', $viewCode);
+				}
+				return $viewCode;
+			},
+		));
+
+		//Render simple view
+		$view->start();
+		$compiler->render('unit-tests/views/test17/index.compiler', array('song' => 'Lights'), true);
+		$view->finish();
+
+		$path = 'unit-tests/cache/' . phalcon_prepare_virtual_path(realpath("unit-tests/"), ".") . '.views.test17.index.compiler.compiled';
+
+		$this->assertTrue(file_exists($path));
+		$this->assertEquals(file_get_contents($path), 'Hello <?php echo $song; ?>!'."\n");
+		$this->assertEquals($view->getContent(), "Hello Lights!\n");
+
+	}
+
+	public function testCompilerEngine()
+	{
+		@unlink('unit-tests/views/test17/index.compiler.php');
+
+		$di = new Phalcon\DI();
+
+		$view = new Phalcon\Mvc\View();
+		$view->setDI($di);
+		$view->setViewsDir('unit-tests/views/');
+
+		$view->registerEngines(array(
+			'.compiler' => function($view, $di) {
+				$compiler = new Phalcon\Mvc\View\Engine\Compiler($view, $di);
+				$compiler->setOptions(array(
+					"compiledSource" => function($viewCode) {
+						preg_match_all('|\${[a-z]+}|', $viewCode, $matches);
+						foreach ($matches as $value) {
+							$viewCode = str_replace($value[0], '<?php echo $' . substr($value[0], 2, -1). '; ?>', $viewCode);
+						}
+						return $viewCode;
+					},
+				));
+				return $compiler;
+			}
+		));
+
+		$view->setVar('song', 'Lights');
+
+		$view->start();
+		$view->render('test17', 'index');
+		$view->finish();
+
+		$this->assertEquals($view->getContent(), "Hello Lights!\n");
+	}
+
+	public function testCompilerParkdown()
+	{
+		// require_once __DIR__ . '/../Parsedown.php';
+
+		if (!class_exists('Parsedown')) {
+			$this->markTestSkipped('Compiler Parsedown engine could not be found');
+			return false;
+		}
+
+		@unlink('unit-tests/views/test17/index.md.php');
+
+		$di = new Phalcon\DI();
+
+		$view = new Phalcon\Mvc\View();
+		$view->setDI($di);
+		$view->setViewsDir('unit-tests/views/');
+
+		$view->registerEngines(array(
+			'.md' => function($view, $di) {
+				$compiler = new Phalcon\Mvc\View\Engine\Compiler($view, $di);
+				$compiler->setOptions(array(
+					"compiledSource" => function($viewCode) {
+						$parsedown = new Parsedown();
+						return $parsedown->text($viewCode);
+					},
+				));
+				return $compiler;
+			}
+		));
+
+		$view->start();
+		$view->render('test17', 'index');
+		$view->finish();
+
+		$this->assertEquals($view->getContent(), "<h1>Header</h1>\n<p>Hello <em>Parsedown</em>!</p>");
+	}
+
+}

--- a/unit-tests/phpunit.xml
+++ b/unit-tests/phpunit.xml
@@ -88,6 +88,7 @@
 			<file>unit-tests/ViewCacheTest.php</file>
 			<file>unit-tests/ViewEnginesTest.php</file>
 			<file>unit-tests/ViewEnginesVoltTest.php</file>
+			<file>unit-tests/ViewEnginesCompilerTest.php</file>
 			<file>unit-tests/ViewSimpleTest.php</file>
 			<file>unit-tests/ViewTest.php</file>
 		</testsuite>

--- a/unit-tests/views/test17/index.compiler
+++ b/unit-tests/views/test17/index.compiler
@@ -1,0 +1,1 @@
+Hello ${song}!

--- a/unit-tests/views/test17/index.md
+++ b/unit-tests/views/test17/index.md
@@ -1,0 +1,3 @@
+# Header
+
+Hello _Parsedown_!


### PR DESCRIPTION
Generic view engine compiler class.
For example, used to compile the Markdown.

``` php
require_once __DIR__ . '/Parsedown.php';

$di = new Phalcon\DI();
$view = new Phalcon\Mvc\View();
$view->setDI($di);

$view->registerEngines(array(
    '.md' => function($view, $di) {
        $compiler = new Phalcon\Mvc\View\Engine\Compiler($view, $di);
        // required compileSource option
        $compiler->setOptions(array(
            "compiledSource" => function($viewCode) {
                $parsedown = new Parsedown();
                return $parsedown->text($viewCode);
            },
        ));
        return $compiler;
    }
));

$view->start();
$view->render('test', 'index');
$view->finish();

// test/index.md
/*
# Header

Hello _Parsedown_!
*/

// test/index.md.php
/*
<h1>Header</h1>
<p>Hello <em>Parsedown</em>!</p>
*/
```
