### PR TITLE
__callStatic arguments should not be optional

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3953,7 +3953,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * @param	array arguments
 	 * @return	mixed
 	 */
-	public static function __callStatic(string method, arguments = null)
+	public static function __callStatic(string method, arguments)
 	{
 		var extraMethod, type, modelName, value, model,
 			attributes, field, extraMethodFirst, metaData;


### PR DESCRIPTION
as php will send an empty array for arguments
It produces errors when using mock objects, etc..
(This is https://github.com/phalcon/cphalcon/pull/10565 but with __callStatic)
