### PR TITLE
Fixing Phalcon\Dispatcher::getHandlerClass

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -673,7 +673,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		if substr(this->_handlerName, 0, 1) === "\\" {
 			let camelizedClass = this->_handlerName;
 		} else {
-			let camelizedClass = substr(this->_handlerName, 1);
+			let camelizedClass = str_replace(' ', '', ucwords(str_replace('_', ' ', this->_handlerName)))
 		}
 
 		/**


### PR DESCRIPTION
The generation of the handler class in the dispatcher is wrong. If the handler name does not start with \, the first char of the name will be cutted.

This will result in something like this: Api\V1\Controller\etail_tableController

but it shoud be: Api\V1\Controller\**D**etailTableController
