### PR TITLE
Kernel typo fix

### DIFF
--- a/phalcon/kernel.zep
+++ b/phalcon/kernel.zep
@@ -27,7 +27,7 @@ namespace Phalcon;
 class Kernel
 {
 	/**
-	 * Produces a pre-computed hash key based on a string. This function produce different numbers in 32bit/64bit processors
+	 * Produces a pre-computed hash key based on a string. This function produces different numbers in 32bit/64bit processors
 	 *
 	 * @param string key
 	 * @return string


### PR DESCRIPTION
Fixes a typo and cleans up docblock in Phalcon\Kernel.
