### PR TITLE
[2.0.x] [BUG] fixed compatibility with 1.3.x

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3978,12 +3978,6 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	{
 		var modelName, manager, lowerProperty, relation, result, method;
 
-		let method = "get" . ucfirst(property);
-
-		if method_exists(this, method) {
-			return this->{method}();
-		}
-
 		let modelName = get_class(this),
 			manager = this->getModelsManager(),
 			lowerProperty = strtolower(property);
@@ -4021,6 +4015,15 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 			}
 
 			return result;
+		}
+
+		/**
+		 * Check if the property has a the getters
+		 */
+		let method = "get" . ucfirst(property);
+
+		if method_exists(this, method) {
+			return this->{method}();
 		}
 
 		/**


### PR DESCRIPTION
This fixes bug, when the method returns NULL always:

```
class SomeModel extend Phalcon\Mvc\Model
{
    /**
     * @return string
     */
    public function getManufacturer()
    {
        if ($manufacturer = $this->manufacturer) {
            return $manufacturer->name;
        } else {
            return null;
        }
    }

    public function initialize()
    {
        $this->belongsTo('manufacturer_id', 'App\Models\Manufacturer', 'id', [
            'alias'    => 'manufacturer',
            'reusable' => true
        ]);
    }
}
```
