### PR TITLE
[2.0.x] fix "call to undefined method" when using Phalcon\Mvc\Dispatcher::getControllerClass()

### DIFF
--- a/phalcon/mvc/dispatcher.zep
+++ b/phalcon/mvc/dispatcher.zep
@@ -157,14 +157,6 @@ class Dispatcher extends \Phalcon\Dispatcher implements DispatcherInterface
 	}
 
 	/**
-	 * Possible controller class name that will be located to dispatch the request
-	 */
-	public function getControllerClass() -> string
-	{
-		return this->{"getHandlerName"}();
-	}
-
-	/**
 	 * Returns the lastest dispatched controller
 	 */
 	public function getLastController() -> <ControllerInterface>

--- a/unit-tests/DispatcherMvcTest.php
+++ b/unit-tests/DispatcherMvcTest.php
@@ -193,4 +193,72 @@ class DispatcherMvcTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($value, 'index');
 	}
 
+	public function testGetControllerClass()
+	{
+		Phalcon\DI::reset();
+
+		$di = new Phalcon\DI();
+
+		$dispatcher = new Phalcon\Mvc\Dispatcher();
+		$dispatcher->setDI($di);
+
+		$di->set('dispatcher', $dispatcher);
+
+		// With namespace
+		$dispatcher->setNamespaceName('Foo\Bar');
+		$dispatcher->setControllerName('test');
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals($value, 'Foo\Bar\TestController');
+
+		// Without namespace
+		$dispatcher->setNamespaceName(null);
+		$dispatcher->setControllerName('Test');
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals($value, 'TestController');
+	}
+
+	public function testDefaultsResolve()
+	{
+		Phalcon\DI::reset();
+		$di = new Phalcon\DI();
+
+		$dispatcher = new Phalcon\Mvc\Dispatcher();
+		$dispatcher->setDI($di);
+
+		$di->set('dispatcher', $dispatcher);
+
+		$dispatcher->setDefaultNamespace('Foo');
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals($value, 'Foo\IndexController');
+	}
+
+	public function testDefaultsResolvedAfterDispatch()
+	{
+		Phalcon\DI::reset();
+
+		$di = new Phalcon\DI();
+		$di->set('response', new \Phalcon\Http\Response());
+
+		$dispatcher = new Phalcon\Mvc\Dispatcher();
+		$dispatcher->setDI($di);
+
+		$di->set('dispatcher', $dispatcher);
+
+		$dispatcher->setDefaultNamespace('Foo');
+
+		try {
+			$dispatcher->dispatch();
+			$this->assertTrue(FALSE, 'oh, Why?');
+		} catch (Phalcon\Exception $e) {
+			$this->assertEquals($e->getMessage(), "Foo\IndexController handler class cannot be loaded");
+			$this->assertInstanceOf('Phalcon\Mvc\Dispatcher\Exception', $e);
+		}
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals($value, 'Foo\IndexController');
+	}
+
 }


### PR DESCRIPTION
The method `Phalcon\Mvc\Dispatcher::getControllerClass()` doesn't work as it references a method at runtime that doesn't exist:

> Fatal error: Uncaught exception 'RuntimeException' with message 'Call to undefined method Phalcon\Mvc\Dispatcher::gethandlername()'

``` php
public function getControllerClass() -> string
{
    return this->{"getHandlerName"}();
}
```

This PR fixes that error by refactoring the building of the handler class name from `Phalcon\Dispatcher::dispatch` into `Phalcon\Dispatcher::getControllerClass` method. Note that this adds an additional public method to `Phalcon\Dispatcher`, as the broken method was on `Phalcon\Mvc\Dispatcher`.

**Small issue introduced with this change:** The method `getControllerClass` depends on the resolving of defaults in `Dispatcher::dispatch()` to work correctly which isn't great, however fixing this would require reworking how defaults are set, which is outside the scope of this change. As-is, this code won't change the current behaviour of `Dispatcher::dispatch`, but some incorrect behaviour (defaults not used) is possible if calling `getControllerClass` outside of the dispatch loop.
