### PR TITLE
[2.0.x] Fix "Wrong number of parameters" collection manager

### DIFF
--- a/phalcon/mvc/collection/manager.zep
+++ b/phalcon/mvc/collection/manager.zep
@@ -146,7 +146,7 @@ class Manager implements InjectionAwareInterface, EventsAwareInterface
 			*/
 			let eventsManager = this->_eventsManager;
 			if typeof eventsManager == "object" {
-				eventsManager->fire("collectionManager:afterInitialize");
+				eventsManager->fire("collectionManager:afterInitialize", model);
 			}
 
 			let this->_initialized[className] = model;


### PR DESCRIPTION
Fix "Wrong number of parameters" exception in Phalcon\Mvc\Collection\Manager
