### PR TITLE
Fixed compile warning noneexistent-class

### DIFF
--- a/phalcon/validation/validator/confirmation.zep
+++ b/phalcon/validation/validator/confirmation.zep
@@ -91,7 +91,7 @@ class Confirmation extends \Phalcon\Validation\Validator implements \Phalcon\Val
 			 * mbstring is required here
 			 */
 			if !function_exists("mb_strtolower") {
-				throw new Exception("Extension 'mbstring' is required");
+				throw new \Phalcon\Validation\Exception("Extension 'mbstring' is required");
 			}
 
 			let a = mb_strtolower(a, "utf-8");

--- a/phalcon/validation/validator/confirmation.zep
+++ b/phalcon/validation/validator/confirmation.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Exception;
+
 /**
  * Phalcon\Validation\Validator\Confirmation
  *
@@ -91,7 +93,7 @@ class Confirmation extends \Phalcon\Validation\Validator implements \Phalcon\Val
 			 * mbstring is required here
 			 */
 			if !function_exists("mb_strtolower") {
-				throw new \Phalcon\Validation\Exception("Extension 'mbstring' is required");
+				throw new Exception("Extension 'mbstring' is required");
 			}
 
 			let a = mb_strtolower(a, "utf-8");


### PR DESCRIPTION
Warning: Class "Phalcon\Validation\Validator\Exception" does not exist at compile time in cphalcon/phalcon/validation/validator/confirmation.zep on 94 [nonexistent-class]
