### PR TITLE
[2.0.0] Validation refactoring, double array initialization fix

### DIFF
--- a/phalcon/cache/backend/memory.zep
+++ b/phalcon/cache/backend/memory.zep
@@ -155,7 +155,7 @@ class Memory extends Backend implements BackendInterface
 			if !prefix {
 				let keys = (array) array_keys(data);
 			} else {
-			    let keys = [];
+			    	let keys = [];
 				for index, _ in data {
 					let keys[] = index;
 				}

--- a/phalcon/cache/backend/memory.zep
+++ b/phalcon/cache/backend/memory.zep
@@ -148,14 +148,14 @@ class Memory extends Backend implements BackendInterface
 	 */
 	public function queryKeys(var prefix = null) -> array
 	{
-		var data, index;
-		array keys = [];
+		var data, index, keys;
 
 		let data = this->_data;
 		if typeof data == "array" {
 			if !prefix {
 				let keys = (array) array_keys(data);
 			} else {
+			    let keys = [];
 				for index, _ in data {
 					let keys[] = index;
 				}

--- a/phalcon/validation/validator.zep
+++ b/phalcon/validation/validator.zep
@@ -19,13 +19,14 @@
 namespace Phalcon\Validation;
 
 use Phalcon\Validation\Exception;
+use Phalcon\Validation\ValidatorInterface;
 
 /**
  * Phalcon\Validation\Validator
  *
  * This is a base class for validators
  */
-class Validator
+abstract class Validator implements ValidatorInterface
 {
 	protected _options;
 
@@ -84,4 +85,12 @@ class Validator
 		let this->_options[key] = value;
 	}
 
+    /**
+     * Executes the validation
+     *
+     * @param Phalcon\Validation validator
+     * @param string attribute
+     * @return boolean
+     */
+     abstract public function validate(<\Phalcon\Validation> validation, string! attribute) -> boolean;
 }

--- a/phalcon/validation/validator/alnum.zep
+++ b/phalcon/validation/validator/alnum.zep
@@ -21,7 +21,6 @@ namespace Phalcon\Validation\Validator;
 
 use Phalcon\Validation\Validator;
 use Phalcon\Validation\Message;
-use Phalcon\Validation\ValidatorInterface;
 
 /**
  * Phalcon\Validation\Validator\Alnum
@@ -36,7 +35,7 @@ use Phalcon\Validation\ValidatorInterface;
  *)));
  *</code>
  */
-class Alnum extends Validator implements ValidatorInterface
+class Alnum extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/alpha.zep
+++ b/phalcon/validation/validator/alpha.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\Alpha
  *
@@ -32,7 +34,7 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class Alpha extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class Alpha extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/between.zep
+++ b/phalcon/validation/validator/between.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\Between
  *
@@ -35,7 +37,8 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class Between extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface {
+class Between extends Validator
+{
 
 	/**
 	 * Executes the validation

--- a/phalcon/validation/validator/confirmation.zep
+++ b/phalcon/validation/validator/confirmation.zep
@@ -20,6 +20,7 @@
 namespace Phalcon\Validation\Validator;
 
 use Phalcon\Validation\Exception;
+use Phalcon\Validation\Validator;
 
 /**
  * Phalcon\Validation\Validator\Confirmation
@@ -35,7 +36,7 @@ use Phalcon\Validation\Exception;
  *)));
  *</code>
  */
-class Confirmation extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class Confirmation extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/digit.zep
+++ b/phalcon/validation/validator/digit.zep
@@ -22,7 +22,6 @@ namespace Phalcon\Validation\Validator;
 use Phalcon\Validation;
 use Phalcon\Validation\Message;
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\ValidatorInterface;
 
 /**
  * Phalcon\Validation\Validator\Digit
@@ -37,7 +36,7 @@ use Phalcon\Validation\ValidatorInterface;
  *)));
  *</code>
  */
-class Digit extends Validator implements ValidatorInterface
+class Digit extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/email.zep
+++ b/phalcon/validation/validator/email.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\Email
  *
@@ -32,7 +34,7 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class Email extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class Email extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/exclusionin.zep
+++ b/phalcon/validation/validator/exclusionin.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\ExclusionIn
  *
@@ -33,7 +35,7 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class ExclusionIn extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class ExclusionIn extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/file.zep
+++ b/phalcon/validation/validator/file.zep
@@ -20,6 +20,7 @@
 namespace Phalcon\Validation\Validator;
 
 use Phalcon\Validation\Message;
+use Phalcon\Validation\Validator;
 
 /**
  * Phalcon\Validation\Validator\File
@@ -39,7 +40,7 @@ use Phalcon\Validation\Message;
  *)));
  *</code>
  */
-class File extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class File extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/identical.zep
+++ b/phalcon/validation/validator/identical.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\Identical
  *
@@ -34,7 +36,7 @@ namespace Phalcon\Validation\Validator;
  *</code>
  *
  */
-class Identical extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class Identical extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/inclusionin.zep
+++ b/phalcon/validation/validator/inclusionin.zep
@@ -20,7 +20,6 @@
 namespace Phalcon\Validation\Validator;
 
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\ValidatorInterface;
 use Phalcon\Validation\Exception;
 use Phalcon\Validation\Message;
 
@@ -38,7 +37,7 @@ use Phalcon\Validation\Message;
  *)));
  *</code>
  */
-class InclusionIn extends Validator implements ValidatorInterface
+class InclusionIn extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/numericality.zep
+++ b/phalcon/validation/validator/numericality.zep
@@ -22,7 +22,6 @@ namespace Phalcon\Validation\Validator;
 use Phalcon\Validation;
 use Phalcon\Validation\Message;
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\ValidatorInterface;
 
 /**
  * Phalcon\Validation\Validator\Numericality
@@ -37,7 +36,7 @@ use Phalcon\Validation\ValidatorInterface;
  *)));
  *</code>
  */
-class Numericality extends Validator implements ValidatorInterface
+class Numericality extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/presenceof.zep
+++ b/phalcon/validation/validator/presenceof.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\PresenceOf
  *
@@ -32,7 +34,7 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class PresenceOf extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class PresenceOf extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/regex.zep
+++ b/phalcon/validation/validator/regex.zep
@@ -22,7 +22,6 @@ namespace Phalcon\Validation\Validator;
 use Phalcon\Validation;
 use Phalcon\Validation\Message;
 use Phalcon\Validation\Validator;
-use Phalcon\Validation\ValidatorInterface;
 
 /**
  * Phalcon\Validation\Validator\Regex
@@ -38,7 +37,7 @@ use Phalcon\Validation\ValidatorInterface;
  *)));
  *</code>
  */
-class Regex extends Validator implements ValidatorInterface
+class Regex extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/stringlength.zep
+++ b/phalcon/validation/validator/stringlength.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\StringLength
  *
@@ -38,7 +40,7 @@ namespace Phalcon\Validation\Validator;
  *</code>
  *
  */
-class StringLength extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class StringLength extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/uniqueness.zep
+++ b/phalcon/validation/validator/uniqueness.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\Uniqueness
  *
@@ -41,7 +43,7 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class Uniqueness extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class Uniqueness extends Validator
 {
 
 	/**

--- a/phalcon/validation/validator/url.zep
+++ b/phalcon/validation/validator/url.zep
@@ -19,6 +19,8 @@
 
 namespace Phalcon\Validation\Validator;
 
+use Phalcon\Validation\Validator;
+
 /**
  * Phalcon\Validation\Validator\Url
  *
@@ -32,7 +34,7 @@ namespace Phalcon\Validation\Validator;
  *)));
  *</code>
  */
-class Url extends \Phalcon\Validation\Validator implements \Phalcon\Validation\ValidatorInterface
+class Url extends Validator
 {
 
 	/**


### PR DESCRIPTION
## Major changes
- added abstract `validate()` method to `Phalcon\Validation\Validator` class, made this class abstract
- `Phalcon\Validator` class now implements `Phalcon\Validation\ValidatorInterface`
- changed "keys" array initialization in `Phalcon\Cache\Backend\Memory`
- added #10021 fix to make build possible
## Minor changes
- removed `implements Phalcon\Validation\ValidatorInterface` from all `Phalcon\Validation\Validator\*` classes because parent class (`Phalcon\Validation\Validator`) is implementing it right now
- added "use" statements to  `Phalcon\Validation\Validator\*` instead using fully qualified names
