### PR TITLE
Fixing wrong namespace in docblock

### DIFF
--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -80,7 +80,7 @@ class Di implements DiInterface
 	/**
 	 * Events Manager
 	 *
-	 * @var Phalcon\Events\ManagerInterface
+	 * @var \Phalcon\Events\ManagerInterface
 	 */
 	protected _eventsManager;
 


### PR DESCRIPTION
Fixed phalcon/phalcon-devtools#333
