### PR TITLE
[2.0.0] Updated Phalcon\Session

### DIFF
--- a/phalcon/session.zep
+++ b/phalcon/session.zep
@@ -20,6 +20,8 @@
 
 namespace Phalcon;
 
+use Phalcon\Session\AdapterInterface;
+
 /**
  * Phalcon\Session
  *
@@ -29,7 +31,8 @@ namespace Phalcon;
  * but it can be in different applications.
  *
  *<code>
- * $session = new \Phalcon\Session\Adapter\Files(array(
+ * $session = new \Phalcon\Session(array(
+ *    'adapter' => 'files',
  *    'uniqueId' => 'my-private-app'
  * ));
  *
@@ -40,7 +43,275 @@ namespace Phalcon;
  * echo $session->get('var');
  *</code>
  */
-abstract class Session
+class Session implements AdapterInterface
 {
+	protected _started = false;
 
+	protected _regenerated = false;
+
+	/**
+	 * Adapter instance
+	 */
+	protected _adapter;
+
+	/**
+	 * Phalcon\Session constructor
+	 *
+	 * @param array options
+	 */
+	public function __construct(options = null)
+	{
+		var adapter;
+
+		let adapter = "\\Phalcon\\Session\\Adapter\\Files";
+
+		if typeof options == "array" && isset options["adapter"] {
+			/**
+			 * Adapter class can override the default files
+			 */
+			fetch adapter, options["adapter"];
+		}
+
+		/**
+		 * Create the instance
+		 */
+		if typeof adapter == "string" {
+			if strpos(adapter, "\\") !== 0 {
+				let adapter = "\\Phalcon\\Session\\Adapter\\" . adapter;
+			}
+			let this->_adapter = new {adapter}(options);
+		} elseif typeof adapter == "object" && adapter instanceof AdapterInterface {
+			let this->_adapter = adapter;
+		}
+	}
+
+	/**
+	 * Starts the session (if headers are already sent the session will not be started)
+	 *
+	 * @return boolean
+	 */
+	public function start() -> boolean
+	{
+		if !headers_sent() {
+			session_start();
+			let this->_started = true;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Sets session's options
+	 *
+	 *<code>
+	 *	session->setOptions(array(
+	 *		'uniqueId' => 'my-private-app'
+	 *	));
+	 *</code>
+	 *
+	 * @param array options
+	 */
+	public function setOptions(array! options)
+	{
+		return this->_adapter->setOptions(options);
+	}
+
+	/**
+	 * Get internal options
+	 *
+	 * @return array
+	 */
+	public function getOptions()
+	{
+		return this->_adapter->getOptions();
+	}
+
+	/**
+	 * Gets a session variable from an application context
+	 *
+	 * @param string index
+	 * @param mixed defaultValue
+	 * @param boolean remove
+	 * @return mixed
+	 */
+	public function get(string index, defaultValue = null, boolean remove = false)
+	{
+		return this->_adapter->get(index, defaultValue, remove);
+	}
+
+	/**
+	 * Sets a session variable in an application context
+	 *
+	 *<code>
+	 *	session->set('auth', 'yes');
+	 *</code>
+	 *
+	 * @param string index
+	 * @param string value
+	 */
+	public function set(string index, value)
+	{
+		return this->_adapter->set(index, value);
+	}
+
+	/**
+	 * Check whether a session variable is set in an application context
+	 *
+	 *<code>
+	 *	var_dump($session->has('auth'));
+	 *</code>
+	 *
+	 * @param string index
+	 */
+	public function has(string index) -> boolean
+	{
+		return this->_adapter->has(index);
+	}
+
+	/**
+	 * Removes a session variable from an application context
+	 *
+	 *<code>
+	 *	$session->remove('auth');
+	 *</code>
+	 */
+	public function remove(string index)
+	{
+		return this->_adapter->remove(index);
+	}
+
+	/**
+	 * Returns active session id
+	 *
+	 *<code>
+	 *	echo $session->getId();
+	 *</code>
+	 */
+	public function getId() -> string
+	{
+		return this->_adapter->getId();
+	}
+
+	/**
+	 * Set the current session id
+	 *
+	 *<code>
+	 *	$session->setId($id);
+	 *</code>
+	 *
+	 * @param string id
+	 */
+	public function setId(string id)
+	{
+		return this->_adapter->setId(id);
+	}
+
+	/**
+	 * Check whether the session has been started
+	 *
+	 *<code>
+	 *	var_dump($session->isStarted());
+	 *</code>
+	 */
+	public function isStarted() -> boolean
+	{
+		return this->_started;
+	}
+
+	/**
+	 * Destroys the active session
+	 *
+	 *<code>
+	 *	var_dump(session->destroy());
+	 *</code>
+	 */
+	public function destroy() -> boolean
+	{
+		let this->_started = false;
+		this->_adapter->destroy();
+		return session_destroy();
+	}
+
+	/**
+	 * Sets the adapter instance
+	 */
+	public function setAdapter(<AdapterInterface> adapter)
+	{
+		let this->_adapter = adapter;
+	}
+
+	/**
+	 * Returns internal adapter instance
+	 */
+	public function getAdapter() -> <AdapterInterface>
+	{
+		return this->_adapter;
+	}
+
+	/**
+	 * Regenerate the session id
+	 *
+	 * @return boolean
+	 */
+	public function regenerateId() -> boolean
+	{
+		if (this->_started) {
+			session_regenerate_id(true);
+			let this->_regenerated = true;
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Check whether the session id has been regenerate
+	 *
+	 *<code>
+	 *	var_dump($session->isRegenerated());
+	 *</code>
+	 */
+	public function isRegenerated() -> boolean
+	{
+		return this->_regenerated;
+	}
+
+	/**
+	 * Alias: Gets a session variable from an application context
+	 *
+	 * @param string index
+	 * @return mixed
+	 */
+	public function __get(string index)
+	{
+		return this->_adapter->get(index);
+	}
+
+	/**
+	 * Alias: Sets a session variable in an application context
+	 *
+	 * @param string index
+	 * @param string value
+	 */
+	public function __set(string index, value)
+	{
+		return this->_adapter->set(index, value);
+	}
+
+	/**
+	 * Alias: Check whether a session variable is set in an application context
+	 *
+	 * @param string index
+	 */
+	public function __isset(string index) -> boolean
+	{
+		return this->_adapter->has(index);
+	}
+
+	/**
+	 * Alias: Removes a session variable from an application context
+	 */
+	public function __unset(string index)
+	{
+		return this->_adapter->remove(index);
+	}
 }

--- a/unit-tests/SessionTest.php
+++ b/unit-tests/SessionTest.php
@@ -168,4 +168,67 @@ class SessionTest extends PHPUnit_Framework_TestCase
 
 	}
 
+	public function testSessionClass()
+	{
+
+		$session = new Phalcon\Session();
+
+		$this->assertFalse($session->start());
+		$this->assertFalse($session->isStarted());
+
+		@session_start();
+
+		$session->set('some', 'value');
+
+		$this->assertEquals($session->get('some'), 'value');
+		$this->assertTrue($session->has('some'));
+		$this->assertEquals($session->get('undefined', 'my-default'), 'my-default');
+
+		// Automatically deleted after reading
+		$this->assertEquals($session->get('some', NULL, TRUE), 'value');
+		$this->assertFalse($session->has('some'));
+	}
+
+	public function testSessionAdapterFiles()
+	{
+
+		$session = new Phalcon\Session(array('adapter' => 'files'));
+
+		$this->assertFalse($session->start());
+		$this->assertFalse($session->isStarted());
+
+		@session_start();
+
+		$session->set('some', 'value');
+
+		$this->assertEquals($session->get('some'), 'value');
+		$this->assertTrue($session->has('some'));
+		$this->assertEquals($session->get('undefined', 'my-default'), 'my-default');
+
+		// Automatically deleted after reading
+		$this->assertEquals($session->get('some', NULL, TRUE), 'value');
+		$this->assertFalse($session->has('some'));
+	}
+
+	public function testSessionAdapterInstance()
+	{
+
+		$session = new Phalcon\Session(array('adapter' => new Phalcon\Session\Adapter\Files()));
+
+		$this->assertFalse($session->start());
+		$this->assertFalse($session->isStarted());
+
+		@session_start();
+
+		$session->set('some', 'value');
+
+		$this->assertEquals($session->get('some'), 'value');
+		$this->assertTrue($session->has('some'));
+		$this->assertEquals($session->get('undefined', 'my-default'), 'my-default');
+
+		// Automatically deleted after reading
+		$this->assertEquals($session->get('some', NULL, TRUE), 'value');
+		$this->assertFalse($session->has('some'));
+	}
+
 }


### PR DESCRIPTION
When you use the "Phalcon\Session\Adapter\Files" session disappears in the destroy.
When not otherwise(Phalcon\Session\Adapter\Libmemcached) remains without disappearing session.

Example DI:

``` php
$di->setShared('session', function() {
    // Use files
    $session = new Phalcon\Session\Adapter\Files();

    /*
    // Use libmemcached
    $session = new Phalcon\Session\Adapter\Libmemcached([
        'servers' => [
            ['host' => 'localhost', 'port' => 11211, 'weight' => 1],
        ],
        'client' => [],
        'lifetime' => 3600,
    ]);
    */

    $session->start();
    return $session;
});
```

Example Controller Action:

``` php
public function testAction()
{
    // Session write
    $this->session->set("name", "Michael");

    // Session read
    if ($this->session->has("name")) {
        echo 'Name: ', $this->session->get("name");
    }

    // Session destroy
    $this->session->destroy();

    // Redirect
    return $this->response->redirect('dump');
}

public function dumpAction()
{
    var_dump($_SESSION);

    /*
    // Use files
    array (size=0)
      empty

    // Use libmemcached
    array (size=1)
      'name' => string 'Michael' (length=7)    
    */    
}
```

session_destroy has not been called in "Phalcon\Session\Adapter\ XXX" of class destory.

Proposal:

Enclosing the Adapter to Phalcon\Session class.

``` php
$di->setShared('session', function() {
    $session = new Phalcon\Session([
      // Use files (default)
      'adapter' => 'files',
      /*
      // Use libmemcached
      'adapter' => 'libmemcached',
      'options' => [
        'servers' => [
            ['host' => 'localhost', 'port' => 11211, 'weight' => 1],
        ],
        'client' => [],
        'lifetime' => 3600,
      ],
      */
    ]);
    $session->start();
    return $session;
});
```
