### PR TITLE
 Implemented feature #10704, added ability to disable implicit joins for query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [2.0.7](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.7) (2015-XX-XX)
-
+- Added orm.enable_implicit_joins option for allowing implicit joins to be disabled [#10704](https://github.com/phalcon/cphalcon/issues/10704)
+- Fixed bug causing SELECT subqueries to join against all of the tables from the previous query [#10705](https://github.com/phalcon/cphalcon/issues/10705)
 
 # [2.0.6](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.6) (2015-07-21)
 - Builds in TravisCI now uses Docker to perform faster builds

--- a/config.json
+++ b/config.json
@@ -85,6 +85,10 @@
             "type": "bool",
             "default": false
         },
+        "orm.enable_implicit_joins": {
+            "type": "bool",
+            "default": true
+        },
         "orm.cast_on_hydrate": {
             "type": "bool",
             "default": false

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -1248,15 +1248,14 @@ class Query implements QueryInterface, InjectionAwareInterface
 			joinPrepared, manager, selectJoins, joinItem, joins, joinData, schema, source, model,
 			realModelName, completeSource, joinType, aliasExpr, alias, joinAliasName, joinExpr,
 			fromModelName, joinAlias, joinModel, joinSource, preCondition, modelNameAlias,
-			relation, relations, modelAlias, sqlJoin, sqlJoinItem;
+			relation, relations, modelAlias, sqlJoin, sqlJoinItem, selectTables, table, tables, tableItem;
 
 		let models = this->_models,
 			sqlAliases = this->_sqlAliases,
 			sqlAliasesModels = this->_sqlAliasesModels,
 			sqlModelsAliases = this->_sqlModelsAliases,
 			sqlAliasesModelsInstances = this->_sqlAliasesModelsInstances,
-			modelsInstances = this->_modelsInstances,
-			fromModels = models;
+			modelsInstances = this->_modelsInstances;
 
 		let sqlJoins = [],
 			joinModels = [],
@@ -1266,6 +1265,13 @@ class Query implements QueryInterface, InjectionAwareInterface
 			joinPrepared = [];
 
 		let manager = this->_manager;
+
+		let tables = select["tables"];
+		if !isset tables[0] {
+			let selectTables = [tables];
+		} else {
+			let selectTables = tables;
+		}
 
 		let joins = select["joins"];
 		if !isset joins[0] {
@@ -1437,7 +1443,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 		 * Skip all implicit joins if the option is not enabled
 		 */
 		if !this->_enableImplicitJoins {
-			for joinAliasName, joinItem in joinPrepared {
+			for joinAliasName, _ in joinPrepared {
 
 				let joinType = joinTypes[joinAliasName];
 				let joinSource = joinSources[joinAliasName];
@@ -1449,6 +1455,15 @@ class Query implements QueryInterface, InjectionAwareInterface
 				];
 			}
 			return sqlJoins;
+		}
+
+		/**
+		 * Build the list of tables used in the SELECT clause
+		 */
+		let fromModels = [];
+		for tableItem in selectTables {
+			let table = tableItem["qualifiedName"]["name"];
+			let fromModels[table]	= true;
 		}
 
 		/**


### PR DESCRIPTION
I think that the impact on the code for stability concerns is very low because this feature is skipped over with the default settings.  The options name can be changed easily once this is accepted.

I also have a another fix for bug #10705 but I think that I can refactor the solution to better take advantage of calculations performed earlier in the routine.

So I see this as a two part fix with an iterative strategy;
1. To be able to bypass the problematic implicit join code as new issues come up.
2. To iterate on fixing bugs in the join code as they surface and thus being able to re-enable the implicit joining.

Its a terrible situation to hit a blocker bug when doing complicated PHQL queries (such as nested queries) and this will allow the developer to continue building their application in PHP land by performing explicit-only joins until such a time that he has time to fix the Phalcon bug.
