### PR TITLE
Phalcon\Db\Adapter::update badly build data types array

### DIFF
--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -554,7 +554,7 @@ abstract class Adapter implements EventsAwareInterface
 		if !count(bindDataTypes) {
 			return this->{"execute"}(updateSql, updateValues);
 		}
-var_dump(updateSql, updateValues, bindDataTypes);	
+
 		return this->{"execute"}(updateSql, updateValues, bindDataTypes);
 	}
 

--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -462,11 +462,7 @@ abstract class Adapter implements EventsAwareInterface
 		let placeholders = [],
 			updateValues = [];
 
-		if typeof dataTypes == "array" {
-			let bindDataTypes = [];
-		} else {
-			let bindDataTypes = dataTypes;
-		}
+		let bindDataTypes = [];
 
 		/**
 		 * Objects are casted using __toString, null values are converted to string 'null', everything else is passed as '?'
@@ -558,7 +554,7 @@ abstract class Adapter implements EventsAwareInterface
 		if !count(bindDataTypes) {
 			return this->{"execute"}(updateSql, updateValues);
 		}
-
+var_dump(updateSql, updateValues, bindDataTypes);	
 		return this->{"execute"}(updateSql, updateValues, bindDataTypes);
 	}
 


### PR DESCRIPTION
Like #10031 for update method. In fact, condition was useless so no bug appended.
