### PR TITLE
use transaction's connection as readconnection.

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -377,6 +377,13 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 */
 	public function getReadConnection() -> <AdapterInterface>
 	{
+		var transaction;
+
+		let transaction = <TransactionInterface> this->_transaction;
+		if typeof transaction == "object" {
+			return transaction->getConnection();
+		}
+
 		return (<ManagerInterface> this->_modelsManager)->getReadConnection(this);
 	}
 


### PR DESCRIPTION
if read and write connection are set separately and a transaction detected, use transaction's connection instead of predefined readConnection, for 'for update' statements
