### PR TITLE
[2.0.x] Fix duplicated code and incorrect dispatcher behaviour introduced in #10168

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -352,26 +352,11 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 			let this->_finished = true;
 
-			// If the current namespace is null we used the set in this->_defaultNamespace
+			this->_resolveEmptyProperties();
+
 			let namespaceName = this->_namespaceName;
-			if !namespaceName {
-				let namespaceName = this->_defaultNamespace;
-				let this->_namespaceName = namespaceName;
-			}
-
-			// If the handler is null we use the set in this->_defaultHandler
 			let handlerName = this->_handlerName;
-			if !handlerName {
-				let handlerName = this->_defaultHandler;
-				let this->_handlerName = handlerName;
-			}
-
-			// If the action is null we use the set in this->_defaultAction
 			let actionName = this->_actionName;
-			if !actionName {
-				let actionName = this->_defaultAction;
-				let this->_actionName = actionName;
-			}
 
 			// Calling beforeDispatch
 			if typeof eventsManager == "object" {
@@ -653,19 +638,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	{
 		var camelizedClass;
 
-		/**
-		 * If the current namespace is null we used the set in default namespace
-		 */
-		if !this->_namespaceName {
-			let this->_namespaceName = this->_defaultNamespace;
-		}
-
-		/**
-		 * If the handler is null we use the set in default handler
-		 */
-		if !this->_handlerName {
-			let this->_handlerName = this->_defaultHandler;
-		}
+		this->_resolveEmptyProperties();
 
 		/**
 		 * We don't camelize the classes if they are in namespaces
@@ -688,5 +661,26 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		}
 
 		return camelizedClass . this->_handlerSuffix;
+	}
+
+	/**
+	 * Set empty properties to their defaults (where defaults are available)
+	 */
+	protected function _resolveEmptyProperties() -> void
+	{
+		// If the current namespace is null we used the set in this->_defaultNamespace
+		if !this->_namespaceName {
+			let this->_namespaceName = this->_defaultNamespace;
+		}
+
+		// If the handler is null we use the set in this->_defaultHandler
+		if !this->_handlerName {
+			let this->_handlerName = this->_defaultHandler;
+		}
+
+		// If the action is null we use the set in this->_defaultAction
+		if !this->_actionName {
+			let this->_actionName = this->_defaultAction;
+		}
 	}
 }

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -313,7 +313,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		boolean hasService;
 		int numberDispatches;
 		var value, handler, dependencyInjector, namespaceName, handlerName,
-			actionName, camelizedClass, params, eventsManager,
+			actionName, params, eventsManager,
 			handlerSuffix, actionSuffix, handlerClass, status, actionMethod,
 			wasFresh = false, e;
 
@@ -357,6 +357,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			let namespaceName = this->_namespaceName;
 			let handlerName = this->_handlerName;
 			let actionName = this->_actionName;
+			let handlerClass = this->getHandlerClass();
 
 			// Calling beforeDispatch
 			if typeof eventsManager == "object" {
@@ -369,24 +370,6 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 				if this->_finished === false {
 					continue;
 				}
-			}
-
-			// We don't camelize the classes if they are in namespaces
-			if !memstr(handlerName, "\\") {
-				let camelizedClass = camelize(handlerName);
-			} else {
-				let camelizedClass = handlerName;
-			}
-
-			// Create the complete controller class name prepending the namespace
-			if namespaceName {
-				if ends_with(namespaceName, "\\") {
-					let handlerClass = namespaceName . camelizedClass . handlerSuffix;
-				} else {
-					let handlerClass = namespaceName . "\\" . camelizedClass . handlerSuffix;
-				}
-			} else {
-				let handlerClass = camelizedClass . handlerSuffix;
 			}
 
 			// Handlers are retrieved as shared instances from the Service Container
@@ -636,31 +619,34 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	 */
 	public function getHandlerClass() -> string
 	{
-		var camelizedClass;
+		var handlerSuffix, handlerName, namespaceName,
+			camelizedClass, handlerClass;
 
 		this->_resolveEmptyProperties();
 
-		/**
-		 * We don't camelize the classes if they are in namespaces
-		 */
-		if substr(this->_handlerName, 0, 1) === "\\" {
-			let camelizedClass = this->_handlerName;
+		let handlerSuffix = this->_handlerSuffix,
+			handlerName = this->_handlerName,
+			namespaceName = this->_namespaceName;
+
+		// We don't camelize the classes if they are in namespaces
+		if !memstr(handlerName, "\\") {
+			let camelizedClass = camelize(handlerName);
 		} else {
-			let camelizedClass = substr(this->_handlerName, 1);
+			let camelizedClass = handlerName;
 		}
 
-		/**
-		 * Create the complete controller class name prepending the namespace
-		 */
-		if this->_namespaceName {
-			if substr(this->_namespaceName, -1) === "\\" {
-				return this->_namespaceName . camelizedClass . this->_handlerSuffix;
+		// Create the complete controller class name prepending the namespace
+		if namespaceName {
+			if ends_with(namespaceName, "\\") {
+				let handlerClass = namespaceName . camelizedClass . handlerSuffix;
 			} else {
-				return this->_namespaceName . "\\" . camelizedClass . this->_handlerSuffix;
+				let handlerClass = namespaceName . "\\" . camelizedClass . handlerSuffix;
 			}
+		} else {
+			let handlerClass = camelizedClass . handlerSuffix;
 		}
 
-		return camelizedClass . this->_handlerSuffix;
+		return handlerClass;
 	}
 
 	/**

--- a/unit-tests/DispatcherMvcTest.php
+++ b/unit-tests/DispatcherMvcTest.php
@@ -196,4 +196,46 @@ class DispatcherMvcTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($value, 'index');
 	}
 
+	public function testGetControllerClass()
+	{
+		Phalcon\DI::reset();
+
+		$di = new Phalcon\DI();
+
+		$dispatcher = new Phalcon\Mvc\Dispatcher();
+		$dispatcher->setDI($di);
+
+		$di->set('dispatcher', $dispatcher);
+
+		// With namespace
+		$dispatcher->setNamespaceName('Foo\Bar');
+		$dispatcher->setControllerName('test');
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals($value, 'Foo\Bar\TestController');
+
+		// Without namespace
+		$dispatcher->setNamespaceName(null);
+		$dispatcher->setControllerName('Test');
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals('TestController', $value);
+	}
+
+	public function testDefaultsResolve()
+	{
+		Phalcon\DI::reset();
+		$di = new Phalcon\DI();
+
+		$dispatcher = new Phalcon\Mvc\Dispatcher();
+		$dispatcher->setDI($di);
+
+		$di->set('dispatcher', $dispatcher);
+
+		$dispatcher->setDefaultNamespace('Foo');
+
+		$value = $dispatcher->getControllerClass();
+		$this->assertEquals('Foo\IndexController', $value);
+	}
+
 }

--- a/unit-tests/DispatcherMvcTest.php
+++ b/unit-tests/DispatcherMvcTest.php
@@ -161,7 +161,7 @@ class DispatcherMvcTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($value, "hello");
 
 		$value = $dispatcher->getControllerClass();
-		$this->assertEquals($value, "est7Controller");
+		$this->assertEquals($value, "Test7Controller");
 	}
 
 	public function testDispatcherForward()


### PR DESCRIPTION
This refactors out duplicate code introduced in #10168 and fixes the `Dispatcher::getHandlerClass` method that was returning a broken value (first character of class name missing):

```
1) DispatcherMvcTest::testDispatcher
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'IndexController handler class cannot be loaded'
+'ndexController handler class cannot be loaded'

2) DispatcherMvcTest::testGetControllerClass
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Foo\Bar\estController'
+'Foo\Bar\TestController'

3) DispatcherMvcTest::testDefaultsResolve
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'Foo\IndexController'
+'Foo\ndexController'
```
