### PR TITLE
[2.0.x] Mvc\Micro\Collection::map() now returns this

### DIFF
--- a/phalcon/mvc/micro/collection.zep
+++ b/phalcon/mvc/micro/collection.zep
@@ -140,7 +140,8 @@ class Collection implements CollectionInterface
 	 */
 	public function map(string! routePattern, var handler, var name = null) -> <Collection>
 	{
-		return this->_addMap(null, routePattern, handler, name);
+		this->_addMap(null, routePattern, handler, name);
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
Previously returned `this` in [1.3.4](https://github.com/phalcon/cphalcon/blob/1.3.4/ext/mvc/micro/collection.c#L258) as do [`get()`](https://github.com/phalcon/cphalcon/blob/2.0.x/phalcon/mvc/micro/collection.zep#L157), [`post()`](https://github.com/phalcon/cphalcon/blob/2.0.x/phalcon/mvc/micro/collection.zep#L171), _et cetera_.

See also https://github.com/phalcon/cphalcon/issues/10296#issuecomment-100293384
