### PR TITLE
[2.0.0] [BUG] fix crash build CI for PHP <= 5.4.0

### DIFF
--- a/unit-tests/ci/apc.ini
+++ b/unit-tests/ci/apc.ini
@@ -1,2 +1,7 @@
 extension=apc.so
 apc.enable_cli=On
+
+; The APC opcode cache needs to be disabled to avoid crash build CI to PHP <= 5.4
+; This allows us to use the user cache
+apc.cache_by_default=0
+apc.max_file_size=0


### PR DESCRIPTION
**Crash build**
- [see 1](https://travis-ci.org/KorsaR-ZN/phalcon-core/jobs/57782974#L2421)
- [see 2](https://travis-ci.org/KorsaR-ZN/phalcon-core/jobs/57777116#L2419)
- [see 2](https://travis-ci.org/KorsaR-ZN/phalcon-core/jobs/57685017#L2416)

**Success build**
- [see](https://travis-ci.org/KorsaR-ZN/phalcon-core/builds/57786844)
