### PR TITLE
Change criteria to get model name from get method on execute

### DIFF
--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -741,7 +741,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	public function execute() -> <ResultsetInterface>
 	{
 		var model;
-		let model = this->_model;
+		let model = this->getModelName();
 		if typeof model != "string" {
 			throw new Exception("Model name must be string");
 		}


### PR DESCRIPTION
This change implements the same behaviour of the Phalcon\Mvc\Model::getSource() method to the Phalcon\Mvc\Model\Criteria::getModelName() method.
Phalcon\Mvc\Model\Criteria::execute() now gets the model name from the method instead of the property.
