### PR TITLE
[2.0.0] Refactored mvc/model/resultset to work with AppendIterator, prevent query re-execution and optimisations

### DIFF
--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -64,13 +64,15 @@ abstract class Resultset
 
 	protected _isFresh = true;
 
-	protected _pointer = -1;
+	protected _pointer = 0;
 
 	protected _count;
 
-	protected _activeRow;
+	protected _activeRow = null;
 
-	protected _rows;
+	protected _rows = null;
+	
+	protected _row = null;
 
 	protected _errorMessages;
 
@@ -89,104 +91,91 @@ abstract class Resultset
 	/**
 	 * Moves cursor to next row in the resultset
 	 */
-	public function next()
+	public function next() -> void
 	{
-		let this->_pointer++;
+		// Seek to the next position
+		this->seek(this->_pointer + 1);
+	}
+	
+	/**
+	 * Check whether internal resource has rows to fetch
+	 *
+	 * @return boolean
+	 */
+	public function valid() -> boolean
+	{		
+		return this->_pointer < this->count();
 	}
 
 	/**
 	 * Gets pointer number of active row in the resultset
 	 *
-	 * @return int
+	 * @return int|null
 	 */
-	public function key()
-	{
+	public function key() -> int | null
+	{		
+		if this->_pointer >= this->count() {
+			return null;
+		}
+		
 		return this->_pointer;
 	}
 
 	/**
 	 * Rewinds resultset to its beginning
 	 */
-	public final function rewind()
-	{
-		var rows, result;
-
-		if this->_type {
-
-			/**
-			 * Here, the resultset act as a result that is fetched one by one
-			 */
-			let result = this->_result;
-			if result !== false {
-				if this->_activeRow !== null {
-					result->dataSeek(0);
-				}
-			}
-		} else {
-
-			/**
-			 * Here, the resultset act as an array
-			 */
-			let rows = this->_rows;
-			if rows === null {
-				let result = this->_result;
-				if typeof result == "object" {
-					let rows = result->fetchAll(),
-						this->_rows = rows;
-				}
-			}
-
-			if typeof rows == "array" {
-				reset(rows);
-			}
-		}
-
-		let this->_pointer = 0;
+	public final function rewind() -> void
+	{		
+		this->seek(0);
 	}
 
 	/**
 	 * Changes internal pointer to a specific position in the resultset
 	 */
-	public final function seek(int position)
+	public final function seek(int position) -> void
 	{
-		var result, rows; int i;
-
-		if this->_pointer != position {
-
-			if this->_type {
-
-				/**
-				 * Here, the resultset act as a result that is fetched one by one
-				 */
+		var result;
+		
+		if this->_type {
+			/**
+			* Fetch from PDO one-by-one. Set new position if required and set this->_row
+			*/
+			if this->_row === null || this->_pointer != position {
 				let result = this->_result;
 				if result !== false {
-					result->dataSeek(position);
-				}
-			} else {
-
-				/**
-				 * Here, the resultset act as an array
-				 */
-				let rows = this->_rows;
-				if rows === null {
-					let result = this->_result;
-					if typeof result == "object" {
-						let rows = result->fetchAll(),
-							this->_rows = rows;
+					/**
+					* 1. If row is not set, query is executed in "result->dataSeek()"
+					*    Set _row to prepare for hydration in "current()"
+					*
+					* 2. Backwards seeks have to re-execute the query
+					*    There is no fetchPrevious :(
+					*/
+					if this->_row === null || this->_pointer > position {
+						result->dataSeek(position);
+						let this->_row = result->$fetch(result);
+					}
+					/**
+					* Requested postion is greater than current pointer,
+					* seek forward until the requested position is reached.
+					* We do not need to re-excute the query!
+					*/
+					while this->_pointer < position {
+						let this->_row = result->$fetch(result);
+						let this->_pointer++;
 					}
 				}
-
-				if typeof rows == "array" {
-					let i = 0;
-					reset(rows);
-					while i < position {
-						next(rows);
-						let i++;
-					}
-				}
+				
+				let this->_pointer = position;
+				let this->_activeRow = null;
 			}
-
-			let this->_pointer = position;
+		} else {
+			/**
+			* Reset activeRow for simple arrays if new position requested
+			*/
+			if this->_pointer != position {
+				let this->_pointer = position;
+				let this->_activeRow = null;
+			}
 		}
 	}
 
@@ -200,7 +189,7 @@ abstract class Resultset
 		let count = this->_count;
 
 		/**
-		 * We only calculate the row number is it wasn't calculated before
+		 * We only calculate the row number if it wasn't calculated before
 		 */
 		if typeof count === "null" {
 			let count = 0;
@@ -247,27 +236,13 @@ abstract class Resultset
 	public function offsetGet(int! index) -> <ModelInterface> | boolean
 	{
 		if index < this->count() {
-
-			/**
-			 * Check if the last record returned is the current requested
-			 */
-			if this->_pointer == index {
-				return this->current();
-			}
-
-			/**
-			 * Move the cursor to the specific position
-			 */
+	   		/**
+	   		 * Move the cursor to the specific position
+	   		 */
 			this->seek(index);
-
-			/**
-			 * Check if the last record returned is the requested
-			 */
-			if this->{"valid"}() !== false {
-				return this->current();
-			}
-
-			return false;
+			
+			return this->{"current"}();
+			
 		}
 		throw new Exception("The index does not exist in the cursor");
 	}
@@ -303,34 +278,28 @@ abstract class Resultset
 	 * Get first row in the resultset
 	 */
 	public function getFirst() -> <ModelInterface> | boolean
-	{
-		/**
-		 * Check if the last record returned is the current requested
-		 */
-		if this->_pointer == 0 {
-			return this->current();
+	{		
+		if this->count() == 0 {
+			return false;
 		}
 
-		/**
-		 * Otherwise re-execute the statement
-		 */
-		this->rewind();
-		if this->{"valid"}() !== false {
-			return this->current();
-		}
-		return false;
+		this->seek(0);
+		return this->{"current"}();
 	}
 
 	/**
 	 * Get last row in the resultset
 	 */
 	public function getLast() -> <ModelInterface> | boolean
-	{
-		this->seek(this->count() - 1);
-		if this->{"valid"}() !== false {
-			return this->current();
+	{		
+		var count;
+		let count = this->count();	
+		if count == 0 {
+			return false;
 		}
-		return false;
+		
+		this->seek(count - 1);
+		return this->{"current"}();
 	}
 
 	/**
@@ -373,14 +342,6 @@ abstract class Resultset
 	public function getCache() -> <BackendInterface>
 	{
 		return this->_cache;
-	}
-
-	/**
-	 * Returns current row in the resultset
-	 */
-	public final function current() -> <ModelInterface>
-	{
-		return this->_activeRow;
 	}
 
 	/**

--- a/phalcon/mvc/model/resultset/complex.zep
+++ b/phalcon/mvc/model/resultset/complex.zep
@@ -78,37 +78,40 @@ class Complex extends Resultset implements ResultsetInterface
 	}
 
 	/**
-	 * Check whether internal resource has rows to fetch
+	 * Returns current row in the resultset
+	 *
+	 * @return Phalcon\Mvc\ModelInterface|false
 	 */
-	public function valid() -> boolean
+	public final function current() -> <ModelInterface> | boolean
 	{
-		var result, rows, row, underscore, hydrateMode,
+		var result, row, underscore, hydrateMode,
 			dirtyState, alias, activeRow, type, columnTypes,
 			column, columnValue, value, attribute, source, attributes,
 			columnMap, rowModel, keepSnapshots, sqlAlias, isPartial;
 
+		
+		let activeRow = this->_activeRow;
+		if activeRow !== null {
+			return activeRow;
+		}
+
+		/**
+		* Get current row
+		*/
 		let isPartial = this->_type;
-
 		if isPartial {
-
-			/**
-			 * The result is bigger than 32 rows so it's retrieved one by one
-			 */
-			let result = this->_result;
-			if result !== false {
-				let row = result->$fetch(result);
-			} else {
-				let row = false;
-			}
+			let row = this->_row;
 		} else {
-			/**
-			 * The full rows are dumped in this_ptr->rows
-			 */
-			let rows = this->_rows;
-			if typeof rows == "array" {
-				let row = current(rows);
-				if typeof row == "object" {
-					next(rows);
+			if this->_rows === null {
+				let result = this->_result;
+				if typeof result == "object" {
+					let this->_rows = result->fetchAll();
+				}
+			}
+
+			if typeof this->_rows == "array" {
+				if !fetch row, this->_rows[this->_pointer] {
+					let row = false;
 				}
 			} else {
 				let row = false;
@@ -118,168 +121,159 @@ class Complex extends Resultset implements ResultsetInterface
 		/**
 		 * Valid records are arrays
 		 */
-		if typeof row == "object" || typeof row == "array" {
+		if typeof row != "object" && typeof row != "array" {
+			let this->_activeRow = false;
+			return false;
+		}
 
-			/**
-			 * The result type=1 so we need to build every row
-			 */
-			if isPartial {
+		/**
+		* Resulset was unserialized, we do not need to hydrate
+		*/
+		if !isPartial {
+			let this->_activeRow = row;
+			return row;
+		}
+		
+		/**
+		 * Get current hydration mode
+		 */
+		let hydrateMode = this->_hydrateMode;
+
+		let underscore = "_";
+
+		/**
+		 * Each row in a complex result is a Phalcon\Mvc\Model\Row instance
+		 */
+		switch hydrateMode {
+
+			case Resultset::HYDRATE_RECORDS:
+				let activeRow = new Row();
+				break;
+
+			case Resultset::HYDRATE_ARRAYS:
+				let activeRow = [];
+				break;
+
+			case Resultset::HYDRATE_OBJECTS:
+			default:
+				let activeRow = new \stdClass();
+				break;
+		}
+
+		/**
+		 * Create every record according to the column types
+		 */
+		let columnTypes = this->_columnTypes;
+
+		/**
+		 * Set records as dirty state PERSISTENT by default
+		 */
+		let dirtyState = 0;
+
+		for alias, column in columnTypes {
+
+			if typeof column != "array" {
+				throw new Exception("Column type is corrupt");
+			}
+
+			let type = column["type"];
+			if type == "object" {
 
 				/**
-				 * Get current hydration mode
+				 * Object columns are assigned column by column
 				 */
-				let hydrateMode = this->_hydrateMode;
-
-				let underscore = "_";
+				let source = column["column"],
+					attributes = column["attributes"],
+					columnMap = column["columnMap"];
 
 				/**
-				 * Each row in a complex result is a Phalcon\Mvc\Model\Row instance
+				 * Assign the values from the _source_attribute notation to its real column name
+				 */
+				let rowModel = [];
+				for attribute in attributes {
+
+					/**
+					 * Columns are supposed to be in the form _table_field
+					 */
+					let columnValue = row[underscore . source . underscore. attribute],
+						rowModel[attribute] = columnValue;
+				}
+
+				/**
+				 * Generate the column value according to the hydration type
 				 */
 				switch hydrateMode {
 
 					case Resultset::HYDRATE_RECORDS:
-						let activeRow = new Row();
+
+						/**
+						 * Check if the resultset must keep snapshots
+						 */
+						if !fetch keepSnapshots, column["keepSnapshots"] {
+							let keepSnapshots = false;
+						}
+
+						/**
+						 * Get the base instance
+						 * Assign the values to the attributes using a column map
+						 */
+						let value = Model::cloneResultMap(column["instance"], rowModel, columnMap, dirtyState, keepSnapshots);
 						break;
 
-					case Resultset::HYDRATE_ARRAYS:
-						let activeRow = [];
-						break;
-
-					case Resultset::HYDRATE_OBJECTS:
 					default:
-						let activeRow = new \stdClass();
+						/**
+		 				 * Other kinds of hydrations
+		 				 */
+						let value = Model::cloneResultMapHydrate(rowModel, columnMap, hydrateMode);
 						break;
 				}
 
 				/**
-				 * Create every record according to the column types
+				 * The complete object is assigned to an attribute with the name of the alias or the model name
 				 */
-				let columnTypes = this->_columnTypes;
+				let attribute = column["balias"];
 
-				/**
-				 * Set records as dirty state PERSISTENT by default
-				 */
-				let dirtyState = 0;
-
-				for alias, column in columnTypes {
-
-					if typeof column != "array" {
-						throw new Exception("Column type is corrupt");
-					}
-
-					let type = column["type"];
-					if type == "object" {
-
-						/**
-						 * Object columns are assigned column by column
-						 */
-						let source = column["column"],
-							attributes = column["attributes"],
-							columnMap = column["columnMap"];
-
-						/**
-						 * Assign the values from the _source_attribute notation to its real column name
-						 */
-						let rowModel = [];
-						for attribute in attributes {
-
-							/**
-							 * Columns are supposed to be in the form _table_field
-							 */
-							let columnValue = row[underscore . source . underscore. attribute],
-								rowModel[attribute] = columnValue;
-						}
-
-						/**
-						 * Generate the column value according to the hydration type
-						 */
-						switch hydrateMode {
-
-							case Resultset::HYDRATE_RECORDS:
-
-								/**
-								 * Check if the resultset must keep snapshots
-								 */
-								if !fetch keepSnapshots, column["keepSnapshots"] {
-									let keepSnapshots = false;
-								}
-
-								/**
-								 * Get the base instance
-								 * Assign the values to the attributes using a column map
-								 */
-								let value = Model::cloneResultMap(column["instance"], rowModel, columnMap, dirtyState, keepSnapshots);
-								break;
-
-							default:
-								/**
-				 				 * Other kinds of hydrations
-				 				 */
-								let value = Model::cloneResultMapHydrate(rowModel, columnMap, hydrateMode);
-								break;
-						}
-
-						/**
-						 * The complete object is assigned to an attribute with the name of the alias or the model name
-						 */
-						let attribute = column["balias"];
-
-					} else {
-
-						/**
-						 * Scalar columns are simply assigned to the result object
-						 */
-						if fetch sqlAlias, column["sqlAlias"] {
-							let value = row[sqlAlias];
-						} else {
-							fetch value, row[alias];
-						}
-
-						/**
-						 * If a "balias" is defined is not an unnamed scalar
-						 */
-						if isset column["balias"] {
-							let attribute = alias;
-						} else {
-							let attribute = str_replace(underscore, "", alias);
-						}
-					}
-
-					/**
-					 * Assign the instance according to the hydration type
-					 */
-					switch hydrateMode {
-
-						case Resultset::HYDRATE_ARRAYS:
-							let activeRow[attribute] = value;
-							break;
-
-						default:
-							let activeRow->{attribute} = value;
-							break;
-					}
-				}
-
-				/**
-				 * Store the generated row in this_ptr->activeRow to be retrieved by 'current'
-				 */
-				let this->_activeRow = activeRow;
 			} else {
 
 				/**
-				 * The row is already built so we just assign it to the activeRow
+				 * Scalar columns are simply assigned to the result object
 				 */
-				let this->_activeRow = row;
+				if fetch sqlAlias, column["sqlAlias"] {
+					let value = row[sqlAlias];
+				} else {
+					fetch value, row[alias];
+				}
+
+				/**
+				 * If a "balias" is defined is not an unnamed scalar
+				 */
+				if isset column["balias"] {
+					let attribute = alias;
+				} else {
+					let attribute = str_replace(underscore, "", alias);
+				}
 			}
 
-			return true;
+			/**
+			 * Assign the instance according to the hydration type
+			 */
+			switch hydrateMode {
+
+				case Resultset::HYDRATE_ARRAYS:
+					let activeRow[attribute] = value;
+					break;
+
+				default:
+					let activeRow->{attribute} = value;
+					break;
+			}
 		}
 
 		/**
-		 * There are no results to retrieve so we update this_ptr->activeRow as false
+		 * Store the generated row in this_ptr->activeRow to be retrieved by 'current'
 		 */
-		let this->_activeRow = false;
-		return false;
+		let this->_activeRow = activeRow;
+		return activeRow;
 	}
 
 	/**
@@ -336,10 +330,13 @@ class Complex extends Resultset implements ResultsetInterface
 	 *
 	 * @param string data
 	 */
-	public function unserialize(data) -> void
+	public function unserialize(string! data) -> void
 	{
 		var resultset;
 
+		/**
+		* Enable fetch by array
+		*/
 		let this->_type = 0;
 
 		let resultset = unserialize(data);

--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -90,34 +90,42 @@ class Simple extends Resultset
 	}
 
 	/**
-	 * Check whether internal resource has rows to fetch
+	 * Returns current row in the resultset
+	 *
+	 * @return Phalcon\Mvc\ModelInterface|false
 	 */
-	public function valid() -> boolean
+	public final function current() -> <ModelInterface> | boolean
 	{
-		var result, row, rows, hydrateMode, columnMap, activeRow;
+		var result, row, hydrateMode, columnMap, activeRow;
+		
+		let activeRow = this->_activeRow;
+		if activeRow !== null {
+			return activeRow;
+		}
 
+		/**
+		* Get current row
+		*/
 		if this->_type {
-
-			let result = this->_result;
-			if typeof result == "object" {
-				let row = result->$fetch(result);
-			} else {
-				let row = false;
-			}
+			/**
+			* Fetch from PDO one-by-one. Functions "next" and "seek" set this->_row
+			*/
+			let row = this->_row;
 		} else {
-
-			let rows = this->_rows;
-			if typeof rows != "array" {
+			/**
+			* Fetch from array. Functions "next" and "seek" set this->_pointer
+			* We have to ensure this->_rows is populated
+			*/
+			if this->_rows === null {
 				let result = this->_result;
 				if typeof result == "object" {
-					let this->_rows = result->fetchAll(), rows = this->_rows;
+					let this->_rows = result->fetchAll();
 				}
 			}
 
-			if typeof rows == "array" {
-				let row = current(rows);
-				if row !== false {
-					next(rows);
+			if typeof this->_rows == "array" {
+				if !fetch row, this->_rows[this->_pointer] {
+					let row = false;
 				}
 			} else {
 				let row = false;
@@ -167,7 +175,7 @@ class Simple extends Resultset
 		}
 
 		let this->_activeRow = activeRow;
-		return true;
+		return activeRow;
 	}
 
 	/**
@@ -177,57 +185,38 @@ class Simple extends Resultset
 	 */
 	public function toArray(boolean renameColumns = true) -> array
 	{
-		var result, activeRow, records, record, renamed, renamedKey,
+		var result, records, record, renamed, renamedKey,
 			key, value, renamedRecords, columnMap;
 
 		if this->_type {
-
+			/**
+			* Fetch from PDO one-by-one. For toArray we fetch all rows at once
+			*/
 			let result = this->_result;
 			if typeof result == "object" {
-
-				let activeRow = this->_activeRow;
-
-				/**
-				 * Check if we need to re-execute the query
-				 */
-				if activeRow !== null {
+				// re-execute query if required and fetchAll rows
+				if this->_row !== null {
 					result->execute();
 				}
-
-				/**
-				 * We fetch all the results in memory
-				 */
 				let records = result->fetchAll();
+				let this->_row = null; 
 			} else {
 				let records = [];
 			}
 
 		} else {
-
+			/**
+			* Fetch from array. this->_rows is alreay our data-array we want to return
+			*/
 			let records = this->_rows;
 			if typeof records != "array" {
 				let result = this->_result;
 				if typeof result == "object" {
-
-					let activeRow = this->_activeRow;
-
-					/**
-				 	 * Check if we need to re-execute the query
-				 	 */
-					if activeRow !== null {
-						result->execute();
-					}
-
 					/**
 					 * We fetch all the results in memory again
 					 */
 					let records = result->fetchAll(),
 						this->_rows = records;
-
-					/**
-					 * Update the row count
-					 */
-					let this->_count = count(records);
 				} else {
 					let records = [];
 				}
@@ -287,11 +276,6 @@ class Simple extends Resultset
 	public function serialize() -> string
 	{
 		/**
-		 * Force to re-execute the query
-		 */
-		let this->_activeRow = false;
-
-		/**
 		 * Serialize the cache using the serialize function
 		 */
 		return serialize([
@@ -306,10 +290,13 @@ class Simple extends Resultset
 	/**
 	 * Unserializing a resultset will allow to only works on the rows present in the saved state
 	 */
-	public function unserialize(string! data)
+	public function unserialize(string! data) -> void
 	{
 		var resultset;
 
+		/**
+		* Enable fetch by array
+		*/
 		let this->_type = 0;
 
 		let resultset = unserialize(data);

--- a/unit-tests/ModelsResultsetTest.php
+++ b/unit-tests/ModelsResultsetTest.php
@@ -542,5 +542,116 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 
 		$this->assertFalse(isset($robots[0]));
 	}
+	
+	public function testResultsetAppendIterator()
+	{
+		if (!$this->_prepareTestMysql()) {
+			$this->markTestSkipped("Skipped");
+			return;
+		}
+		
+		// see http://php.net/manual/en/appenditerator.construct.php
+		$iterator = new \AppendIterator();
+		$robots_first = Robots::find(array('limit' => 2));
+		$robots_second = Robots::find(array('limit' => 1, 'offset' => 2));
+		
+		$robots_first_0 = $robots_first[0];
+		$robots_first_1 = $robots_first[1];
+		$robots_second_0 = $robots_second[0];
+		
+		$iterator->append($robots_first);
+		$iterator->append($robots_second);
+		
+		$iterator->rewind();
+		$this->assertTrue($iterator->valid());
+		$this->assertEquals($iterator->key(), 0);
+		$this->assertEquals($iterator->getIteratorIndex(), 0);
+		$this->assertEquals(get_class($iterator->current()), 'Robots');
+		$this->assertEquals($robots_first_0->name, $iterator->current()->name);
+		
+		$iterator->next();
+		$this->assertTrue($iterator->valid());
+		$this->assertEquals($iterator->key(), 1);
+		$this->assertEquals($iterator->getIteratorIndex(), 0);
+		$this->assertEquals(get_class($iterator->current()), 'Robots');
+		$this->assertEquals($robots_first_1->name, $iterator->current()->name);
+		
+		$iterator->next();
+		$this->assertTrue($iterator->valid());
+		$this->assertEquals($iterator->key(), 0);
+		$this->assertEquals($iterator->getIteratorIndex(), 1);
+		$this->assertEquals(get_class($iterator->current()), 'Robots');
+		$this->assertEquals($robots_second_0->name, $iterator->current()->name);
+		
+		$iterator->next();
+		$this->assertFalse($iterator->valid());
+	}
+	
+	public function testBigResultsetIteration() {
+		if (!$this->_prepareTestSqlite()) {
+			$this->markTestSkipped("Skipped");
+			return;
+		}
+
+		// Resultsets count > 25 use fetch for one row at a time
+		$personas = Personas::find(array(
+			'limit' => 33
+		));
+		
+		$this->assertEquals(count($personas), 33);
+		
+		// take first object as reference
+		$persona_first = $personas[0];
+		$this->assertEquals(get_class($persona_first), 'Personas');
+		
+		// make sure objects are the same -> object was not recreared
+		$this->assertSame($personas[0], $persona_first);
+		$this->assertSame($personas->current(), $persona_first);
+		$personas->rewind();
+		$this->assertTrue($personas->valid());
+		$this->assertSame($personas->current(), $persona_first);
+		
+		// second element
+		$personas->next();
+		$this->assertTrue($personas->valid());
+		$persona_second = $personas->current();
+		$this->assertSame($persona_second, $personas[1]);
+		
+		// move to last element
+		$this->assertSame($personas->getLast(), $personas[32]);
+		
+		// invalid element
+		$personas->seek(33);
+		$this->assertFalse($personas->valid());
+		$this->assertFalse($personas->current());
+		try {
+			$persona = $personas[33];
+			$this->assertFalse(true);
+		}
+		catch(Exception $e){
+			$this->assertEquals($e->getMessage(), 'The index does not exist in the cursor');
+		}
+		
+		// roll-back-cursor -> query needs to be reexecuted
+		// first object was now recreated... different instance, but equal content
+		$this->assertNotSame($personas[0], $persona_first);
+		$this->assertEquals($personas[0], $persona_first);
+		$persona_first = $personas[0];
+		
+		// toArray also re-executes the query and invalidates internal pointer
+		$array = $personas->toArray();
+		$this->assertEquals(count($array), 33);
+		
+		// internal query is re-executed again and set to first 
+		$this->assertNotSame($personas[0], $persona_first);
+		$this->assertEquals($personas[0], $persona_first);
+		
+		// move to second element and validate
+		$personas->next();
+		$this->assertTrue($personas->valid());
+		$this->assertEquals(get_class($personas[1]), 'Personas');
+		$this->assertSame($personas->current(), $personas[1]);
+		$this->assertEquals($persona_second, $personas[1]);
+	}
 
 }


### PR DESCRIPTION
The current resultset implementation does not work with appendIterator (added unit-test).

"valid()" must not move the cursor to the next position. Now: "next()" and "seek()" move the cursor and prepare the row for hydration. Hydration is handled in "current()" instead of "valid()".

It is now safe to call valid() and current() multiple times. current() keeps the activeRow in memory. See https://github.com/phalcon/cphalcon/issues/2502

Array access does not trigger re-execution if the same index is called multiple times or the index is ahead of current pointer:

``` php
$robots = Robots::find();
for($i = 0; $i < count($robots); ++$i) {
  echo $robots[$i]->name;
}
```

See https://github.com/phalcon/cphalcon/pull/10057
