### PR TITLE
added test to check exact exception message for 2.0.0 DI when service is missing

### DIFF
--- a/unit-tests/DiTest.php
+++ b/unit-tests/DiTest.php
@@ -381,6 +381,18 @@ class DiTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(true);
 	}
 
+    /**
+     * Prior to 2.0.0 exception message was "Service 'servicewhichdoesnotexist' wasn't found in the dependency injection container"
+     *
+     * @expectedException \Phalcon\Di\Exception
+     * @expectedExceptionMessage Service 'servicewhichdoesnotexist' wasn't found in the dependency injection container
+     */
+    public function testGettingNonExistentServiceShouldThrowExceptionWithExpectedMessage()
+    {
+        $di = new \Phalcon\DI\FactoryDefault();
+        $di->get('servicewhichdoesnotexist');
+    }
+
 	public function testIssue1242()
 	{
 		$di = new \Phalcon\Di();

--- a/unit-tests/DiTest.php
+++ b/unit-tests/DiTest.php
@@ -381,17 +381,17 @@ class DiTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(true);
 	}
 
-    /**
-     * Prior to 2.0.0 exception message was "Service 'servicewhichdoesnotexist' wasn't found in the dependency injection container"
-     *
-     * @expectedException \Phalcon\Di\Exception
-     * @expectedExceptionMessage Service 'servicewhichdoesnotexist' wasn't found in the dependency injection container
-     */
-    public function testGettingNonExistentServiceShouldThrowExceptionWithExpectedMessage()
-    {
-        $di = new \Phalcon\DI\FactoryDefault();
-        $di->get('servicewhichdoesnotexist');
-    }
+    	/**
+     	* Prior to 2.0.0 exception message was "Service 'servicewhichdoesnotexist' wasn't found in the dependency injection container"
+     	*
+     	* @expectedException \Phalcon\Di\Exception
+     	* @expectedExceptionMessage Service 'servicewhichdoesnotexist' wasn't found in the dependency injection container
+     	*/
+    	public function testGettingNonExistentServiceShouldThrowExceptionWithExpectedMessage()
+    	{
+        	$di = new \Phalcon\DI\FactoryDefault();
+        	$di->get('servicewhichdoesnotexist');
+    	}
 
 	public function testIssue1242()
 	{


### PR DESCRIPTION
it was changed from since version 1 and some tests in our app were failing because of it. its not very important, but wont do any harm to include it :)
