### PR TITLE
Phalcon\Validation::getDefaultMessage() should now return null instead of phalcon/validation.zep warning if no message was found

### DIFF
--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -267,9 +267,14 @@ class Validation extends Injectable
 
 	/**
 	 * Get default message for validator type
+	 *
+	 * @param string type
 	 */
 	public function getDefaultMessage(string! type) -> string
 	{
+	    if (!array_key_exists(type, $this->_defaultMessages)) {
+	        return "";
+	    }
 		return this->_defaultMessages[type];
 	}
 

--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -272,9 +272,9 @@ class Validation extends Injectable
 	 */
 	public function getDefaultMessage(string! type) -> string
 	{
-	    if (!array_key_exists(type, $this->_defaultMessages)) {
-	        return "";
-	    }
+		if !isset this->_defaultMessages[type] {
+			return "";
+		}
 		return this->_defaultMessages[type];
 	}
 

--- a/unit-tests/ValidationTest.php
+++ b/unit-tests/ValidationTest.php
@@ -997,4 +997,10 @@ class ValidationTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals($expectedMessages, $messages);
 	}
+
+    public function testGetDefaultValidationMessageShouldReturnEmptyStringIfNoneIsSet()
+    {
+        $validation = new \Phalcon\Validation();
+        $this->assertEmpty($validation->getDefaultMessage('_notexistentvalidationmessage_'));
+    }
 }

--- a/unit-tests/ValidationTest.php
+++ b/unit-tests/ValidationTest.php
@@ -998,9 +998,9 @@ class ValidationTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($expectedMessages, $messages);
 	}
 
-    public function testGetDefaultValidationMessageShouldReturnEmptyStringIfNoneIsSet()
-    {
-        $validation = new \Phalcon\Validation();
-        $this->assertEmpty($validation->getDefaultMessage('_notexistentvalidationmessage_'));
-    }
+	public function testGetDefaultValidationMessageShouldReturnEmptyStringIfNoneIsSet()
+	{
+		$validation = new \Phalcon\Validation();
+		$this->assertEmpty($validation->getDefaultMessage('_notexistentvalidationmessage_'));
+	}
 }


### PR DESCRIPTION
this was default behavior of Phalcon\Validation::getDefaultMessage prior to version 2
