### PR TITLE
The filter now no longer removes the ' character, fixes #10595

### DIFF
--- a/phalcon/filter.zep
+++ b/phalcon/filter.zep
@@ -147,7 +147,7 @@ class Filter implements FilterInterface
 				/**
 				 * The 'email' filter uses the filter extension
 				 */
-				return filter_var(str_replace("'", "", value), constant("FILTER_SANITIZE_EMAIL"));
+				return filter_var(value, constant("FILTER_SANITIZE_EMAIL"));
 
 			case Filter::FILTER_INT:
 				/**


### PR DESCRIPTION
In regards to issue #10595
