### PR TITLE
[2.0.x] Cache docblock cleanup

### DIFF
--- a/phalcon/cache/backend.zep
+++ b/phalcon/cache/backend.zep
@@ -101,8 +101,6 @@ abstract class Backend
 
 	/**
 	 * Stops the frontend without store any cached content
-	 *
-	 * @param boolean stopBuffer
 	 */
 	public function stop(boolean stopBuffer = true) -> void
 	{
@@ -114,8 +112,6 @@ abstract class Backend
 
 	/**
 	 * Checks whether the last cache is fresh or cached
-	 *
-	 * @return boolean
 	 */
 	public function isFresh() -> boolean
 	{
@@ -124,8 +120,6 @@ abstract class Backend
 
 	/**
 	 * Checks whether the cache has starting buffering or not
-	 *
-	 * @return boolean
 	 */
 	public function isStarted() -> boolean
 	{

--- a/phalcon/cache/backend/apc.zep
+++ b/phalcon/cache/backend/apc.zep
@@ -195,9 +195,6 @@ class Apc extends Backend implements BackendInterface
 
 	/**
 	 * Deletes a value from the cache by its key
-	 *
-	 * @param string keyName
-	 * @return boolean
 	 */
 	public function delete(string! keyName) -> boolean
 	{
@@ -258,8 +255,6 @@ class Apc extends Backend implements BackendInterface
 
 	/**
  	 * Immediately invalidates all existing items.
- 	 *
-	 * @return boolean
 	 */
 	public function flush() -> boolean
 	{

--- a/phalcon/cache/backend/file.zep
+++ b/phalcon/cache/backend/file.zep
@@ -172,7 +172,7 @@ class File extends Backend implements BackendInterface
 	 * @param int lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(var keyName = null, var content = null, lifetime = null, stopBuffer = true) -> void
+	public function save(var keyName = null, var content = null, lifetime = null, boolean stopBuffer = true) -> void
 	{
 		var lastKey, frontend, cacheDir, isBuffering, cacheFile, cachedContent, preparedContent, status;
 
@@ -451,8 +451,6 @@ class File extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return boolean
 	 */
 	public function flush() -> boolean
 	{
@@ -483,8 +481,6 @@ class File extends Backend implements BackendInterface
 
 	/**
 	 * Return a file-system safe identifier for a given key
-	 *
-	 * @return string
 	 */
 	public function getKey(key) -> string
 	{

--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -91,8 +91,8 @@ class Libmemcached extends Backend implements BackendInterface
 	}
 
 	/**
-	* Create internal connection to memcached
-	*/
+	 * Create internal connection to memcached
+	 */
 	public function _connect()
 	{
 		var options, memcache, client, servers;
@@ -112,13 +112,11 @@ class Libmemcached extends Backend implements BackendInterface
 			throw new Exception("Cannot connect to Memcached server");
 		}
 
-		if isset options["client"] {
-			let client = options["client"];
-			if typeof client == "array" {
-				memcache->setOptions(client);
-			} else {
+		if fetch client, options["client"] {
+			if typeof client !== "array" {
 				throw new Exception("Client options must be instance of array");
 			}
+			memcache->setOptions(client);
 		}
 
 		let this->_memcache = memcache;
@@ -164,7 +162,7 @@ class Libmemcached extends Backend implements BackendInterface
 	 * @param long lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(keyName = null, content = null, lifetime = null, stopBuffer = true)
+	public function save(keyName = null, content = null, lifetime = null, boolean stopBuffer = true)
 	{
 		var lastKey, frontend, memcache, cachedContent, preparedContent, tmp, tt1, success, options,
 			specialKey, keys, isBuffering;
@@ -441,8 +439,6 @@ class Libmemcached extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return boolean
 	 */
 	public function flush() -> boolean
 	{

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -90,8 +90,8 @@ class Memcache extends Backend implements BackendInterface
 	}
 
 	/**
-	* Create internal connection to memcached
-	*/
+	 * Create internal connection to memcached
+	 */
 	public function _connect()
 	{
 		var options, memcache, persistent, success, host, port;
@@ -157,7 +157,7 @@ class Memcache extends Backend implements BackendInterface
 	 * @param long lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(var keyName = null, var content = null, var lifetime = null, var stopBuffer = true)
+	public function save(var keyName = null, var content = null, var lifetime = null, boolean stopBuffer = true)
 	{
 		var lastKey, frontend, memcache, cachedContent, preparedContent, tmp, ttl, success, options,
 			specialKey, keys, isBuffering;
@@ -221,10 +221,9 @@ class Memcache extends Backend implements BackendInterface
 
 		let options = this->_options;
 
-		if !isset options["statsKey"] {
+		if !fetch specialKey, options["statsKey"] {
 			throw new Exception("Unexpected inconsistency in options");
 		}
-		let specialKey = options["statsKey"];
 
 		if typeof specialKey != "null" {
 			/**
@@ -285,8 +284,8 @@ class Memcache extends Backend implements BackendInterface
 		}
 
 		/**
-		* Delete the key from memcached
-		*/
+		 * Delete the key from memcached
+		 */
 		let ret = memcache->delete(prefixedKey);
 		return ret;
 	}
@@ -315,8 +314,8 @@ class Memcache extends Backend implements BackendInterface
 		}
 
 		/**
-		* Get the key from memcached
-		*/
+		 * Get the key from memcached
+		 */
 		let realKey = [];
 		let keys = memcache->get(specialKey);
 		if typeof keys == "array" {
@@ -433,8 +432,6 @@ class Memcache extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return boolean
 	 */
 	public function flush() -> boolean
 	{

--- a/phalcon/cache/backend/memory.zep
+++ b/phalcon/cache/backend/memory.zep
@@ -83,7 +83,7 @@ class Memory extends Backend implements BackendInterface
 	 * @param long lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(var keyName = null, var content = null, lifetime = null, stopBuffer = true) -> void
+	public function save(var keyName = null, var content = null, lifetime = null, boolean stopBuffer = true) -> void
 	{
 		var lastKey, frontend, cachedContent, preparedContent, isBuffering;
 
@@ -266,8 +266,6 @@ class Memory extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return boolean
 	 */
 	public function flush() -> boolean
 	{

--- a/phalcon/cache/backend/mongo.zep
+++ b/phalcon/cache/backend/mongo.zep
@@ -141,7 +141,6 @@ class Mongo extends Backend implements BackendInterface
 		}
 
 		return mongoCollection;
-
 	}
 
 	/**
@@ -186,7 +185,7 @@ class Mongo extends Backend implements BackendInterface
 	 * @param long lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(keyName = null, content = null, lifetime = null, stopBuffer = true)
+	public function save(keyName = null, content = null, lifetime = null, boolean stopBuffer = true)
 	{
 		var lastkey, prefix, frontend, cachedContent, tmp, ttl,
 			collection, timestamp, conditions, document, preparedContent,
@@ -280,8 +279,8 @@ class Mongo extends Backend implements BackendInterface
 	 */
 	public function delete(keyName) -> boolean
 	{
-
 		this->_getCollection()->remove(["key": this->_prefix . keyName]);
+
 		if ((int) rand()) % 100 == 0 {
 			this->gc();
 		}
@@ -434,12 +433,9 @@ class Mongo extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return bool
 	 */
 	public function flush() -> boolean
 	{
-
 		this->_getCollection()->remove();
 
 		if (int) rand() % 100 == 0 {

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -91,8 +91,8 @@ class Redis extends Backend implements BackendInterface
 	}
 
 	/**
-	* Create internal connection to redis
-	*/
+	 * Create internal connection to redis
+	 */
 	public function _connect()
 	{
 		var options, redis, persistent, success, host, port, auth;
@@ -167,7 +167,7 @@ class Redis extends Backend implements BackendInterface
 	 * @param long lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(keyName = null, content = null, lifetime = null, stopBuffer = true)
+	public function save(keyName = null, content = null, lifetime = null, boolean stopBuffer = true)
 	{
 		var prefixedKey, lastKey, prefix, frontend, redis, cachedContent, preparedContent,
 			tmp, tt1, success, options, specialKey, isBuffering;
@@ -436,10 +436,8 @@ class Redis extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return boolean
 	 */
-	public function flush()
+	public function flush() -> boolean
 	{
 		var options, specialKey, redis, keys, key, lastKey;
 

--- a/phalcon/cache/backend/xcache.zep
+++ b/phalcon/cache/backend/xcache.zep
@@ -104,7 +104,7 @@ class Xcache extends Backend implements BackendInterface
 	 * @param long lifetime
 	 * @param boolean stopBuffer
 	 */
-	public function save(keyName = null, content = null, lifetime = null, stopBuffer = true)
+	public function save(keyName = null, content = null, lifetime = null, boolean stopBuffer = true)
 	{
 		var lastKey, frontend, cachedContent, preparedContent, tmp, tt1, success, isBuffering,
 			options, keys, specialKey;
@@ -131,8 +131,8 @@ class Xcache extends Backend implements BackendInterface
 		}
 
 		/**
-		* Take the lifetime from the frontend or read it from the set in start()
-		*/
+		 * Take the lifetime from the frontend or read it from the set in start()
+		 */
 		if !lifetime {
 			let tmp = this->_lastLifetime;
 			if !tmp {
@@ -215,7 +215,7 @@ class Xcache extends Backend implements BackendInterface
 	 * @param string prefix
 	 * @return array
 	 */
-	public function queryKeys(prefix = null)
+	public function queryKeys(prefix = null) -> array
 	{
 		var options, prefixed, specialKey, keys, retval, key, realKey;
 
@@ -257,7 +257,7 @@ class Xcache extends Backend implements BackendInterface
 	 * @param   long lifetime
 	 * @return boolean
 	 */
-	public function exists(var keyName = null, lifetime = null)
+	public function exists(var keyName = null, lifetime = null) -> boolean
 	{
 		var lastKey;
 
@@ -339,8 +339,6 @@ class Xcache extends Backend implements BackendInterface
 
 	/**
 	 * Immediately invalidates all existing items.
-	 *
-	 * @return boolean
 	 */
 	public function flush() -> boolean
 	{

--- a/phalcon/cache/backendinterface.zep
+++ b/phalcon/cache/backendinterface.zep
@@ -59,17 +59,13 @@ interface BackendInterface
 
 	/**
 	 * Checks whether the last cache is fresh or cached
-	 *
-	 * @return boolean
 	 */
-	public function isFresh();
+	public function isFresh() -> boolean;
 
 	/**
 	 * Checks whether the cache has starting buffering or not
-	 *
-	 * @return boolean
 	 */
-	public function isStarted();
+	public function isStarted() -> boolean;
 
 	/**
 	 * Sets the last key used in the cache

--- a/phalcon/cache/frontend/base64.zep
+++ b/phalcon/cache/frontend/base64.zep
@@ -73,10 +73,8 @@ class Base64 implements FrontendInterface
 
 	/**
 	 * Returns the cache lifetime
-	 *
-	 * @return integer
 	 */
-	public function getLifetime()
+	public function getLifetime() -> int
 	{
 		var options, lifetime;
 		let options = this->_frontendOptions;
@@ -90,8 +88,6 @@ class Base64 implements FrontendInterface
 
 	/**
 	 * Check whether if frontend is buffering output
-	 *
-	 * @return boolean
 	 */
 	public function isBuffering() -> boolean
 	{

--- a/phalcon/cache/frontend/data.zep
+++ b/phalcon/cache/frontend/data.zep
@@ -77,10 +77,8 @@ class Data implements FrontendInterface
 
 	/**
 	 * Returns the cache lifetime
-	 *
-	 * @return integer
 	 */
-	public function getLifetime()
+	public function getLifetime() -> int
 	{
 		var options, lifetime;
 		let options = this->_frontendOptions;
@@ -94,8 +92,6 @@ class Data implements FrontendInterface
 
 	/**
 	 * Check whether if frontend is buffering output
-	 *
-	 * @return boolean
 	 */
 	public function isBuffering() -> boolean
 	{

--- a/phalcon/cache/frontend/igbinary.zep
+++ b/phalcon/cache/frontend/igbinary.zep
@@ -76,10 +76,8 @@ class Igbinary extends Data implements FrontendInterface
 
 	/**
 	 * Returns the cache lifetime
-	 *
-	 * @return integer
 	 */
-	public function getLifetime()
+	public function getLifetime() -> int
 	{
 		var options, lifetime;
 		let options = this->_frontendOptions;
@@ -93,8 +91,6 @@ class Igbinary extends Data implements FrontendInterface
 
 	/**
 	 * Check whether if frontend is buffering output
-	 *
-	 * @return boolean
 	 */
 	public function isBuffering() -> boolean
 	{

--- a/phalcon/cache/frontend/json.zep
+++ b/phalcon/cache/frontend/json.zep
@@ -70,10 +70,8 @@ class Json implements FrontendInterface
 
 	/**
 	 * Returns the cache lifetime
-	 *
-	 * @return integer
 	 */
-	public function getLifetime()
+	public function getLifetime() -> int
 	{
 		var options, lifetime;
 		let options = this->_frontendOptions;
@@ -87,8 +85,6 @@ class Json implements FrontendInterface
 
 	/**
 	 * Check whether if frontend is buffering output
-	 *
-	 * @return boolean
 	 */
 	public function isBuffering() -> boolean
 	{

--- a/phalcon/cache/frontend/none.zep
+++ b/phalcon/cache/frontend/none.zep
@@ -62,8 +62,6 @@ class None implements FrontendInterface
 
 	/**
 	 * Returns cache lifetime, always one second expiring content
-	 *
-	 * @return int
 	 */
 	public function getLifetime() -> int
 	{
@@ -72,8 +70,6 @@ class None implements FrontendInterface
 
 	/**
 	 * Check whether if frontend is buffering output, always false
-	 *
-	 * @return boolean
 	 */
 	public function isBuffering() -> boolean
 	{

--- a/phalcon/cache/frontend/output.zep
+++ b/phalcon/cache/frontend/output.zep
@@ -88,10 +88,8 @@ class Output implements FrontendInterface
 
 	/**
 	 * Returns the cache lifetime
-	 *
-	 * @return integer
 	 */
-	public function getLifetime()
+	public function getLifetime() -> int
 	{
 		var options, lifetime;
 		let options = this->_frontendOptions;
@@ -105,8 +103,6 @@ class Output implements FrontendInterface
 
 	/**
 	 * Check whether if frontend is buffering output
-	 *
-	 * @return boolean
 	 */
 	public function isBuffering() -> boolean
 	{
@@ -129,7 +125,6 @@ class Output implements FrontendInterface
 	 */
 	public function getContent()
 	{
-
 		if this->_buffering {
 			return ob_get_contents();
 		}

--- a/phalcon/cache/frontendinterface.zep
+++ b/phalcon/cache/frontendinterface.zep
@@ -29,17 +29,13 @@ interface FrontendInterface
 
 	/**
 	 * Returns the cache lifetime
-	 *
-	 * @return int
 	 */
-	public function getLifetime();
+	public function getLifetime() -> int;
 
 	/**
 	 * Check whether if frontend is buffering output
-	 *
-	 * @return boolean
 	 */
-	public function isBuffering();
+	public function isBuffering() -> boolean;
 
 	/**
 	 * Starts the frontend

--- a/phalcon/cache/multiple.zep
+++ b/phalcon/cache/multiple.zep
@@ -17,7 +17,6 @@
  +------------------------------------------------------------------------+
  */
 
-
 namespace Phalcon\Cache;
 
 use Phalcon\Cache\Exception;
@@ -88,7 +87,7 @@ class Multiple
 	}
 
 	/**
-	 * Adds a backend		 
+	 * Adds a backend
 	 */
 	public function push(<BackendInterface> backend) -> <Multiple>
 	{


### PR DESCRIPTION
`\Phalcon\Cache\Backend\Libmemcached::_connect()` and `\Phalcon\Cache\Backend\Memcache::save()` now also make use of Zephir's `fetch`.
