### PR TITLE
[2.0.x] Mvc/Model: Setter fallback

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3928,7 +3928,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	public function __set(string property, value)
 	{
 		var lowerProperty, related, modelName, manager, lowerKey, relation, referencedModel,
-			key, item;
+			key, item, method;
 
 		/**
 		 * Values are probably relationships if they are objects
@@ -3980,7 +3980,13 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 		/**
 		 * Fallback assigning the value to the instance
 		 */
-		let this->{property} = value;
+		let method = "set" . Text::camelize(property);
+
+		if method_exists(this, method) {
+			this->{method}(value);
+		} else {
+			let this->{property} = value;
+		}
 
 		return value;
 	}

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -568,6 +568,7 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 			'songs',
 			'subscriptores',
 			'tipo_documento',
+			'server',
 		);
 
 		$tables = $connection->listTables();

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -565,10 +565,10 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 			'prueba',
 			'robots',
 			'robots_parts',
+			'server',
 			'songs',
 			'subscriptores',
 			'tipo_documento',
-			'server',
 		);
 
 		$tables = $connection->listTables();

--- a/unit-tests/ModelsTest.php
+++ b/unit-tests/ModelsTest.php
@@ -96,6 +96,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 
 		$this->issue1534($di);
 		$this->issue886($di);
+		$this->getterSetterMagic($di);
 	}
 
 	public function ytestModelsPostgresql()
@@ -139,6 +140,24 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 	public function testIssue10371()
 	{
 		$this->assertTrue(in_array('addBehavior', get_class_methods('Phalcon\Mvc\Model')));
+	}
+
+	protected function getterSetterMagic($di)
+	{
+		$this->_prepareDb($di->getShared('db'));
+
+		$server = new Server();
+		$server->name = 'mothership';
+
+		// protected var with getter, setter
+		$server->ip = '192-168-0-1';
+
+		// private var only with getter
+		$server->mac = '11:--:22:--:33:--';
+
+		$this->assertEquals('mothership', $server->name);
+		$this->assertEquals('192.168.0.1', $server->ip);
+		$this->assertEquals('11:00:22:00:33:00', $server->mac);
 	}
 
 	protected function issue1534($di)

--- a/unit-tests/models/Server.php
+++ b/unit-tests/models/Server.php
@@ -1,0 +1,23 @@
+<?php
+
+
+class Server extends Phalcon\Mvc\Model
+{
+	public $name;
+
+	protected $ip;
+
+	private $mac;
+
+	public function setIp($value) {
+		$this->ip = str_replace('-', '.', $value);
+	}
+
+	public function getIp() {
+		return $this->ip;
+	}
+
+	public function getMac() {
+		return str_replace('-', '0', $this->mac);
+	}
+}

--- a/unit-tests/schemas/mysql/phalcon_test.sql
+++ b/unit-tests/schemas/mysql/phalcon_test.sql
@@ -412,6 +412,14 @@ CREATE TABLE IF NOT EXISTS `issue_2019` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
+CREATE TABLE `server` (
+	`id` smallint(6) unsigned NOT NULL AUTO_INCREMENT,
+	`name` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+	`ip` varchar(20) COLLATE utf8_unicode_ci NOT NULL,
+	`mac` varchar(100) COLLATE utf8_unicode_ci DEFAULT NULL,
+	PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;


### PR DESCRIPTION
Add setter fallback in "__set" magic.
This is useful if you use protected (private) properties and assign a value directly to a property.
If this property has setter/getter functions they will be called preferably. 
