### PR TITLE
When creating tables in Postgres, inline PRIMARY keys are now escaped properly

### DIFF
--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -381,7 +381,7 @@ class Postgresql extends Dialect
 			let createLines[] = columnLine;
 		}
 		if !empty primaryColumns {
-			let createLines[] = "PRIMARY KEY (" . implode(",",primaryColumns) . ")";
+			let createLines[] = "PRIMARY KEY (" . this->getColumnList(primaryColumns) . ")";
 		}
 
 		/**


### PR DESCRIPTION
For reference, before this PR, I got this error message:

```
db_1            | ERROR:  column "userid" named in key does not exist at character 168
db_1            | STATEMENT:  CREATE TABLE "Sid_Pomelo_Models_Users" (
db_1            |               "userID" BIGINT NOT NULL,
db_1            |               "emailAddress" CHARACTER VARYING(255) NOT NULL,
db_1            |               "password" CHARACTER VARYING(100) NOT NULL,
db_1            |               PRIMARY KEY (userID)
db_1            |       )
```

![image](https://cloud.githubusercontent.com/assets/1364214/9275498/5e4406b6-4295-11e5-8e52-5e4c0c32b372.png)
