### PR TITLE
Update Pdo::escapeString

### DIFF
--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -392,7 +392,7 @@ abstract class Pdo extends Adapter
 	 *	$escapedStr = $connection->escapeString('some dangerous value');
 	 *</code>
 	 */
-	public function escapeString(string! str) -> string
+	public function escapeString(string str) -> string
 	{
 		return this->_pdo->quote(str);
 	}


### PR DESCRIPTION
Fixes exception when `str` not string (for example int)
