### PR TITLE
Implements ability to retrieve limit from paginate object

### DIFF
--- a/phalcon/paginator/adapter/model.zep
+++ b/phalcon/paginator/adapter/model.zep
@@ -194,7 +194,8 @@ class Model implements AdapterInterface
 
 		let page->last = pagesTotal,
 			page->total_pages = pagesTotal,
-			page->total_items = n;
+			page->total_items = n,
+			page->limit = this->_limitRows;
 
 		return page;
 	}

--- a/phalcon/paginator/adapter/nativearray.zep
+++ b/phalcon/paginator/adapter/nativearray.zep
@@ -163,7 +163,8 @@ class NativeArray implements AdapterInterface
 			page->current = pageNumber,
 			page->last = totalPages,
 			page->total_pages = totalPages,
-			page->total_items = number;
+			page->total_items = number,
+			page->limit = this->_limitRows;
 
 		return page;
 	}

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -232,7 +232,8 @@ class QueryBuilder implements AdapterInterface
 			page->last = totalPages,
 			page->current = numberPage,
 			page->total_pages = totalPages,
-			page->total_items = rowcount;
+			page->total_items = rowcount,
+			page->limit = this->_limitRows;
 
 		return page;
 	}

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -165,6 +165,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->before, 1);
 		$this->assertEquals($page->next, 2);
 		$this->assertEquals($page->last, 6);
+		$this->assertEquals($page->limit, 3);
 
 		$this->assertEquals($page->current, 1);
 		$this->assertEquals($page->total_pages, 6);
@@ -203,6 +204,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->before, 1);
 		$this->assertEquals($page->next, 2);
 		$this->assertEquals($page->last, 2);
+		$this->assertEquals($page->limit, 25);
 
 		$this->assertEquals($page->current, 1);
 		$this->assertEquals($page->total_pages, 2);
@@ -249,6 +251,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->before, 1);
 		$this->assertEquals($page->next, 2);
 		$this->assertEquals($page->last, 218);
+		$this->assertEquals($page->limit, 10);
 
 		$this->assertEquals($page->current, 1);
 		$this->assertEquals($page->total_pages, 218);
@@ -316,6 +319,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->before, 1);
 		$this->assertEquals($page->next, 2);
 		$this->assertEquals($page->last, 4);
+		$this->assertEquals($page->limit, 10);
 
 		$this->assertEquals($page->current, 1);
 		$this->assertEquals($page->total_pages, 4);
@@ -351,6 +355,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->before, 1);
 		$this->assertEquals($page->next, 2);
 		$this->assertEquals($page->last, 218);
+		$this->assertEquals($page->limit, 10);
 
 		$this->assertEquals($page->current, 1);
 		$this->assertEquals($page->total_pages, 218);


### PR DESCRIPTION
Adds a property called "limit" to the paginate object of the paginator in all three adapters.
This is rather useful, especially to display the limit in the view.
Related issue #3209.
The travis build error is not from this pull request, it's from a commit on the 2.0 branch. See #10021.
