### PR TITLE
Improved regular expression in Mvc\Url to detect external resources

### DIFF
--- a/phalcon/mvc/url.zep
+++ b/phalcon/mvc/url.zep
@@ -176,7 +176,7 @@ class Url implements UrlInterface, InjectionAwareInterface
 
 		if local == null {
 			if typeof uri == "string" && (memstr(uri, "//") || memstr(uri, ":")) {
-				if preg_match("#^[a-z0-9]+://#i", uri) {
+				if preg_match("#^[a-z0-9]+:(:?//)?#i", uri) {
 					let local = false;
 				} else {
 					let local = true;

--- a/phalcon/mvc/url.zep
+++ b/phalcon/mvc/url.zep
@@ -176,7 +176,7 @@ class Url implements UrlInterface, InjectionAwareInterface
 
 		if local == null {
 			if typeof uri == "string" && (memstr(uri, "//") || memstr(uri, ":")) {
-				if preg_match("#^[a-zA-Z\:]*//#", uri) || preg_match("#^[a-zA-Z]+:#", uri) {
+				if preg_match("#^[a-z0-9]+://#i", uri) {
 					let local = false;
 				} else {
 					let local = true;

--- a/phalcon/mvc/url.zep
+++ b/phalcon/mvc/url.zep
@@ -176,7 +176,7 @@ class Url implements UrlInterface, InjectionAwareInterface
 
 		if local == null {
 			if typeof uri == "string" && (memstr(uri, "//") || memstr(uri, ":")) {
-				if preg_match("#^[a-z0-9]+:(:?//)?#i", uri) {
+				if preg_match("^(//(?=[a-z0-9]+)|[a-z0-9]+:(:?//)?)#i", uri) {
 					let local = false;
 				} else {
 					let local = true;


### PR DESCRIPTION
- Cleanup local regexp
- Digits for matching need for example for `e2dk` protocol
