### PR TITLE
Fixed annotation errors

### DIFF
--- a/phalcon/assets/manager.zep
+++ b/phalcon/assets/manager.zep
@@ -286,7 +286,7 @@ class Manager
 	/**
 	 * Traverses a collection calling the callback to generate its HTML
 	 *
-	 * @param Phalcon\Assets\Collection collection
+	 * @param \Phalcon\Assets\Collection collection
 	 * @param callback callback
 	 * @param string type
 	 */
@@ -697,7 +697,7 @@ class Manager
 	/**
 	 * Traverses a collection and generate its HTML
 	 *
-	 * @param Phalcon\Assets\Collection collection
+	 * @param \Phalcon\Assets\Collection collection
 	 * @param string type
 	 */
 	public function outputInline(<Collection> collection, type)

--- a/phalcon/cache/backend/mongo.zep
+++ b/phalcon/cache/backend/mongo.zep
@@ -60,7 +60,7 @@ class Mongo extends Backend implements BackendInterface
 	/**
 	* Phalcon\Cache\Backend\Mongo constructor
 	*
-	* @param Phalcon\Cache\FrontendInterface frontend
+	* @param \Phalcon\Cache\FrontendInterface frontend
 	* @param array options
 	*/
 	public function __construct(<FrontendInterface> frontend, options = null)

--- a/phalcon/cache/backend/xcache.zep
+++ b/phalcon/cache/backend/xcache.zep
@@ -53,7 +53,7 @@ class Xcache extends Backend implements BackendInterface
 	/**
 	 * Phalcon\Cache\Backend\Xcache constructor
 	 *
-	 * @param Phalcon\Cache\FrontendInterface frontend
+	 * @param \Phalcon\Cache\FrontendInterface frontend
 	 * @param array options
 	 */
 	public function __construct(<FrontendInterface> frontend, options = null)

--- a/phalcon/db/result/pdo.zep
+++ b/phalcon/db/result/pdo.zep
@@ -69,7 +69,7 @@ class Pdo implements ResultInterface
 	/**
 	 * Phalcon\Db\Result\Pdo constructor
 	 *
-	 * @param Phalcon\Db\AdapterInterface connection
+	 * @param \Phalcon\Db\AdapterInterface connection
 	 * @param \PDOStatement result
 	 * @param string sqlStatement
 	 * @param array bindParams

--- a/phalcon/db/resultinterface.zep
+++ b/phalcon/db/resultinterface.zep
@@ -30,7 +30,7 @@ interface ResultInterface
 	/**
 	 * Phalcon\Db\Result\Pdo constructor
 	 *
-	 * @param Phalcon\Db\AdapterInterface connection
+	 * @param \Phalcon\Db\AdapterInterface connection
 	 * @param \PDOStatement result
 	 * @param string sqlStatement
 	 * @param array bindParams

--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -120,7 +120,7 @@ class Service implements ServiceInterface
 	 * Resolves the service
 	 *
 	 * @param array parameters
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @return mixed
 	 */
 	public function resolve(parameters = null, <DiInterface> dependencyInjector = null)

--- a/phalcon/di/service/builder.zep
+++ b/phalcon/di/service/builder.zep
@@ -33,7 +33,7 @@ class Builder
 	/**
 	 * Resolves a constructor/call parameter
 	 *
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @param int position
 	 * @param array argument
 	 * @return mixed
@@ -122,7 +122,7 @@ class Builder
 	/**
 	 * Builds a service using a complex service definition
 	 *
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @param array definition
 	 * @param array parameters
 	 * @return mixed

--- a/phalcon/di/serviceinterface.zep
+++ b/phalcon/di/serviceinterface.zep
@@ -71,7 +71,7 @@ interface ServiceInterface
 	 * Resolves the service
 	 *
 	 * @param array parameters
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @return mixed
 	 */
 	public function resolve(parameters = null, <\Phalcon\DiInterface> dependencyInjector = null);

--- a/phalcon/events/manager.zep
+++ b/phalcon/events/manager.zep
@@ -199,7 +199,7 @@ class Manager implements ManagerInterface
 	 * Internal handler to call a queue of events
 	 *
 	 * @param \SplPriorityQueue|array queue
-	 * @param Phalcon\Events\Event event
+	 * @param \Phalcon\Events\Event event
 	 * @return mixed
 	 */
 	public final function fireQueue(var queue, <Event> event)

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -147,7 +147,7 @@ abstract class Element implements ElementInterface
 	/**
 	 * Adds a group of validators
 	 *
-	 * @param Phalcon\Validation\ValidatorInterface[]
+	 * @param \Phalcon\Validation\ValidatorInterface[]
 	 * @return Phalcon\Forms\ElementInterface
 	 */
 	public function addValidators(array! validators, boolean merge = true) -> <ElementInterface>

--- a/phalcon/forms/elementinterface.zep
+++ b/phalcon/forms/elementinterface.zep
@@ -34,7 +34,7 @@ interface ElementInterface
 	/**
 	 * Sets the parent form to the element
 	 *
-	 * @param Phalcon\Forms\Form form
+	 * @param \Phalcon\Forms\Form form
 	 * @return Phalcon\Forms\ElementInterface
 	 */
 	public function setForm(<\Phalcon\Forms\Form> form);
@@ -85,7 +85,7 @@ interface ElementInterface
 	/**
 	 * Adds a group of validators
 	 *
-	 * @param Phalcon\Validation\ValidatorInterface[]
+	 * @param \Phalcon\Validation\ValidatorInterface[]
 	 * @param boolean merge
 	 * @return Phalcon\Forms\ElementInterface
 	 */
@@ -94,7 +94,7 @@ interface ElementInterface
 	/**
 	 * Adds a validator to the element
 	 *
-	 * @param Phalcon\Validation\ValidatorInterface
+	 * @param \Phalcon\Validation\ValidatorInterface
 	 * @return Phalcon\Forms\ElementInterface
 	 */
 	public function addValidator(<ValidatorInterface> validator);
@@ -237,7 +237,7 @@ interface ElementInterface
 	/**
 	 * Sets the validation messages related to the element
 	 *
-	 * @param Phalcon\Validation\Message\Group group
+	 * @param \Phalcon\Validation\Message\Group group
 	 * @return Phalcon\Forms\ElementInterface
 	 */
 	public function setMessages(<Group> group);
@@ -245,7 +245,7 @@ interface ElementInterface
 	/**
 	 * Appends a message to the internal message list
 	 *
-	 * @param Phalcon\Validation\Message message
+	 * @param \Phalcon\Validation\Message message
 	 * @return Phalcon\Forms\ElementInterface
 	 */
 	public function appendMessage(<MessageInterface> message);

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -442,7 +442,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	/**
 	 * Adds an element to the form
 	 *
-	 * @param Phalcon\Forms\ElementInterface element
+	 * @param \Phalcon\Forms\ElementInterface element
 	 * @param string $postion
  	 * @param bool $type If $type is TRUE, the element wile add before $postion, else is after
 	 * @return Phalcon\Forms\Form

--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -333,7 +333,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 	 * Returns a collection resultset
 	 *
 	 * @param array params
-	 * @param Phalcon\Mvc\Collection collection
+	 * @param \Phalcon\Mvc\Collection collection
 	 * @param \MongoDb connection
 	 * @param boolean unique
 	 * @return array
@@ -444,7 +444,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 	 * Perform a count over a resultset
 	 *
 	 * @param array params
-	 * @param Phalcon\Mvc\Collection collection
+	 * @param \Phalcon\Mvc\Collection collection
 	 * @param \MongoDb connection
 	 * @return int
 	 */
@@ -508,7 +508,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 	/**
 	 * Executes internal hooks before save a document
 	 *
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @param boolean disableEvents
 	 * @param boolean exists
 	 * @return boolean

--- a/phalcon/mvc/collection/manager.zep
+++ b/phalcon/mvc/collection/manager.zep
@@ -106,7 +106,7 @@ class Manager implements InjectionAwareInterface, EventsAwareInterface
 	/**
 	 * Returns a custom events manager related to a model
 	 *
-	 * @param Phalcon\Mvc\CollectionInterface $model
+	 * @param \Phalcon\Mvc\CollectionInterface $model
  	 * @return Phalcon\Events\ManagerInterface
 	 */
 	public function getCustomEventsManager(<CollectionInterface> model) //-> <\Phalcon\Events\ManagerInterface>
@@ -209,7 +209,7 @@ class Manager implements InjectionAwareInterface, EventsAwareInterface
 	/**
 	 * Returns the connection related to a model
 	 *
-	 * @param Phalcon\Mvc\CollectionInterface $model
+	 * @param \Phalcon\Mvc\CollectionInterface $model
 	 * @return \Mongo
 	 */
 	public function getConnection(<CollectionInterface> model)

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -500,7 +500,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 *));
 	 *</code>
 	 *
-	 * @param Phalcon\Mvc\ModelInterface|Phalcon\Mvc\Model\Row base
+	 * @param \Phalcon\Mvc\ModelInterface|Phalcon\Mvc\Model\Row base
 	 * @param array data
 	 * @param array columnMap
 	 * @param int dirtyState
@@ -678,7 +678,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 *));
 	 *</code>
 	 *
-	 * @param Phalcon\Mvc\ModelInterface $base
+	 * @param \Phalcon\Mvc\ModelInterface $base
 	 * @param array data
 	 * @param int dirtyState
 	 * @return Phalcon\Mvc\ModelInterface
@@ -924,8 +924,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Checks if the current record already exists or not
 	 *
-	 * @param Phalcon\Mvc\Model\MetadataInterface metaData
-	 * @param Phalcon\Db\AdapterInterface connection
+	 * @param \Phalcon\Mvc\Model\MetadataInterface metaData
+	 * @param \Phalcon\Db\AdapterInterface connection
 	 * @param string|array table
 	 * @return boolean
 	 */
@@ -2092,8 +2092,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Sends a pre-build INSERT SQL statement to the relational database system
 	 *
-	 * @param Phalcon\Mvc\Model\MetadataInterface metaData
-	 * @param Phalcon\Db\AdapterInterface connection
+	 * @param \Phalcon\Mvc\Model\MetadataInterface metaData
+	 * @param \Phalcon\Db\AdapterInterface connection
 	 * @param string|array table
 	 * @param boolean|string identityField
 	 * @return boolean
@@ -2281,8 +2281,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Sends a pre-build UPDATE SQL statement to the relational database system
 	 *
-	 * @param Phalcon\Mvc\Model\MetaDataInterface metaData
-	 * @param Phalcon\Db\AdapterInterface connection
+	 * @param \Phalcon\Mvc\Model\MetaDataInterface metaData
+	 * @param \Phalcon\Db\AdapterInterface connection
 	 * @param string|array table
 	 * @return boolean
 	 */
@@ -2491,8 +2491,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Saves related records that must be stored prior to save the master record
 	 *
-	 * @param Phalcon\Db\AdapterInterface connection
-	 * @param Phalcon\Mvc\ModelInterface[] related
+	 * @param \Phalcon\Db\AdapterInterface connection
+	 * @param \Phalcon\Mvc\ModelInterface[] related
 	 * @return boolean
 	 */
 	protected function _preSaveRelatedRecords(<AdapterInterface> connection, related) -> boolean

--- a/phalcon/mvc/model/behavior.zep
+++ b/phalcon/mvc/model/behavior.zep
@@ -79,7 +79,7 @@ abstract class Behavior
 	/**
 	 * Acts as fallbacks when a missing method is called on the model
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @param string method
 	 * @param array arguments
 	 */

--- a/phalcon/mvc/model/behaviorinterface.zep
+++ b/phalcon/mvc/model/behaviorinterface.zep
@@ -44,7 +44,7 @@ interface BehaviorInterface
 	/**
 	 * Calls a method when it's missing in the model
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @param string method
 	 * @param array arguments
 	 */

--- a/phalcon/mvc/model/managerinterface.zep
+++ b/phalcon/mvc/model/managerinterface.zep
@@ -174,7 +174,7 @@ interface ManagerInterface
 	 * @param string method
 	 * @param string modelName
 	 * @param string modelRelation
-	 * @param Phalcon\Mvc\Model record
+	 * @param \Phalcon\Mvc\Model record
 	 * @param array parameters
 	 * @return Phalcon\Mvc\Model\ResultsetInterface
 	 */
@@ -186,7 +186,7 @@ interface ManagerInterface
 	 * @param string method
 	 * @param string modelName
 	 * @param string modelRelation
-	 * @param Phalcon\Mvc\Model record
+	 * @param \Phalcon\Mvc\Model record
 	 * @param array parameters
 	 * @return Phalcon\Mvc\Model\ResultsetInterface
 	 */
@@ -198,7 +198,7 @@ interface ManagerInterface
 	 * @param string method
 	 * @param string modelName
 	 * @param string modelRelation
-	 * @param Phalcon\Mvc\Model record
+	 * @param \Phalcon\Mvc\Model record
 	 * @param array parameters
 	 * @return Phalcon\Mvc\Model\ResultsetInterface
 	 */
@@ -288,7 +288,7 @@ interface ManagerInterface
 	 * Notify the behaviors that are listening in the model
 	 *
 	 * @param string eventName
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 */
 	public function notifyEvent(eventName, <ModelInterface> model);
 
@@ -297,7 +297,7 @@ interface ManagerInterface
 	 * This method expects that the endpoint listeners/behaviors returns true
 	 * meaning that a least one is implemented
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @param string eventName
 	 * @param array data
 	 * @return boolean

--- a/phalcon/mvc/model/message.zep
+++ b/phalcon/mvc/model/message.zep
@@ -65,7 +65,7 @@ class Message implements MessageInterface
 	 * @param string message
 	 * @param string|array field
 	 * @param string type
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 */
 	public function __construct(string! message, field = null, type = null, model = null)
 	{

--- a/phalcon/mvc/model/metadata/strategyinterface.zep
+++ b/phalcon/mvc/model/metadata/strategyinterface.zep
@@ -27,8 +27,8 @@ interface StrategyInterface
 	/**
 	 * The meta-data is obtained by reading the column descriptions from the database information schema
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @return array
 	 */
 	public function getMetaData(<ModelInterface> model, <DiInterface> dependencyInjector);
@@ -36,8 +36,8 @@ interface StrategyInterface
 	/**
 	 * Read the model's column map, this can't be inferred
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @return array
 	 * @todo Not implemented
 	 */

--- a/phalcon/mvc/model/metadatainterface.zep
+++ b/phalcon/mvc/model/metadatainterface.zep
@@ -45,7 +45,7 @@ interface MetaDataInterface
 	/**
 	 * Reads meta-data for certain model
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function readMetaData(<ModelInterface> model);
@@ -53,7 +53,7 @@ interface MetaDataInterface
 	/**
 	 * Reads meta-data for certain model using a MODEL_* constant
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @param int index
 	 * @return mixed
 	 */
@@ -62,7 +62,7 @@ interface MetaDataInterface
 	/**
 	 * Writes meta-data for certain model using a MODEL_* constant
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @param int index
 	 * @param mixed data
 	 */
@@ -71,7 +71,7 @@ interface MetaDataInterface
 	/**
 	 * Reads the ordered/reversed column map for certain model
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function readColumnMap(<ModelInterface> model);
@@ -79,7 +79,7 @@ interface MetaDataInterface
 	/**
 	 * Reads column-map information for certain model using a MODEL_* constant
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @param int index
 	 */
 	public function readColumnMapIndex(<ModelInterface> model, index);
@@ -87,7 +87,7 @@ interface MetaDataInterface
 	/**
 	 * Returns table attributes names (fields)
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getAttributes(<ModelInterface> model);
@@ -95,7 +95,7 @@ interface MetaDataInterface
 	/**
 	 * Returns an array of fields which are part of the primary key
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getPrimaryKeyAttributes(<ModelInterface> model);
@@ -103,7 +103,7 @@ interface MetaDataInterface
 	/**
 	 * Returns an arrau of fields which are not part of the primary key
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getNonPrimaryKeyAttributes(<ModelInterface> model);
@@ -111,7 +111,7 @@ interface MetaDataInterface
 	/**
 	 * Returns an array of not null attributes
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getNotNullAttributes(<ModelInterface> model);
@@ -119,7 +119,7 @@ interface MetaDataInterface
 	/**
 	 * Returns attributes and their data types
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getDataTypes(<ModelInterface> model);
@@ -127,7 +127,7 @@ interface MetaDataInterface
 	/**
 	 * Returns attributes which types are numerical
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getDataTypesNumeric(<ModelInterface> model);
@@ -135,7 +135,7 @@ interface MetaDataInterface
 	/**
 	 * Returns the name of identity field (if one is present)
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return string
 	 */
 	public function getIdentityField(<ModelInterface> model);
@@ -143,7 +143,7 @@ interface MetaDataInterface
 	/**
 	 * Returns attributes and their bind data types
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getBindTypes(<ModelInterface> model);
@@ -151,7 +151,7 @@ interface MetaDataInterface
 	/**
 	 * Returns attributes that must be ignored from the INSERT SQL generation
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getAutomaticCreateAttributes(<ModelInterface> model);
@@ -159,7 +159,7 @@ interface MetaDataInterface
 	/**
 	 * Returns attributes that must be ignored from the UPDATE SQL generation
 	 *
-	 * @param Phalcon\Mvc\ModelInterface model
+	 * @param \Phalcon\Mvc\ModelInterface model
 	 * @return array
 	 */
 	public function getAutomaticUpdateAttributes(<ModelInterface> model) -> array;

--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -93,8 +93,8 @@ abstract class Resultset
 	 * Phalcon\Mvc\Model\Resultset constructor
 	 *
 	 * @param array columnTypes
-	 * @param Phalcon\Db\ResultInterface|false result
-	 * @param Phalcon\Cache\BackendInterface cache
+	 * @param \Phalcon\Db\ResultInterface|false result
+	 * @param \Phalcon\Cache\BackendInterface cache
 	 */
 	public function __construct(result, <BackendInterface> cache = null)
 	{
@@ -289,7 +289,7 @@ abstract class Resultset
 	 * Resultsets cannot be changed. It has only been implemented to meet the definition of the ArrayAccess interface
 	 *
 	 * @param int index
-	 * @param Phalcon\Mvc\ModelInterface value
+	 * @param \Phalcon\Mvc\ModelInterface value
 	 */
 	public function offsetSet(var index, var value)
 	{
@@ -394,7 +394,7 @@ abstract class Resultset
 	 * Updates every record in the resultset
 	 *
 	 * @param array data
-	 * @param Closure conditionCallback
+	 * @param \Closure conditionCallback
 	 * @return boolean
 	 */
 	public function update(var data, <\Closure> conditionCallback = null) -> boolean

--- a/phalcon/mvc/model/resultset/complex.zep
+++ b/phalcon/mvc/model/resultset/complex.zep
@@ -46,8 +46,8 @@ class Complex extends Resultset implements ResultsetInterface
 	 * Phalcon\Mvc\Model\Resultset\Complex constructor
 	 *
 	 * @param array columnTypes
-	 * @param Phalcon\Db\ResultInterface result
-	 * @param Phalcon\Cache\BackendInterface cache
+	 * @param \Phalcon\Db\ResultInterface result
+	 * @param \Phalcon\Cache\BackendInterface cache
 	 */
 	public function __construct(var columnTypes, <ResultInterface> result = null, <BackendInterface> cache = null)
 	{

--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -44,9 +44,9 @@ class Simple extends Resultset
 	 * Phalcon\Mvc\Model\Resultset\Simple constructor
 	 *
 	 * @param array columnMap
-	 * @param Phalcon\Mvc\ModelInterface|Phalcon\Mvc\Model\Row model
-	 * @param Phalcon\Db\Result\Pdo|null result
-	 * @param Phalcon\Cache\BackendInterface cache
+	 * @param \Phalcon\Mvc\ModelInterface|Phalcon\Mvc\Model\Row model
+	 * @param \Phalcon\Db\Result\Pdo|null result
+	 * @param \Phalcon\Cache\BackendInterface cache
 	 * @param boolean keepSnapshots
 	 */
 	public function __construct(var columnMap, var model, result, <BackendInterface> cache = null, keepSnapshots = null)

--- a/phalcon/mvc/model/row.zep
+++ b/phalcon/mvc/model/row.zep
@@ -71,7 +71,7 @@ class Row implements EntityInterface, ResultInterface, \ArrayAccess
 	 * Rows cannot be changed. It has only been implemented to meet the definition of the ArrayAccess interface
 	 *
 	 * @param string|int index
-	 * @param Phalcon\Mvc\ModelInterface value
+	 * @param \Phalcon\Mvc\ModelInterface value
 	 */
 	public function offsetSet(var index, var value)
 	{

--- a/phalcon/mvc/model/transaction.zep
+++ b/phalcon/mvc/model/transaction.zep
@@ -82,7 +82,7 @@ class Transaction implements TransactionInterface
 	/**
 	 * Phalcon\Mvc\Model\Transaction constructor
 	 *
-	 * @param Phalcon\DiInterface $ependencyInjector
+	 * @param \Phalcon\DiInterface $ependencyInjector
 	 * @param boolean autoBegin
 	 * @param string service
 	 */

--- a/phalcon/mvc/model/validatorinterface.zep
+++ b/phalcon/mvc/model/validatorinterface.zep
@@ -39,7 +39,7 @@ interface ValidatorInterface
 	/**
 	 * Executes the validator
 	 *
-	 * @param Phalcon\Mvc\ModelInterface record
+	 * @param \Phalcon\Mvc\ModelInterface record
 	 * @return boolean
 	 */
 	public function validate(<EntityInterface> record) -> boolean;

--- a/phalcon/mvc/modelinterface.zep
+++ b/phalcon/mvc/modelinterface.zep
@@ -101,7 +101,7 @@ interface ModelInterface
 	/**
 	 * Assigns values to a model from an array
 	 *
-	 * @param Phalcon\Mvc\Model object
+	 * @param \Phalcon\Mvc\Model object
 	 * @param array data
 	 * @param array columnMap
 	 * @return Phalcon\Mvc\Model
@@ -111,7 +111,7 @@ interface ModelInterface
 	/**
 	 * Assigns values to a model from an array returning a new model
 	 *
-	 * @param Phalcon\Mvc\Model base
+	 * @param \Phalcon\Mvc\Model base
 	 * @param array data
 	 * @param array columnMap
 	 * @param int dirtyState
@@ -123,7 +123,7 @@ interface ModelInterface
 	/**
 	 * Assigns values to a model from an array returning a new model
 	 *
-	 * @param Phalcon\Mvc\ModelInterface base
+	 * @param \Phalcon\Mvc\ModelInterface base
 	 * @param array data
 	 * @param int dirtyState
 	 * @return Phalcon\Mvc\ModelInterface
@@ -158,7 +158,7 @@ interface ModelInterface
 	/**
 	 * Create a criteria for a especific model
 	 *
-	 * @param Phalcon\DiInterface dependencyInjector
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @return Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public static function query(<DiInterface> dependencyInjector = null);

--- a/phalcon/mvc/router/annotations.zep
+++ b/phalcon/mvc/router/annotations.zep
@@ -236,7 +236,7 @@ class Annotations extends Router
 	 * @param string namespaceName
 	 * @param string controller
 	 * @param string action
-	 * @param Phalcon\Annotations\Annotation annotation
+	 * @param \Phalcon\Annotations\Annotation annotation
 	 */
 	public function processActionAnnotation(string! module, string! namespaceName, string! controller, string! action,
 		<Annotation> annotation)

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -567,7 +567,7 @@ class View extends Injectable implements ViewInterface
 	 * @param string viewPath
 	 * @param boolean silence
 	 * @param boolean mustClean
-	 * @param Phalcon\Cache\BackendInterface $cache
+	 * @param \Phalcon\Cache\BackendInterface $cache
 	 */
 	protected function _engineRender(engines, string viewPath, boolean silence, boolean mustClean, <BackendInterface> cache = null)
 	{

--- a/phalcon/tag/select.zep
+++ b/phalcon/tag/select.zep
@@ -147,7 +147,7 @@ abstract class Select
 	/**
 	 * Generate the OPTION tags based on a resultset
 	 *
-	 * @param Phalcon\Mvc\Model\Resultset resultset
+	 * @param \Phalcon\Mvc\Model\Resultset resultset
 	 * @param array using
 	 * @param mixed value
 	 * @param string closeOption

--- a/phalcon/validation/message/group.zep
+++ b/phalcon/validation/message/group.zep
@@ -75,7 +75,7 @@ class Group implements \Countable, \ArrayAccess, \Iterator
 	 *</code>
 	 *
 	 * @param int index
-	 * @param Phalcon\Validation\Message message
+	 * @param \Phalcon\Validation\Message message
 	 */
 	public function offsetSet(int! index, var message)
 	{
@@ -136,7 +136,7 @@ class Group implements \Countable, \ArrayAccess, \Iterator
 	 * $messages->appendMessages($messagesArray);
 	 *</code>
 	 *
-	 * @param Phalcon\Validation\MessageInterface[] messages
+	 * @param \Phalcon\Validation\MessageInterface[] messages
 	 */
 	public function appendMessages(messages)
 	{


### PR DESCRIPTION
Added the backslash in front of Phalcon in annotation tags, where it was missing.
Also added a backslash in front of a Closure type hint, where it was missing.
