### PR TITLE
Correctly assing keys and values to select field options

### DIFF
--- a/phalcon/forms/element/select.zep
+++ b/phalcon/forms/element/select.zep
@@ -74,9 +74,13 @@ class Select extends Element implements ElementInterface {
 	 */
 	public function addOption(var option) -> <Element>
 	{
-		var key, value;
-		for key, value in option {
-			let this->_optionsValues[key] = value;
+		if is_array(option) {
+			var key, value;
+			for key, value in option {
+				let this->_optionsValues[key] = value;
+			}
+		} else {
+			let this->_optionsValues[] = option;
 		}
 		return this;
 	}

--- a/phalcon/forms/element/select.zep
+++ b/phalcon/forms/element/select.zep
@@ -75,7 +75,7 @@ class Select extends Element implements ElementInterface {
 	public function addOption(var option) -> <Element>
 	{
 		var key, value;
-		for key, value in options {
+		for key, value in option {
 			let this->_optionsValues[key] = value;
 		}
 		return this;

--- a/phalcon/forms/element/select.zep
+++ b/phalcon/forms/element/select.zep
@@ -74,7 +74,10 @@ class Select extends Element implements ElementInterface {
 	 */
 	public function addOption(var option) -> <Element>
 	{
-		let this->_optionsValues[] = option;
+		var key, value;
+		for key, value in options {
+			let this->_optionsValues[key] = value;
+		}
 		return this;
 	}
 

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -517,4 +517,12 @@ class FormsTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals('<input type="text" name="name" class="big-input" />', $element->render());
 	}
+
+	public function testCorrectlyAddOptionToSelectElement()
+	{
+		$element = new Select('test-select');
+		$element->addOption(array('key' => 'value'));
+
+		$this->assertEquals('<select id="test-select" name="test-select"><option value="key">value</option></select>', preg_replace('/[[:cntrl:]]/', '', $element->render()));
+	}
 }

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -518,11 +518,19 @@ class FormsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('<input type="text" name="name" class="big-input" />', $element->render());
 	}
 
-	public function testCorrectlyAddOptionToSelectElement()
+	public function testCorrectlyAddOptionToSelectElementIfParameterIsAnArray()
 	{
 		$element = new Select('test-select');
 		$element->addOption(array('key' => 'value'));
 
 		$this->assertEquals('<select id="test-select" name="test-select"><option value="key">value</option></select>', preg_replace('/[[:cntrl:]]/', '', $element->render()));
+	}
+
+	public function testCorrectlyAddOptionToSelectElementIfParameterIsAString()
+	{
+		$element = new Select('test-select');
+		$element->addOption('value');
+
+		$this->assertEquals('<select id="test-select" name="test-select"><option value="0">value</option></select>', preg_replace('/[[:cntrl:]]/', '', $element->render()));
 	}
 }


### PR DESCRIPTION
`Phalcon\Forms\Element\Select::addOption()` incorrectly assigned the keys and values creating optgroups instead of options.
