### PR TITLE
Image\Adapter\Gd::save() no longer fails if the method or the instance is created with a filename without an extension

### DIFF
--- a/phalcon/image/adapter/gd.zep
+++ b/phalcon/image/adapter/gd.zep
@@ -501,7 +501,14 @@ class Gd extends Adapter implements AdapterInterface
 	{
 		var ext;
 
-		let ext = strtolower(pathinfo(file, PATHINFO_EXTENSION));
+		let ext = pathinfo(file, PATHINFO_EXTENSION);
+
+		// If no extension is given, revert to the original type.
+		if !ext {
+			let ext = image_type_to_extension(this->_type, false);
+		}
+
+		let ext = strtolower(ext);
 
 		if strcmp(ext, "gif") == 0 {
 			let this->_type = 1;


### PR DESCRIPTION
See #10709

Previously, something like these examples would have failed:

``` php
$image = new \Phalcon\Image\Adapter\Gd('image.jpg');
// ...
$image->save();
```

or...

``` php
$image = new \Phalcon\Image\Adapter\Gd('image.jpg');
// ...
$image->save('filename-without-extension');
```
