### PR TITLE
Model tables can now have prefixes (#10328)

### DIFF
--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -122,6 +122,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	protected _initialized;
 
+	protected _prefix = "";
+
 	protected _sources;
 
 	protected _schemas;
@@ -313,6 +315,22 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	}
 
 	/**
+	 * Sets the prefix for all model sources
+	 */
+	public function setModelPrefix(string! prefix) -> void
+	{
+		let this->_prefix = prefix;
+	}
+
+	/**
+	 * Returns the prefix for all model sources
+	 */
+	public function getModelPrefix() -> string
+	{
+		return this->_prefix;
+	}
+
+	/**
 	 * Sets the mapped source for a model
 	 */
 	public function setModelSource(<ModelInterface> model, string! source) -> void
@@ -356,9 +374,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
 		if !isset this->_sources[entityName] {
 			let this->_sources[entityName] = uncamelize(get_class_ns(model));
-		}
+        }
 
-		return this->_sources[entityName];
+		return this->_prefix . this->_sources[entityName];
 	}
 
 	/**

--- a/unit-tests/ModelsTest.php
+++ b/unit-tests/ModelsTest.php
@@ -812,4 +812,30 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$personer->refresh();
 		$this->assertEquals($personerData, $personer->toArray());
 	}
+
+	public function testModelPrefixes()
+	{
+		$di = $this->_getDI(
+			function() {
+				require 'unit-tests/config.db.php';
+				$db = new Phalcon\Db\Adapter\Pdo\Mysql($configMysql);
+				return $db;
+			}
+		);
+
+		$di->set(
+			'modelsManager',
+			function () {
+				$modelsManager = new Phalcon\Mvc\Model\Manager();
+
+				$modelsManager->setModelPrefix('test_');
+
+				return $modelsManager;
+			}
+		);
+
+		$persona = new Personas();
+
+		$this->assertEquals('test_personas', $persona->getSource());
+	}
 }


### PR DESCRIPTION
This does introduce a problem: to override a model's source developers can only use:

``` php
public function initialize()
{
    $this->setSource('new_source');
}
```

I personally don't like overriding the `getSource()` method as it bypasses the models manager but I know many people do it.
