### PR TITLE
[2.0.x] Flash\Session::getMessages('key') now returns an empty array if there are no 'key' messages (fixes #10279)

### DIFF
--- a/phalcon/flash/session.zep
+++ b/phalcon/flash/session.zep
@@ -138,6 +138,8 @@ class Session extends \Phalcon\Flash implements FlashInterface, InjectionAwareIn
 			if typeof type == "string" {
 				if fetch returnMessages, messages[type] {
 					return returnMessages;
+				} else {
+					return [];
 				}
 			}
 			return messages;


### PR DESCRIPTION
Fixes #10279. This is also effectively a _resubmission_ of #920.
