### PR TITLE
[2.0.x] Fix micro collection

### DIFF
--- a/phalcon/mvc/micro/collection.zep
+++ b/phalcon/mvc/micro/collection.zep
@@ -140,7 +140,8 @@ class Collection implements CollectionInterface
 	 */
 	public function map(string! routePattern, var handler, var name = null) -> <Collection>
 	{
-		return this->_addMap(null, routePattern, handler, name);
+		this->_addMap(null, routePattern, handler, name);
+		return this;
 	}
 
 	/**


### PR DESCRIPTION
The return is meant to be an instance of Collection, however since
_addMap does not return anything it was NULL instead.
