### PR TITLE
make transactionManager service name be concordant

### DIFF
--- a/phalcon/di/factorydefault.zep
+++ b/phalcon/di/factorydefault.zep
@@ -56,7 +56,7 @@ class FactoryDefault extends \Phalcon\Di
 			"session":            new Service("session", "Phalcon\\Session\\Adapter\\Files", true),
 			"sessionBag":         new Service("sessionBag", "Phalcon\\Session\\Bag"),
 			"eventsManager":      new Service("eventsManager", "Phalcon\\Events\\Manager", true),
-			"transactionManager": new Service("transactions", "Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
+			"transactionManager": new Service("transactionManager", "Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
 			"assets":             new Service("assets", "Phalcon\\Assets\\Manager", true)
 		];
 	}


### PR DESCRIPTION
make transactionManager service name be concordant.

``` php
foreach ($di->getServices() as $service) {
    $realService = $di->get($service->getName());
} 
```

will throw:
Service 'transactions' wasn't found in the dependency injection container
