### PR TITLE
[2.0.x]  "static::" instead of "self::" in \Phalcon\Version class

### DIFF
--- a/phalcon/version.zep
+++ b/phalcon/version.zep
@@ -121,11 +121,11 @@ class Version
 
 		let version       = static::_getVersion();
 
-		let major         = version[static::VERSION_MAJOR],
-			medium        = version[static::VERSION_MEDIUM],
-			minor         = version[static::VERSION_MINOR],
-			special       = version[static::VERSION_SPECIAL],
-			specialNumber = version[static::VERSION_SPECIAL_NUMBER];
+		let major         = version[self::VERSION_MAJOR],
+			medium        = version[self::VERSION_MEDIUM],
+			minor         = version[self::VERSION_MINOR],
+			special       = version[self::VERSION_SPECIAL],
+			specialNumber = version[self::VERSION_SPECIAL_NUMBER];
 
 		let result  = major . "." . medium . "." . minor . " ";
 		let suffix  = static::_getSpecial(special);
@@ -151,11 +151,11 @@ class Version
 
 		let version       = static::_getVersion();
 
-		let major         = version[static::VERSION_MAJOR],
-			medium        = version[static::VERSION_MEDIUM],
-			minor         = version[static::VERSION_MINOR],
-			special       = version[static::VERSION_SPECIAL],
-			specialNumber = version[static::VERSION_SPECIAL_NUMBER];
+		let major         = version[self::VERSION_MAJOR],
+			medium        = version[self::VERSION_MEDIUM],
+			minor         = version[self::VERSION_MINOR],
+			special       = version[self::VERSION_SPECIAL],
+			specialNumber = version[self::VERSION_SPECIAL_NUMBER];
 
 		return major . sprintf("%02s", medium) . sprintf("%02s", minor) . special . specialNumber;
 	}
@@ -176,15 +176,15 @@ class Version
 
 		switch part {
 
-			case static::VERSION_MAJOR:
-			case static::VERSION_MEDIUM:
-			case static::VERSION_MINOR:
-			case static::VERSION_SPECIAL_NUMBER:
+			case self::VERSION_MAJOR:
+			case self::VERSION_MEDIUM:
+			case self::VERSION_MINOR:
+			case self::VERSION_SPECIAL_NUMBER:
 				let result = version[part];
 				break;
 
-			case static::VERSION_SPECIAL:
-				let result = static::_getSpecial(version[static::VERSION_SPECIAL]);
+			case self::VERSION_SPECIAL:
+				let result = static::_getSpecial(version[self::VERSION_SPECIAL]);
 				break;
 
 			default:

--- a/phalcon/version.zep
+++ b/phalcon/version.zep
@@ -119,16 +119,16 @@ class Version
 		var version, major, medium, minor,
 			special, specialNumber, result, suffix;
 
-		let version       = self::_getVersion();
+		let version       = static::_getVersion();
 
-		let major         = version[self::VERSION_MAJOR],
-			medium        = version[self::VERSION_MEDIUM],
-			minor         = version[self::VERSION_MINOR],
-			special       = version[self::VERSION_SPECIAL],
-			specialNumber = version[self::VERSION_SPECIAL_NUMBER];
+		let major         = version[static::VERSION_MAJOR],
+			medium        = version[static::VERSION_MEDIUM],
+			minor         = version[static::VERSION_MINOR],
+			special       = version[static::VERSION_SPECIAL],
+			specialNumber = version[static::VERSION_SPECIAL_NUMBER];
 
 		let result  = major . "." . medium . "." . minor . " ";
-		let suffix  = self::_getSpecial(special);
+		let suffix  = static::_getSpecial(special);
 
 		if suffix != "" {
 			let result .= suffix . " " . specialNumber;
@@ -149,13 +149,13 @@ class Version
 		var version, major, medium, minor,
 			special, specialNumber;
 
-		let version       = self::_getVersion();
+		let version       = static::_getVersion();
 
-		let major         = version[self::VERSION_MAJOR],
-			medium        = version[self::VERSION_MEDIUM],
-			minor         = version[self::VERSION_MINOR],
-			special       = version[self::VERSION_SPECIAL],
-			specialNumber = version[self::VERSION_SPECIAL_NUMBER];
+		let major         = version[static::VERSION_MAJOR],
+			medium        = version[static::VERSION_MEDIUM],
+			minor         = version[static::VERSION_MINOR],
+			special       = version[static::VERSION_SPECIAL],
+			specialNumber = version[static::VERSION_SPECIAL_NUMBER];
 
 		return major . sprintf("%02s", medium) . sprintf("%02s", minor) . special . specialNumber;
 	}
@@ -172,23 +172,23 @@ class Version
 	{
 		var version, result;
 
-		let version = self::_getVersion();
+		let version = static::_getVersion();
 
 		switch part {
 
-			case self::VERSION_MAJOR:
-			case self::VERSION_MEDIUM:
-			case self::VERSION_MINOR:
-			case self::VERSION_SPECIAL_NUMBER:
+			case static::VERSION_MAJOR:
+			case static::VERSION_MEDIUM:
+			case static::VERSION_MINOR:
+			case static::VERSION_SPECIAL_NUMBER:
 				let result = version[part];
 				break;
 
-			case self::VERSION_SPECIAL:
-				let result = self::_getSpecial(version[self::VERSION_SPECIAL]);
+			case static::VERSION_SPECIAL:
+				let result = static::_getSpecial(version[static::VERSION_SPECIAL]);
 				break;
 
 			default:
-				let result = self::get();
+				let result = static::get();
 				break;
 		}
 


### PR DESCRIPTION
Reason: simpler class extending

Example: 

``` php
namespace MyFooBar {

    class Version extends \Er\Version
    {
        protected static function _getVersion()
        {
            return [6, 5, 4, 3, 2];
        }
    }
}
namespace {
    echo \MyFooBar\Version::get();
}
```
