### PR TITLE
Added options for cookie parameters. Removed DocBlock, and more...

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,15 @@
  - Mvc\View component is now disabled automatically when redirecting using Http\Response
  - Mvc\Model::dynamicUpdate now works better as it compares if every field has changed according to its data type
  - Added Db\Adapter\Pdo::getErrorInfo() to obtain the last error generated in a PDO connection
+ - Phalcon\Session\Adapter
+ -- Added public method:
+ --- getOption(), getCookieParams(), setCookieParams(), setName(), getName(),
+ --- regenerateId(), reset(), commit(), abort(), clear(), status(), encode(), decode()
+ -- Added protected method:
+ --- configure(), legacySessionReset(), legacySessionAbort(), legacySessionStatus()
+ -- Added options:
+ --- name, cookie_lifetime, cookie_path, cookie_domain, cookie_secure, cookie_httponly
+ -- Phalcon\Session\Adapter\Files added options: savePath
 
 1.3.4
  - Fix improper access to \Phalcon\Debug::$_charset (#2840)

--- a/phalcon/session/adapter.zep
+++ b/phalcon/session/adapter.zep
@@ -14,18 +14,58 @@
  +------------------------------------------------------------------------+
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
  +------------------------------------------------------------------------+
  */
 
 namespace Phalcon\Session;
 
+use Phalcon\Session\Exception;
+
 /**
  * Phalcon\Session\Adapter
  *
- * Base class for Phalcon\Session adapters
+ * Base class for Phalcon\Session adapter
+ *
+ *<code>
+ * $session = new \Phalcon\Session\Adapter\SomeAdapter(array(
+ *    'uniqueId' => 'my-private-app',
+ *    'name' => 'session-name',
+ *    'cookie_lifetime' => 'session-cookie-lifetime',
+ *    'cookie_path' => 'session-cookie-path',
+ *    'cookie_domain' => 'session-cookie-domain',
+ *    'cookie_secure' => 'session-cookie-secure',
+ *    'cookie_httponly' => 'session-cookie-httponly'
+ * ));
+ *
+ * $session->start();
+ *
+ * $session->set('var', 'some-value');
+ *
+ * echo $session->get('var');
+ *</code>
  */
-abstract class Adapter
+abstract class Adapter implements AdapterInterface
 {
+
+	/**
+	 * if sessions are disabled.
+	 * @see PHP_SESSION_DISABLED
+	 */
+	const SESSION_DISABLED = 0;
+
+	/**
+	 * if sessions are enabled, but none exists.
+	 * @see PHP_SESSION_NONE
+	 */
+	const SESSION_NONE = 1;
+
+	/**
+	 * if sessions are enabled, and one exists.
+	 * @see PHP_SESSION_ACTIVE
+	 */
+	const SESSION_ACTIVE = 2;
+
 
 	protected _uniqueId;
 
@@ -35,20 +75,21 @@ abstract class Adapter
 
 	/**
 	 * Phalcon\Session\Adapter constructor
-	 *
-	 * @param array options
 	 */
 	public function __construct(options = null)
 	{
 		if typeof options == "array" {
 			this->setOptions(options);
 		}
+
+		/**
+		* Configure Session (cookie parameters, etc...)
+		*/
+		this->configure();
 	}
 
 	/**
 	 * Starts the session (if headers are already sent the session will not be started)
-	 *
-	 * @return boolean
 	 */
 	public function start() -> boolean
 	{
@@ -57,7 +98,26 @@ abstract class Adapter
 			let this->_started = true;
 			return true;
 		}
+
 		return false;
+	}
+
+	/**
+	 * Gets the session cookie parameters
+	 * @see http://php.net/manual/en/function.session-get-cookie-params.php
+	 */
+	public function getCookieParams() -> array
+	{
+		return session_get_cookie_params();
+	}
+
+	/**
+	 * Sets the session cookie parameters
+	 * @see http://php.net/manual/en/function.session-set-cookie-params.php
+	 */
+	public function setCookieParams(int! lifetime, string! path, string! domain, bool! secure = false, bool! httpOnly = false) -> void
+	{
+		session_set_cookie_params(lifetime, path, domain, secure, httpOnly);
 	}
 
 	/**
@@ -68,8 +128,6 @@ abstract class Adapter
 	 *		'uniqueId' => 'my-private-app'
 	 *	));
 	 *</code>
-	 *
-	 * @param array options
 	 */
 	public function setOptions(array! options)
 	{
@@ -84,23 +142,31 @@ abstract class Adapter
 
 	/**
 	 * Get internal options
-	 *
-	 * @return array
 	 */
-	public function getOptions()
+	public function getOptions() -> array
 	{
 		return this->_options;
 	}
 
 	/**
-	 * Gets a session variable from an application context
-	 *
-	 * @param string index
-	 * @param mixed defaultValue
-	 * @param boolean remove
-	 * @return mixed
+	 * Returns an option in the session's options
+	 * Returns defaultValue if the option hasn't set
 	 */
-	public function get(string index, defaultValue = null, boolean remove = false)
+	public function getOption(string! key, var defaultValue = null) -> var
+	{
+		var value;
+
+		if fetch value, this->_options[key] {
+			return value;
+		} else {
+			return defaultValue;
+		}
+	}
+
+	/**
+	 * Gets a session variable from an application context
+	 */
+	public function get(string! index, var defaultValue = null, boolean remove = false) -> var
 	{
 		var value, key;
 
@@ -122,11 +188,8 @@ abstract class Adapter
 	 *<code>
 	 *	session->set('auth', 'yes');
 	 *</code>
-	 *
-	 * @param string index
-	 * @param string value
 	 */
-	public function set(string index, value)
+	public function set(string! index, var value) -> void
 	{
 		let _SESSION[this->_uniqueId . index] = value;
 	}
@@ -137,10 +200,8 @@ abstract class Adapter
 	 *<code>
 	 *	var_dump($session->has('auth'));
 	 *</code>
-	 *
-	 * @param string index
 	 */
-	public function has(string index) -> boolean
+	public function has(string! index) -> boolean
 	{
 		return isset _SESSION[this->_uniqueId . index];
 	}
@@ -152,7 +213,7 @@ abstract class Adapter
 	 *	$session->remove('auth');
 	 *</code>
 	 */
-	public function remove(string index)
+	public function remove(string! index) -> void
 	{
 		unset _SESSION[this->_uniqueId . index];
 	}
@@ -175,12 +236,28 @@ abstract class Adapter
 	 *<code>
 	 *	$session->setId($id);
 	 *</code>
-	 *
-	 * @param string id
 	 */
-	public function setId(string id)
+	public function setId(string! id) -> void
 	{
 		session_id(id);
+	}
+
+	/**
+	 * Gets the current session name
+	 * @see http://php.net/manual/en/function.session-name.php
+	 */
+	public function getName() -> string
+	{
+		return session_name();
+	}
+
+	/**
+	 * Sets the current session name and return the old session name
+	 * @see http://php.net/manual/en/function.session-name.php
+	 */
+	public function setName(string! name) -> string
+	{
+		return session_name(name);
 	}
 
 	/**
@@ -192,6 +269,7 @@ abstract class Adapter
 	 */
 	public function isStarted() -> boolean
 	{
+		let this->_started = this->status() == self::SESSION_ACTIVE;
 		return this->_started;
 	}
 
@@ -204,38 +282,147 @@ abstract class Adapter
 	 */
 	public function destroy() -> boolean
 	{
+		if !this->isStarted() {
+			throw new Exception("Trying to destroy uninitialized session...");
+		}
+
 		let this->_started = false;
 		return session_destroy();
 	}
 
 	/**
-	 * Alias: Gets a session variable from an application context
+	 * Re-initialize session array with original values
+	 * This function return VOID see https://bugs.php.net/bug.php?id=69482
 	 *
-	 * @param string index
-	 * @return mixed
+	 * @see http://php.net/manual/en/function.session-reset.php
 	 */
-	public function __get(string index)
+	public function reset() -> void
+	{
+		if !this->isStarted() {
+			throw new Exception("Trying to reset uninitialized session...");
+		}
+
+		if function_exists("session_reset") {
+			session_reset();
+		} else {
+			this->legacySessionReset();
+		}
+	}
+
+	/**
+	 * Write session data and end session
+	 * @see http://php.net/manual/en/function.session-write-close.php
+	 */
+	public function commit() -> void
+	{
+		let this->_started = false;
+		session_write_close();
+	}
+
+	/**
+	 * Discard session array changes and finish session
+	 * This function return VOID see https://bugs.php.net/bug.php?id=69482
+	 *
+	 * @see http://php.net/manual/en/function.session-abort.php
+	 */
+	public function abort() -> void
+	{
+		let this->_started = false;
+
+		if function_exists("session_abort") {
+			session_abort();
+		} else {
+			this->legacySessionAbort();
+		}
+	}
+
+	/**
+	 * Update the current session id with a newly generated one.
+	 * Returns NEW session ID on success or FALSE on failure.
+	 * @see http://php.net/manual/en/function.session-regenerate-id.php
+	 */
+	public function regenerateId(bool! deleteSession = false) -> string|boolean
+	{
+		if session_regenerate_id(deleteSession) {
+			return this->getId();
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Returns the current session status (const: SESSION_DISABLED, SESSION_NONE, SESSION_ACTIVE)
+	 * @see http://php.net/manual/en/function.session-status.php
+	 */
+	public function status() -> int
+	{
+		if function_exists("session_status") {
+			return session_status();
+		} else {
+			return this->legacySessionStatus();
+		}
+	}
+
+	/**
+	 * Clear all session variables
+	 * @see http://php.net/manual/en/function.session-unset.php
+	 */
+	public function clear() -> void
+	{
+		if !this->isStarted() {
+			throw new Exception("Trying to clear uninitialized session...");
+		}
+
+		session_unset();
+	}
+
+	/**
+	 * Encodes the current session data as a session encoded string
+	 * @see http://php.net/manual/en/function.session-encode.php
+	 */
+	public function encode() -> string
+	{
+		return session_encode();
+	}
+
+	/**
+	 * Decodes session data from a session encoded string, and populates the current session
+	 * @see http://php.net/manual/en/function.session-encode.php
+	 */
+	public function decode(string data) -> boolean
+	{
+		return session_decode(data);
+	}
+
+	/**
+	 * The read callback must always return a session encoded (serialized) string,
+	 * or an empty string if there is no data to read.
+	 */
+	public function read(string! sessionId) -> string
+	{
+		throw new Exception("Please implement method read() for your adapter session.");
+	}
+
+	/**
+	 * Alias: Gets a session variable from an application context
+	 */
+	public function __get(string! index) -> var
 	{
 		return this->get(index);
 	}
 
 	/**
 	 * Alias: Sets a session variable in an application context
-	 *
-	 * @param string index
-	 * @param string value
 	 */
-	public function __set(string index, value)
+	public function __set(string! index, var value) -> void
 	{
-		return this->set(index, value);
+		this->set(index, value);
 	}
 
 	/**
 	 * Alias: Check whether a session variable is set in an application context
-	 *
-	 * @param string index
 	 */
-	public function __isset(string index) -> boolean
+	public function __isset(string! index) -> boolean
 	{
 		return this->has(index);
 	}
@@ -243,8 +430,71 @@ abstract class Adapter
 	/**
 	 * Alias: Removes a session variable from an application context
 	 */
-	public function __unset(string index)
+	public function __unset(string! index) -> void
 	{
-		return this->remove(index);
+		this->remove(index);
+	}
+
+	/**
+	 * Configure session adapter
+	 */
+	protected function configure() -> void
+	{
+		var params, name;
+
+		let params = this->getCookieParams();
+		let name = this->getOption("name");
+
+		if name {
+			this->setName(name);
+		}
+
+		this->setCookieParams(
+			this->getOption("cookie_lifetime", 	params["lifetime"]),
+			this->getOption("cookie_path", 		params["path"]),
+			this->getOption("cookie_domain", 	params["domain"]),
+			this->getOption("cookie_secure", 	params["secure"]),
+			this->getOption("cookie_httponly", 	params["httponly"])
+		);
+	}
+
+	/**
+	 * Implementation of the function session_reset() for PHP < v5.6
+	 * Please do not call manually, use this Phalcon\Session\AdapterInterface::reset() for it
+	 */
+	protected function legacySessionReset() -> void
+	{
+		if method_exists(this, "read") {
+			this->clear();
+			this->decode(this->read(this->getId()));
+			return;
+		}
+
+		throw new Exception("Please implement method read() for your adapter session.");
+	}
+
+	/**
+	 * Implementation of the function session_abort() for PHP < v5.6
+	 * Please do not call manually, use this Phalcon\Session\AdapterInterface::abort() for it
+	 */
+	protected function legacySessionAbort() -> void
+	{
+		this->reset();
+		this->commit();
+	}
+
+	/**
+	 * Implementation of the function session_status() for PHP < v5.4
+	 * Please do not call manually, use this Phalcon\Session\AdapterInterface::status() for it
+	 */
+	protected function legacySessionStatus() -> int
+	{
+		if this->_started || session_decode(null) {
+			return self::SESSION_ACTIVE;
+		} elseif ini_get("session.serialize_handler") === null {
+			return self::SESSION_DISABLED;
+		} else {
+			return self::SESSION_NONE;
+		}
 	}
 }

--- a/phalcon/session/adapter/files.zep
+++ b/phalcon/session/adapter/files.zep
@@ -19,7 +19,6 @@
 
 namespace Phalcon\Session\Adapter;
 
-use Phalcon\Session\AdapterInterface;
 use Phalcon\Session\Adapter;
 
 /**
@@ -29,7 +28,14 @@ use Phalcon\Session\Adapter;
  *
  *<code>
  * $session = new \Phalcon\Session\Adapter\Files(array(
- *    'uniqueId' => 'my-private-app'
+ *    'uniqueId' => 'my-private-app',
+ *    'savePath' => 'session-save-path',
+ *    'name' => 'session-name',
+ *    'cookie_lifetime' => 'session-cookie-lifetime',
+ *    'cookie_path' => 'session-cookie-path',
+ *    'cookie_domain' => 'session-cookie-domain',
+ *    'cookie_secure' => 'session-cookie-secure',
+ *    'cookie_httponly' => 'session-cookie-httponly'
  * ));
  *
  * $session->start();
@@ -39,7 +45,36 @@ use Phalcon\Session\Adapter;
  * echo $session->get('var');
  *</code>
  */
-class Files extends Adapter implements AdapterInterface
+class Files extends Adapter
 {
+	/**
+	 * {@inheritdoc}
+	 */
+	public function read(string! sessionId) -> string
+	{
+		var session_file;
+		let session_file = session_save_path() . DIRECTORY_SEPARATOR . "sess_" . this->getId();
 
+		if is_file(session_file) {
+			return file_get_contents(session_file);
+		} else {
+			return "";
+		}
+
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure() -> void
+	{
+		var path;
+		let path = this->getOption("savePath");
+
+		if path {
+			session_save_path(path);
+		}
+
+		parent::configure();
+	}
 }

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -21,7 +21,6 @@ namespace Phalcon\Session\Adapter;
 
 use Phalcon\Session\Adapter;
 use Phalcon\Session\Exception;
-use Phalcon\Session\AdapterInterface;
 use Phalcon\Cache\Backend\Libmemcached;
 use Phalcon\Cache\Frontend\Data as FrontendData;
 
@@ -40,7 +39,15 @@ use Phalcon\Cache\Frontend\Data as FrontendData;
  *         Memcached::OPT_PREFIX_KEY => 'prefix.',
  *     ),
  *    'lifetime' => 3600,
- *    'prefix' => 'my_'
+ *    'prefix' => 'my_',
+ *
+ *    'uniqueId' => 'my-private-app',
+ *    'name' => 'session-name',
+ *    'cookie_lifetime' => 'session-cookie-lifetime',
+ *    'cookie_path' => 'session-cookie-path',
+ *    'cookie_domain' => 'session-cookie-domain',
+ *    'cookie_secure' => 'session-cookie-secure',
+ *    'cookie_httponly' => 'session-cookie-httponly'
  * ));
  *
  * $session->start();
@@ -50,10 +57,10 @@ use Phalcon\Cache\Frontend\Data as FrontendData;
  * echo $session->get('var');
  *</code>
  */
-class Libmemcached extends Adapter implements AdapterInterface
+class Libmemcached extends Adapter
 {
 
-	protected _libmemcached = NULL { get };
+	protected _libmemcached = null { get };
 
 	protected _lifetime = 8600 { get };
 
@@ -64,8 +71,6 @@ class Libmemcached extends Adapter implements AdapterInterface
 	 */
 	public function __construct(options = null)
 	{
-		var servers, client, lifetime, prefix, statsKey;
-
 		if typeof options != "array" {
 			throw new Exception("The options must be an array");
 		}
@@ -73,46 +78,6 @@ class Libmemcached extends Adapter implements AdapterInterface
 		if !isset options["servers"] {
 			throw new Exception("No servers given in options");
 		}
-
-		let servers = options["servers"];
-
-		if !isset options["client"] {
-			let client = NULL;
-		} else {
-			let client = options["client"];
-		}
-
-		if fetch lifetime, options["lifetime"] {
-			let this->_lifetime = lifetime;
-		} else {
-			let this->_lifetime = 8600;
-		}
-
-		if !fetch prefix, options["prefix"] {
-			let prefix = NULL;
-		} else {
-			let prefix = options["prefix"];
-		}
-
-		if !fetch statsKey, options["statsKey"] {
-			let statsKey = NULL;
-		} else {
-			let statsKey = options["statsKey"];
-		}
-
-		let this->_libmemcached = new Libmemcached(
-			new FrontendData(["lifetime": this->_lifetime]),
-			["servers": servers, "client": client, "prefix": prefix, "statsKey": statsKey]
-		);
-
-		session_set_save_handler(
-			[this, "open"],
-			[this, "close"],
-			[this, "read"],
-			[this, "write"],
-			[this, "destroy"],
-			[this, "gc"]
-		);
 
 		parent::__construct(options);
 	}
@@ -129,45 +94,64 @@ class Libmemcached extends Adapter implements AdapterInterface
 
 	/**
 	 * {@inheritdoc}
-	 *
-	 * @param string sessionId
-	 * @return mixed
 	 */
-    public function read(sessionId)
-    {
-        return this->_libmemcached->get(sessionId, this->_lifetime);
-    }
+	public function read(string! sessionId) -> var
+	{
+		return this->_libmemcached->get(sessionId, this->_lifetime);
+	}
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param string sessionId
-     * @param string data
-     */
-    public function write(sessionId, data)
-    {
-        this->_libmemcached->save(sessionId, data, this->_lifetime);
-    }
+	/**
+	 * {@inheritdoc}
+	 */
+	public function write(string! sessionId, data) -> void
+	{
+		this->_libmemcached->save(sessionId, data, this->_lifetime);
+	}
 
-    /**
-     * {@inheritdoc}
-     *
-     * @param  string  sessionId
-     * @return boolean
-     */
-    public function destroy(session_id = null)
-    {
-        if session_id === null {
-            let session_id = this->getId();
-        }
-        return this->_libmemcached->delete(session_id);
-    }
+	/**
+	 * {@inheritdoc}
+	 */
+	public function destroy(string session_id = null) -> boolean
+	{
+		if session_id === null {
+			return this->_libmemcached->delete(this->getId());
+		}
 
-    /**
-     * {@inheritdoc}
-     */
-    public function gc() -> boolean
-    {
+		return this->_libmemcached->delete(session_id);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function gc() -> boolean
+	{
 		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure() -> void
+	{
+		let this->_lifetime = this->getOption("lifetime", this->getLifetime());
+
+		let this->_libmemcached = new Libmemcached(
+			new FrontendData(["lifetime": this->_lifetime]), [
+				"servers": this->getOption("servers"),
+				"client": this->getOption("client"),
+				"prefix": this->getOption("prefix"),
+				"statsKey": this->getOption("statsKey")
+		]);
+
+		session_set_save_handler(
+			[this, "open"],
+			[this, "close"],
+			[this, "read"],
+			[this, "write"],
+			[this, "destroy"],
+			[this, "gc"]
+		);
+
+		parent::configure();
 	}
 }

--- a/phalcon/session/adapterinterface.zep
+++ b/phalcon/session/adapterinterface.zep
@@ -14,6 +14,7 @@
  +------------------------------------------------------------------------+
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
  +------------------------------------------------------------------------+
  */
 
@@ -29,76 +30,139 @@ interface AdapterInterface
 
 	/**
 	 * Starts session, optionally using an adapter
-	 *
-	 * @param array options
 	 */
-	public function start();
+	public function start() -> boolean;
+	
+	/**
+	 * Gets the session cookie parameters
+	 * @see http://php.net/manual/en/function.session-get-cookie-params.php
+	 */
+	public function getCookieParams() -> array;
+
+	/**
+	 * Sets the session cookie parameters
+	 * @see http://php.net/manual/en/function.session-set-cookie-params.php
+	 */
+	public function setCookieParams(int! lifetime, string! path, string! domain, bool! secure = false, bool! httpOnly = false) -> void;
 
 	/**
 	 * Sets session options
-	 *
-	 * @param array options
 	 */
-	public function setOptions(array! options);
+	public function setOptions(array! options) -> void;
 
 	/**
 	 * Get internal options
-	 *
-	 * @return array
 	 */
-	public function getOptions();
+	public function getOptions() -> array;
+
+	/**
+	 * Returns an option in the session's options
+	 * Returns defaultValue if the option hasn't set
+	 */
+	public function getOption(string! key, var defaultValue = null) -> var;
 
 	/**
 	 * Gets a session variable from an application context
-	 *
-	 * @param string index
-	 * @param mixed defaultValue
-	 * @return mixed
 	 */
-	public function get(index, defaultValue = null);
+	public function get(string! index, var defaultValue = null) -> var;
 
 	/**
 	 * Sets a session variable in an application context
-	 *
-	 * @param string index
-	 * @param string value
 	 */
-	public function set(index, value);
+	public function set(string! index, var value) -> void;
 
 	/**
 	 * Check whether a session variable is set in an application context
-	 *
-	 * @param string index
-	 * @return boolean
 	 */
-	public function has(index);
+	public function has(string! index) -> boolean;
 
 	/**
 	 * Removes a session variable from an application context
-	 *
-	 * @param string index
 	 */
-	public function remove(index);
+	public function remove(string! index) -> void;
 
 	/**
 	 * Returns active session id
-	 *
-	 * @return string
 	 */
-	public function getId();
+	public function getId() -> string;
+
+	/**
+	 * Set the current session id
+	 *
+	 *<code>
+	 *	$session->setId($id);
+	 *</code>
+	 */
+	public function setId(string! id) -> void;
+
+	/**
+	 * Gets the current session name
+	 * @see http://php.net/manual/en/function.session-name.php
+	 */
+	public function getName() -> string;
+
+	/**
+	 * Sets the current session name and return the old session name
+	 * @see http://php.net/manual/en/function.session-name.php
+	 */
+	public function setName(string! name) -> string;
 
 	/**
 	 * Check whether the session has been started
-	 *
-	 * @return boolean
 	 */
-	public function isStarted();
+	public function isStarted() -> boolean;
 
 	/**
 	 * Destroys the active session
-	 *
-	 * @return boolean
 	 */
-	public function destroy();
+	public function destroy() -> boolean;
 
+	/**
+	 * Re-initialize session array with original values
+	 * @see http://php.net/manual/en/function.session-reset.php
+	 */
+	public function reset() -> void;
+
+	/**
+	 * Write session data and end session
+	 * @see http://php.net/manual/en/function.session-write-close.php
+	 */
+	public function commit() -> void;
+
+	/**
+	 * Discard session array changes and finish session
+	 * @see http://php.net/manual/en/function.session-abort.php
+	 */
+	public function abort() -> void;
+
+	/**
+	 * Update the current session id with a newly generated one.
+	 * Returns NEW session ID on success or FALSE on failure.
+	 * @see http://php.net/manual/en/function.session-regenerate-id.php
+	 */
+	public function regenerateId(bool! deleteSession = false) -> string|boolean;
+
+	/**
+	 * Returns the current session status (const: SESSION_DISABLED, SESSION_NONE, SESSION_ACTIVE)
+	 * @see http://php.net/manual/en/function.session-status.php
+	 */
+	public function status() -> int;
+	
+	/**
+	 * Clear all session variables
+	 * @see http://php.net/manual/en/function.session-unset.php
+	 */
+	public function clear() -> void;
+
+	/**
+	 * Encodes the current session data as a session encoded string
+	 * @see http://php.net/manual/en/function.session-encode.php
+	 */
+	public function encode() -> string;
+
+	/**
+	 * Decodes session data from a session encoded string
+	 * @see http://php.net/manual/en/function.session-encode.php
+	 */
+	public function decode(string data) -> boolean;
 }

--- a/unit-tests/SessionTest.php
+++ b/unit-tests/SessionTest.php
@@ -15,129 +15,159 @@
 	+------------------------------------------------------------------------+
 	| Authors: Andres Gutierrez <andres@phalconphp.com>                      |
 	|          Eduar Carvajal <eduar@phalconphp.com>                         |
+	|          Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
 	+------------------------------------------------------------------------+
 */
 
+use Phalcon\Session\Adapter as SessionAdapter;
+use Phalcon\Session\AdapterInterface as SessionAdapterInterface;
+
+/**
+ * Class SessionTest
+ */
 class SessionTest extends PHPUnit_Framework_TestCase
 {
-
 	protected $stack = array();
 
-	protected function setUp()
-	{
+	/**
+	 * @var SessionAdapterInterface
+	 */
+	protected $session;
 
+	public static function setUpBeforeClass()
+	{
+		@session_unset();
+		@session_destroy();
+		@session_write_close();
+
+		session_save_path(__DIR__ . '/cache');
+	}
+
+	public function setUp()
+	{
 		$this->stack = array(
 			'save_handler' => ini_get('session.save_handler'),
 			'save_path' => ini_get('session.save_path'),
-			'serialize_handler' => ini_get('session.serialize_handler'),
+			'serialize_handler' => ini_get('session.serialize_handler')
 		);
 
+		$this->session = $this->createAdapter();
 	}
 
-	protected function tearDown()
+	public function tearDown()
 	{
-		@session_write_close();
+		@$this->sessionStart();
+		@$this->session->clear();
+		@$this->session->destroy();
+		$this->session = null;
 
 		foreach ($this->stack as $key => $val) {
 			@ini_set($key, $val);
 		}
-
 	}
 
-	public function testSessionFiles()
+	/**
+	 * Test method getOptions, getOption
+	 * @throws Exception
+	 */
+	public function testSessionGetOptions()
 	{
+		$options = array(
+			'option1' => 'test-value-1',
+			'option2' => 'test-value-2'
+		);
 
-		$session = new Phalcon\Session\Adapter\Files();
+		$session = $this->createAdapter($options);
 
-		$this->assertFalse($session->start());
-		$this->assertFalse($session->isStarted());
+		$this->assertEquals($session->getOptions(), $options);
 
-		@session_start();
+		$this->assertEquals($session->getOption('option1'), 'test-value-1');
+		$this->assertEquals($session->getOption('option2'), 'test-value-2');
 
-		$session->set('some', 'value');
-
-		$this->assertEquals($session->get('some'), 'value');
-		$this->assertTrue($session->has('some'));
-		$this->assertEquals($session->get('undefined', 'my-default'), 'my-default');
-
-		// Automatically deleted after reading
-		$this->assertEquals($session->get('some', NULL, TRUE), 'value');
-		$this->assertFalse($session->has('some'));
+		// Test getOption default value
+		$this->assertEquals($session->getOption('option3'), null);
+		$this->assertEquals($session->getOption('option4', 'test-value-4'), 'test-value-4');
 	}
 
-	public function testSessionFilesWrite()
+
+	/**
+	 * Test method setOptions
+	 * @throws Exception
+	 */
+	public function testSessionSetOptions()
 	{
+		$options = array(
+			'option-1' => 'test-value-1',
+			'option-2' => 'test-value-2'
+		);
 
-		$session_path =  __DIR__ . '/cache';
-		ini_set('session.save_handler', 'files');
-		ini_set('session.save_path', $session_path);
-		ini_set('session.serialize_handler', 'php');
+		$session = $this->createAdapter();
+		$session->setOptions($options);
 
-		// Write
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
+		$this->assertEquals($session->getOptions(), $options);
 
-		$session->set('some', 'write-value');
+		$this->assertEquals($session->getOption('option-1'), 'test-value-1');
+		$this->assertEquals($session->getOption('option-2'), 'test-value-2');
 
-		$this->assertEquals($session->get('some'), 'write-value');
-		$this->assertTrue($session->has('some'));
+		// Test getOption default value
+		$this->assertEquals($session->getOption('option-3'), null);
+		$this->assertEquals($session->getOption('option-4', 'test-value-4'), 'test-value-4');
+	}
 
-		$session_id = $session->getId();
+	/**
+	 * Test gets\sets session id
+	 * @throws Exception
+	 */
+	public function testSessionSetId()
+	{
+		$this->sessionStart();
+
+		$session_id = $this->session->getId();
 		$this->assertNotEmpty($session_id);
 
-		session_write_close();
-		unset($session);
-
-		// Check session file
-		$session_file = $session_path . '/sess_' . $session_id;
-		$this->assertTrue(is_file($session_file));
-		$this->assertNotEmpty(@file_get_contents($session_file));
-
-		// Read
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
-
-		$session->setId($session_id);
-
-		$this->assertTrue($session->has('some'));
-		$this->assertEquals($session->get('some'), 'write-value');
-
-		$session->remove('some');
-		$this->assertFalse($session->has('some'));
-
-		@session_write_close();
-		unset($session);
-
-		// Check session file
-		$this->assertTrue(is_file($session_file));
-		$this->assertEmpty(@file_get_contents($session_file));
-		@unlink($session_file);
-
+		$this->session->setId($session_id_new = md5($session_id));
+		$this->assertEquals($this->session->getId(), $session_id_new);
 	}
 
-	public function testSessionFilesWriteMagicMethods()
+	/**
+	 * Test gets\sets session name
+	 * @throws Exception
+	 */
+	public function testSessionSetName()
 	{
+		$this->sessionStart();
 
-		$session_path =  __DIR__ . '/cache';
-		ini_set('session.save_handler', 'files');
-		ini_set('session.save_path', $session_path);
-		ini_set('session.serialize_handler', 'php');
+		$session_name = $this->session->getName();
+		$this->assertNotEmpty($session_name);
 
-		// Write
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
+		$this->assertEquals($this->session->setName('some-name'), $session_name);
+		$this->assertEquals($this->session->getName(), 'some-name');
+	}
 
-		$session->some = 'write-magic-value';
+	/**
+	 * Test adapter Phalcon\Session\Adapter\File, option savePath
+	 * @throws Exception
+	 */
+	public function testSessionAdapterFilesOptionSavePath()
+	{
+		$session_path_old = session_save_path();
 
-		$this->assertEquals($session->some, 'write-magic-value');
-		$this->assertTrue(isset($session->some));
+		$session_path = __DIR__ . '/cache/session';
+
+		if (!is_dir($session_path)) {
+			@mkdir($session_path, 0777, true);
+		}
+
+		$session = $this->createAdapter(array(
+			'savePath' => $session_path
+		));
+
+		$this->sessionStart();
+		$session->set('some', 'write-value');
 
 		$session_id = $session->getId();
 
-		@session_write_close();
+		$session->commit();
 		unset($session);
 
 		// Check session file
@@ -145,27 +175,380 @@ class SessionTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(is_file($session_file));
 		$this->assertNotEmpty(@file_get_contents($session_file));
 
-		// Read
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
-
-		$session->setId($session_id);
-
-		$this->assertTrue(isset($session->some));
-		$this->assertEquals($session->some, 'write-magic-value');
-
-		unset($session->some);
-		$this->assertFalse(isset($session->some));
-
-		@session_write_close();
-		unset($session);
-
-		// Check session file
-		$this->assertTrue(is_file($session_file));
-		$this->assertEmpty(@file_get_contents($session_file));
 		@unlink($session_file);
+		@rmdir($session_path);
 
+		session_save_path($session_path_old);
 	}
 
+	/**
+	 * Test session start, start force and status
+	 *
+	 * @throws Exception
+	 */
+	public function testSessionStart()
+	{
+		$this->assertEquals($this->session->status(), SessionAdapter::SESSION_NONE);
+
+		// Test not force start
+		$this->assertFalse($this->session->start());
+		$this->assertFalse($this->session->isStarted());
+		$this->assertEquals($this->session->status(), SessionAdapter::SESSION_NONE);
+
+		// Test force start
+		$this->assertFalse($this->session->start());
+		$this->assertFalse($this->session->isStarted());
+
+		@session_start();
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertEquals($this->session->status(), SessionAdapter::SESSION_ACTIVE);
+	}
+
+
+	/**
+	 * Test session, getters, setters, has, remove
+	 * @throws Exception
+	 */
+	public function testSessionMethodsManipulate()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some', 'write-value');
+
+		// Test gets and sets method
+		$this->assertEquals($this->session->get('some'), 'write-value');
+		$this->assertTrue($this->session->has('some'));
+
+		// Test gets default value
+		$this->assertEquals($this->session->get('undefined-key', 'default-value'), 'default-value');
+
+		// Automatically deleted after reading
+		$this->assertEquals($this->session->get('some', null, true), 'write-value');
+		$this->assertFalse($this->session->has('some'));
+
+		// Test remove key
+		$this->session->set('some2', 'write-value');
+		$this->session->remove('some2');
+		$this->assertFalse($this->session->has('some'));
+	}
+
+	/**
+	 * Test session magic methods
+	 * @throws Exception
+	 */
+	public function testSessionMagicMethodsManipulate()
+	{
+		$this->sessionStart();
+
+		$this->session->some = 'write-magic-value';
+
+		$this->assertEquals($this->session->some, 'write-magic-value');
+		$this->assertTrue(isset($this->session->some));
+
+		$this->session->some2 = 'write-magic-value';
+		unset($this->session->some2);
+		$this->assertFalse(isset($this->session->some2));
+	}
+
+
+	/**
+	 * Test session regenerate id
+	 * @throws Exception
+	 */
+	public function testSessionRegenerateId()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->assertTrue($this->session->has('some-key-1'));
+
+		$this->assertNotEmpty($session_id = $this->session->getId());
+
+		$newId = @$this->session->regenerateId();
+		$this->assertNotEquals($newId, $session_id);
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+	}
+
+	/**
+	 * Test session commit
+	 * @throws Exception
+	 */
+	public function testSessionCommit()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+		$this->session->commit();
+
+		$this->assertFalse($this->session->isStarted());
+
+		if (method_exists($this->session, 'read')) {
+			$this->assertNotEmpty($data = $this->session->read($this->session->getId()));
+		}
+
+		// The value of the session should not be updated after the start
+		$this->session->set('some-key-3', 'some-value-3');
+
+		$this->sessionStart();
+		$this->assertFalse($this->session->has('some-key-3'));
+	}
+
+	/**
+	 * Test session reset
+	 * @throws Exception
+	 */
+	public function testSessionReset()
+	{
+		$this->sessionStart();
+
+		/**
+		 * Test, reset to empty data
+		 */
+		$this->session->set('some-key-1', 'some-value-1');
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		$this->session->reset();
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertFalse($this->session->has('some-key-1'));
+
+
+		/**
+		 * Test, reset to previous data
+		 */
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+		$this->session->commit();
+
+		$this->assertFalse($this->session->isStarted());
+
+		$this->sessionStart();
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->session->set('some-key-2', 'some-value-22');
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-22');
+
+		// test key3
+		$this->session->set('some-key-3', 'some-value-3');
+		$this->assertTrue($this->session->has('some-key-3'));
+		$this->assertEquals($this->session->get('some-key-3'), 'some-value-3');
+
+		// Reset
+		$this->session->reset();
+
+		$this->assertTrue($this->session->isStarted());
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertFalse($this->session->has('some-key-3'));
+
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+	}
+
+	public function testSessionAbort()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		$this->session->commit();
+		$this->assertFalse($this->session->isStarted());
+
+		// Session start
+		$this->sessionStart();
+
+		// Change session data
+		$this->session->set('some-key-2', 'some-value-22');
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-22');
+
+		$this->session->set('some-key-3', 'some-value-3');
+		$this->assertTrue($this->session->has('some-key-3'));
+		$this->assertEquals($this->session->get('some-key-3'), 'some-value-3');
+
+		/**
+		 * Test abort session
+		 */
+		$this->session->abort();
+		$this->assertFalse($this->session->isStarted());
+
+		$this->sessionStart();
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		$this->assertFalse($this->session->has('some-key-3'));
+	}
+
+
+	/**
+	 * Test session clear
+	 * @throws Exception
+	 */
+	public function testSessionClear()
+	{
+		$this->sessionStart();
+
+		$session_id = $this->session->getId();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		/**
+		 * Test session clear
+		 */
+		$this->session->clear();
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertEquals($this->session->getId(), $session_id);
+
+		$this->assertFalse($this->session->has('some-key-1'));
+		$this->assertFalse($this->session->has('some-key-2'));
+	}
+
+	/**
+	 * Test session clear
+	 * @throws Exception
+	 */
+	public function testSessionDestroy()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		/**
+		 * Test session clear
+		 */
+		$this->assertTrue($this->session->destroy());
+
+		$this->assertFalse($this->session->isStarted());
+		$this->assertEquals($this->session->getId(), '');
+
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertTrue($this->session->has('some-key-2'));
+
+		$this->sessionStart();
+
+		$this->assertFalse($this->session->has('some-key-1'));
+		$this->assertFalse($this->session->has('some-key-2'));
+	}
+
+	/**
+	 * Test session clear
+	 * @throws Exception
+	 */
+	public function testSessionEncodeDecode()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		/**
+		 * Test session encode
+		 */
+		$this->assertNotEmpty($session_data = $this->session->encode());
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertTrue($this->session->has('some-key-2'));
+
+		// test key3
+		$this->session->set('some-key-3', 'some-value-3');
+		$this->assertTrue($this->session->has('some-key-3'));
+		$this->assertEquals($this->session->get('some-key-3'), 'some-value-3');
+
+		// clear current session
+		$this->session->clear();
+
+		$this->assertFalse($this->session->has('some-key-1'));
+		$this->assertFalse($this->session->has('some-key-2'));
+		$this->assertFalse($this->session->has('some-key-3'));
+
+		/**
+		 * Test session decode
+		 */
+		$this->assertTrue($this->session->decode($session_data));
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		// test key3
+		$this->assertFalse($this->session->has('some-key-3'));
+	}
+
+	protected function sessionStart()
+	{
+		if (!$this->session->start()) {
+			@session_start();
+		}
+
+		$this->assertTrue($this->session->isStarted());
+	}
+
+	/**
+	 * @param array $options
+	 * @return SessionAdapter\Files
+	 */
+	protected function createAdapter(Array $options = null)
+	{
+		return new Phalcon\Session\Adapter\Files($options);
+	}
 }


### PR DESCRIPTION
Update `Phalcon\Session\Adapter`, `Phalcon\Session\AdapterInterface` and also full coverage of the tests... And more improvements...

_Added public method:_
- `getOption()`
- `getCookieParams()`
- `setCookieParams()`
- `setName()`
- `getName()`
- `regenerateId()`
- `reset()`
- `commit()`
- `abort()`
- `clear()`
- `status()`
- `encode()`
- `decode()`

_Added protected method_
- `configure()`
- `legacySessionReset()`
- `legacySessionAbort()`
- `legacySessionStatus()`

_Added options:_
- name (session name) 
- cookie_lifetime
- cookie_path
- cookie_domain
- cookie_secure
- cookie_httponly

_`Phalcon\Session\Adapter\Files` added options:_
- savePath
