### PR TITLE
Add 'setParameter' to Phalcon\Di\ServiceInterface

### DIFF
--- a/phalcon/di/serviceinterface.zep
+++ b/phalcon/di/serviceinterface.zep
@@ -77,6 +77,11 @@ interface ServiceInterface
 	public function resolve(parameters = null, <\Phalcon\DiInterface> dependencyInjector = null);
 
 	/**
+	 * Changes a parameter in the definition without resolve the service
+	 */
+	public function setParameter(int position, array! parameter) -> <ServiceInterface>;
+
+	/**
 	 * Restore the interal state of a service
 	 */
 	public static function __set_state(array! attributes) -> <ServiceInterface>;


### PR DESCRIPTION
Since \Phalcon\DiInterface::getService returns \Phalcon\Di\ServiceInterface:

```
    /**
     * Returns the corresponding Phalcon\Di\Service instance for a service
     *
     * @param string $name 
     * @return \Phalcon\Di\ServiceInterface
     */
    public function getService($name);
```

\Phalcon\Di\ServiceInterface::setParameter should be added.
