### PR TITLE
[2.0.x] Phalcon\Image\Adapter::resize uses Phalcon\Image::AUTO as default

### DIFF
--- a/phalcon/image/adapter.zep
+++ b/phalcon/image/adapter.zep
@@ -73,7 +73,7 @@ abstract class Adapter
  	 * Resize the image to the given size
  	 */
 	//Phalcon\Image::AUTO
-	public function resize(int width = null, int height = null, int master = 7) -> <Adapter>
+	public function resize(int width = null, int height = null, int master = Image::AUTO) -> <Adapter>
 	{
 		var ratio;
 


### PR DESCRIPTION
Phalcon\Image\Adapter::resize uses Phalcon\Image::AUTO as default _master_ parameter
