### PR TITLE
[2.0.x] Model\Resultset: Bugfix for seek(position > 0) operations on plain resultset

### DIFF
--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -148,15 +148,16 @@ abstract class Resultset
 					if this->_row === null || this->_pointer > position {
 						result->dataSeek(position);
 						let this->_row = result->$fetch(result);
-					}
-					/**
-					* Requested postion is greater than current pointer,
-					* seek forward until the requested position is reached.
-					* We do not need to re-excute the query!
-					*/
-					while this->_pointer < position {
-						let this->_row = result->$fetch(result);
-						let this->_pointer++;
+					} else {
+						/**
+						* Requested postion is greater than current pointer,
+						* seek forward until the requested position is reached.
+						* We do not need to re-excute the query!
+						*/
+						while this->_pointer < position {
+							let this->_row = result->$fetch(result);
+							let this->_pointer++;
+						}
 					}
 				}
 				

--- a/unit-tests/ModelsResultsetTest.php
+++ b/unit-tests/ModelsResultsetTest.php
@@ -566,21 +566,21 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 0);
 		$this->assertEquals($iterator->getIteratorIndex(), 0);
-		$this->assertInstanceOf(Robots::class, $iterator->current());
+		$this->assertEquals(get_class($iterator->current()), 'Robots');
 		$this->assertEquals($robots_first_0->name, $iterator->current()->name);
 		
 		$iterator->next();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 1);
 		$this->assertEquals($iterator->getIteratorIndex(), 0);
-		$this->assertInstanceOf(Robots::class, $iterator->current());
+		$this->assertEquals(get_class($iterator->current()), 'Robots');
 		$this->assertEquals($robots_first_1->name, $iterator->current()->name);
 		
 		$iterator->next();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 0);
 		$this->assertEquals($iterator->getIteratorIndex(), 1);
-		$this->assertInstanceOf(Robots::class, $iterator->current());
+		$this->assertEquals(get_class($iterator->current()), 'Robots');
 		$this->assertEquals($robots_second_0->name, $iterator->current()->name);
 		
 		$iterator->next();
@@ -600,11 +600,11 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		
 		$this->assertEquals(count($personas), 33);
 		
-		$this->assertInstanceOf(Personas::class, $personas->getLast());
+		$this->assertEquals(get_class($personas->getLast()), 'Personas');
 		
 		// take first object as reference
 		$persona_first = $personas[0];
-		$this->assertInstanceOf(Personas::class, $persona_first);
+		$this->assertEquals(get_class($persona_first), 'Personas');
 		
 		// make sure objects are the same -> object was not recreared
 		$this->assertSame($personas[0], $persona_first);
@@ -651,13 +651,13 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		// move to second element and validate
 		$personas->next();
 		$this->assertTrue($personas->valid());
-		$this->assertInstanceOf(Personas::class, $personas[1]);
+		$this->assertEquals(get_class($personas[1]), 'Personas');
 		$this->assertSame($personas->current(), $personas[1]);
 		$this->assertEquals($persona_second, $personas[1]);
 		
 		// pick some random indices
-		$this->assertInstanceOf(Personas::class, $personas[12]);
-		$this->assertInstanceOf(Personas::class, $personas[23]);
-		$this->assertInstanceOf(Personas::class, $personas[23]);
+		$this->assertEquals(get_class($personas[12]), 'Personas');
+		$this->assertEquals(get_class($personas[23]), 'Personas');
+		$this->assertEquals(get_class($personas[23]), 'Personas');
 	}
 }

--- a/unit-tests/ModelsResultsetTest.php
+++ b/unit-tests/ModelsResultsetTest.php
@@ -566,21 +566,21 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 0);
 		$this->assertEquals($iterator->getIteratorIndex(), 0);
-		$this->assertEquals(get_class($iterator->current()), 'Robots');
+		$this->assertInstanceOf(Robots::class, $iterator->current());
 		$this->assertEquals($robots_first_0->name, $iterator->current()->name);
 		
 		$iterator->next();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 1);
 		$this->assertEquals($iterator->getIteratorIndex(), 0);
-		$this->assertEquals(get_class($iterator->current()), 'Robots');
+		$this->assertInstanceOf(Robots::class, $iterator->current());
 		$this->assertEquals($robots_first_1->name, $iterator->current()->name);
 		
 		$iterator->next();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 0);
 		$this->assertEquals($iterator->getIteratorIndex(), 1);
-		$this->assertEquals(get_class($iterator->current()), 'Robots');
+		$this->assertInstanceOf(Robots::class, $iterator->current());
 		$this->assertEquals($robots_second_0->name, $iterator->current()->name);
 		
 		$iterator->next();
@@ -600,9 +600,11 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		
 		$this->assertEquals(count($personas), 33);
 		
+		$this->assertInstanceOf(Personas::class, $personas->getLast());
+		
 		// take first object as reference
 		$persona_first = $personas[0];
-		$this->assertEquals(get_class($persona_first), 'Personas');
+		$this->assertInstanceOf(Personas::class, $persona_first);
 		
 		// make sure objects are the same -> object was not recreared
 		$this->assertSame($personas[0], $persona_first);
@@ -649,9 +651,13 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		// move to second element and validate
 		$personas->next();
 		$this->assertTrue($personas->valid());
-		$this->assertEquals(get_class($personas[1]), 'Personas');
+		$this->assertInstanceOf(Personas::class, $personas[1]);
 		$this->assertSame($personas->current(), $personas[1]);
 		$this->assertEquals($persona_second, $personas[1]);
+		
+		// pick some random indices
+		$this->assertInstanceOf(Personas::class, $personas[12]);
+		$this->assertInstanceOf(Personas::class, $personas[23]);
+		$this->assertInstanceOf(Personas::class, $personas[23]);
 	}
-
 }


### PR DESCRIPTION
Bugfix for seek(position > 0) operations if seek(0) was not called before and rolling pointers are in use. Covered now by unit-test. See #10100 

Example: $personas->getLast()

``` php
$personas = Personas::find());
$this->assertInstanceOf(Personas::class, $personas->getLast());
```
