### PR TITLE
[2.0.x] [NFR] Added method generate random text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Added `Phalcon\Mvc\Model\Validator\Ip` from incubator
 - Added parameter return `defaultValue` in `Phalcon\Mvc\Model\Validator::getOption()`
 - Fixed in `Phalcon\Validation\Validator\Identical` the name of parameter `value` to `accepted` according docs
+- Added method `Text:dynamic()` generate random text in accordance with the template see [#10571](https://github.com/phalcon/cphalcon/pull/10571)
 
 # [2.0.3](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.3) (2015-06-10)
 - Added support for Behaviors in `Phalcon\Mvc\Collection`

--- a/phalcon/text.zep
+++ b/phalcon/text.zep
@@ -247,4 +247,37 @@ abstract class Text
 
 		return rtrim(a, separator) . separator . ltrim(b, separator);
 	}
+
+	/**
+	 * Generates random text in accordance with the template
+	 *
+	 * <code>
+	 *    echo Phalcon\Text::dynamic("{Hi|Hello}, my name is a {Bob|Mark|Jon}!"); // Hi my name is a Bob
+	 *    echo Phalcon\Text::dynamic("{Hi|Hello}, my name is a {Bob|Mark|Jon}!"); // Hi my name is a Jon
+	 *    echo Phalcon\Text::dynamic("{Hi|Hello}, my name is a {Bob|Mark|Jon}!"); // Hello my name is a Bob
+	 * </code>
+	 */
+	public static function dynamic(string! text, string! leftDelimiter = "{", string! rightDelimiter = "}", string! separator = "|") -> string
+	{
+		if substr_count(text, leftDelimiter) !== substr_count(text, rightDelimiter) {
+			throw new \RuntimeException("Syntax error in string \"" . text . "\"");
+		}
+
+		var ld_s, rd_s, result, pattern;
+
+		let ld_s 	= preg_quote(leftDelimiter);
+		let rd_s 	= preg_quote(rightDelimiter);
+		let pattern = "/" . ld_s . "([^" . ld_s . rd_s . "]+)" . rd_s . "/";
+		let result 	= text;
+
+		while strpos(result, leftDelimiter) !== false {
+			let result = preg_replace_callback(pattern, function (matches) {
+				var words;
+				let words = explode("|", matches[1]);
+				return words[array_rand(words)];
+			}, result);
+		}
+
+		return result;
+	}
 }

--- a/tests/PhalconTest/Text.php
+++ b/tests/PhalconTest/Text.php
@@ -75,4 +75,10 @@ class Text extends PhText
 	{
 		return call_user_func_array('parent::concat', func_get_args());
 	}
+
+	public static function dynamic($text, $leftDelimiter = '{', $rightDelimiter = '}', $separator = '|')
+	{
+		return parent::dynamic($text, $leftDelimiter, $rightDelimiter, $separator);
+	}
+
 }

--- a/tests/unit/Phalcon/Text/TextDynamicTest.php
+++ b/tests/unit/Phalcon/Text/TextDynamicTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * TextDynamicTest.php
+ * \Phalcon\Text\TextDynamicTest
+ *
+ * Tests the Phalcon\Text component
+ *
+ * Phalcon Framework
+ *
+ * @copyright (c) 2011-2015 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+namespace Phalcon\Tests\unit\Phalcon\Text;
+
+
+use \PhalconTest\Text as PhTText;
+
+
+class TextDynamicTest extends Helper\TextBase
+{
+	/**
+	 * Tests the dynamic function
+	 *
+	 * @author Stanislav Kiryukhin <korsar.zn@gmail.com>
+	 * @since  2015-07-01
+	 */
+	public function testTextDynamicString()
+	{
+		$this->specify(
+			"dynamic do not return the correct string",
+			function () {
+
+				$actual = PhTText::dynamic('{Hi|Hello}, my name is a Bob!');
+				expect($actual)->notContains('{');
+				expect($actual)->notContains('}');
+
+				expect(preg_match('/^(Hi|Hello), my name is a Bob!$/', $actual))->equals(1);
+			}
+		);
+	}
+
+	/**
+	 * Tests the dynamic function
+	 *
+	 * @author Stanislav Kiryukhin <korsar.zn@gmail.com>
+	 * @since  2015-07-01
+	 */
+	public function testTextDynamicStringCustomDelimeter()
+	{
+		$actual = PhTText::dynamic('(Hi|Hello), my name is a Bob!', '(', ')');
+		expect($actual)->notContains('(');
+		expect($actual)->notContains(')');
+
+		expect(preg_match('/^(Hi|Hello), my name is a Bob!$/', $actual))->equals(1);
+	}
+}


### PR DESCRIPTION
Generates random text in accordance with the template:

```
echo Phalcon\Text::dynamic("{Hi|Hello}, my name is a {Bob|Mark|Jon}!"); 
    // Hi my name is a Bob

echo Phalcon\Text::dynamic("{Hi|Hello}, my name is a {Bob|Mark|Jon}!");
    // Hi my name is a Jon

echo Phalcon\Text::dynamic("{Hi|Hello}, my name is a {Bob|Mark|Jon}!");
   // Hello my name is a Bob
```
