### PR TITLE
New system for column types

### DIFF
--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -84,7 +84,7 @@ class Mysql extends PdoAdapter implements AdapterInterface
 	 */
 	public function describeColumns(string table, string schema = null) -> <Column[]>
 	{
-		var columns, columnType, columnTypeObject, field, definition,
+		var columns, columnType, columnTypeClass,columnTypeObject, field, definition,
 			oldColumn, sizePattern, matches, matchOne, matchTwo, columnName,pregMatches;
 
 		let oldColumn = null,
@@ -113,9 +113,8 @@ class Mysql extends PdoAdapter implements AdapterInterface
 			preg_match("#[^(]*#",columnType,pregMatches);
 			let definition["type"] = Column::getColumnTypeByDialect("mysql",pregMatches[0]);
 			
-			let columnTypeObject = Column::getColumnTypes(pregMatches[0]);
-			let columnTypeObject = {columnTypeObject}();
-			
+			let columnTypeClass = Column::getColumnTypes(definition["type"]);
+			let columnTypeObject = new {columnTypeClass}();
 			if columnTypeObject->isNumeric() {
 				let definition["isNumeric"] = true;
 			}

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -111,7 +111,7 @@ class Mysql extends PdoAdapter implements AdapterInterface
 			let columnType = field[1];
 			
 			preg_match("#[^(]*#",columnType,pregMatches);
-			let definition["type"] = Column::getColumnTypeByDialect("mysql",pregMatches[0]);
+			let definition["type"] = Column::getColumnTypeByDialectKeyword("mysql",pregMatches[0]);
 			
 			let columnTypeClass = Column::getColumnTypes(definition["type"]);
 			

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -116,7 +116,6 @@ class Mysql extends PdoAdapter implements AdapterInterface
 			let columnTypeObject = Column::getColumnTypes(pregMatches[0]);
 			let columnTypeObject = {columnTypeObject}();
 			
-			
 			if columnTypeObject->isNumeric() {
 				let definition["isNumeric"] = true;
 			}

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -114,6 +114,7 @@ class Mysql extends PdoAdapter implements AdapterInterface
 			let definition["type"] = Column::getColumnTypeByDialect("mysql",pregMatches[0]);
 			
 			let columnTypeClass = Column::getColumnTypes(definition["type"]);
+			
 			let columnTypeObject = new {columnTypeClass}();
 			if columnTypeObject->isNumeric() {
 				let definition["isNumeric"] = true;

--- a/phalcon/db/adapter/pdo/oracle.zep
+++ b/phalcon/db/adapter/pdo/oracle.zep
@@ -105,12 +105,12 @@ class Oracle extends PdoAdapter implements AdapterInterface
 				columnType = field[1];
 
 			
-			let definition["type"] = Column::getColumnTypeByDialect("postgresql",columnType),
+			let definition["type"] = Column::getColumnTypeByDialectKeyword("postgresql",columnType),
 				definition["scale"] = columnScale,
 				definition["size"] = columnPrecision;
 				
 			let columnTypeObject = Column::getColumnTypes(definition["type"]);
-			let columnTypeObject = {columnTypeObject}();
+			let columnTypeObject = new {columnTypeObject}();
 
 			if columnTypeObject->isNumeric() {
 				let definition["isNumeric"] = true;

--- a/phalcon/db/adapter/pdo/oracle.zep
+++ b/phalcon/db/adapter/pdo/oracle.zep
@@ -87,7 +87,7 @@ class Oracle extends PdoAdapter implements AdapterInterface
 	public function describeColumns(string! table, string schema = null) -> <Column[]>
 	{
 		var columns, oldColumn, field, definition, columnSize,
-			columnPrecision, columnScale, columnType, columnName;
+			columnPrecision, columnScale, columnType, columnName, columnTypeObject;
 
 		let columns = [];
 
@@ -104,72 +104,19 @@ class Oracle extends PdoAdapter implements AdapterInterface
 				columnScale = field[4],
 				columnType = field[1];
 
-			loop {
+			
+			let definition["type"] = Column::getColumnTypeByDialect("postgresql",columnType),
+				definition["scale"] = columnScale,
+				definition["size"] = columnPrecision;
+				
+			let columnTypeObject = Column::getColumnTypes(definition["type"]);
+			let columnTypeObject = {columnTypeObject}();
 
-				/**
-				 * Check the column type to get the correct Phalcon type
-				 */
-				if memstr(columnType, "NUMBER") {
-					let definition["type"]      = Column::TYPE_DECIMAL,
-						definition["isNumeric"] = true,
-						definition["size"]      = columnPrecision,
-						definition["scale"]     = columnScale,
-						definition["bindType"]  = 32;
-					break;
-				}
-
-				if memstr(columnType, "INTEGER") {
-					let definition["type"]       = Column::TYPE_INTEGER,
-						definition["isNumeric"]  = true,
-						definition["size"]       = columnPrecision,
-						definition["bindType"]   = 1;
-					break;
-				}
-
-				if memstr(columnType, "VARCHAR2") {
-					let definition["type"] = Column::TYPE_VARCHAR,
-						definition["size"] = columnSize;
-						break;
-				}
-
-				if memstr(columnType, "FLOAT") {
-					let definition["type"]      = Column::TYPE_FLOAT,
-						definition["isNumeric"] = true,
-						definition["size"]      = columnSize,
-						definition["scale"]     = columnScale,
-						definition["bindType"]  = 32;
-					break;
-				}
-
-				if memstr(columnType, "TIMESTAMP") {
-					let definition["type"] = Column::TYPE_INTEGER;
-					break;
-				}
-
-				if memstr(columnType, "RAW") {
-					let definition["type"] = Column::TYPE_TEXT;
-					break;
-				}
-
-				if memstr(columnType, "BLOB") {
-					let definition["type"] = Column::TYPE_TEXT;
-					break;
-				}
-
-				if memstr(columnType, "CLOB") {
-					let definition["type"] = Column::TYPE_TEXT;
-					break;
-				}
-
-				if memstr(columnType, "CHAR") {
-					let definition["type"] = Column::TYPE_CHAR,
-						definition["size"] = columnSize;
-					break;
-				}
-
-				let definition["type"] = Column::TYPE_TEXT;
-				break;
+			if columnTypeObject->isNumeric() {
+				let definition["isNumeric"] = true;
 			}
+            let definition["bindType"] = columnTypeObject->getBindType();
+
 
 			if oldColumn === null {
 				let definition["first"] = true;

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -118,7 +118,7 @@ class Postgresql extends PdoAdapter implements AdapterInterface
 				numericSize = field[3],
 				numericScale = field[4];
 
-			let definition["type"] = Column::getColumnTypeByDialect("postgresql",columnType),
+			let definition["type"] = Column::getColumnTypeByDialectKeyword("postgresql",columnType),
 				definition["isNumeric"] = true,
 				definition["scale"] = numericScale,
 				definition["size"] = empty charSize ? numericSize : charSize;

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -118,129 +118,15 @@ class Postgresql extends PdoAdapter implements AdapterInterface
 				numericSize = field[3],
 				numericScale = field[4];
 
-			loop {
+			let definition["type"] = Column::getColumnTypeByDialect("postgresql",columnType),
+				definition["isNumeric"] = true,
+				definition["scale"] = numericScale,
+				definition["size"] = numericSize,
+				definition["size"] = charSize;
 
-				/**
-				 * Smallint(1) is boolean
-				 */
-				if memstr(columnType, "smallint(1)") {
-					let definition["type"] = Column::TYPE_BOOLEAN,
-						definition["bindType"] = Column::BIND_PARAM_BOOL;
-					break;
-				}
+			
 
-				/**
-				 * Int
-				 */
-				if memstr(columnType, "int") {
-					let definition["type"] = Column::TYPE_INTEGER,
-						definition["isNumeric"] = true,
-						definition["size"] = numericSize,
-						definition["bindType"] = Column::BIND_PARAM_INT;
-					break;
-				}
-
-				/**
-				 * Varchar
-				 */
-				if memstr(columnType, "varying") {
-					let definition["type"] = Column::TYPE_VARCHAR,
-						definition["size"] = charSize;
-					break;
-				}
-
-				/**
-				 * Special type for datetime
-				 */
-				if memstr(columnType, "date") {
-					let definition["type"] = Column::TYPE_DATE,
-						definition["size"] = 0;
-					break;
-				}
-
-				/**
-				 * Numeric
-				 */
-				if memstr(columnType, "numeric") {
-					let definition["type"] = Column::TYPE_DECIMAL,
-						definition["isNumeric"] = true,
-						definition["size"] = numericSize,
-						definition["scale"] = numericScale,
-						definition["bindType"] = Column::BIND_PARAM_DECIMAL;
-					break;
-				}
-
-				/**
-				 * Chars are chars
-				 */
-				if memstr(columnType, "char") {
-					let definition["type"] = Column::TYPE_CHAR,
-						definition["size"] = charSize;
-					break;
-				}
-
-				/**
-				 * Date
-				 */
-				if memstr(columnType, "timestamp") {
-					let definition["type"] = Column::TYPE_DATETIME,
-						definition["size"] = 0;
-					break;
-				}
-
-				/**
-				 * Text are varchars
-				 */
-				if memstr(columnType, "text") {
-					let definition["type"] = Column::TYPE_TEXT,
-						definition["size"] = charSize;
-					break;
-				}
-
-				/**
-				 * Float/Smallfloats/Decimals are float
-				 */
-				if memstr(columnType, "float") {
-					let definition["type"] = Column::TYPE_FLOAT,
-						definition["isNumeric"] = true,
-						definition["size"] = numericSize,
-						definition["bindType"] = Column::BIND_PARAM_DECIMAL;
-					break;
-				}
-
-				/**
-				 * Boolean
-				 */
-				if memstr(columnType, "bool") {
-					let definition["type"] = Column::TYPE_BOOLEAN,
-						definition["size"] = 0,
-						definition["bindType"] = Column::BIND_PARAM_BOOL;
-					break;
-				}
-
-				/**
-				 * UUID
-				 */
-				if memstr(columnType, "uuid") {
-					let definition["type"] = Column::TYPE_CHAR,
-						definition["size"] = 36;
-					break;
-				}
-
-				/**
-				 * By default is string
-				 */
-				let definition["type"] = Column::TYPE_VARCHAR;
-				break;
-			}
-
-			/**
-			 * Check if the column is unsigned, only MySQL support this
-			 */
-			if memstr(columnType, "unsigned") {
-				let definition["unsigned"] = true;
-			}
-
+			
 			/**
 			 * Positions
 			 */

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -121,8 +121,7 @@ class Postgresql extends PdoAdapter implements AdapterInterface
 			let definition["type"] = Column::getColumnTypeByDialect("postgresql",columnType),
 				definition["isNumeric"] = true,
 				definition["scale"] = numericScale,
-				definition["size"] = numericSize,
-				definition["size"] = charSize;
+				definition["size"] = empty charSize ? numericSize : charSize;
 
 			
 

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -84,7 +84,7 @@ class Sqlite extends PdoAdapter implements AdapterInterface
 	public function describeColumns(string table, string schema = null) -> <Column[]>
 	{
 		var columns, columnType, field, definition,
-			oldColumn, sizePattern, matches, matchOne, matchTwo, columnName;
+			oldColumn, sizePattern, matches, matchOne, matchTwo, columnName,pregMatches,columnTypeObject;
 
 		let oldColumn = null,
 			sizePattern = "#\\(([0-9]+)(?:,\\s*([0-9]+))*\\)#";
@@ -106,115 +106,20 @@ class Sqlite extends PdoAdapter implements AdapterInterface
 			 */
 			let columnType = field[2];
 
-			loop {
-
-				/**
-				 * Tinyint(1) is boolean
-				 */
-				if memstr(columnType, "tinyint(1)") {
-					let definition["type"] = Column::TYPE_BOOLEAN,
-						definition["bindType"] = Column::BIND_PARAM_BOOL,
-						columnType = "boolean"; // Change column type to skip size check
-					break;
-				}
-
-				/**
-				 * Smallint/Bigint/Integers/Int are int
-				 */
-				if memstr(columnType, "int") || memstr(columnType, "INT") {
-
-					let definition["type"] = Column::TYPE_INTEGER,
-						definition["isNumeric"] = true,
-						definition["bindType"] = Column::BIND_PARAM_INT;
-
-					if field[5] {
-						let definition["autoIncrement"] = true;
-					}
-					break;
-				}
-
-				/**
-				 * Varchar are varchars
-				 */
-				if memstr(columnType, "varchar") {
-					let definition["type"] = Column::TYPE_VARCHAR;
-					break;
-				}
-
-				/**
-				 * Date/Datetime are varchars
-				 */
-				if memstr(columnType, "date") {
-					let definition["type"] = Column::TYPE_DATE;
-					break;
-				}
-
-				/**
-				 * Timestamp as date
-				 */
-				if memstr(columnType, "timestamp") {
-					let definition["type"] = Column::TYPE_DATE;
-					break;
-				}
-
-				/**
-				 * Decimals are floats
-				 */
-				if memstr(columnType, "decimal") {
-					let definition["type"] = Column::TYPE_DECIMAL,
-						definition["isNumeric"] = true,
-						definition["bindType"] = Column::BIND_PARAM_DECIMAL;
-					break;
-				}
-
-				/**
-				 * Chars are chars
-				 */
-				if memstr(columnType, "char") {
-					let definition["type"] = Column::TYPE_CHAR;
-					break;
-				}
-
-				/**
-				 * Special type for datetime
-				 */
-				if memstr(columnType, "datetime") {
-					let definition["type"] = Column::TYPE_DATETIME;
-					break;
-				}
-
-				/**
-				 * Text are varchars
-				 */
-				if memstr(columnType, "text") {
-					let definition["type"] = Column::TYPE_TEXT;
-					break;
-				}
-
-				/**
-				 * Float/Smallfloats/Decimals are float
-				 */
-				if memstr(columnType, "float") {
-					let definition["type"] = Column::TYPE_FLOAT,
-						definition["isNumeric"] = true,
-						definition["bindType"] = Column::TYPE_DECIMAL;
-					break;
-				}
-
-				/**
-				 * Enum are treated as char
-				 */
-				if memstr(columnType, "enum") {
-					let definition["type"] = Column::TYPE_CHAR;
-					break;
-				}
-
-				/**
-				 * By default is string
-				 */
-				let definition["type"] = Column::TYPE_VARCHAR;
-				break;
+			preg_match("#[^(]*#",columnType,pregMatches);
+			let definition["type"] = Column::getColumnTypeByDialect("sqlite",pregMatches[0]);
+			
+			let columnTypeObject = Column::getColumnTypes(pregMatches[0]);
+			let columnTypeObject = {columnTypeObject}();
+			
+			
+			if columnTypeObject->isNumeric() {
+				let definition["isNumeric"] = true;
 			}
+            let definition["bindType"] = columnTypeObject->getBindType();
+
+
+			
 
 			/**
 			 * If the column type has a parentheses we try to get the column size from it

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -109,8 +109,8 @@ class Sqlite extends PdoAdapter implements AdapterInterface
 			preg_match("#[^(]*#",columnType,pregMatches);
 			let definition["type"] = Column::getColumnTypeByDialect("sqlite",pregMatches[0]);
 			
-			let columnTypeObject = Column::getColumnTypes(pregMatches[0]);
-			let columnTypeObject = {columnTypeObject}();
+			let columnTypeObject = Column::getColumnTypes(definition["type"]);
+			let columnTypeObject = new {columnTypeObject}();
 			
 			
 			if columnTypeObject->isNumeric() {

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -84,7 +84,7 @@ class Sqlite extends PdoAdapter implements AdapterInterface
 	public function describeColumns(string table, string schema = null) -> <Column[]>
 	{
 		var columns, columnType, field, definition,
-			oldColumn, sizePattern, matches, matchOne, matchTwo, columnName,pregMatches,columnTypeObject;
+			oldColumn, sizePattern, matches, matchOne, matchTwo, columnName,pregMatches,columnTypeObject,columnTypeClass;
 
 		let oldColumn = null,
 			sizePattern = "#\\(([0-9]+)(?:,\\s*([0-9]+))*\\)#";
@@ -109,9 +109,11 @@ class Sqlite extends PdoAdapter implements AdapterInterface
 			preg_match("#[^(]*#",columnType,pregMatches);
 			let definition["type"] = Column::getColumnTypeByDialect("sqlite",pregMatches[0]);
 			
-			let columnTypeObject = Column::getColumnTypes(definition["type"]);
-			let columnTypeObject = new {columnTypeObject}();
-			
+			let columnTypeClass = Column::getColumnTypes(definition["type"]);
+			if empty columnTypeClass {
+				throw new \Exception(pregMatches[0] . " - ".definition["type"]."-".var_export(Column::columnTypesDialect,true));
+			}
+			let columnTypeObject = new {columnTypeClass}();
 			
 			if columnTypeObject->isNumeric() {
 				let definition["isNumeric"] = true;

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -107,12 +107,9 @@ class Sqlite extends PdoAdapter implements AdapterInterface
 			let columnType = field[2];
 
 			preg_match("#[^(]*#",columnType,pregMatches);
-			let definition["type"] = Column::getColumnTypeByDialect("sqlite",pregMatches[0]);
+			let definition["type"] = Column::getColumnTypeByDialectKeyword("sqlite",pregMatches[0]);
 			
 			let columnTypeClass = Column::getColumnTypes(definition["type"]);
-			if empty columnTypeClass {
-				throw new \Exception(pregMatches[0] . " - ".definition["type"]."-".var_export(Column::columnTypesDialect,true));
-			}
 			let columnTypeObject = new {columnTypeClass}();
 			
 			if columnTypeObject->isNumeric() {

--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -257,7 +257,7 @@ class Column implements ColumnInterface
 	
 	public static function initialize() {
 		
-		var type,className,dialects,dialect,dialectType;
+		var type,className,dialects,dialect,dialectType,dialectTypes,dtypes;
 	
 		if empty self::columnTypes {
 			let self::columnTypes  = [
@@ -277,13 +277,22 @@ class Column implements ColumnInterface
 				
 				let dialects = (new {className}())->getDialects();
 				
-				for dialect, dialectType in dialects {
-					if preg_match("#\\(#",dialectType) {
-						let dialectType = substr(dialectType, 0, strpos(dialectType, "("));
-					}
-					let dialectType = strtoupper(dialectType);
+				for dialect, dialectTypes in dialects {
 					
-					let self::columnTypesDialect[dialect][dialectType] = type;
+					if typeof dialectTypes == "string" {
+						let dtypes = [dialectTypes];
+					} else {
+						let dtypes = dialectTypes;
+					}
+					
+					for dialectType in dtypes {
+						if preg_match("#\\(#",dialectType) {
+							let dialectType = substr(dialectType, 0, strpos(dialectType, "("));
+						}
+						let dialectType = strtoupper(dialectType);
+						
+						let self::columnTypesDialect[dialect][dialectType] = type;
+					}
 				}
 			}
 									

--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -50,6 +50,57 @@ class Column implements ColumnInterface
 {
 
 	/**
+	 * Integer abstract type
+	 */
+	const TYPE_INTEGER = "integer";
+
+	/**
+	 * Date abstract type
+	 */
+	const TYPE_DATE = "date";
+
+	/**
+	 * Varchar abstract type
+	 */
+	const TYPE_VARCHAR = "varchar";
+
+	/**
+	 * Decimal abstract type
+	 */
+	const TYPE_DECIMAL = "decimal";
+
+	/**
+	 * Datetime abstract type
+	 */
+	const TYPE_DATETIME = "datetime";
+
+	/**
+	 * Char abstract type
+	 */
+	const TYPE_CHAR = "char";
+
+	/**
+	 * Text abstract data type
+	 */
+	const TYPE_TEXT = "text";
+
+	/**
+	 * Float abstract data type
+	 */
+	const TYPE_FLOAT = "float";
+
+	/**
+	 * Boolean abstract data type
+	 */
+	const TYPE_BOOLEAN = "boolean";
+
+	/**
+	 * Double abstract data type
+	 *
+	 */
+	const TYPE_DOUBLE = "double";
+
+	/**
 	 * Bind Type Null
 	 */
 	const BIND_PARAM_NULL = 0;
@@ -209,10 +260,15 @@ class Column implements ColumnInterface
 		if empty self::columnTypes {
 			let self::columnTypes  = [
 										"integer" : "\\Phalcon\\Db\\Column\\Type\\Integer",
+										"bigint" : "\\Phalcon\\Db\\Column\\Type\\Bigint",
 										"date" : "\\Phalcon\\Db\\Column\\Type\\Date",
 										"varchar" : "\\Phalcon\\Db\\Column\\Type\\Varchar",
+										"char" : "\\Phalcon\\Db\\Column\\Type\\CharType",
+										"text" : "\\Phalcon\\Db\\Column\\Type\\Text",
 										"decimal" : "\\Phalcon\\Db\\Column\\Type\\Decimal",
-										"datetime" : "\\Phalcon\\Db\\Column\\Type\\Datetime"
+										"float" : "\\Phalcon\\Db\\Column\\Type\\FloatType",
+										"datetime" : "\\Phalcon\\Db\\Column\\Type\\Datetime",
+										"enum" : "\\Phalcon\\Db\\Column\\Type\\Enum"
 									];
 			let self::columnTypesDialect = [];
 			for type, className in self::columnTypes {
@@ -252,7 +308,7 @@ class Column implements ColumnInterface
 	{
 	
 		var type, notNull, primary, size, scale, dunsigned, first,
-			after, bindType, isNumeric, autoIncrement, defaultValue,
+			after, isNumeric, autoIncrement, defaultValue,
 			typeReference, typeValues,typeClass,columnTypes;
 			
 		let columnTypes = self::getColumnTypes();
@@ -272,7 +328,7 @@ class Column implements ColumnInterface
 				
 			} else {
 				
-				if !fetch typeClass,columnTypes[type] {
+				if !fetch typeClass,columnTypes[strtolower(type)] {
 					throw new Exception("Unknown column type \"" . type . "\"");
 				}
 				
@@ -381,7 +437,15 @@ class Column implements ColumnInterface
 	
 	public function getType(onlyName = true) -> string
 	{
-		return onlyName ? strtolower(get_class(this->_type)) : this->_type;
+		var completeClassName;
+		if onlyName === true {
+			let completeClassName = get_class(this->_type);
+        		
+			return strtolower(str_replace("Type","",substr(completeClassName, strrpos(completeClassName,"\\")+1)));
+		}
+		else {
+		return this->_type;
+		}
 	}
 
 	/**

--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -99,6 +99,8 @@ class Column implements ColumnInterface
 	 *
 	 */
 	const TYPE_DOUBLE = "double";
+	
+	const TYPE_ENUM = "enum";
 
 	/**
 	 * Bind Type Null
@@ -273,10 +275,14 @@ class Column implements ColumnInterface
 			let self::columnTypesDialect = [];
 			for type, className in self::columnTypes {
 				
-			
 				let dialects = (new {className}())->getDialects();
 				
 				for dialect, dialectType in dialects {
+					if preg_match("#\\(#",dialectType) {
+						let dialectType = substr(dialectType, 0, strpos(dialectType, "("));
+					}
+					let dialectType = strtoupper(dialectType);
+					
 					let self::columnTypesDialect[dialect][dialectType] = type;
 				}
 			}
@@ -284,16 +290,22 @@ class Column implements ColumnInterface
 		}
 	}
 	
-	public static function getColumnTypeByDialect(string! dialect, string! type) {
+	public static function getColumnTypeByDialect(string dialect, string type) {
 		
-		var columnType;
+		var formattedType;
+		
 		
 		self::initialize();
 		
-		if fetch columnType, self::columnTypesDialect[dialect][type] {
-			return columnType;
+		if !isset self::columnTypesDialect[dialect] {
+			throw new Exception("Unknown dialect");
 		}
-		return "varchar"; 
+		let formattedType = strtoupper(type);
+		if isset self::columnTypesDialect[dialect][formattedType] {
+			return self::columnTypesDialect[dialect][formattedType];
+		}
+		
+		return "varchar";
 	}
 	
 	public function getDialect(dialect) {
@@ -399,9 +411,9 @@ class Column implements ColumnInterface
 		/**
 		 * Check if the field is numeric
 		 */
-		if fetch isNumeric, definition["isNumeric"] {
-			let this->_isNumeric = isNumeric;
-		}
+		//if fetch isNumeric, definition["isNumeric"] {
+			let this->_isNumeric = this->_type->isNumeric();
+		//}
 
 		/**
 		 * Check if the field is auto-increment/serial
@@ -488,7 +500,8 @@ class Column implements ColumnInterface
 	 */
 	public function isNumeric() -> boolean
 	{
-		return this->_isNumeric;
+		//return this->_isNumeric;
+		return this->_type->isNumeric();
 	}
 
 	/**

--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -50,51 +50,6 @@ class Column implements ColumnInterface
 {
 
 	/**
-	 * Integer abstract type
-	 */
-	const TYPE_INTEGER = "integer";
-
-	/**
-	 * Date abstract type
-	 */
-	const TYPE_DATE = "date";
-
-	/**
-	 * Varchar abstract type
-	 */
-	const TYPE_VARCHAR = "varchar";
-
-	/**
-	 * Decimal abstract type
-	 */
-	const TYPE_DECIMAL = "decimal";
-
-	/**
-	 * Datetime abstract type
-	 */
-	const TYPE_DATETIME = "datetime";
-
-	/**
-	 * Char abstract type
-	 */
-	const TYPE_CHAR = "char";
-
-	/**
-	 * Text abstract data type
-	 */
-	const TYPE_TEXT = "text";
-
-	/**
-	 * Float abstract data type
-	 */
-	const TYPE_FLOAT = "float";
-
-	/**
-	 * Boolean abstract data type
-	 */
-	const TYPE_BOOLEAN = "boolean";
-
-	/**
 	 * Bind Type Null
 	 */
 	const BIND_PARAM_NULL = 0;
@@ -237,10 +192,14 @@ class Column implements ColumnInterface
 		
 	}
 	
-	public static function getColumnTypes() {
+	public static function getColumnTypes( name = null ) {
 		self::initialize();
 		
-		return self::columnTypes;
+		if name !== null {
+			return isset self::columnTypes[name] ? self::columnTypes[name] : false;
+		} else {
+			return self::columnTypes;
+		}
 	}
 	
 	public static function initialize() {
@@ -414,9 +373,9 @@ class Column implements ColumnInterface
 		/**
 		 * The bind type to cast the field when passing it to PDO
 		 */
-		if fetch bindType, definition["bindType"] {
+		//if fetch bindType, definition["bindType"] {
 			let this->_bindType = this->_type->getBindType();//bindType;
-		}
+		//}
 
 	}
 	
@@ -536,9 +495,9 @@ class Column implements ColumnInterface
 		}
 
 		if fetch scale, data["_scale"] {
-			if definition["type"] == self::TYPE_INTEGER || definition["type"] == self::TYPE_FLOAT || definition["type"] == self::TYPE_DECIMAL {
+			//if definition["type"] == self::TYPE_INTEGER || definition["type"] == self::TYPE_FLOAT || definition["type"] == self::TYPE_DECIMAL {
 				let definition["scale"] = scale;
-			}
+			//}
 		}
 
 		if fetch defaultValue, data["_default"] {

--- a/phalcon/db/column/type.zep
+++ b/phalcon/db/column/type.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Db\Column;
 
 use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
+use Phalcon\Db\Column;
 
 /**
  * Phalcon\Db\Column
@@ -47,35 +48,7 @@ use Phalcon\Db\ColumnInterface;
  */
 abstract class Type
 {
-	/**
-	 * Bind Type Null
-	 */
-	const BIND_PARAM_NULL = 0;
 
-	/**
-	 * Bind Type Integer
-	 */
-	const BIND_PARAM_INT = 1;
-
-	/**
-	 * Bind Type String
-	 */
-	const BIND_PARAM_STR = 2;
-
-	/**
-	 * Bind Type Bool
-	 */
-	const BIND_PARAM_BOOL = 5;
-
-	/**
-	 * Bind Type Decimal
-	 */
-	const BIND_PARAM_DECIMAL = 32;
-
-	/**
-	 * Skip binding by type
-	 */
-	const BIND_SKIP = 1024;
 
 
 	protected dialect = [];
@@ -98,8 +71,8 @@ abstract class Type
 	 */
 	protected _isNumeric = false;
 	
-	protected _bindType = 2;
-
+	protected _bindType = Column::BIND_PARAM_STR;
+	
 	public function getDialects() {
 		return $this->dialect;
 	}
@@ -119,10 +92,10 @@ abstract class Type
 	public function hasDialectName(dialect,test) {
 		var name;
 		
-		if fetch name, this->getNameForDialect(dialect) {
-			if name == test {
-				return true;
-			}
+		let name = this->getNameForDialect(dialect);
+		
+		if name == test {
+			return true;
 		}
 		
 		return false;
@@ -130,6 +103,9 @@ abstract class Type
 	
 	public function getBindType() {
 		return this->_bindType;
+	}
+	public function isNumeric() {
+		return this->_isNumeric;
 	}
 	
 	public function getNameForDialect(dialect) {
@@ -143,8 +119,11 @@ abstract class Type
 	}
 	
 	public function getDialect(dialect) {
-		return this->dialect[dialect];
+		return isset this->dialect[dialect] ? this->dialect[dialect] : false ;
 	}
 	
+	public function castValue(value) {
+		return value;
+	}
 	
 }

--- a/phalcon/db/column/type.zep
+++ b/phalcon/db/column/type.zep
@@ -73,6 +73,13 @@ abstract class Type
 	
 	protected _bindType = Column::BIND_PARAM_STR;
 	
+	public function __construct()
+	{
+		this->setup();
+	}
+	
+	abstract public function setup(){}
+	
 	public function getDialects() {
 		return $this->dialect;
 	}
@@ -119,7 +126,9 @@ abstract class Type
 	}
 	
 	public function getDialect(dialect) {
-		return isset this->dialect[dialect] ? this->dialect[dialect] : false ;
+		var out;
+		let out = isset this->dialect[dialect] ? this->dialect[dialect] : false ;
+		return out;
 	}
 	
 	public function castValue(value) {

--- a/phalcon/db/column/type.zep
+++ b/phalcon/db/column/type.zep
@@ -1,0 +1,150 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Column;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\ColumnInterface;
+
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+abstract class Type
+{
+	/**
+	 * Bind Type Null
+	 */
+	const BIND_PARAM_NULL = 0;
+
+	/**
+	 * Bind Type Integer
+	 */
+	const BIND_PARAM_INT = 1;
+
+	/**
+	 * Bind Type String
+	 */
+	const BIND_PARAM_STR = 2;
+
+	/**
+	 * Bind Type Bool
+	 */
+	const BIND_PARAM_BOOL = 5;
+
+	/**
+	 * Bind Type Decimal
+	 */
+	const BIND_PARAM_DECIMAL = 32;
+
+	/**
+	 * Skip binding by type
+	 */
+	const BIND_SKIP = 1024;
+
+
+	protected dialect = [];
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _autoIncrement = false;
+	
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _scale = false;
+	
+	/**
+	 * The column have some numeric type?
+	 */
+	protected _isNumeric = false;
+	
+	protected _bindType = 2;
+
+	public function getDialects() {
+		return $this->dialect;
+	}
+	
+	public function getName() {
+		return get_class(this);
+	}
+
+	public function supportScale() {
+		return this->_scale;
+	}
+	
+	public function supportAutoIncrement() {
+		return this->_autoIncrement;
+	}
+	
+	public function hasDialectName(dialect,test) {
+		var name;
+		
+		if fetch name, this->getNameForDialect(dialect) {
+			if name == test {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+	
+	public function getBindType() {
+		return this->_bindType;
+	}
+	
+	public function getNameForDialect(dialect) {
+		var name;
+		
+		if !fetch name, this->dialect[dialect] {
+			throw new Exception("Unsupported dialect \"" . dialect . "\""); 
+		}
+		let name = substr(name, 0, strpos(name, "("));
+		return name;
+	}
+	
+	public function getDialect(dialect) {
+		return this->dialect[dialect];
+	}
+	
+	
+}

--- a/phalcon/db/column/type.zep
+++ b/phalcon/db/column/type.zep
@@ -24,34 +24,14 @@ use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column;
 
 /**
- * Phalcon\Db\Column
+ * Phalcon\Db\Column\Type
  *
- * Allows to define columns to be used on create or alter table operations
- *
- *<code>
- *	use Phalcon\Db\Column as Column;
- *
- * //column definition
- * $column = new Column("id", array(
- *   "type" => Column::TYPE_INTEGER,
- *   "size" => 10,
- *   "unsigned" => true,
- *   "notNull" => true,
- *   "autoIncrement" => true,
- *   "first" => true
- * ));
- *
- * //add column to existing table
- * $connection->addColumn("robots", null, $column);
- *</code>
- *
+ * ColumnType 
  */
 abstract class Type
 {
 
-
-
-	protected dialect = [];
+	protected dialects = [];
 	/**
 	 * Column is autoIncrement?
 	 *
@@ -80,8 +60,12 @@ abstract class Type
 	
 	abstract public function setup(){}
 	
+	public function castValue(value) {
+		return value;
+	}
+	
 	public function getDialects() {
-		return $this->dialect;
+		return this->dialects;
 	}
 	
 	public function getName() {
@@ -100,43 +84,12 @@ abstract class Type
 		return this->_autoIncrement;
 	}
 	
-	public function hasDialectName(dialect,test) {
-		var name;
-		
-		let name = this->getNameForDialect(dialect);
-		
-		if name == test {
-			return true;
-		}
-		
-		return false;
-	}
-	
 	public function getBindType() {
 		return this->_bindType;
 	}
+	
 	public function isNumeric() {
 		return this->_isNumeric;
-	}
-	
-	public function getNameForDialect(dialect) {
-		var name;
-		
-		if !fetch name, this->dialect[dialect] {
-			throw new Exception("Unsupported dialect \"" . dialect . "\""); 
-		}
-		let name = substr(name, 0, strpos(name, "("));
-		return name;
-	}
-	
-	public function getDialect(dialect) {
-		var out;
-		let out = isset this->dialect[dialect] ? this->dialect[dialect] : false ;
-		return out;
-	}
-	
-	public function castValue(value) {
-		return value;
 	}
 	
 }

--- a/phalcon/db/column/type.zep
+++ b/phalcon/db/column/type.zep
@@ -85,7 +85,11 @@ abstract class Type
 	}
 	
 	public function getName() {
-		return get_class(this);
+		var completeClassName;
+		
+		let completeClassName = get_class(this);
+                		
+		return strtolower(str_replace("Type","",substr(completeClassName, strrpos(completeClassName,"\\")+1)));
 	}
 
 	public function supportScale() {

--- a/phalcon/db/column/type/bigint.zep
+++ b/phalcon/db/column/type/bigint.zep
@@ -21,22 +21,16 @@ namespace Phalcon\Db\Column\Type;
 use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column;
 
-class Datetime extends ColumnType
+class Bigint extends Integer
 {
-	
 	public function setup()
 	{
+		parent::setup();
 		let this->dialect = [
-    				"mysql":"DATETIME",
-    				"postgresql":"TIMESTAMP"
-    			];
-		let this->_autoIncrement = false;
-		let this->_scale = false;
-		let this->_isNumeric = false;
-	}
-
-	public function castValue(value) {
-		return (string)value;
+                  		"mysql":"BIGINT(#size#)",
+                  		"postgresql":"BIGINT"
+                  	];
 	}
 }

--- a/phalcon/db/column/type/bigint.zep
+++ b/phalcon/db/column/type/bigint.zep
@@ -30,6 +30,7 @@ class Bigint extends Integer
 		parent::setup();
 		let this->dialect = [
                   		"mysql":"BIGINT(#size#)",
+                  		"sqlite":"INT",
                   		"postgresql":"BIGINT"
                   	];
 	}

--- a/phalcon/db/column/type/bigint.zep
+++ b/phalcon/db/column/type/bigint.zep
@@ -28,7 +28,7 @@ class Bigint extends Integer
 	public function setup()
 	{
 		parent::setup();
-		let this->dialect = [
+		let this->dialects = [
                   		"mysql":"BIGINT(#size#)",
                   		"sqlite":"INT",
                   		"postgresql":"BIGINT"

--- a/phalcon/db/column/type/charType.zep
+++ b/phalcon/db/column/type/charType.zep
@@ -19,13 +19,13 @@
 namespace Phalcon\Db\Column\Type;
 
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column as Column;
 
 class CharType extends ColumnType
 {
-
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
         		"mysql":"CHAR(#size#)",
         		"sqlite":["CHARACTER(#size#)","CHAR(#size#)"],
         		"postgresql":"CHARACTER(#size#)"
@@ -33,5 +33,6 @@ class CharType extends ColumnType
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
+		let this->_bindType = Column::BIND_PARAM_STR;
 	}
 }

--- a/phalcon/db/column/type/charType.zep
+++ b/phalcon/db/column/type/charType.zep
@@ -18,25 +18,19 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-class Datetime extends ColumnType
+class CharType extends ColumnType
 {
-	
+
 	public function setup()
 	{
 		let this->dialect = [
-    				"mysql":"DATETIME",
-    				"postgresql":"TIMESTAMP"
-    			];
+        		"mysql":"CHAR(#size#)",
+        		"postgresql":"CHARACTER(#size#)"
+        	];
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
-	}
-
-	public function castValue(value) {
-		return (string)value;
 	}
 }

--- a/phalcon/db/column/type/charType.zep
+++ b/phalcon/db/column/type/charType.zep
@@ -27,6 +27,7 @@ class CharType extends ColumnType
 	{
 		let this->dialect = [
         		"mysql":"CHAR(#size#)",
+        		"sqlite":"CHARACTER(#size#)",
         		"postgresql":"CHARACTER(#size#)"
         	];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/charType.zep
+++ b/phalcon/db/column/type/charType.zep
@@ -27,7 +27,7 @@ class CharType extends ColumnType
 	{
 		let this->dialect = [
         		"mysql":"CHAR(#size#)",
-        		"sqlite":"CHARACTER(#size#)",
+        		"sqlite":["CHARACTER(#size#)","CHAR(#size#)"],
         		"postgresql":"CHARACTER(#size#)"
         	];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/date.zep
+++ b/phalcon/db/column/type/date.zep
@@ -29,6 +29,7 @@ class Date extends ColumnType
 	{
 		let this->dialect = [
 				"mysql":"DATE",
+				"sqlite":"DATE",
 				"postgresql":"DATE"
 			];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/date.zep
+++ b/phalcon/db/column/type/date.zep
@@ -18,16 +18,15 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column as Column;
 
 class Date extends ColumnType
 {
 	
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
 				"mysql":"DATE",
 				"sqlite":"DATE",
 				"postgresql":"DATE"
@@ -35,6 +34,7 @@ class Date extends ColumnType
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
+		let this->_bindType = Column::BIND_PARAM_STR;
 	}
 	
 	public function castValue(value) {

--- a/phalcon/db/column/type/date.zep
+++ b/phalcon/db/column/type/date.zep
@@ -1,0 +1,69 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Column\Type;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\ColumnInterface;
+use Phalcon\Db\Column\Type as ColumnType;
+
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+class Date extends ColumnType
+{
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _autoIncrement = false;
+	
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _scale = false;
+	
+	/**
+	 * The column have some numeric type?
+	 */
+	protected _isNumeric = false;
+
+}

--- a/phalcon/db/column/type/date.zep
+++ b/phalcon/db/column/type/date.zep
@@ -65,5 +65,8 @@ class Date extends ColumnType
 	 * The column have some numeric type?
 	 */
 	protected _isNumeric = false;
-
+	
+	public function castValue(value) {
+		return (string)value;
+	}
 }

--- a/phalcon/db/column/type/date.zep
+++ b/phalcon/db/column/type/date.zep
@@ -22,49 +22,19 @@ use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-/**
- * Phalcon\Db\Column
- *
- * Allows to define columns to be used on create or alter table operations
- *
- *<code>
- *	use Phalcon\Db\Column as Column;
- *
- * //column definition
- * $column = new Column("id", array(
- *   "type" => Column::TYPE_INTEGER,
- *   "size" => 10,
- *   "unsigned" => true,
- *   "notNull" => true,
- *   "autoIncrement" => true,
- *   "first" => true
- * ));
- *
- * //add column to existing table
- * $connection->addColumn("robots", null, $column);
- *</code>
- *
- */
 class Date extends ColumnType
 {
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _autoIncrement = false;
 	
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _scale = false;
-	
-	/**
-	 * The column have some numeric type?
-	 */
-	protected _isNumeric = false;
+	public function setup()
+	{
+		let this->dialect = [
+				"mysql":"DATE",
+				"postgresql":"DATE"
+			];
+		let this->_autoIncrement = false;
+		let this->_scale = false;
+		let this->_isNumeric = false;
+	}
 	
 	public function castValue(value) {
 		return (string)value;

--- a/phalcon/db/column/type/datetime.zep
+++ b/phalcon/db/column/type/datetime.zep
@@ -1,0 +1,69 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Column\Type;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\ColumnInterface;
+use Phalcon\Db\Column\Type as ColumnType;
+
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+class Datetime extends ColumnType
+{
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _autoIncrement = false;
+	
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _scale = false;
+	
+	/**
+	 * The column have some numeric type?
+	 */
+	protected _isNumeric = false;
+
+}

--- a/phalcon/db/column/type/datetime.zep
+++ b/phalcon/db/column/type/datetime.zep
@@ -66,4 +66,7 @@ class Datetime extends ColumnType
 	 */
 	protected _isNumeric = false;
 
+	public function castValue(value) {
+		return (string)value;
+	}
 }

--- a/phalcon/db/column/type/datetime.zep
+++ b/phalcon/db/column/type/datetime.zep
@@ -29,6 +29,7 @@ class Datetime extends ColumnType
 	{
 		let this->dialect = [
     				"mysql":"DATETIME",
+    				"sqlite":"TIMESTAMP",
     				"postgresql":"TIMESTAMP"
     			];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/datetime.zep
+++ b/phalcon/db/column/type/datetime.zep
@@ -18,16 +18,14 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column as Column;
 
 class Datetime extends ColumnType
 {
-	
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
     				"mysql":"DATETIME",
     				"sqlite":"TIMESTAMP",
     				"postgresql":"TIMESTAMP"
@@ -35,6 +33,7 @@ class Datetime extends ColumnType
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
+		let this->_bindType = Column::BIND_PARAM_DECIMAL;
 	}
 
 	public function castValue(value) {

--- a/phalcon/db/column/type/decimal.zep
+++ b/phalcon/db/column/type/decimal.zep
@@ -1,0 +1,70 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Column\Type;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\ColumnInterface;
+use Phalcon\Db\Column\Type as ColumnType;
+
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+class Decimal extends ColumnType
+{
+	protected dialect = [];
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _autoIncrement = false;
+	
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _scale = true;
+	
+	/**
+	 * The column have some numeric type?
+	 */
+	protected _isNumeric = true;
+
+}

--- a/phalcon/db/column/type/decimal.zep
+++ b/phalcon/db/column/type/decimal.zep
@@ -27,6 +27,7 @@ class Decimal extends ColumnType
 	{
 		let this->dialect = [
 				"mysql":"DECIMAL(#size#,#scale#)",
+				"sqlite":"NUMERIC(#size#,#scale#)",
 				"postgresql":"NUMERIC(#size#,#scale#)"
 			];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/decimal.zep
+++ b/phalcon/db/column/type/decimal.zep
@@ -67,4 +67,7 @@ class Decimal extends ColumnType
 	 */
 	protected _isNumeric = true;
 
+	public function castValue(value) {
+		return floatval(value);
+	}
 }

--- a/phalcon/db/column/type/decimal.zep
+++ b/phalcon/db/column/type/decimal.zep
@@ -19,13 +19,14 @@
 namespace Phalcon\Db\Column\Type;
 
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column as Column;
 
 class Decimal extends ColumnType
 {
 	
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
 				"mysql":"DECIMAL(#size#,#scale#)",
 				"sqlite":"NUMERIC(#size#,#scale#)",
 				"postgresql":"NUMERIC(#size#,#scale#)"
@@ -33,6 +34,7 @@ class Decimal extends ColumnType
 		let this->_autoIncrement = false;
 		let this->_scale = true;
 		let this->_isNumeric = true;
+		let this->_bindType = Column::BIND_PARAM_STR;
 	}
 
 	public function castValue(value) {

--- a/phalcon/db/column/type/decimal.zep
+++ b/phalcon/db/column/type/decimal.zep
@@ -18,54 +18,21 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-/**
- * Phalcon\Db\Column
- *
- * Allows to define columns to be used on create or alter table operations
- *
- *<code>
- *	use Phalcon\Db\Column as Column;
- *
- * //column definition
- * $column = new Column("id", array(
- *   "type" => Column::TYPE_INTEGER,
- *   "size" => 10,
- *   "unsigned" => true,
- *   "notNull" => true,
- *   "autoIncrement" => true,
- *   "first" => true
- * ));
- *
- * //add column to existing table
- * $connection->addColumn("robots", null, $column);
- *</code>
- *
- */
 class Decimal extends ColumnType
 {
-	protected dialect = [];
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _autoIncrement = false;
 	
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _scale = true;
-	
-	/**
-	 * The column have some numeric type?
-	 */
-	protected _isNumeric = true;
+	public function setup()
+	{
+		let this->dialect = [
+				"mysql":"DECIMAL(#size#,#scale#)",
+				"postgresql":"NUMERIC(#size#,#scale#)"
+			];
+		let this->_autoIncrement = false;
+		let this->_scale = true;
+		let this->_isNumeric = true;
+	}
 
 	public function castValue(value) {
 		return floatval(value);

--- a/phalcon/db/column/type/enum.zep
+++ b/phalcon/db/column/type/enum.zep
@@ -24,7 +24,7 @@ class Enum extends ColumnType
 {
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
 				"mysql":"ENUM(#values#)",
 				"postgresql":"ENUM(#values#)"
 			];

--- a/phalcon/db/column/type/enum.zep
+++ b/phalcon/db/column/type/enum.zep
@@ -18,25 +18,18 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-class Datetime extends ColumnType
+class Enum extends ColumnType
 {
-	
 	public function setup()
 	{
 		let this->dialect = [
-    				"mysql":"DATETIME",
-    				"postgresql":"TIMESTAMP"
-    			];
+				"mysql":"ENUM(#values#)",
+				"postgresql":"ENUM(#values#)"
+			];
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
-	}
-
-	public function castValue(value) {
-		return (string)value;
 	}
 }

--- a/phalcon/db/column/type/floatType.zep
+++ b/phalcon/db/column/type/floatType.zep
@@ -22,21 +22,39 @@ use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-class Datetime extends ColumnType
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+class FloatType extends ColumnType
 {
-	
 	public function setup()
 	{
 		let this->dialect = [
-    				"mysql":"DATETIME",
-    				"postgresql":"TIMESTAMP"
-    			];
+				"mysql":"FLOAT(#size#,#scale#)",
+				"postgresql":"FLOAT"
+			];
 		let this->_autoIncrement = false;
-		let this->_scale = false;
-		let this->_isNumeric = false;
-	}
-
-	public function castValue(value) {
-		return (string)value;
+		let this->_scale = true;
+		let this->_isNumeric = true;
 	}
 }

--- a/phalcon/db/column/type/floatType.zep
+++ b/phalcon/db/column/type/floatType.zep
@@ -22,35 +22,14 @@ use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-/**
- * Phalcon\Db\Column
- *
- * Allows to define columns to be used on create or alter table operations
- *
- *<code>
- *	use Phalcon\Db\Column as Column;
- *
- * //column definition
- * $column = new Column("id", array(
- *   "type" => Column::TYPE_INTEGER,
- *   "size" => 10,
- *   "unsigned" => true,
- *   "notNull" => true,
- *   "autoIncrement" => true,
- *   "first" => true
- * ));
- *
- * //add column to existing table
- * $connection->addColumn("robots", null, $column);
- *</code>
- *
- */
+
 class FloatType extends ColumnType
 {
 	public function setup()
 	{
 		let this->dialect = [
 				"mysql":"FLOAT(#size#,#scale#)",
+				"sqlite":"FLOAT",
 				"postgresql":"FLOAT"
 			];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/floatType.zep
+++ b/phalcon/db/column/type/floatType.zep
@@ -18,16 +18,14 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
-
+use Phalcon\Db\Column as Column;
 
 class FloatType extends ColumnType
 {
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
 				"mysql":"FLOAT(#size#,#scale#)",
 				"sqlite":"FLOAT",
 				"postgresql":"FLOAT"
@@ -35,5 +33,6 @@ class FloatType extends ColumnType
 		let this->_autoIncrement = false;
 		let this->_scale = true;
 		let this->_isNumeric = true;
+		let this->_bindType = Column::BIND_PARAM_DECIMAL;
 	}
 }

--- a/phalcon/db/column/type/integer.zep
+++ b/phalcon/db/column/type/integer.zep
@@ -28,7 +28,7 @@ class Integer extends ColumnType
 		let this->dialect = [
 				"mysql":"INT(#size#)",
 				"sqlite":"INT",
-				"postgresql":"INT"
+				"postgresql":"INTEGER"
 			];
 		let this->_autoIncrement = true;
 		let this->_scale = true;

--- a/phalcon/db/column/type/integer.zep
+++ b/phalcon/db/column/type/integer.zep
@@ -18,65 +18,21 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 use Phalcon\Db\Column;
 
-/**
- * Phalcon\Db\Column
- *
- * Allows to define columns to be used on create or alter table operations
- *
- *<code>
- *	use Phalcon\Db\Column as Column;
- *
- * //column definition
- * $column = new Column("id", array(
- *   "type" => Column::TYPE_INTEGER,
- *   "size" => 10,
- *   "unsigned" => true,
- *   "notNull" => true,
- *   "autoIncrement" => true,
- *   "first" => true
- * ));
- *
- * //add column to existing table
- * $connection->addColumn("robots", null, $column);
- *</code>
- *
- */
 class Integer extends ColumnType
 {
-	protected dialect = [
-		"mysql":"int",
-		"postgresql":"integer"
-	];
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _autoIncrement = true;
-	
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _scale = true;
-	
-	/**
-	 * The column have some numeric type?
-	 */
-	protected _isNumeric = true;
-	
-
-	protected _bindType = Column::BIND_PARAM_INT;
-
-	public function __construct()
+	public function setup()
 	{
-		
+		let this->dialect = [
+				"mysql":"INT(#size#)",
+				"postgresql":"INT"
+			];
+		let this->_autoIncrement = true;
+		let this->_scale = true;
+		let this->_isNumeric = true;
+		let this->_bindType = Column::BIND_PARAM_INT;
 	}
 	public function castValue(value) {
 		return (int)value;

--- a/phalcon/db/column/type/integer.zep
+++ b/phalcon/db/column/type/integer.zep
@@ -25,7 +25,7 @@ class Integer extends ColumnType
 {
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
 				"mysql":"INT(#size#)",
 				"sqlite":"INT",
 				"postgresql":"INTEGER"

--- a/phalcon/db/column/type/integer.zep
+++ b/phalcon/db/column/type/integer.zep
@@ -27,6 +27,7 @@ class Integer extends ColumnType
 	{
 		let this->dialect = [
 				"mysql":"INT(#size#)",
+				"sqlite":"INT",
 				"postgresql":"INT"
 			];
 		let this->_autoIncrement = true;

--- a/phalcon/db/column/type/integer.zep
+++ b/phalcon/db/column/type/integer.zep
@@ -1,0 +1,80 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Column\Type;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\ColumnInterface;
+use Phalcon\Db\Column\Type as ColumnType;
+
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+class Integer extends ColumnType
+{
+	protected dialect = [
+		"mysql":"int",
+		"postgresql":"integer"
+	];
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _autoIncrement = true;
+	
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _scale = true;
+	
+	/**
+	 * The column have some numeric type?
+	 */
+	protected _isNumeric = true;
+	
+
+	protected _bindType = ColumnType::BIND_PARAM_INT;
+
+	public function __construct()
+	{
+		
+	}
+}

--- a/phalcon/db/column/type/integer.zep
+++ b/phalcon/db/column/type/integer.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Db\Column\Type;
 use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column;
 
 /**
  * Phalcon\Db\Column
@@ -71,10 +72,13 @@ class Integer extends ColumnType
 	protected _isNumeric = true;
 	
 
-	protected _bindType = ColumnType::BIND_PARAM_INT;
+	protected _bindType = Column::BIND_PARAM_INT;
 
 	public function __construct()
 	{
 		
+	}
+	public function castValue(value) {
+		return (int)value;
 	}
 }

--- a/phalcon/db/column/type/text.zep
+++ b/phalcon/db/column/type/text.zep
@@ -33,6 +33,7 @@ class Text extends ColumnType
 	{
 		let this->dialect = [
 				"mysql":"TEXT",
+				"sqlite":"TEXT",
 				"postgresql":"TEXT"
 			];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/text.zep
+++ b/phalcon/db/column/type/text.zep
@@ -22,21 +22,21 @@ use Phalcon\Db\Exception;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-class Datetime extends ColumnType
+class Text extends ColumnType
 {
+
+	public function castValue(value) {
+		return (string)value;
+	}
 	
 	public function setup()
 	{
 		let this->dialect = [
-    				"mysql":"DATETIME",
-    				"postgresql":"TIMESTAMP"
-    			];
+				"mysql":"TEXT",
+				"postgresql":"TEXT"
+			];
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
-	}
-
-	public function castValue(value) {
-		return (string)value;
 	}
 }

--- a/phalcon/db/column/type/text.zep
+++ b/phalcon/db/column/type/text.zep
@@ -25,11 +25,13 @@ class Text extends ColumnType
 {
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
 				"mysql":"TEXT",
 				"sqlite":"TEXT",
 				"postgresql":"TEXT"
 			];
+			
+		let this->_bindType = Column::BIND_PARAM_STR;
 	}
 	public function castValue(value) {
 		return (int)value;

--- a/phalcon/db/column/type/text.zep
+++ b/phalcon/db/column/type/text.zep
@@ -18,17 +18,11 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column;
 
 class Text extends ColumnType
 {
-
-	public function castValue(value) {
-		return (string)value;
-	}
-	
 	public function setup()
 	{
 		let this->dialect = [
@@ -36,8 +30,8 @@ class Text extends ColumnType
 				"sqlite":"TEXT",
 				"postgresql":"TEXT"
 			];
-		let this->_autoIncrement = false;
-		let this->_scale = false;
-		let this->_isNumeric = false;
+	}
+	public function castValue(value) {
+		return (int)value;
 	}
 }

--- a/phalcon/db/column/type/varchar.zep
+++ b/phalcon/db/column/type/varchar.zep
@@ -19,13 +19,14 @@
 namespace Phalcon\Db\Column\Type;
 
 use Phalcon\Db\Column\Type as ColumnType;
+use Phalcon\Db\Column as Column;
 
 class Varchar extends ColumnType
 {
 
 	public function setup()
 	{
-		let this->dialect = [
+		let this->dialects = [
         		"mysql":"VARCHAR(#size#)",
         		"sqlite":"VARCHAR(#size#)",
         		"postgresql":"CHARACTER VARYING(#size#)"
@@ -33,5 +34,6 @@ class Varchar extends ColumnType
 		let this->_autoIncrement = false;
 		let this->_scale = false;
 		let this->_isNumeric = false;
+		let this->_bindType = Column::BIND_PARAM_STR;
 	}
 }

--- a/phalcon/db/column/type/varchar.zep
+++ b/phalcon/db/column/type/varchar.zep
@@ -27,6 +27,7 @@ class Varchar extends ColumnType
 	{
 		let this->dialect = [
         		"mysql":"VARCHAR(#size#)",
+        		"sqlite":"VARCHAR(#size#)",
         		"postgresql":"CHARACTER VARYING(#size#)"
         	];
 		let this->_autoIncrement = false;

--- a/phalcon/db/column/type/varchar.zep
+++ b/phalcon/db/column/type/varchar.zep
@@ -1,0 +1,73 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Column\Type;
+
+use Phalcon\Db\Exception;
+use Phalcon\Db\ColumnInterface;
+use Phalcon\Db\Column\Type as ColumnType;
+
+/**
+ * Phalcon\Db\Column
+ *
+ * Allows to define columns to be used on create or alter table operations
+ *
+ *<code>
+ *	use Phalcon\Db\Column as Column;
+ *
+ * //column definition
+ * $column = new Column("id", array(
+ *   "type" => Column::TYPE_INTEGER,
+ *   "size" => 10,
+ *   "unsigned" => true,
+ *   "notNull" => true,
+ *   "autoIncrement" => true,
+ *   "first" => true
+ * ));
+ *
+ * //add column to existing table
+ * $connection->addColumn("robots", null, $column);
+ *</code>
+ *
+ */
+class Varchar extends ColumnType
+{
+	protected dialect = [
+		"mysql":"varchar(#size#)",
+		"postgresql":"CHARACTER VARYING(#size#)"
+	];
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _autoIncrement = false;
+	
+	/**
+	 * Column is autoIncrement?
+	 *
+	 * @var boolean
+	 */
+	protected _scale = false;
+	
+	/**
+	 * The column have some numeric type?
+	 */
+	protected _isNumeric = false;
+
+}

--- a/phalcon/db/column/type/varchar.zep
+++ b/phalcon/db/column/type/varchar.zep
@@ -18,59 +18,19 @@
 
 namespace Phalcon\Db\Column\Type;
 
-use Phalcon\Db\Exception;
-use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Column\Type as ColumnType;
 
-/**
- * Phalcon\Db\Column
- *
- * Allows to define columns to be used on create or alter table operations
- *
- *<code>
- *	use Phalcon\Db\Column as Column;
- *
- * //column definition
- * $column = new Column("id", array(
- *   "type" => Column::TYPE_INTEGER,
- *   "size" => 10,
- *   "unsigned" => true,
- *   "notNull" => true,
- *   "autoIncrement" => true,
- *   "first" => true
- * ));
- *
- * //add column to existing table
- * $connection->addColumn("robots", null, $column);
- *</code>
- *
- */
 class Varchar extends ColumnType
 {
-	protected dialect = [
-		"mysql":"varchar(#size#)",
-		"postgresql":"CHARACTER VARYING(#size#)"
-	];
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _autoIncrement = false;
-	
-	/**
-	 * Column is autoIncrement?
-	 *
-	 * @var boolean
-	 */
-	protected _scale = false;
-	
-	/**
-	 * The column have some numeric type?
-	 */
-	protected _isNumeric = false;
 
-	public function castValue(value) {
-		return (string)value;
+	public function setup()
+	{
+		let this->dialect = [
+        		"mysql":"VARCHAR(#size#)",
+        		"postgresql":"CHARACTER VARYING(#size#)"
+        	];
+		let this->_autoIncrement = false;
+		let this->_scale = false;
+		let this->_isNumeric = false;
 	}
 }

--- a/phalcon/db/column/type/varchar.zep
+++ b/phalcon/db/column/type/varchar.zep
@@ -70,4 +70,7 @@ class Varchar extends ColumnType
 	 */
 	protected _isNumeric = false;
 
+	public function castValue(value) {
+		return (string)value;
+	}
 }

--- a/phalcon/db/columninterface.zep
+++ b/phalcon/db/columninterface.zep
@@ -51,7 +51,7 @@ interface ColumnInterface
 	 *
 	 * @return int
 	 */
-	public function getType();
+	public function getType(onlyName = true);
 
 	/**
 	 * Returns column type reference

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -50,7 +50,7 @@ class MySQL extends Dialect
 		
 		let columnSql = columnType->getDialect("mysql");
 		if columnSql === false {
-			throw new Exception("Unrecognized Mysql data type");
+			throw new Exception("Unrecognized Mysql data type for " . column->getType() );
 		}
 		let columnSql = str_replace("#size#",column->getSize(),columnSql);
 		let columnSql = str_replace("#scale#",column->getScale() ,columnSql);
@@ -67,10 +67,10 @@ class MySQL extends Dialect
 				for value in typeValues {
 					let valueSql .= "\"" . addcslashes(value, "\"") . "\", ";
 				}
-				let columnSql = str_replace("#values#","(" . substr(valueSql, 0, -2) . ")",columnSql);
+				let columnSql = str_replace("#values#", substr(valueSql, 0, -2) ,columnSql);
 				
 			} else {
-				let columnSql = str_replace("#values#","(\"" . addcslashes(typeValues, "\"") . "\")",columnSql);
+				let columnSql = str_replace("#values#","\"" . addcslashes(typeValues, "\"") . "\"",columnSql);
 			}
 		}
 		

--- a/phalcon/db/dialect/oracle.zep
+++ b/phalcon/db/dialect/oracle.zep
@@ -71,55 +71,20 @@ class Oracle extends Dialect
 	 */
 	public function getColumnDefinition(<ColumnInterface> column) -> string
 	{
-		var columnSql, size, scale, type;
+		var columnSql,columnType, size, type;
 
+		let columnType = column->getType(false);
 		let type = column->getType();
 		let size = column->getSize();
-
-		switch type {
-
-			case Column::TYPE_INTEGER:
-				let columnSql = "INTEGER";
-			break;
-
-			case Column::TYPE_DATE:
-				let columnSql = "DATE";
-			break;
-
-			case Column::TYPE_VARCHAR:
-				let columnSql = "VARCHAR2(" . size . ")";
-			break;
-
-			case Column::TYPE_DECIMAL:
-				let scale = column->getScale();
-				let columnSql = "NUMBER(" . size . "," . scale . ")";
-			break;
-
-			case Column::TYPE_DATETIME:
-				let columnSql = "TIMESTAMP";
-			break;
-
-			case Column::TYPE_CHAR:
-				let columnSql = "CHAR(" . size . ")";
-			break;
-
-			case Column::TYPE_TEXT:
-				let columnSql = "TEXT";
-			break;
-
-			case Column::TYPE_FLOAT:
-				let scale = column->getScale();
-				let columnSql = "FLOAT(" . size . "," . scale .")";
-			break;
-
-			case Column::TYPE_BOOLEAN:
-				let columnSql = "TINYINT(1)";
-			break;
-
-			default:
-				throw new Exception("Unrecognized Oracle data type");
+		let columnSql = "";
+		
+		let columnSql = columnType->getDialect("oracle");
+		if columnSql === false {
+			throw new Exception("Unrecognized Orcale data type");
 		}
-
+		let columnSql = str_replace("#size#",size,columnSql);
+		let columnSql = str_replace("#scale#",column->getScale() ,columnSql);
+		
 		return columnSql;
 	}
 

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -52,9 +52,9 @@ class Postgresql extends Dialect
 			let columnType = column->getTypeReference();
 		}*/
 
-		let columnSql = columnType->getDialect("postresql");
+		let columnSql = columnType->getDialect("postgresql");
 		if columnSql === false {
-			throw new Exception("Unrecognized Postgresql data type");
+			throw new Exception("Unrecognized Postgresql data type for " . column->getType() );
 		}
 		let columnSql = str_replace("#size#",column->getSize(),columnSql);
 		let columnSql = str_replace("#scale#",column->getScale() ,columnSql);
@@ -67,10 +67,10 @@ class Postgresql extends Dialect
 				for value in typeValues {
 					let valueSql .= "\"" . addcslashes(value, "\"") . "\", ";
 				}
-				let columnSql = str_replace("#values#","(" . substr(valueSql, 0, -2) . ")",columnSql);
+				let columnSql = str_replace("#values#", substr(valueSql, 0, -2) ,columnSql);
 				
 			} else {
-				let columnSql = str_replace("#values#","(\"" . addcslashes(typeValues, "\"") . "\")",columnSql);
+				let columnSql = str_replace("#values#","\"" . addcslashes(typeValues, "\"") . "\"",columnSql);
 			}
 		}
 

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -43,9 +43,8 @@ class Postgresql extends Dialect
 	 */
 	public function getColumnDefinition(<ColumnInterface> column) -> string
 	{
-		var size, columnType, columnSql, typeValues;
+		var columnType, columnSql, typeValues;
 
-		let size = column->getSize();
 		let columnType = column->getType(false);
 		let columnSql = "";
 		/*if typeof columnType == "string" {
@@ -54,7 +53,10 @@ class Postgresql extends Dialect
 		}*/
 
 		let columnSql = columnType->getDialect("postresql");
-		let columnSql = str_replace("#size#",size,columnSql);
+		if columnSql === false {
+			throw new Exception("Unrecognized Postgresql data type");
+		}
+		let columnSql = str_replace("#size#",column->getSize(),columnSql);
 		let columnSql = str_replace("#scale#",column->getScale() ,columnSql);
 		
 		let typeValues = column->getTypeValues();

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -51,7 +51,7 @@ class Sqlite extends Dialect
 		
 		let columnSql = columnType->getDialect("sqlite");
 		if columnSql === false {
-			throw new Exception("Unrecognized sqlite data type");
+			throw new Exception("Unrecognized sqlite data type for " . column->getType() );
 		}
 		let columnSql = str_replace("#size#",column->getSize(),columnSql);
 		let columnSql = str_replace("#scale#",column->getScale() ,columnSql);

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2193,7 +2193,7 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 	{
 		var bindSkip, fields, values, bindTypes, manager, bindDataTypes, field,
 			automaticAttributes, snapshotValue, uniqueKey, uniqueParams, uniqueTypes,
-			snapshot, nonPrimary, columnMap, attributeField, value, primaryKeys, bindType;
+			snapshot, nonPrimary, columnMap, attributeField, value, primaryKeys, bindType,columnTypeClassName,columnType;
 		boolean useDynamicUpdate, changed;
 
 		let bindSkip = Column::BIND_SKIP,
@@ -2283,31 +2283,16 @@ abstract class Model implements ModelInterface, ResultInterface, InjectionAwareI
 								if snapshotValue === null {
 									let changed = true;
 								} else {
-									switch (bindType) {
-										case Column::TYPE_BOOLEAN:
-											let changed = (boolean)snapshotValue !== (boolean)value;
-											break;
-										case Column::TYPE_INTEGER:
-											let changed = (int)snapshotValue !== (int)value;
-											break;
-										case Column::TYPE_DECIMAL:
-										case Column::TYPE_FLOAT:
-											let changed = floatval(snapshotValue) !== floatval(value);
-											break;
-										case Column::TYPE_DATE:
-										case Column::TYPE_VARCHAR:
-										case Column::TYPE_DATETIME:
-										case Column::TYPE_CHAR:
-										case Column::TYPE_TEXT:
-										case Column::TYPE_VARCHAR:
-											let changed = (string)snapshotValue !== (string)value;
-											break;
-
-										/**
-										 * Any other type is not really supported...
-										 */
-										default:
-											let changed = value != snapshotValue;
+								
+									let columnTypeClassName = Column::getColumnTypes(bindType);
+								
+									if columnTypeClassName !== false {
+									
+										let columnType = new {columnTypeClassName}();
+										let changed = columnType->castValue(snapshotValue) !== columnType->castValue(value);
+									
+									} else {
+										let changed = value != snapshotValue;
 									}
 								}
 							}

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -706,7 +706,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 			for field, value in data {
 				if fetch type, dataTypes[field] {
 					if value !== null && value !== "" {
-						if type == Column::TYPE_VARCHAR {
+						if type == "varchar" {
 							/**
 							 * For varchar types we use LIKE operator
 							 */

--- a/phalcon/mvc/model/metadata/strategy/annotations.zep
+++ b/phalcon/mvc/model/metadata/strategy/annotations.zep
@@ -36,7 +36,7 @@ class Annotations implements StrategyInterface
 		var annotations, className, reflection, propertiesAnnotations;
 		var property, propAnnotations, columnAnnotation, columnName, feature;
 		var fieldTypes, fieldBindTypes, numericTyped, primaryKeys, nonPrimaryKeys, identityField,
-			notNull, attributes, automaticDefault, defaultValues, defaultValue;
+			notNull, attributes, automaticDefault, defaultValues, defaultValue,columnTypeClassName,columnType;
 
 		if typeof dependencyInjector != "object" {
 			throw new Exception("The dependency injector is invalid");
@@ -98,47 +98,23 @@ class Annotations implements StrategyInterface
 			 * Check if annotation has the 'type' named parameter
 			 */
 			let feature = columnAnnotation->getNamedParameter("type");
-
-			switch feature {
-				case "integer":
-					let fieldTypes[property] = Column::TYPE_INTEGER,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_INT,
-						numericTyped[columnName] = true;
-					break;
-
-				case "decimal":
-					let fieldTypes[columnName] = Column::TYPE_DECIMAL,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_DECIMAL,
-						numericTyped[columnName] = true;
-					break;
-
-				case "boolean":
-					let fieldTypes[columnName] = Column::TYPE_BOOLEAN,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_BOOL;
-					break;
-
-				case "date":
-					let fieldTypes[columnName] = Column::TYPE_DATE,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_STR;
-					break;
-
-				case "datetime":
-					let fieldTypes[columnName] = Column::TYPE_DATETIME,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_STR;
-					break;
-
-				case "text":
-					let fieldTypes[columnName] = Column::TYPE_TEXT,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_STR;
-					break;
-
-				default:
-					/**
-					 * By default all columns are varchar/string
-					 */
-					let fieldTypes[columnName] = Column::TYPE_VARCHAR,
-						fieldBindTypes[columnName] = Column::BIND_PARAM_STR;
+			
+			let columnTypeClassName = Column::getColumnTypes(feature);
+			
+			if columnTypeClassName !== false {
+				let columnType = new {columnTypeClassName}();
+			} else {
+				let columnTypeClassName = Column::getColumnTypes("varchar");
+				let columnType = new {columnTypeClassName}();
 			}
+			
+			let fieldTypes[property] = columnType->getName(),
+				fieldBindTypes[columnName] = columnType->getBindType();
+				
+			if columnType->isNumeric() {
+				let numericTyped[columnName] = true;
+			}
+			
 
 			/**
 			 * All columns marked with the 'Primary' annotation are considered primary keys

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -179,7 +179,7 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 			10 => Phalcon\Db\Column::__set_state(array(
 				'_columnName' => 'estado',
 				'_schemaName' => NULL,
-				'_type' => 5,
+				'_type' => 'enum',
 				'_isNumeric' => false,
 				'_size' => 0,
 				'_scale' => 0,
@@ -351,7 +351,7 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 				'_columnName' => 'estado',
 				'_schemaName' => NULL,
 				'_type' => 5,
-				'_isNumeric' => false,
+				'_isNumeric' => true,
 				'_size' => 1,
 				'_scale' => 0,
 				'_default' => NULL,

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -584,7 +584,7 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 
 		$expectedDescribe = $this->getExpectedColumnsMysql();
 		$describe = $connection->describeColumns('personas');
-
+    
 		$this->assertEquals($describe, $expectedDescribe);
 
 		$describe = $connection->describeColumns('personas', 'phalcon_test');

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -254,7 +254,7 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$column11 = $columns['column11'];
 
 		$this->assertEquals($column11->getName(), 'column11');
-		$this->assertEquals($column11->getType(), 'BIGINT');
+		$this->assertEquals($column11->getType(), 'bigint');
 		$this->assertEquals($column11->getTypeReference(), Column::TYPE_INTEGER);
 		$this->assertEquals($column11->getSize(), 20);
 		$this->assertEquals($column11->getScale(), 0);
@@ -265,7 +265,7 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$column12 = $columns['column12'];
 
 		$this->assertEquals($column12->getName(), 'column12');
-		$this->assertEquals($column12->getType(), 'ENUM');
+		$this->assertEquals($column12->getType(), 'enum');
 		$this->assertEquals($column12->getTypeReference(), -1);
 		$this->assertEquals($column12->getTypeValues(), array('A', 'B', 'C'));
 		$this->assertEquals($column12->getSize(), 0);
@@ -643,10 +643,10 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
     $this->assertEquals($dialect->modifyColumn('table', 'schema', $columns['column9'],$columns['column2']), 'ALTER TABLE "schema"."table" RENAME COLUMN "column2" TO "column9";ALTER TABLE "schema"."table" ALTER COLUMN "column9" TYPE CHARACTER VARYING(10);ALTER TABLE "schema"."table" ALTER COLUMN "column9" SET DEFAULT "column9"');
     $this->assertEquals($dialect->modifyColumn('table', null, $columns['column10'],$columns['column2']), 'ALTER TABLE "table" RENAME COLUMN "column2" TO "column10";ALTER TABLE "table" ALTER COLUMN "column10" SET DEFAULT "10"');
     $this->assertEquals($dialect->modifyColumn('table', 'schema', $columns['column10'],$columns['column2']), 'ALTER TABLE "schema"."table" RENAME COLUMN "column2" TO "column10";ALTER TABLE "schema"."table" ALTER COLUMN "column10" SET DEFAULT "10"');
-    $this->assertEquals($dialect->modifyColumn('table', null, $columns['column11'],$columns['column2']), 'ALTER TABLE "table" RENAME COLUMN "column2" TO "column11";');
-    $this->assertEquals($dialect->modifyColumn('table', 'schema', $columns['column11'],$columns['column2']), 'ALTER TABLE "schema"."table" RENAME COLUMN "column2" TO "column11";');
-    $this->assertEquals($dialect->modifyColumn('table', null, $columns['column12'],$columns['column2']), 'ALTER TABLE "table" RENAME COLUMN "column2" TO "column12";ALTER TABLE "table" ALTER COLUMN "column12" SET NOT NULL;ALTER TABLE "table" ALTER COLUMN "column12" SET DEFAULT "A"');
-    $this->assertEquals($dialect->modifyColumn('table', 'schema', $columns['column12'],$columns['column2']), 'ALTER TABLE "schema"."table" RENAME COLUMN "column2" TO "column12";ALTER TABLE "schema"."table" ALTER COLUMN "column12" SET NOT NULL;ALTER TABLE "schema"."table" ALTER COLUMN "column12" SET DEFAULT "A"');
+    $this->assertEquals($dialect->modifyColumn('table', null, $columns['column11'],$columns['column2']), 'ALTER TABLE "table" RENAME COLUMN "column2" TO "column11";ALTER TABLE "table" ALTER COLUMN "column11" TYPE BIGINT;');
+    $this->assertEquals($dialect->modifyColumn('table', 'schema', $columns['column11'],$columns['column2']), 'ALTER TABLE "schema"."table" RENAME COLUMN "column2" TO "column11";ALTER TABLE "schema"."table" ALTER COLUMN "column11" TYPE BIGINT;');
+    $this->assertEquals($dialect->modifyColumn('table', null, $columns['column12'],$columns['column2']), 'ALTER TABLE "table" RENAME COLUMN "column2" TO "column12";ALTER TABLE "table" ALTER COLUMN "column12" TYPE ENUM("A", "B", "C");ALTER TABLE "table" ALTER COLUMN "column12" SET NOT NULL;ALTER TABLE "table" ALTER COLUMN "column12" SET DEFAULT "A"');
+    $this->assertEquals($dialect->modifyColumn('table', 'schema', $columns['column12'],$columns['column2']), 'ALTER TABLE "schema"."table" RENAME COLUMN "column2" TO "column12";ALTER TABLE "schema"."table" ALTER COLUMN "column12" TYPE ENUM("A", "B", "C");ALTER TABLE "schema"."table" ALTER COLUMN "column12" SET NOT NULL;ALTER TABLE "schema"."table" ALTER COLUMN "column12" SET DEFAULT "A"');
 
     //Drop Columns
     $this->assertEquals($dialect->dropColumn('table', null, 'column1'), 'ALTER TABLE "table"  DROP COLUMN "column1"');


### PR DESCRIPTION
I changed the system of column types to be more extensible , now we can add more column type with php : 

Create column type class : 

``` php
namespace MyNamespace\ColumnType;

use Phalcon\Db\Column\Type as ColumnType;
use Phalcon\Db\Column;

class Smallint extends ColumnType
{
    public function setup()
    {
        $this->dialects = [
                "mysql":"SMALLINT(#size#)",
                "sqlite":"SMALLINT",
                "postgresql":"SMALLINT"
            ];
        $this->_autoIncrement = true;
        $this->_scale = true;
        $this->_isNumeric = true;
        $this->_bindType = Column::BIND_PARAM_INT;
    }
    public function castValue(value) {
        return (int)value;
    }
}
```

And add your type in the system : 

```
Phalcon\Db\Column::addType( (new MyNamespace\ColumnType\Smallint()) );
```

Now you can use this new type in your model annotations for example.

I'm open for all advices and contributions for optimise this, i'm a beginner with Zephir.
