### PR TITLE
[2.0.x] ACL adapter is now abstract and implements AdapterInterface and EventsAwareInterface (again)

### DIFF
--- a/phalcon/acl/adapter.zep
+++ b/phalcon/acl/adapter.zep
@@ -20,14 +20,14 @@
 namespace Phalcon\Acl;
 
 use Phalcon\Events\ManagerInterface;
+use Phalcon\Events\EventsAwareInterface;
 
 /**
  * Phalcon\Acl\Adapter
  *
  * Adapter for Phalcon\Acl adapters
  */
-
-class Adapter
+abstract class Adapter implements AdapterInterface, EventsAwareInterface
 {
 	/**
 	 * Events manager
@@ -61,7 +61,7 @@ class Adapter
 
 	/**
 	 * Active access which the list is checking if some role can access it
-	 * "@var mixed
+	 * @var mixed
 	 */
 	protected _activeAccess { get };
 

--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Acl\Adapter;
 
 use Phalcon\Acl\Adapter;
 use Phalcon\Acl\Resource;
+use Phalcon\Acl\Role;
 use Phalcon\Acl\Exception;
 
 /**
@@ -161,7 +162,7 @@ class Memory extends Adapter
 			let roleObject = role;
 		} else {
 			let roleName = role;
-			let roleObject = new \Phalcon\Acl\Role(role);
+			let roleObject = new Role(role);
 		}
 
 		if isset this->_rolesNames[roleName] {
@@ -612,20 +613,16 @@ class Memory extends Adapter
 
 	/**
 	 * Return an array with every role registered in the list
-	 *
-	 * @return Phalcon\Acl\Role[]
 	 */
-	public function getRoles()
+	public function getRoles() -> <Role[]>
 	{
 		return this->_roles;
 	}
 
 	/**
 	 * Return an array with every resource registered in the list
-	 *
-	 * @return Phalcon\Acl\Resource[]
 	 */
-	public function getResources()
+	public function getResources() -> <$Resource[]>
 	{
 		return this->_resources;
 	}

--- a/phalcon/acl/adapterinterface.zep
+++ b/phalcon/acl/adapterinterface.zep
@@ -63,7 +63,7 @@ interface AdapterInterface
 	 * Access names can be a particular action, by example
 	 * search, update, delete, etc or a list of them
 	 */
-	public function addResource(resourceObject, accessList = null) -> boolean;
+	public function addResource(resourceObject, accessList) -> boolean;
 
 	/**
 	 * Adds access to resources
@@ -107,15 +107,11 @@ interface AdapterInterface
 
 	/**
 	 * Return an array with every role registered in the list
-	 *
-	 * @return Phalcon\Acl\RoleInterface[]
 	 */
-	public function getRoles();
+	public function getRoles() -> <RoleInterface[]>;
 
 	/**
 	 * Return an array with every resource registered in the list
-	 *
-	 * @return Phalcon\Acl\ResourceInterface[]
 	 */
-	public function getResources();
+	public function getResources() -> <ResourceInterface[]>;
 }


### PR DESCRIPTION
This relationship existed in [1.3.4](https://github.com/phalcon/cphalcon/blob/1.3.4/ext/acl/adapter.c#L67).
