### PR TITLE
[2.0.x] Added `stats()` methods to Beanstalk

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2.0.2
+ - Added `stats()` methods to Beanstalk
+
 2.0.1
  - Added missing Phalcon\Debug::listenLowSeverity
  - Added new theme in Phalcon\Debug

--- a/phalcon/queue/beanstalk.zep
+++ b/phalcon/queue/beanstalk.zep
@@ -198,6 +198,40 @@ class Beanstalk
 	}
 
 	/**
+	 * Get stats of the Beanstalk server.
+	 */
+	public function stats() -> boolean|array
+	{
+		var response;
+
+		this->write("stats");
+
+		let response = this->readYaml();
+		if response[0] != "OK" {
+			return false;
+		}
+
+		return response[2];
+	}
+
+	/**
+	 * Get stats of a tube.
+	 */
+	public function statsTube(string! tube) -> boolean|array
+	{
+		var response;
+
+		this->write("stats-tube " . tube);
+
+		let response = this->readYaml();
+		if response[0] != "OK" {
+			return false;
+		}
+
+		return response[2];
+	}
+
+	/**
 	 * Inspect the next ready job.
 	 */
 	public function peekReady() -> boolean|<Job>
@@ -237,6 +271,36 @@ class Beanstalk
 	final public function readStatus() -> array
 	{
 		return explode(" ", this->read());
+	}
+
+	/**
+	 * Fetch a YAML payload from the Beanstalkd server
+	 */
+	final public function readYaml() -> array
+	{
+		var response, status, numberOfBytes, data;
+
+		let response = this->readStatus();
+
+		let status = response[0];
+
+		if count(response) > 1 {
+			let numberOfBytes = response[1];
+
+			let response = this->read();
+
+			let data = yaml_parse(response);
+		} else {
+			let numberOfBytes = 0;
+
+			let data = [];
+		}
+
+		return [
+			status,
+			numberOfBytes,
+			data
+		];
 	}
 
 	/**

--- a/phalcon/queue/beanstalk/job.zep
+++ b/phalcon/queue/beanstalk/job.zep
@@ -117,6 +117,24 @@ class Job
 	}
 
 	/**
+	 * Get stats of the job.
+	 */
+	public function stats() -> boolean|array
+	{
+		var queue, response;
+
+		let queue = this->_queue;
+		queue->write("stats-job " . this->_id);
+
+		let response = queue->readYaml();
+		if response[0] == "NOT_FOUND" {
+			return false;
+		}
+
+		return response[2];
+	}
+
+	/**
 	 * Checks if the job has been modified after unserializing the object
 	 */
 	public function __wakeup()

--- a/unit-tests/BeanstalkTest.php
+++ b/unit-tests/BeanstalkTest.php
@@ -93,4 +93,39 @@ class BeanstalkTest extends PHPUnit_Framework_TestCase
 
 		$this->assertTrue($job->delete());
 	}
+
+	public function testStats()
+	{
+		$queue = new Phalcon\Queue\Beanstalk();
+		try {
+			@$queue->connect();
+		}
+		catch (Exception $e) {
+			$this->markTestSkipped($e->getMessage());
+			return;
+		}
+
+		$this->assertTrue($queue->choose('beanstalk-test') !== false);
+
+		$queueStats = $queue->stats();
+		$this->assertTrue(is_array($queueStats));
+
+		$tubeStats = $queue->statsTube('beanstalk-test');
+		$this->assertTrue(is_array($tubeStats));
+		$this->assertTrue($jobStats['name'] === 'beanstalk-test');
+
+		$this->assertTrue($queue->statsTube('beanstalk-test-does-not-exist') === false);
+
+		$this->assertTrue($queue->choose('beanstalk-test') !== false);
+
+		$queue->put('doSomething');
+
+		$queue->watch('beanstalk-test');
+
+		$job = $queue->peekReady();
+		$jobStats = $job->stats();
+
+		$this->assertTrue(is_array($jobStats));
+		$this->assertTrue($jobStats['tube'] === 'beanstalk-test');
+	}
 }


### PR DESCRIPTION
Also features `Queue\Beanstalk::readYaml()` as a way to read YAML data from a Beanstalk server.
