### PR TITLE
Add error code in Memcached

### DIFF
--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -220,7 +220,7 @@ class Libmemcached extends Backend implements BackendInterface
 		}
 
 		if !success {
-			throw new Exception("Failed storing data in memcached");
+			throw new Exception("Failed storing data in memcached, error code: " . memcache->getResultCode());
 		}
 
 		let options = this->_options;


### PR DESCRIPTION
I'm having some trouble with Memcached->set() and I can't access the «getResultCode()» directly (this->_memcache is private). So adding the error code in the Exception message would help.
