### PR TITLE
Reenabling disabled unit tests

### DIFF
--- a/tests/unit/Phalcon/Assets/AssetsFilterTest.php
+++ b/tests/unit/Phalcon/Assets/AssetsFilterTest.php
@@ -273,19 +273,31 @@ class AssetsFilterTest extends TBase
                 expect($actual)->equals($expected);
             }
         );
-//        //Enabling join
-//        $js->join(true);
-//        $this->assertEquals($assets->outputJs('js'), '<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' . PHP_EOL);
-//
-//        //Disabling join
-//        $js->join(false);
-//        $this->assertEquals($assets->outputJs('js'), '<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' . PHP_EOL);
-//
-//        //Filter - Join
-//        $js->join(false);
-//        $js->addFilter(new Phalcon\Assets\Filters\None());
-//        $this->assertEquals($assets->outputJs('js'), '<script type="text/javascript" src="/unit-tests/assets/jquery.js"></script>' . PHP_EOL);
 
+		//Enabling join
+		$js->join(true);
+		$this->assertEquals(
+			$assets->outputJs('js'),
+			'<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' . 
+			PHP_EOL
+		);
+
+		//Disabling join
+		$js->join(false);
+		$this->assertEquals(
+			$assets->outputJs('js'),
+			'<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' .
+			PHP_EOL
+		);
+
+		//Filter - Join
+		$js->join(false);
+		$js->addFilter(new Phalcon\Assets\Filters\None());
+		$this->assertEquals(
+			$assets->outputJs('js'),
+			'<script type="text/javascript" src="/unit-tests/assets/jquery.js"></script>' .
+			PHP_EOL
+		);
     }
 
     public function testFilterSimpleJoin()

--- a/tests/unit/Phalcon/Assets/AssetsFilterTest.php
+++ b/tests/unit/Phalcon/Assets/AssetsFilterTest.php
@@ -274,30 +274,30 @@ class AssetsFilterTest extends TBase
             }
         );
 
-		//Enabling join
-		$js->join(true);
-		$this->assertEquals(
-			$assets->outputJs('js'),
-			'<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' . 
-			PHP_EOL
-		);
+	//Enabling join
+	$js->join(true);
+	$this->assertEquals(
+		$assets->outputJs('js'),
+		'<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' . 
+		PHP_EOL
+	);
 
-		//Disabling join
-		$js->join(false);
-		$this->assertEquals(
-			$assets->outputJs('js'),
-			'<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' .
-			PHP_EOL
-		);
+	//Disabling join
+	$js->join(false);
+	$this->assertEquals(
+		$assets->outputJs('js'),
+		'<script type="text/javascript" src="unit-tests/assets/jquery.js"></script>' .
+		PHP_EOL
+	);
 
-		//Filter - Join
-		$js->join(false);
-		$js->addFilter(new Phalcon\Assets\Filters\None());
-		$this->assertEquals(
-			$assets->outputJs('js'),
-			'<script type="text/javascript" src="/unit-tests/assets/jquery.js"></script>' .
-			PHP_EOL
-		);
+	//Filter - Join
+	$js->join(false);
+	$js->addFilter(new Phalcon\Assets\Filters\None());
+	$this->assertEquals(
+		$assets->outputJs('js'),
+		'<script type="text/javascript" src="/unit-tests/assets/jquery.js"></script>' .
+		PHP_EOL
+	);
     }
 
     public function testFilterSimpleJoin()

--- a/tests/unit/Phalcon/Escaper/EscaperTest.php
+++ b/tests/unit/Phalcon/Escaper/EscaperTest.php
@@ -242,7 +242,7 @@ class EscaperTest extends TBase
                           . '\3f c\3d d\26 e\3d f\27 \29 \3b \20 \7d ';
                 $actual   = $escaper->escapeCss($source);
 
-                //expect($actual)->equals($expected);
+                expect($actual)->equals($expected);
 
             }
         );

--- a/tests/unit/Phalcon/Version/VersionTest.php
+++ b/tests/unit/Phalcon/Version/VersionTest.php
@@ -185,12 +185,19 @@ class VersionTest extends CdTest
      */
     public function testVersionGetPart()
     {
+        /*
+         * Note: getId() returns a version string in the format ABBCCDE
+         * where A is the major version, BB is the medium version (2 digits)
+         * CC is the minor version (2 digits), D is the release type (see Phalcon\Version)
+         * and E is the release number (for example 2 for RC2)
+         */
+
         $this->specify(
             "getPart(VERSION_MAJOR) does not return the correct result",
             function () {
 
                 $id       = PhTVersion::getId();
-                $expected = intval($id[PhTVersion::VERSION_MAJOR]);
+                $expected = intval($id[0]); //The major version is the first digit
                 $actual   = PhTVersion::getPart(PhTVersion::VERSION_MAJOR);
 
                 expect($actual)->equals($expected);
@@ -201,7 +208,7 @@ class VersionTest extends CdTest
             "getPart(VERSION_MEDIUM) does not return the correct result",
             function () {
                 $id       = PhTVersion::getId();
-                $expected = intval($id[PhTVersion::VERSION_MEDIUM]);
+                $expected = intval($id[1].$id[2]); //The medium version is the second and third digits
                 $actual   = PhTVersion::getPart(PhTVersion::VERSION_MEDIUM);
 
                 expect($actual)->equals($expected);
@@ -212,7 +219,7 @@ class VersionTest extends CdTest
             "getPart(VERSION_MINOR) does not return the correct result",
             function () {
                 $id       = PhTVersion::getId();
-                $expected = intval($id[PhTVersion::VERSION_MINOR]);
+                $expected = intval($id[3].$id[4]); //The minor version is the fourth and fifth digits
                 $actual   = PhTVersion::getPart(PhTVersion::VERSION_MINOR);
 
                 expect($actual)->equals($expected);

--- a/tests/unit/Phalcon/Version/VersionTest.php
+++ b/tests/unit/Phalcon/Version/VersionTest.php
@@ -208,7 +208,7 @@ class VersionTest extends CdTest
             }
         );
 
-        /*$this->specify(
+        $this->specify(
             "getPart(VERSION_MINOR) does not return the correct result",
             function () {
                 $id       = PhTVersion::getId();
@@ -217,7 +217,7 @@ class VersionTest extends CdTest
 
                 expect($actual)->equals($expected);
             }
-        );*/
+        );
 
         $this->specify(
             "getPart(VERSION_SPECIAL) does not return the correct result",
@@ -230,7 +230,7 @@ class VersionTest extends CdTest
             }
         );
 
-        /*$this->specify(
+        $this->specify(
             "getPart(VERSION_SPECIAL_NUMBER) does not return the correct result",
             function () {
                 $id       = PhTVersion::getId();
@@ -240,7 +240,7 @@ class VersionTest extends CdTest
 
                 expect($actual)->equals($expected);
             }
-        );*/
+        );
 
         $this->specify(
             "getPart() with incorrect parameters does not return get()",

--- a/tests/unit/Phalcon/Version/VersionTest.php
+++ b/tests/unit/Phalcon/Version/VersionTest.php
@@ -242,7 +242,7 @@ class VersionTest extends CdTest
             function () {
                 $id       = PhTVersion::getId();
                 $special  = $this->numberToSpecial($id[5]);
-                $expected = ($special) ? $id[6] : '';
+                $expected = ($special) ? $id[6] : 0;
                 $actual   = PhTVersion::getPart(PhTVersion::VERSION_SPECIAL_NUMBER);
 
                 expect($actual)->equals($expected);


### PR DESCRIPTION
This commit:
- enables disabled tests in the asset filter
- fixes and reenables the version tests
- reenables an escaper test
