### PR TITLE
Check array key exists before accessing. Support mysql double column types

### DIFF
--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -103,6 +103,13 @@ class Column implements ColumnInterface
 	const TYPE_BOOLEAN = 8;
 
 	/**
+	 * Double abstract data type
+	 *
+	 */
+	const TYPE_DOUBLE = 9;
+	
+	
+	/**
 	 * Bind Type Null
 	 */
 	const BIND_PARAM_NULL = 0;
@@ -291,7 +298,7 @@ class Column implements ColumnInterface
 		 * Check if the column has a decimal scale
 		 */
 		if fetch scale, definition["scale"] {
-			if type == self::TYPE_INTEGER || type == self::TYPE_FLOAT || type == self::TYPE_DECIMAL {
+			if type == self::TYPE_INTEGER || type == self::TYPE_FLOAT || type == self::TYPE_DECIMAL || type == self::TYPE_DOUBLE {
 				let this->_scale = scale;
 			} else {
 				throw new Exception("Column type does not support scale parameter");

--- a/phalcon/db/dialect.zep
+++ b/phalcon/db/dialect.zep
@@ -361,20 +361,22 @@ abstract class Dialect
 				/**
 				 * Escape column name
 				 */
+                                if isset column[0] {
 				let columnItem = column[0];
-				if typeof columnItem == "array" {
-					let columnSql = this->getSqlExpression(columnItem, escapeChar);
-				} else {
-					if columnItem == "*" {
-						let columnSql = columnItem;
+					if typeof columnItem == "array" {
+						let columnSql = this->getSqlExpression(columnItem, escapeChar);
 					} else {
-						if globals_get("db.escape_identifiers") {
-							let columnSql = escapeChar . columnItem . escapeChar;
-						} else {
+						if columnItem == "*" {
 							let columnSql = columnItem;
+						} else {
+							if globals_get("db.escape_identifiers") {
+								let columnSql = escapeChar . columnItem . escapeChar;
+							} else {
+								let columnSql = columnItem;
+							}
 						}
 					}
-				}
+                                }
 
 				/**
 				 * Escape column domain


### PR DESCRIPTION
Hello,
I ran into a few issues when porting a 1.3.x project to 2. I was hoping you could include the following changes. 

1) Check array key exists before accessing. 
2) Support mysql double column types
