### PR TITLE
Fixed wrong return types

### DIFF
--- a/phalcon/annotations/adapter/apc.zep
+++ b/phalcon/annotations/adapter/apc.zep
@@ -62,7 +62,7 @@ class Apc extends Adapter implements AdapterInterface
 	 * Reads parsed annotations from APC
 	 *
 	 * @param string key
-	 * @return Phalcon\Annotations\Reflection
+	 * @return \Phalcon\Annotations\Reflection
 	 */
 	public function read(string! key) -> <Reflection> | boolean
 	{

--- a/phalcon/annotations/adapter/files.zep
+++ b/phalcon/annotations/adapter/files.zep
@@ -58,7 +58,7 @@ class Files extends Adapter implements AdapterInterface
 	 * Reads parsed annotations from files
 	 *
 	 * @param string key
-	 * @return Phalcon\Annotations\Reflection
+	 * @return \Phalcon\Annotations\Reflection
 	 */
 	public function read(string key) -> <Reflection> | boolean | int
 	{

--- a/phalcon/annotations/adapter/memory.zep
+++ b/phalcon/annotations/adapter/memory.zep
@@ -40,7 +40,7 @@ class Memory extends Adapter implements AdapterInterface
 	* Reads parsed annotations from memory
 	*
 	* @param string key
-	* @return Phalcon\Annotations\Reflection
+	* @return \Phalcon\Annotations\Reflection
 	*/
 	public function read(string! key) -> <Reflection> | boolean
 	{

--- a/phalcon/annotations/adapter/xcache.zep
+++ b/phalcon/annotations/adapter/xcache.zep
@@ -39,7 +39,7 @@ class Xcache extends Adapter implements AdapterInterface
 	 * Reads parsed annotations from XCache
 	 *
 	 * @param string key
-	 * @return Phalcon\Annotations\Reflection
+	 * @return \Phalcon\Annotations\Reflection
 	 */
 	public function read(string! key) -> <Reflection> | boolean
 	{

--- a/phalcon/annotations/adapterinterface.zep
+++ b/phalcon/annotations/adapterinterface.zep
@@ -43,7 +43,7 @@ interface AdapterInterface
 	 * Parses or retrieves all the annotations found in a class
 	 *
 	 * @param string|object className
-	 * @return Phalcon\Annotations\Reflection
+	 * @return \Phalcon\Annotations\Reflection
 	 */
 	public function get(className);
 
@@ -60,7 +60,7 @@ interface AdapterInterface
 	 *
 	 * @param string className
 	 * @param string methodName
-	 * @return Phalcon\Annotations\Collection
+	 * @return \Phalcon\Annotations\Collection
 	 */
 	public function getMethod(className, methodName);
 
@@ -77,7 +77,7 @@ interface AdapterInterface
 	 *
 	 * @param string className
 	 * @param string propertyName
-	 * @return Phalcon\Annotations\Collection
+	 * @return \Phalcon\Annotations\Collection
 	 */
 	public function getProperty(className, propertyName);
 }

--- a/phalcon/annotations/collection.zep
+++ b/phalcon/annotations/collection.zep
@@ -88,7 +88,7 @@ class Collection implements \Iterator, \Countable
 	/**
 	 * Returns the current annotation in the iterator
 	 *
-	 * @return Phalcon\Annotations\Annotation
+	 * @return \Phalcon\Annotations\Annotation
 	 */
 	public function current() -> <Annotation> | boolean
 	{

--- a/phalcon/assets/collection.zep
+++ b/phalcon/assets/collection.zep
@@ -133,7 +133,7 @@ class Collection implements \Countable, \Iterator
 	 * @param boolean local
 	 * @param boolean filter
 	 * @param array attributes
-	 * @return Phalcon\Assets\Collection
+	 * @return \Phalcon\Assets\Collection
 	 */
 	public function addJs(string! path, var local = null, boolean filter = false, attributes = null) -> <Collection>
 	{

--- a/phalcon/cli/router.zep
+++ b/phalcon/cli/router.zep
@@ -389,7 +389,7 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Cli\Router\Route
+	 * @return \Phalcon\Cli\Router\Route
 	 */
 	public function add(string! pattern, paths = null) -> <Route>
 	{
@@ -472,7 +472,7 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 	 * Returns a route object by its id
 	 *
 	 * @param int id
-	 * @return Phalcon\Cli\Router\Route
+	 * @return \Phalcon\Cli\Router\Route
 	 */
 	public function getRouteById(var id) -> <Route> | boolean
 	{

--- a/phalcon/cli/router/route.zep
+++ b/phalcon/cli/router/route.zep
@@ -449,7 +449,7 @@ class Route
 	 * If the callback returns false the route is treated as not matched
 	 *
 	 * @param callback callback
-	 * @return Phalcon\Cli\Router\Route
+	 * @return \Phalcon\Cli\Router\Route
 	 */
 	public function beforeMatch(var callback) -> <Route>
 	{
@@ -518,7 +518,7 @@ class Route
 	 *
 	 * @param string name
 	 * @param callable converter
-	 * @return Phalcon\Cli\Router\Route
+	 * @return \Phalcon\Cli\Router\Route
 	 */
 	public function convert(string! name, converter) -> <Route>
 	{

--- a/phalcon/db/profiler.zep
+++ b/phalcon/db/profiler.zep
@@ -82,7 +82,7 @@ class Profiler
 	 * Starts the profile of a SQL sentence
 	 *
 	 * @param string sqlStatement
-	 * @return Phalcon\Db\Profiler
+	 * @return \Phalcon\Db\Profiler
 	 */
 	public function startProfile(var sqlStatement, var sqlVariables = null, var sqlBindTypes = null) -> <Profiler>
 	{

--- a/phalcon/diinterface.zep
+++ b/phalcon/diinterface.zep
@@ -36,7 +36,7 @@ interface DiInterface extends \ArrayAccess
 	 * @param string name
 	 * @param mixed definition
 	 * @param boolean shared
-	 * @return Phalcon\Di\ServiceInterface
+	 * @return \Phalcon\Di\ServiceInterface
 	 */
 	public function set(string! name, definition, boolean shared = false) -> <ServiceInterface>;
 
@@ -45,7 +45,7 @@ interface DiInterface extends \ArrayAccess
 	 *
 	 * @param string name
 	 * @param mixed definition
-	 * @return Phalcon\Di\ServiceInterface
+	 * @return \Phalcon\Di\ServiceInterface
 	 */
 	public function setShared(string! name, definition) -> <ServiceInterface>;
 
@@ -62,7 +62,7 @@ interface DiInterface extends \ArrayAccess
 	 * @param string name
 	 * @param mixed definition
 	 * @param boolean shared
-	 * @return Phalcon\Di\ServiceInterface
+	 * @return \Phalcon\Di\ServiceInterface
 	 */
 	public function attempt(string! name, definition, boolean shared = false) -> <ServiceInterface>;
 

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -104,7 +104,7 @@ abstract class Element implements ElementInterface
 	 * Sets the element filters
 	 *
 	 * @param array|string filters
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setFilters(var filters) -> <ElementInterface>
 	{
@@ -148,7 +148,7 @@ abstract class Element implements ElementInterface
 	 * Adds a group of validators
 	 *
 	 * @param \Phalcon\Validation\ValidatorInterface[]
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function addValidators(array! validators, boolean merge = true) -> <ElementInterface>
 	{
@@ -257,7 +257,7 @@ abstract class Element implements ElementInterface
 	 *
 	 * @param string attribute
 	 * @param mixed value
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setAttribute(string attribute, value) -> <ElementInterface>
 	{
@@ -309,7 +309,7 @@ abstract class Element implements ElementInterface
 	 *
 	 * @param string option
 	 * @param mixed value
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setUserOption(string option, value) -> <ElementInterface>
 	{
@@ -337,7 +337,7 @@ abstract class Element implements ElementInterface
 	 * Sets options for the element
 	 *
 	 * @param array options
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setUserOptions(options) -> <ElementInterface>
 	{
@@ -419,7 +419,7 @@ abstract class Element implements ElementInterface
 	 * or there is no value available for the element in _POST
 	 *
 	 * @param mixed value
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setDefault(value) -> <ElementInterface>
 	{

--- a/phalcon/forms/element/select.zep
+++ b/phalcon/forms/element/select.zep
@@ -48,7 +48,7 @@ class Select extends Element implements ElementInterface {
 	 * Set the choice's options
 	 *
 	 * @param array|object options
-	 * @return Phalcon\Forms\Element
+	 * @return \Phalcon\Forms\Element
 	 */
 	public function setOptions(var options) -> <Element>
 	{

--- a/phalcon/forms/elementinterface.zep
+++ b/phalcon/forms/elementinterface.zep
@@ -35,14 +35,14 @@ interface ElementInterface
 	 * Sets the parent form to the element
 	 *
 	 * @param \Phalcon\Forms\Form form
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setForm(<\Phalcon\Forms\Form> form);
 
 	/**
 	 * Returns the parent form to the element
 	 *
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function getForm();
 
@@ -50,7 +50,7 @@ interface ElementInterface
 	 * Sets the element's name
 	 *
 	 * @param string name
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setName(string name);
 
@@ -63,7 +63,7 @@ interface ElementInterface
 	 * Sets the element's filters
 	 *
 	 * @param array|string filters
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setFilters(filters);
 
@@ -71,7 +71,7 @@ interface ElementInterface
 	 * Adds a filter to current list of filters
 	 *
 	 * @param string filter
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function addFilter(filter);
 
@@ -87,7 +87,7 @@ interface ElementInterface
 	 *
 	 * @param \Phalcon\Validation\ValidatorInterface[]
 	 * @param boolean merge
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function addValidators(array! validators, merge = true);
 
@@ -95,14 +95,14 @@ interface ElementInterface
 	 * Adds a validator to the element
 	 *
 	 * @param \Phalcon\Validation\ValidatorInterface
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function addValidator(<ValidatorInterface> validator);
 
 	/**
 	 * Returns the validators registered for the element
 	 *
-	 * @return Phalcon\Validation\ValidatorInterface[]
+	 * @return \Phalcon\Validation\ValidatorInterface[]
 	 */
 	public function getValidators();
 
@@ -121,7 +121,7 @@ interface ElementInterface
 	 *
 	 * @param string attribute
 	 * @param mixed value
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setAttribute(attribute, value);
 
@@ -138,7 +138,7 @@ interface ElementInterface
 	 * Sets default attributes for the element
 	 *
 	 * @param array attributes
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setAttributes(array! attributes);
 
@@ -152,7 +152,7 @@ interface ElementInterface
 	 *
 	 * @param string option
 	 * @param mixed value
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setUserOption(option, value);
 
@@ -169,7 +169,7 @@ interface ElementInterface
 	 * Sets options for the element
 	 *
 	 * @param array options
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setUserOptions(options);
 
@@ -184,7 +184,7 @@ interface ElementInterface
 	 * Sets the element label
 	 *
 	 * @param string label
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setLabel(label);
 
@@ -203,7 +203,7 @@ interface ElementInterface
 	 * or there is no value available for the element in _POST
 	 *
 	 * @param mixed value
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setDefault(value);
 
@@ -225,7 +225,7 @@ interface ElementInterface
 	 * Returns the messages that belongs to the element
 	 * The element needs to be attached to a form
 	 *
-	 * @return Phalcon\Validation\Message\Group
+	 * @return \Phalcon\Validation\Message\Group
 	 */
 	public function getMessages();
 
@@ -238,7 +238,7 @@ interface ElementInterface
 	 * Sets the validation messages related to the element
 	 *
 	 * @param \Phalcon\Validation\Message\Group group
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function setMessages(<Group> group);
 
@@ -246,14 +246,14 @@ interface ElementInterface
 	 * Appends a message to the internal message list
 	 *
 	 * @param \Phalcon\Validation\Message message
-	 * @return Phalcon\Forms\ElementInterface
+	 * @return \Phalcon\Forms\ElementInterface
 	 */
 	public function appendMessage(<MessageInterface> message);
 
 	/**
 	 * Clears every element in the form to its default value
 	 *
-	 * @return Phalcon\Forms\Element
+	 * @return \Phalcon\Forms\Element
 	 */
 	public function clear();
 

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -86,7 +86,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 * Sets the form's action
 	 *
 	 * @param string action
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function setAction(var action) -> <Form>
 	{
@@ -107,7 +107,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 *
 	 * @param string option
 	 * @param mixed value
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function setUserOption(var option, var value) -> <Form>
 	{
@@ -154,7 +154,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 * Sets the entity related to the model
 	 *
 	 * @param object entity
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function setEntity(var entity) -> <Form>
 	{
@@ -186,7 +186,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 * @param array data
 	 * @param object entity
 	 * @param array whitelist
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function bind(array! data, var entity, var whitelist = null) -> <Form>
 	{
@@ -412,7 +412,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 * Returns the messages generated for a specific element
 	 *
 	 * @param string name
-	 * @return Phalcon\Validation\Message\Group
+	 * @return \Phalcon\Validation\Message\Group
 	 */
 	public function getMessagesFor(var name) -> <Group>
 	{
@@ -445,7 +445,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 * @param \Phalcon\Forms\ElementInterface element
 	 * @param string $postion
  	 * @param bool $type If $type is TRUE, the element wile add before $postion, else is after
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function add(<ElementInterface> element, string postion = null, boolean type = null) -> <Form>
 	{
@@ -666,7 +666,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 * Clears every element in the form to its default value
 	 *
 	 * @param array fields
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function clear(var fields = null) -> <Form>
 	{

--- a/phalcon/forms/manager.zep
+++ b/phalcon/forms/manager.zep
@@ -31,7 +31,7 @@ class Manager
 	 *
 	 * @param string name
 	 * @param object entity
-	 * @return Phalcon\Forms\Form
+	 * @return \Phalcon\Forms\Form
 	 */
 	public function create(name = null, entity = null) -> <Form>
 	{

--- a/phalcon/http/cookie.zep
+++ b/phalcon/http/cookie.zep
@@ -115,7 +115,7 @@ class Cookie implements InjectionAwareInterface
 	 * Sets the cookie's value
 	 *
 	 * @param string value
-	 * @return Phalcon\Http\Cookie
+	 * @return \Phalcon\Http\Cookie
 	 */
 	public function setValue(value) -> <Cookie>
 	{

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -268,7 +268,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	/**
 	 * Returns coookies set by the user
 	 *
-	 * @return Phalcon\Http\Response\CookiesInterface
+	 * @return \Phalcon\Http\Response\CookiesInterface
 	 */
 	public function getCookies() -> <CookiesInterface>
 	{
@@ -284,7 +284,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 *
 	 * @param string name
 	 * @param string value
-	 * @return Phalcon\Http\Response
+	 * @return \Phalcon\Http\Response
 	 */
 	public function setHeader(string name, value) -> <Response>
 	{
@@ -385,7 +385,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 *
 	 * @param string contentType
 	 * @param string charset
-	 * @return Phalcon\Http\Response
+	 * @return \Phalcon\Http\Response
 	 */
 	public function setContentType(string contentType, charset = null) -> <Response>
 	{
@@ -434,7 +434,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 * @param string|array location
 	 * @param boolean externalRedirect
 	 * @param int statusCode
-	 * @return Phalcon\Http\Response
+	 * @return \Phalcon\Http\Response
 	 */
 	public function redirect(location = null, boolean externalRedirect = false, int statusCode = 302) -> <Response>
 	{
@@ -515,7 +515,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 *
 	 * @param mixed content
 	 * @param int jsonOptions
-	 * @return Phalcon\Http\Response
+	 * @return \Phalcon\Http\Response
 	 */
 	public function setJsonContent(var content, jsonOptions = 0, depth = 512) -> <Response>
 	{
@@ -527,7 +527,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 * Appends a string to the HTTP response body
 	 *
 	 * @param string content
-	 * @return Phalcon\Http\Response
+	 * @return \Phalcon\Http\Response
 	 */
 	public function appendContent(content) -> <Response>
 	{
@@ -627,7 +627,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 *
 	 * @param string filePath
 	 * @param string attachmentName
-	 * @return Phalcon\Http\Response
+	 * @return \Phalcon\Http\Response
 	 */
 	public function setFileToSend(string filePath, attachmentName = null, attachment = true) -> <Response>
 	{

--- a/phalcon/http/responseinterface.zep
+++ b/phalcon/http/responseinterface.zep
@@ -44,7 +44,7 @@ interface ResponseInterface
 	 *
 	 * @param string name
 	 * @param string value
-	 * @return Phalcon\Http\ResponseInterface
+	 * @return \Phalcon\Http\ResponseInterface
 	 */
 	public function setHeader(string name, value) -> <ResponseInterface>;
 
@@ -72,7 +72,7 @@ interface ResponseInterface
 	 *
 	 * @param string contentType
 	 * @param string charset
-	 * @return Phalcon\Http\ResponseInterface
+	 * @return \Phalcon\Http\ResponseInterface
 	 */
 	public function setContentType(string contentType, charset = null) -> <ResponseInterface>;
 
@@ -82,7 +82,7 @@ interface ResponseInterface
 	 * @param string location
 	 * @param boolean externalRedirect
 	 * @param int statusCode
-	 * @return Phalcon\Http\ResponseInterface
+	 * @return \Phalcon\Http\ResponseInterface
 	 */
 	public function redirect(location = null, boolean externalRedirect = false, int statusCode = 302) -> <ResponseInterface>;
 
@@ -99,7 +99,7 @@ interface ResponseInterface
 	 *</code>
 	 *
 	 * @param string content
-	 * @return Phalcon\Http\ResponseInterface
+	 * @return \Phalcon\Http\ResponseInterface
 	 */
 	public function setJsonContent(content) -> <ResponseInterface>;
 
@@ -107,7 +107,7 @@ interface ResponseInterface
 	 * Appends a string to the HTTP response body
 	 *
 	 * @param string content
-	 * @return Phalcon\Http\ResponseInterface
+	 * @return \Phalcon\Http\ResponseInterface
 	 */
 	public function appendContent(content) -> <ResponseInterface>;
 

--- a/phalcon/logger/adapterinterface.zep
+++ b/phalcon/logger/adapterinterface.zep
@@ -32,14 +32,14 @@ interface AdapterInterface
 	/**
 	 * Sets the message formatter
 	 *
-	 * @return Phalcon\Logger\Adapter
+	 * @return \Phalcon\Logger\Adapter
 	 */
 	public function setFormatter(<FormatterInterface> formatter);
 
 	/**
 	 * Returns the internal formatter
 	 *
-	 * @return Phalcon\Logger\FormatterInterface
+	 * @return \Phalcon\Logger\FormatterInterface
 	 */
 	public function getFormatter();
 
@@ -47,7 +47,7 @@ interface AdapterInterface
 	 * Filters the logs sent to the handlers to be greater or equals than a specific level
 	 *
 	 * @param int level
-	 * @return Phalcon\Logger\Adapter
+	 * @return \Phalcon\Logger\Adapter
 	 */
 	public function setLogLevel(int level);
 
@@ -61,28 +61,28 @@ interface AdapterInterface
 	/**
 	 * Sends/Writes messages to the file log
 	 *
-	 * @return Phalcon\Logger\Adapter1
+	 * @return \Phalcon\Logger\Adapter1
 	 */
 	public function log(var type, var message = null, array! context = null);
 
 	/**
  	 * Starts a transaction
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function begin();
 
 	/**
  	 * Commits the internal transaction
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function commit();
 
 	/**
  	 * Rollbacks the internal transaction
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function rollback();
 
@@ -94,49 +94,49 @@ interface AdapterInterface
 	/**
  	 * Sends/Writes a debug message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function debug(string! message, array! context = null);
 
 	/**
  	 * Sends/Writes an error message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function error(string! message, array! context = null);
 
 	/**
  	 * Sends/Writes an info message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function info(string! message, array! context = null);
 
 	/**
  	 * Sends/Writes a notice message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function notice(string! message, array! context = null);
 
 	/**
  	 * Sends/Writes a warning message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function warning(string! message, array! context = null);
 
 	/**
  	 * Sends/Writes an alert message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function alert(string! message, array! context = null);
 
 	/**
  	 * Sends/Writes an emergency message to the log
  	 *
- 	 * @return Phalcon\Logger\Adapter
+ 	 * @return \Phalcon\Logger\Adapter
  	 */
 	public function emergency(string! message, array! context = null);
 }

--- a/phalcon/mvc/application.zep
+++ b/phalcon/mvc/application.zep
@@ -183,7 +183,7 @@ class Application extends Injectable
 	 * Handles a MVC request
 	 *
 	 * @param string uri
-	 * @return Phalcon\Http\ResponseInterface|boolean
+	 * @return \Phalcon\Http\ResponseInterface|boolean
 	 */
 	public function handle(uri = null) -> <ResponseInterface> | boolean
 	{

--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -915,7 +915,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 	 * Find a document by its id (_id)
 	 *
 	 * @param string|\MongoId id
-	 * @return Phalcon\Mvc\Collection
+	 * @return \Phalcon\Mvc\Collection
 	 */
 	public static function findById(id) -> <Collection>
 	{

--- a/phalcon/mvc/collection/manager.zep
+++ b/phalcon/mvc/collection/manager.zep
@@ -107,7 +107,7 @@ class Manager implements InjectionAwareInterface, EventsAwareInterface
 	 * Returns a custom events manager related to a model
 	 *
 	 * @param \Phalcon\Mvc\CollectionInterface $model
- 	 * @return Phalcon\Events\ManagerInterface
+ 	 * @return \Phalcon\Events\ManagerInterface
 	 */
 	public function getCustomEventsManager(<CollectionInterface> model) //-> <\Phalcon\Events\ManagerInterface>
 	{

--- a/phalcon/mvc/collectioninterface.zep
+++ b/phalcon/mvc/collectioninterface.zep
@@ -105,7 +105,7 @@ interface CollectionInterface
 	 * Find a document by its id
 	 *
 	 * @param string id
-	 * @return Phalcon\Mvc\Collection
+	 * @return \Phalcon\Mvc\Collection
 	 */
 	public static function findById(id) -> <CollectionInterface>;
 

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -107,7 +107,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function map(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -139,7 +139,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function get(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -171,7 +171,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function post(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -203,7 +203,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string $routePattern
 	 * @param callable $handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function put(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -235,7 +235,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string $routePattern
 	 * @param callable $handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function patch(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -267,7 +267,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function head(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -299,7 +299,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function delete(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -331,7 +331,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function options(string! routePattern, handler) -> <RouteInterface>
 	{
@@ -443,7 +443,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 * Sets a handler that will be called when the router doesn't match any of the defined routes
 	 *
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Micro
+	 * @return \Phalcon\Mvc\Micro
 	 */
 	public function notFound(var handler) -> <Micro>
 	{
@@ -455,7 +455,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 * Sets a handler that will be called when an exception is thrown handling the route
 	 *
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Micro
+	 * @return \Phalcon\Mvc\Micro
 	 */
 	public function error(var handler) -> <Micro>
 	{
@@ -500,7 +500,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 * @param string  serviceName
 	 * @param mixed   definition
 	 * @param boolean shared
-	 * @return Phalcon\DI\ServiceInterface
+	 * @return \Phalcon\DI\ServiceInterface
 	 */
 	public function setService(string! serviceName, var definition, boolean shared = false) -> <ServiceInterface>
 	{
@@ -980,7 +980,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 * Appends a before middleware to be called before execute the route
 	 *
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Micro
+	 * @return \Phalcon\Mvc\Micro
 	 */
 	public function before(handler) -> <Micro>
 	{
@@ -992,7 +992,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 * Appends an 'after' middleware to be called after execute the route
 	 *
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Micro
+	 * @return \Phalcon\Mvc\Micro
 	 */
 	public function after(handler) -> <Micro>
 	{
@@ -1004,7 +1004,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 * Appends a 'finish' middleware to be called when the request is finished
 	 *
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Micro
+	 * @return \Phalcon\Mvc\Micro
 	 */
 	public function finish(handler) -> <Micro>
 	{

--- a/phalcon/mvc/micro/collection.zep
+++ b/phalcon/mvc/micro/collection.zep
@@ -95,7 +95,7 @@ class Collection implements CollectionInterface
 	 *
 	 * @param mixed handler
 	 * @param boolean lazy
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function setHandler(var handler, boolean lazy = false) -> <Collection>
 	{
@@ -136,7 +136,7 @@ class Collection implements CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function map(string! routePattern, var handler, var name = null) -> <Collection>
 	{
@@ -150,7 +150,7 @@ class Collection implements CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function get(string! routePattern, handler, var name = null) -> <Collection>
 	{
@@ -164,7 +164,7 @@ class Collection implements CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function post(string! routePattern, handler, var name = null) -> <Collection>
 	{
@@ -178,7 +178,7 @@ class Collection implements CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function put(string! routePattern, var handler, var name = null) -> <Collection>
 	{
@@ -192,7 +192,7 @@ class Collection implements CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function patch(string! routePattern, var handler, var name = null) -> <Collection>
 	{
@@ -206,7 +206,7 @@ class Collection implements CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function head(string! routePattern, var handler, var name = null) -> <Collection>
 	{
@@ -220,7 +220,7 @@ class Collection implements CollectionInterface
 	 * @param  string   routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function delete(string! routePattern, var handler, var name = null) -> <Collection>
 	{
@@ -233,7 +233,7 @@ class Collection implements CollectionInterface
 	 *
 	 * @param string routePattern
 	 * @param callable handler
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function options(string! routePattern, handler, var name = null) -> <Collection>
 	{

--- a/phalcon/mvc/micro/collectioninterface.zep
+++ b/phalcon/mvc/micro/collectioninterface.zep
@@ -49,7 +49,7 @@ interface CollectionInterface
 	 *
 	 * @param mixed handler
 	 * @param boolean lazy
-	 * @return Phalcon\Mvc\Micro\Collection
+	 * @return \Phalcon\Mvc\Micro\Collection
 	 */
 	public function setHandler(handler, boolean lazy = false);
 
@@ -76,7 +76,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function map(string! routePattern, handler, name = null);
 
@@ -86,7 +86,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function get(string! routePattern, handler, name = null);
 
@@ -96,7 +96,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function post(string! routePattern, handler, name = null);
 
@@ -106,7 +106,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function put(string! routePattern, handler, name = null);
 
@@ -116,7 +116,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function patch(string! routePattern, handler, name = null);
 
@@ -126,7 +126,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function head(string! routePattern, handler, name = null);
 
@@ -136,7 +136,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function delete(string! routePattern, handler, name = null);
 
@@ -146,7 +146,7 @@ interface CollectionInterface
 	 * @param  string routePattern
 	 * @param  callable handler
 	 * @param  string name
-	 * @return Phalcon\Mvc\Router\RouteInterface
+	 * @return \Phalcon\Mvc\Router\RouteInterface
 	 */
 	public function options(string! routePattern, handler, name = null);
 

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -420,7 +420,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * @param array data
 	 * @param array dataColumnMap array to transform keys of data to another
 	 * @param array whiteList
-	 * @return Phalcon\Mvc\Model
+	 * @return \Phalcon\Mvc\Model
 	 */
 	public function assign(array! data, var dataColumnMap = null, var whiteList = null) -> <Model>
 	{
@@ -505,7 +505,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * @param array columnMap
 	 * @param int dirtyState
 	 * @param boolean keepSnapshots
-	 * @return Phalcon\Mvc\Model
+	 * @return \Phalcon\Mvc\Model
 	 */
 	public static function cloneResultMap(var base, array! data, var columnMap, int dirtyState = 0, boolean keepSnapshots = null) -> <Model>
 	{
@@ -681,7 +681,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * @param \Phalcon\Mvc\ModelInterface $base
 	 * @param array data
 	 * @param int dirtyState
-	 * @return Phalcon\Mvc\ModelInterface
+	 * @return \Phalcon\Mvc\ModelInterface
 	 */
 	public static function cloneResult(<ModelInterface> base, array! data, int dirtyState = 0)
 	{
@@ -827,7 +827,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * </code>
 	 *
 	 * @param string|array parameters
-	 * @return Phalcon\Mvc\Model
+	 * @return \Phalcon\Mvc\Model
 	 */
 	public static function findFirst(var parameters = null) -> <Model>
 	{
@@ -1076,7 +1076,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * @param string function
 	 * @param string alias
 	 * @param array parameters
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	protected static function _groupResult(string! functionName, string! alias, var parameters) -> <ResultsetInterface>
 	{
@@ -3838,7 +3838,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 *
 	 * @param string alias
 	 * @param array arguments
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	public function getRelated(string alias, arguments = null) -> <ResultsetInterface>
 	{
@@ -4116,7 +4116,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Magic method to get related records using the relation alias as a property
 	 *
 	 * @param string property
-	 * @return Phalcon\Mvc\Model\Resultset|Phalcon\Mvc\Model
+	 * @return \Phalcon\Mvc\Model\Resultset|Phalcon\Mvc\Model
 	 */
 	public function __get(string! property)
 	{

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -131,7 +131,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	 *</code>
 	 *
 	 * @param string|array columns
-	 * @return Phalcon\Mvc\Model\Criteria
+	 * @return \Phalcon\Mvc\Model\Criteria
 	 */
 	public function columns(var columns) -> <Criteria>
 	{

--- a/phalcon/mvc/model/criteriainterface.zep
+++ b/phalcon/mvc/model/criteriainterface.zep
@@ -71,7 +71,7 @@ interface CriteriaInterface
 	 *
 	 * @param int limit
 	 * @param int offset
-	 * @return Phalcon\Mvc\Model\CriteriaInterface
+	 * @return \Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public function limit(int limit, offset = null) -> <CriteriaInterface>;
 
@@ -91,7 +91,7 @@ interface CriteriaInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\CriteriaInterface
+	 * @return \Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public function andWhere(string! conditions, bindParams = null, bindTypes = null) -> <CriteriaInterface>;
 
@@ -101,7 +101,7 @@ interface CriteriaInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\CriteriaInterface
+	 * @return \Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public function orWhere(string! conditions, bindParams = null, bindTypes = null) -> <CriteriaInterface>;
 
@@ -115,7 +115,7 @@ interface CriteriaInterface
 	 * @param string expr
 	 * @param mixed minimum
 	 * @param mixed maximum
-	 * @return Phalcon\Mvc\Model\CriteriaInterface
+	 * @return \Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public function betweenWhere(string! expr, minimum, maximum) -> <CriteriaInterface>;
 
@@ -129,7 +129,7 @@ interface CriteriaInterface
 	 * @param string expr
 	 * @param mixed minimum
 	 * @param mixed maximum
-	 * @return Phalcon\Mvc\Model\CriteriaInterface
+	 * @return \Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public function notBetweenWhere(string! expr, minimum, maximum) -> <CriteriaInterface>;
 

--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -1187,7 +1187,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	/**
 	 * Helper method to query records based on a relation definition
 	 *
-	 * @return Phalcon\Mvc\Model\Resultset\Simple|Phalcon\Mvc\Model\Resultset\Simple|false
+	 * @return \Phalcon\Mvc\Model\Resultset\Simple|Phalcon\Mvc\Model\Resultset\Simple|false
 	 */
 	public function getRelationRecords(<RelationInterface> relation, string! method, <ModelInterface> record, var parameters = null)
 	{

--- a/phalcon/mvc/model/managerinterface.zep
+++ b/phalcon/mvc/model/managerinterface.zep
@@ -176,7 +176,7 @@ interface ManagerInterface
 	 * @param string modelRelation
 	 * @param \Phalcon\Mvc\Model record
 	 * @param array parameters
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	public function getBelongsToRecords(method, modelName, modelRelation, <ModelInterface> record, parameters = null);
 
@@ -188,7 +188,7 @@ interface ManagerInterface
 	 * @param string modelRelation
 	 * @param \Phalcon\Mvc\Model record
 	 * @param array parameters
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	public function getHasManyRecords(method, modelName, modelRelation, <ModelInterface> record, parameters = null);
 
@@ -200,7 +200,7 @@ interface ManagerInterface
 	 * @param string modelRelation
 	 * @param \Phalcon\Mvc\Model record
 	 * @param array parameters
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	public function getHasOneRecords(method, modelName, modelRelation, <ModelInterface> record, parameters = null);
 
@@ -240,7 +240,7 @@ interface ManagerInterface
 	 * Query all the relationships defined on a model
 	 *
 	 * @param string modelName
-	 * @return Phalcon\Mvc\Model\RelationInterface[]
+	 * @return \Phalcon\Mvc\Model\RelationInterface[]
 	 */
 	public function getRelations(modelName);
 
@@ -257,7 +257,7 @@ interface ManagerInterface
 	 * Creates a Phalcon\Mvc\Model\Query without execute it
 	 *
 	 * @param string phql
-	 * @return Phalcon\Mvc\Model\QueryInterface
+	 * @return \Phalcon\Mvc\Model\QueryInterface
 	 */
 	public function createQuery(phql);
 
@@ -266,7 +266,7 @@ interface ManagerInterface
 	 *
 	 * @param string phql
 	 * @param array placeholders
-	 * @return Phalcon\Mvc\Model\QueryInterface
+	 * @return \Phalcon\Mvc\Model\QueryInterface
 	 */
 	public function executeQuery(phql, placeholders = null);
 
@@ -274,7 +274,7 @@ interface ManagerInterface
 	 * Creates a Phalcon\Mvc\Model\Query\Builder
 	 *
 	 * @param string params
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function createBuilder(params = null);
 
@@ -307,7 +307,7 @@ interface ManagerInterface
 	/**
 	 * Returns the last query created or executed in the models manager
 	 *
-	 * @return Phalcon\Mvc\Model\QueryInterface
+	 * @return \Phalcon\Mvc\Model\QueryInterface
 	 */
 	public function getLastQuery();
 
@@ -316,7 +316,7 @@ interface ManagerInterface
 	 *
 	 * @param string modelName
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Relation
+	 * @return \Phalcon\Mvc\Model\Relation
 	 */
 	public function getRelationByAlias(string modelName, string alias);
 

--- a/phalcon/mvc/model/metadatainterface.zep
+++ b/phalcon/mvc/model/metadatainterface.zep
@@ -38,7 +38,7 @@ interface MetaDataInterface
 	/**
 	 * Return the strategy to obtain the meta-data
 	 *
-	 * @return Phalcon\Mvc\Model\MetaData\StrategyInterface
+	 * @return \Phalcon\Mvc\Model\MetaData\StrategyInterface
 	 */
 	public function getStrategy();
 

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -2662,7 +2662,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 	 * @param array intermediate
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\StatusInterface
+	 * @return \Phalcon\Mvc\Model\Query\StatusInterface
 	 */
 	protected final function _executeInsert(var intermediate, var bindParams, var bindTypes) -> <StatusInterface>
 	{
@@ -2797,7 +2797,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 	 * @param array intermediate
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\StatusInterface
+	 * @return \Phalcon\Mvc\Model\Query\StatusInterface
 	 */
 	protected final function _executeUpdate(var intermediate, var bindParams, var bindTypes) -> <StatusInterface>
 	{
@@ -2953,7 +2953,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 	 * @param array intermediate
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\StatusInterface
+	 * @return \Phalcon\Mvc\Model\Query\StatusInterface
 	 */
 	protected final function _executeDelete(var intermediate, var bindParams, var bindTypes) -> <StatusInterface>
 	{
@@ -3034,7 +3034,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 	 * @param array intermediate
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	protected final function _getRelatedRecords(<ModelInterface> model, var intermediate, var bindParams, var bindTypes)
 	 -> <ResultsetInterface>

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -298,7 +298,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * Sets SELECT DISTINCT / SELECT ALL flag
 	 *
 	 * @param bool|null distinct
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	 public function distinct(var distinct) -> <Builder>
 	 {
@@ -322,7 +322,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 *</code>
 	 *
 	 * @param string|array columns
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function columns(var columns) -> <Builder>
 	{
@@ -349,7 +349,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 *</code>
 	 *
 	 * @param string|array models
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function from(var models) -> <Builder>
 	{
@@ -366,7 +366,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 *
 	 * @param string model
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function addFrom(var model, var alias = null) -> <Builder>
 	{
@@ -416,7 +416,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param string conditions
 	 * @param string alias
 	 * @param string type
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function join(string! model, var conditions = null, var alias = null, var type = null) -> <Builder>
 	{
@@ -437,7 +437,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param string conditions
 	 * @param string alias
 	 * @param string type
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function innerJoin(string! model, var conditions = null, var alias = null) -> <Builder>
 	{
@@ -455,7 +455,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param string model
 	 * @param string conditions
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function leftJoin(string! model, var conditions = null, var alias = null) -> <Builder>
 	{
@@ -473,7 +473,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param string model
 	 * @param string conditions
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function rightJoin(string! model, var conditions = null, var alias = null) -> <Builder>
 	{
@@ -493,7 +493,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param mixed conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function where(var conditions, var bindParams = null, var bindTypes = null) -> <Builder>
 	{
@@ -541,7 +541,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function andWhere(string! conditions, var bindParams = null, var bindTypes = null) -> <Builder>
 	{
@@ -600,7 +600,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function orWhere(string! conditions, var bindParams = null, var bindTypes = null) -> <Builder>
 	{
@@ -823,7 +823,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 *</code>
 	 *
 	 * @param string|array orderBy
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function orderBy(var orderBy) -> <Builder>
 	{
@@ -935,7 +935,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 *</code>
 	 *
 	 * @param string|array group
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function groupBy(var group) -> <Builder>
 	{

--- a/phalcon/mvc/model/query/builderinterface.zep
+++ b/phalcon/mvc/model/query/builderinterface.zep
@@ -38,7 +38,7 @@ interface BuilderInterface
 	 * Sets the columns to be queried
 	 *
 	 * @param string|array columns
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function columns(columns);
 
@@ -53,7 +53,7 @@ interface BuilderInterface
 	 * Sets the models who makes part of the query
 	 *
 	 * @param string|array models
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function from(models);
 
@@ -62,7 +62,7 @@ interface BuilderInterface
 	 *
 	 * @param string model
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function addFrom(model, alias = null);
 
@@ -79,7 +79,7 @@ interface BuilderInterface
 	 * @param string model
 	 * @param string conditions
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function join(model, conditions = null, alias = null);
 
@@ -90,7 +90,7 @@ interface BuilderInterface
 	 * @param string conditions
 	 * @param string alias
 	 * @param string type
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function innerJoin(model, conditions = null, alias = null);
 
@@ -100,7 +100,7 @@ interface BuilderInterface
 	 * @param string model
 	 * @param string conditions
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function leftJoin(model, conditions = null, alias = null);
 
@@ -110,7 +110,7 @@ interface BuilderInterface
 	 * @param string model
 	 * @param string conditions
 	 * @param string alias
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function rightJoin(model, conditions = null, alias = null);
 
@@ -120,7 +120,7 @@ interface BuilderInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function where(conditions, bindParams = null, bindTypes = null);
 
@@ -130,7 +130,7 @@ interface BuilderInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function andWhere(conditions, bindParams = null, bindTypes = null);
 
@@ -140,7 +140,7 @@ interface BuilderInterface
 	 * @param string conditions
 	 * @param array bindParams
 	 * @param array bindTypes
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function orWhere(conditions, bindParams = null, bindTypes = null);
 
@@ -150,7 +150,7 @@ interface BuilderInterface
 	 * @param string expr
 	 * @param mixed minimum
 	 * @param mixed maximum
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function betweenWhere(expr, minimum, maximum);
 
@@ -160,7 +160,7 @@ interface BuilderInterface
 	 * @param string expr
 	 * @param mixed minimum
 	 * @param mixed maximum
-	 * @return Phalcon\Mvc\Model\Query\Builder
+	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function notBetweenWhere(expr, minimum, maximum);
 
@@ -185,7 +185,7 @@ interface BuilderInterface
 	 * Sets a ORDER BY condition clause
 	 *
 	 * @param string orderBy
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function orderBy(orderBy);
 
@@ -200,7 +200,7 @@ interface BuilderInterface
 	 * Sets a HAVING condition clause
 	 *
 	 * @param string having
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function having(having);
 
@@ -216,7 +216,7 @@ interface BuilderInterface
 	 *
 	 * @param int limit
 	 * @param int offset
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function limit(limit, offset = null);
 
@@ -231,7 +231,7 @@ interface BuilderInterface
 	 * Sets a LIMIT clause
 	 *
 	 * @param string group
-	 * @return Phalcon\Mvc\Model\Query\BuilderInterface
+	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function groupBy(group);
 
@@ -252,7 +252,7 @@ interface BuilderInterface
 	/**
 	 * Returns the query built
 	 *
-	 * @return Phalcon\Mvc\Model\QueryInterface
+	 * @return \Phalcon\Mvc\Model\QueryInterface
 	 */
 	public function getQuery();
 

--- a/phalcon/mvc/model/queryinterface.zep
+++ b/phalcon/mvc/model/queryinterface.zep
@@ -39,7 +39,7 @@ interface QueryInterface
 	 * Sets the cache parameters of the query
 	 *
 	 * @param array cacheOptions
-	 * @return Phalcon\Mvc\Model\Query
+	 * @return \Phalcon\Mvc\Model\Query
 	 */
 	public function cache(cacheOptions);
 
@@ -54,7 +54,7 @@ interface QueryInterface
 	 * Tells to the query if only the first row in the resultset must be returned
 	 *
 	 * @param boolean uniqueRow
-	 * @return Phalcon\Mvc\Model\Query
+	 * @return \Phalcon\Mvc\Model\Query
 	 */
 	public function setUniqueRow(boolean uniqueRow);
 

--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -532,7 +532,7 @@ abstract class Resultset
 	 *</code>
 	 *
 	 * @param callback filter
-	 * @return Phalcon\Mvc\Model[]
+	 * @return \Phalcon\Mvc\Model[]
 	 */
 	public function filter(var filter) -> array
 	{

--- a/phalcon/mvc/model/resultsetinterface.zep
+++ b/phalcon/mvc/model/resultsetinterface.zep
@@ -36,14 +36,14 @@ interface ResultsetInterface
 	/**
 	 * Get first row in the resultset
 	 *
-	 * @return Phalcon\Mvc\ModelInterface
+	 * @return \Phalcon\Mvc\ModelInterface
 	 */
 	public function getFirst();
 
 	/**
 	 * Get last row in the resultset
 	 *
-	 * @return Phalcon\Mvc\ModelInterface
+	 * @return \Phalcon\Mvc\ModelInterface
 	 */
 	public function getLast();
 
@@ -60,7 +60,7 @@ interface ResultsetInterface
 	/**
 	 * Returns the associated cache for the resultset
 	 *
-	 * @return Phalcon\Cache\BackendInterface
+	 * @return \Phalcon\Cache\BackendInterface
 	 */
 	public function getCache();
 

--- a/phalcon/mvc/modelinterface.zep
+++ b/phalcon/mvc/modelinterface.zep
@@ -104,7 +104,7 @@ interface ModelInterface
 	 * @param \Phalcon\Mvc\Model object
 	 * @param array data
 	 * @param array columnMap
-	 * @return Phalcon\Mvc\Model
+	 * @return \Phalcon\Mvc\Model
 	 */
 	public function assign(array! data, var dataColumnMap = null, var whiteList = null);
 
@@ -116,7 +116,7 @@ interface ModelInterface
 	 * @param array columnMap
 	 * @param int dirtyState
 	 * @param boolean keepSnapshots
-	 * @return Phalcon\Mvc\Model result
+	 * @return \Phalcon\Mvc\Model result
 	 */
 	public static function cloneResultMap(base, array! data, var columnMap, dirtyState = 0, keepSnapshots = null);
 
@@ -126,7 +126,7 @@ interface ModelInterface
 	 * @param \Phalcon\Mvc\ModelInterface base
 	 * @param array data
 	 * @param int dirtyState
-	 * @return Phalcon\Mvc\ModelInterface
+	 * @return \Phalcon\Mvc\ModelInterface
 	 */
 	public static function cloneResult(<ModelInterface> base, array! data, dirtyState = 0);
 
@@ -151,7 +151,7 @@ interface ModelInterface
 	 * Allows to query the first record that match the specified conditions
 	 *
 	 * @param array parameters
-	 * @return Phalcon\Mvc\ModelInterface
+	 * @return \Phalcon\Mvc\ModelInterface
 	 */
 	public static function findFirst(parameters = null);
 
@@ -159,7 +159,7 @@ interface ModelInterface
 	 * Create a criteria for a especific model
 	 *
 	 * @param \Phalcon\DiInterface dependencyInjector
-	 * @return Phalcon\Mvc\Model\CriteriaInterface
+	 * @return \Phalcon\Mvc\Model\CriteriaInterface
 	 */
 	public static function query(<DiInterface> dependencyInjector = null);
 
@@ -235,7 +235,7 @@ interface ModelInterface
 	/**
 	 * Returns all the validation messages
 	 *
-	 * @return Phalcon\Mvc\Model\MessageInterface[]
+	 * @return \Phalcon\Mvc\Model\MessageInterface[]
 	 */
 	public function getMessages();
 
@@ -298,7 +298,7 @@ interface ModelInterface
 	 *
 	 * @param string alias
 	 * @param array arguments
-	 * @return Phalcon\Mvc\Model\ResultsetInterface
+	 * @return \Phalcon\Mvc\Model\ResultsetInterface
 	 */
 	public function getRelated(alias, arguments = null);
 

--- a/phalcon/mvc/router/group.zep
+++ b/phalcon/mvc/router/group.zep
@@ -179,7 +179,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addGet(string! pattern, var paths = null) -> <RouteInterface>
 	{
@@ -191,7 +191,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addPost(string! pattern, var paths = null) -> <RouteInterface>
 	{
@@ -203,7 +203,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addPut(string! pattern, var paths = null) -> <RouteInterface>
 	{
@@ -215,7 +215,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addPatch(string! pattern, var paths = null) -> <RouteInterface>
 	{
@@ -227,7 +227,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addDelete(string! pattern, var paths = null) -> <RouteInterface>
 	{
@@ -239,7 +239,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addOptions(string! pattern, var paths = null) -> <RouteInterface>
 	{
@@ -251,7 +251,7 @@ class Group implements GroupInterface
 	 *
 	 * @param string pattern
 	 * @param string/array paths
-	 * @return Phalcon\Mvc\Router\Route
+	 * @return \Phalcon\Mvc\Router\Route
 	 */
 	public function addHead(string! pattern, var paths = null) -> <RouteInterface>
 	{

--- a/phalcon/mvc/router/groupinterface.zep
+++ b/phalcon/mvc/router/groupinterface.zep
@@ -98,7 +98,7 @@ interface GroupInterface
 	 * Set common paths for all the routes in the group
 	 *
 	 * @param array paths
-	 * @return Phalcon\Mvc\Router\Group
+	 * @return \Phalcon\Mvc\Router\Group
 	 */
 	public function setPaths(var paths) -> <GroupInterface>;
 

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -261,7 +261,7 @@ class View extends Injectable implements ViewInterface
 	 *</code>
 	 *
 	 * @param int|array level
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function disableLevel(var level) -> <View>
 	{
@@ -320,7 +320,7 @@ class View extends Injectable implements ViewInterface
 	 * Sets a template before the controller layout
 	 *
 	 * @param string|array templateBefore
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function setTemplateBefore(var templateBefore) -> <View>
 	{
@@ -345,7 +345,7 @@ class View extends Injectable implements ViewInterface
 	 * Sets a "template after" controller layout
 	 *
 	 * @param string|array templateAfter
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function setTemplateAfter(var templateAfter) -> <View>
 	{
@@ -375,7 +375,7 @@ class View extends Injectable implements ViewInterface
 	 *
 	 * @param string key
 	 * @param mixed value
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function setParamToView(string! key, value) -> <View>
 	{
@@ -392,7 +392,7 @@ class View extends Injectable implements ViewInterface
 	 *
 	 * @param array params
 	 * @param boolean merge
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function setVars(array! params, boolean merge = true) -> <View>
 	{
@@ -421,7 +421,7 @@ class View extends Injectable implements ViewInterface
 	 *
 	 * @param string key
 	 * @param mixed value
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function setVar(string! key, value) -> <View>
 	{
@@ -971,7 +971,7 @@ class View extends Injectable implements ViewInterface
 	 * </code>
 	 *
 	 * @param string|array renderView
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function pick(var renderView) -> <View>
 	{
@@ -1222,7 +1222,7 @@ class View extends Injectable implements ViewInterface
 	 *</code>
 	 *
 	 * @param boolean|array options
-	 * @return Phalcon\Mvc\View
+	 * @return \Phalcon\Mvc\View
 	 */
 	public function cache(var options = true) -> <View>
 	{

--- a/phalcon/mvc/view/simple.zep
+++ b/phalcon/mvc/view/simple.zep
@@ -448,7 +448,7 @@ class Simple extends Injectable implements ViewBaseInterface
 	 * Sets the cache options
 	 *
 	 * @param  array options
-	 * @return Phalcon\Mvc\View\Simple
+	 * @return \Phalcon\Mvc\View\Simple
 	 */
 	public function setCacheOptions(options) -> <Simple>
 	{

--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -72,7 +72,7 @@ class Validation extends Injectable
 	 *
 	 * @param array|object data
 	 * @param object entity
-	 * @return Phalcon\Validation\Message\Group
+	 * @return \Phalcon\Validation\Message\Group
 	 */
 	public function validate(var data = null, var entity = null) -> <Group>
 	{
@@ -180,7 +180,7 @@ class Validation extends Injectable
 	 *
 	 * @param string field
 	 * @param array|string filters
-	 * @return Phalcon\Validation
+	 * @return \Phalcon\Validation
 	 */
 	public function setFilters(string field, filters) -> <Validation>
 	{
@@ -327,7 +327,7 @@ class Validation extends Injectable
 	 *
 	 * @param object entity
 	 * @param array|object data
-	 * @return Phalcon\Validation
+	 * @return \Phalcon\Validation
 	 */
 	public function bind(entity, data) -> <Validation>
 	{

--- a/phalcon/validation/message/group.zep
+++ b/phalcon/validation/message/group.zep
@@ -56,7 +56,7 @@ class Group implements \Countable, \ArrayAccess, \Iterator
 	 *</code>
 	 *
 	 * @param int index
-	 * @return Phalcon\Validation\Message
+	 * @return \Phalcon\Validation\Message
 	 */
 	public function offsetGet(int! index) -> <Message> | boolean
 	{
@@ -221,7 +221,7 @@ class Group implements \Countable, \ArrayAccess, \Iterator
 	/**
 	 * Returns the current message in the iterator
 	 *
-	 * @return Phalcon\Validation\Message
+	 * @return \Phalcon\Validation\Message
 	 */
 	public function current() -> <Message> | boolean
 	{
@@ -260,7 +260,7 @@ class Group implements \Countable, \ArrayAccess, \Iterator
 	 * Magic __set_state helps to re-build messages variable when exporting
 	 *
 	 * @param array group
-	 * @return Phalcon\Validation\Message\Group
+	 * @return \Phalcon\Validation\Message\Group
 	 */
 	public static function __set_state(group) -> <Group>
 	{


### PR DESCRIPTION
As agreed on beforehand, when returning a namespaced PHP object, we need the backslash in front of the object.
