### PR TITLE
[2.0.0] [NFR] Global container

### DIFF
--- a/phalcon/factory.zep
+++ b/phalcon/factory.zep
@@ -1,0 +1,81 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
+ +------------------------------------------------------------------------+
+*/
+namespace Phalcon;
+
+use Phalcon\Di;
+
+/**
+ * Phalcon\Filter\Exception
+ *
+ * Exceptions thrown in Phalcon\Filter will use this class
+ *
+ */
+abstract class Factory
+{
+	protected static _app;
+
+	/**
+	 * Returns global Application instance
+	 */
+	public static function app() -> <Phalcon\Mvc\Application>
+	{
+		if typeof self::_app != "object" {
+			throw new Exception("Application isn't registered in the global container");
+		}
+
+		return self::_app;
+	}
+
+	/**
+	 * Returns global Dependency Injector
+	 */
+	public static function di() -> <Phalcon\DiInterface>
+	{
+		if isset self::_app {
+			return self::_app->getDI();
+		} else {
+			return Di::getDefault();
+		}
+	}
+
+	/**
+	 * Returns global Event Manager
+	 */
+	public static function eventsManager() -> <Phalcon\Events\ManagerInterface>
+	{
+		return self::di()->get("eventsManager");
+	}
+
+	/**
+	 * Sets global Application instance
+	 */
+	public static function setApplication(<Phalcon\Mvc\Application> application) -> void
+	{
+		let self::_app = application;
+	}
+
+	/**
+	 * Returns Service instance from global DI
+	 */
+	public static function __callStatic(string! method, array! arguments)
+	{
+		return self::di()->get(method, arguments);
+	}
+}

--- a/phalcon/mvc/application.zep
+++ b/phalcon/mvc/application.zep
@@ -19,6 +19,7 @@
 
 namespace Phalcon\Mvc;
 
+use Phalcon\Factory;
 use Phalcon\Di\Injectable;
 use Phalcon\Mvc\ViewInterface;
 use Phalcon\Mvc\Application\Exception;
@@ -91,6 +92,11 @@ class Application extends Injectable
 		if typeof dependencyInjector == "object" {
 			let this->_dependencyInjector = dependencyInjector;
 		}
+
+		/**
+		 * Register current application in global factory
+		 */
+		 Factory::setApplication(this);
 	}
 
 	/**


### PR DESCRIPTION
It will be convenient to reduce communication between classes.
See:
- #10005
- https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/forms/manager.zep#L44
- https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/db/adapter.zep#L132
- https://github.com/phalcon/cphalcon/blob/2.0.0/phalcon/queue/beanstalk.zep#L165
- etc...

**Examples**

```
   // Gets CLASS instance
   instance = Phalcon\Factory::di()->get(CLASS);

   // Gets Application instance
   instance = Phalcon\Factory::app();

   // Gets Dispatcher service
   instance = Phalcon\Factory::getDispatcher();

   // Gets ModelManager service
   instance = Phalcon\Factory::getModelsManager();
```
