### PR TITLE
Crypt Chaining Fix & Docblock Cleanup

### DIFF
--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -19,6 +19,7 @@
 
 namespace Phalcon;
 
+use Phalcon\CryptInterface;
 use Phalcon\Crypt\Exception;
 
 /**
@@ -37,7 +38,7 @@ use Phalcon\Crypt\Exception;
  *	echo $crypt->decrypt($encrypted, $key);
  *</code>
  */
-class Crypt implements \Phalcon\CryptInterface
+class Crypt implements CryptInterface
 {
 
 	protected _key;
@@ -66,9 +67,8 @@ class Crypt implements \Phalcon\CryptInterface
 	* @brief Phalcon\CryptInterface Phalcon\Crypt::setPadding(int $scheme)
 	*
 	* @param int scheme Padding scheme
-	* @return Phalcon\CryptInterface
 	*/
-	public function setPadding(int! scheme)
+	public function setPadding(int! scheme) -> <CryptInterface>
 	{
 		let this->_padding = scheme;
 	}

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -71,6 +71,7 @@ class Crypt implements CryptInterface
 	public function setPadding(int! scheme) -> <CryptInterface>
 	{
 		let this->_padding = scheme;
+		return this;
 	}
 
 	/**

--- a/phalcon/cryptinterface.zep
+++ b/phalcon/cryptinterface.zep
@@ -29,96 +29,61 @@ interface CryptInterface
 
 	/**
 	 * Sets the cipher algorithm
-	 *
-	 * @param string cipher
-	 * @return Phalcon\EncryptInterface
 	 */
-	public function setCipher(cipher);
+	public function setCipher(string! cipher) -> <CryptInterface>;
 
 	/**
 	 * Returns the current cipher
-	 *
-	 * @return string
 	 */
-	public function getCipher();
+	public function getCipher() -> string;
 
 	/**
 	 * Sets the encrypt/decrypt mode
-	 *
-	 * @param string cipher
-	 * @return Phalcon\EncryptInterface
 	 */
-	public function setMode(mode);
+	public function setMode(string! mode) -> <CryptInterface>;
 
 	/**
 	 * Returns the current encryption mode
-	 *
-	 * @return string
 	 */
-	public function getMode();
+	public function getMode() -> string;
 
 	/**
 	 * Sets the encryption key
-	 *
-	 * @param string key
-	 * @return Phalcon\EncryptInterface
 	 */
-	public function setKey(key);
+	public function setKey(string! key) -> <CryptInterface>;
 
 	/**
 	 * Returns the encryption key
-	 *
-	 * @return string
 	 */
-	public function getKey();
+	public function getKey() -> string;
 
 	/**
 	 * Encrypts a text
-	 *
-	 * @param string text
-	 * @param string key
-	 * @return string
 	 */
-	public function encrypt(text, key = null);
+	public function encrypt(string! text, string! key = null) -> string;
 
 	/**
 	 * Decrypts a text
-	 *
-	 * @param string text
-	 * @param string key
-	 * @return string
 	 */
-	public function decrypt(text, key = null);
+	public function decrypt(string! text, string! key = null) -> string;
 
 	/**
 	 * Encrypts a text returning the result as a base64 string
-	 *
-	 * @param string text
-	 * @param string key
-	 * @return string
 	 */
-	public function encryptBase64(text, key = null);
+	public function encryptBase64(string! text, key = null) -> string;
 
 	/**
 	 * Decrypt a text that is coded as a base64 string
-	 *
-	 * @param string text
-	 * @param string key
-	 * @return string
 	 */
-	public function decryptBase64(text, key = null);
+	public function decryptBase64(string! text, key = null) -> string;
 
 	/**
 	 * Returns a list of available cyphers
-	 *
-	 * @return array
 	 */
-	public function getAvailableCiphers();
+	public function getAvailableCiphers() -> array;
 
 	/**
 	 * Returns a list of available modes
-	 *
-	 * @return array
 	 */
-	public function getAvailableModes();
+	public function getAvailableModes() -> array;
 }

--- a/phalcon/cryptinterface.zep
+++ b/phalcon/cryptinterface.zep
@@ -60,7 +60,7 @@ interface CryptInterface
 	/**
 	 * Encrypts a text
 	 */
-	public function encrypt(string! text, string! key = null) -> string;
+	public function encrypt(string! text, key = null) -> string;
 
 	/**
 	 * Decrypts a text


### PR DESCRIPTION
Generally cleans up the unneeded docblocks but also:
- removes mentions of the non-existing EncryptInterface
- makes the interface match implementation in terms of variable types
- fixes setter chaining when using setPadding method
