### PR TITLE
[2.0.x] Throw exceptions first

### DIFF
--- a/phalcon/events/event.zep
+++ b/phalcon/events/event.zep
@@ -89,11 +89,11 @@ class Event
 	 */
 	public function stop() -> void
 	{
-		if this->_cancelable {
-			let this->_stopped = true;
-		} else {
+		if !this->_cancelable {
 			throw new Exception("Trying to cancel a non-cancelable event");
 		}
+
+		let this->_stopped = true;
 	}
 
 	/**

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -427,11 +427,11 @@ class Request implements RequestInterface, InjectionAwareInterface
 		var rawBody;
 
 		let rawBody = this->getRawBody();
-		if typeof rawBody == "string" {
-			return json_decode(rawBody, associative);
+		if typeof rawBody != "string" {
+			return false;
 		}
 
-		return false;
+		return json_decode(rawBody, associative);
 	}
 
 	/**

--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -284,10 +284,11 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 	 */
 	public function readAttribute(string! attribute)
 	{
-		if isset this->{attribute} {
-			return this->{attribute};
+		if !isset this->{attribute} {
+			return null;
 		}
-		return null;
+
+		return this->{attribute};
 	}
 
 	/**
@@ -405,14 +406,15 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 			documentsCursor->rewind();
 
 			let document = documentsCursor->current();
-			if typeof document == "array" {
 
-				/**
-				 * Assign the values to the base object
-				 */
-				return self::cloneResult(base, document);
+			if typeof document != "array" {
+				return false;
 			}
-			return false;
+
+			/**
+			 * Assign the values to the base object
+			 */
+			return self::cloneResult(base, document);
 		}
 
 		/**
@@ -762,29 +764,29 @@ abstract class Collection implements CollectionInterface, InjectionAwareInterfac
 	{
 		var id, mongoId;
 
-		if fetch id, this->_id {
+		if !fetch id, this->_id {
+			return false;
+		}
 
-			if typeof id == "object" {
-				let mongoId = id;
-			} else {
-
-				/**
-				 * Check if the model use implicit ids
-				 */
-				if this->_modelsManager->isUsingImplicitObjectIds(this) {
-					let mongoId = new \MongoId(id);
-					let this->_id = mongoId;
-				} else {
-					let mongoId = id;
-				}
-			}
+		if typeof id == "object" {
+			let mongoId = id;
+		} else {
 
 			/**
-			 * Perform the count using the function provided by the driver
+			 * Check if the model use implicit ids
 			 */
-			return collection->count(["_id": mongoId]) > 0;
+			if this->_modelsManager->isUsingImplicitObjectIds(this) {
+				let mongoId = new \MongoId(id);
+				let this->_id = mongoId;
+			} else {
+				let mongoId = id;
+			}
 		}
-		return false;
+
+		/**
+		 * Perform the count using the function provided by the driver
+		 */
+		return collection->count(["_id": mongoId]) > 0;
 	}
 
 	/**

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3121,10 +3121,11 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	 */
 	public function readAttribute(string! attribute)
 	{
-		if isset this->{attribute} {
-			return this->{attribute};
+		if !isset this->{attribute} {
+			return null;
 		}
-		return null;
+
+		return this->{attribute};
 	}
 
 	/**
@@ -3468,10 +3469,8 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	{
 		var snapshot;
 		let snapshot = this->_snapshot;
-		if typeof snapshot == "array" {
-			return true;
-		}
-		return false;
+
+		return typeof snapshot == "array";
 	}
 
 	/**

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -742,20 +742,19 @@ class Query implements QueryInterface, InjectionAwareInterface
 	{
 		var modelName, model, source, schema;
 
-		if fetch modelName, qualifiedName["name"] {
-
-			let model = manager->load(modelName),
-				source = model->getSource(),
-				schema = model->getSchema();
-
-			if schema {
-				return [schema, source];
-			}
-
-			return source;
+		if !fetch modelName, qualifiedName["name"] {
+			throw new Exception("Corrupted SELECT AST");
 		}
 
-		throw new Exception("Corrupted SELECT AST");
+		let model = manager->load(modelName),
+			source = model->getSource(),
+			schema = model->getSchema();
+
+		if schema {
+			return [schema, source];
+		}
+
+		return source;
 	}
 
 	/**

--- a/phalcon/mvc/model/query/status.zep
+++ b/phalcon/mvc/model/query/status.zep
@@ -78,10 +78,10 @@ class Status implements StatusInterface
 	{
 		var model;
 		let model = this->_model;
-		if typeof model == "object" {
-			return model->getMessages();
+		if typeof model != "object" {
+			return [];
 		}
-		return [];
+		return model->getMessages();
 	}
 
 	/**


### PR DESCRIPTION
In other words, the methods return the typical use case at the very end of the method and all exceptions are caught before.

For example, instead of this:

``` zephir
public function stop() -> void
{
    if this->_cancelable {
        let this->_stopped = true;
    } else {
        throw new Exception("Trying to cancel a non-cancelable event");
    }
}
```

... do this:

``` zephir
public function stop() -> void
{
    if !this->_cancelable {
        throw new Exception("Trying to cancel a non-cancelable event");
    }

    let this->_stopped = true;
 }

```
