### PR TITLE
[2.0.x] The Mvc Router no longer chops off the first character of the params

### DIFF
--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -583,10 +583,14 @@ class Router implements InjectionAwareInterface, RouterInterface
 			 * Check for parameters
 			 */
 			if fetch paramsStr, parts["params"] {
-				let strParams = substr(paramsStr, 1);
-				if strParams {
-					let params = explode("/", strParams);
+				if typeof paramsStr == "string" {
+					let strParams = trim(paramsStr, "/");
+
+					if strParams {
+						let params = explode("/", strParams);
+					}
 				}
+
 				unset parts["params"];
 			}
 


### PR DESCRIPTION
See http://forum.phalconphp.com/discussion/6655/route-notfound-setting-params-error
