### PR TITLE
[2.0.x] [BUG] fix doesn't correct column domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed bug that added two ? in Mvc\Url::get when using query parameters (#10421)
 - Now string attributes in models can be marked to allow empty string values (#440)
 - Added an option to return the SQL to be generated from a Mvc\Model\Query instance (#1908)
+- Fix doesn't correct column domain in `Phalcon\Db\Dialect::select()` see [#10439](https://github.com/phalcon/cphalcon/pull/10439)
 
 # 2.0.2 (2015-05-26)
  - Added `stats()` methods to Beanstalk

--- a/phalcon/db/dialect.zep
+++ b/phalcon/db/dialect.zep
@@ -495,7 +495,7 @@ abstract class Dialect implements DialectInterface
 			"type": "all"
 		];
 
-		if (fetch domain, expression["balias"] || fetch domain, expression["domain"]) && domain != "" {
+		if (fetch domain, expression["column"] || fetch domain, expression["domain"]) && domain != "" {
 			let objectExpression["domain"] = domain;
 		}
 


### PR DESCRIPTION
## 2.0.2

```
$table1 = new \Models\Table1();
$table2 = new \Models\Table2();

$readConnection = $table1->getReadConnection();

$builder = new \Phalcon\Mvc\Model\Query\Builder();
$builder->from(get_class($table1))
   ->addFrom(get_class($table2), 't2');

echo $readConnection->getDialect()->select($builder->getQuery()->parse());
```

**Outputs**

```
SELECT `models\Table1`.*, `t2`.* FROM `table1`, `table2` AS `t2`
```
## 2.0.3 (after merge)

**Outputs**

```
SELECT `table1`.*, `t2`.* FROM `table1`, `table2` AS `t2`
```
