### PR TITLE
Added \Phalcon\Secutity\Random::base58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-XX-XX)
+- Added `Phalcon\Security\Random::base58` - to generate a random base58 string
+
 # [2.0.7](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.7) (2015-08-17)
 - `Image\Adapter\Gd::save()` no longer fails if the method or the instance is created with a filename without an extension
 - Fixed segfault in `Image\Adapter\Imagick::text()`
@@ -5,7 +8,7 @@
 - Now you can import macros from other files using `{% include "file.volt" %}`
 - Undefined function calls fall back to macro calls in Volt
 - Automatic bound parameters in `Mvc\Model\Criteria` now uses a different prefix
-than `Mvc\Model\Query\Builder` to avoid collissions
+than `Mvc\Model\Query\Builder` to avoid collisions
 - Added `Cache\Multiple::flush()` to flush the cache backends added to the multiple system
 - Fixed `Session\Bag::remove()`
 - `Session\Bag::destroy()` eliminates any temporary data in the variables bag
@@ -37,7 +40,7 @@ belongs to the uniqueId or the whole session data
 - Now `Validation\Validator\Identical` allows both 'accepted' and 'value' as value to keep backwards compatibility
 - Added `\Phalcon\Mvc\Model\MetaData\Redis` adapter.
 - Added Redis Session adapter
-- Fixed bug in Mvc\Model\Criteria::fromInput unallowing it to use renamed columns
+- Fixed bug in `Mvc\Model\Criteria::fromInput` unallowing it to use renamed columns
 - Fixed bug in `Http\Request` getRawBody()/getPut() clears input buffer [#10694](https://github.com/phalcon/cphalcon/issues/10694)
 
 # [2.0.5](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.5) (2015-07-14)
@@ -91,7 +94,7 @@ belongs to the uniqueId or the whole session data
 
 # [2.0.3](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.3) (2015-06-10)
 - Added support for Behaviors in `Phalcon\Mvc\Collection`
-- Added SoftDelete and Timestampable behaviors to Collections
+- Added `SoftDelete` and `Timestampable` behaviors to Collections
 - Implemented Namespace aliases in PHQL
 - Now you can define if a virtual foreign key must ignore null values or not
 - Fixed bug that added two ? in `Mvc\Url::get()` when using query parameters ([#10421](https://github.com/phalcon/cphalcon/issues/10421))
@@ -122,7 +125,7 @@ belongs to the uniqueId or the whole session data
  - Added new theme in `Phalcon\Debug`
  - Allow to count and iterate `Phalcon\Session\Bag` as in 1.3.x
  - Renamed `getEventsManager()` to `getInternalEventsManager()` in `Phalcon\Di` to avoid collision with existing services
- - Added constants FILTER_* to Phalcon\Filter for filters names
+ - Added constants FILTER_* to `Phalcon\Filter` for filters names
  - Fixed multibyte characters in cssmin/jsmin
  - Added `Phalcon\Security::destroyToken()` to remove current token key and value from session
    removed first argument (password), since it's not used in the function

--- a/phalcon/security/random.zep
+++ b/phalcon/security/random.zep
@@ -169,16 +169,10 @@ class Random
 	 */
 	public function base58(n = null)
 	{
-		var bytes, del, key, byte, alphabet;
+		var bytes, key, byte;
+		string alphabet;
 
-		let alphabet = array_merge(
-			range("A", "H"),
-			range("J", "N"),
-			range("P", "Z"),
-			range("a", "k"),
-			range("m", "z"),
-			range("1", "9")
-		);
+		let alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 		let bytes = unpack("C*", this->bytes(n));
 
@@ -189,7 +183,7 @@ class Random
 				let byte = this->number(57);
 			}
 
-			let bytes[key] = alphabet[byte];
+			let bytes[key] = substr(alphabet, byte, 1);
 		}
 
 		return join("", bytes);

--- a/phalcon/security/random.zep
+++ b/phalcon/security/random.zep
@@ -81,8 +81,6 @@ namespace Phalcon\Security;
  */
 class Random
 {
-	const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-
 	/**
 	 * Generates a random binary string
 	 *
@@ -169,23 +167,25 @@ class Random
 	 * @link https://en.wikipedia.org/wiki/Base58
 	 * @throws Exception If secure random number generator is not available or unexpected partial read
 	 */
-	public function base58(n = null)
+	public function base58(n = null) -> string
 	{
-		var bytes, key, byte;
+		var bytes, idx;
+		string byteString = "",
+			alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
 		let bytes = unpack("C*", this->bytes(n));
 
-		for key, byte in bytes {
-			let byte = byte % 64;
+		for idx in bytes {
+			let idx = idx % 64;
 
-			if byte >= 58 {
-				let byte = this->number(57);
+			if idx >= 58 {
+				let idx = this->number(57);
 			}
 
-			let bytes[key] = substr(self::BASE58_ALPHABET, byte, 1);
+			let byteString .= alphabet[(int) idx];
 		}
 
-		return join("", bytes);
+		return byteString;
 	}
 
 	/**
@@ -287,7 +287,8 @@ class Random
 	 */
 	public function number(int len) -> int
 	{
-		var hex, bin, mask, rnd, ret, first;
+		var hex, mask, rnd, ret;
+		string bin = "";
 
 		if len <= 0 {
 			throw new Exception("Require a positive integer > 0");
@@ -303,17 +304,16 @@ class Random
 			let hex = "0" . hex;
 		}
 
-		let bin = pack("H*", hex);
+		let bin .= pack("H*", hex);
 
-		let mask = ord(substr(bin, 0, 1));
+		let mask = ord(bin[0]);
 		let mask = mask | (mask >> 1);
 		let mask = mask | (mask >> 2);
 		let mask = mask | (mask >> 4);
 
 		do {
-			let rnd = this->bytes(strlen(bin)),
-				first = ord(substr(rnd, 0, 1));
-			let rnd = substr_replace(rnd, chr(first & mask), 0, 1);
+			let rnd = this->bytes(strlen(bin));
+			let rnd = substr_replace(rnd, chr(ord(substr(rnd, 0, 1)) & mask), 0, 1);
 		} while (bin < rnd);
 
 		let ret = unpack("H*", rnd);

--- a/tests/PhalconTest/Security/Random.php
+++ b/tests/PhalconTest/Security/Random.php
@@ -35,6 +35,11 @@ class Random extends PhRandom
         return parent::hex($len);
     }
 
+    public function base58($len = null)
+    {
+        return parent::base58($len);
+    }
+
     public function base64($len = null)
     {
         return parent::base64($len);

--- a/tests/unit/Phalcon/Security/RandomTest.php
+++ b/tests/unit/Phalcon/Security/RandomTest.php
@@ -98,6 +98,55 @@ class RandomTest extends TBase
     }
 
     /**
+     * Tests the random base58 generation
+     *
+     * @author Serghei Iakovlev <sadhooklay@gmail.com>
+     * @since  2015-08-20
+     */
+    public function testRandomBase58()
+    {
+        $this->specify(
+            "The base58 string contains valid chars and result is valid size",
+            function () {
+                $lens = [
+                    2,
+                    12,
+                    16,
+                    24,
+                    48,
+                    100
+                ];
+
+                $random = new PhTRandom();
+
+                $isValid = function($base58) {
+                    $alphabet = array_merge(
+                        range("A", "H"),
+                        range("J", "N"),
+                        range("P", "Z"),
+                        range("a", "k"),
+                        range("m", "z"),
+                        range("1", "9")
+                    );
+
+                    return (preg_match('#^[^'.join('', $alphabet).']+$#i', $base58) === 0);
+                };
+
+                foreach ($lens as $len) {
+                    $actual = $random->base58($len);
+
+                    expect(strlen($actual))->equals($len);
+                    expect($isValid($actual))->true();
+                }
+
+                $actual = $random->base58();
+                expect(strlen($actual))->equals(16);
+                expect($isValid($actual))->true();
+            }
+        );
+    }
+
+    /**
      * Tests the random base64 generation
      *
      * @author Serghei Iakovlev <sadhooklay@gmail.com>


### PR DESCRIPTION
Added `\Phalcon\Secutity\Random::base58`.

From [Wikipedia](https://en.wikipedia.org/wiki/Base58):

> Base58 is a group of binary-to-text encoding schemes used to represent large integers as alphanumeric text. It is similar to Base64 but has been modified to avoid both non-alphanumeric characters and letters which might look ambiguous when printed. It is therefore designed for human users who manually enter the data, copying from some visual source, but also allows easy copy and paste because a double-click will usually select the whole string.

The result may contain alphanumeric characters except `0`, `O`, `I` and `l`. 

``` php
$random = new \Phalcon\Security\Random();

// Random base58 string
echo $random->base58();   // 4kUgL2pdQMSCQtjE
echo $random->base58();   // Umjxqf7ZPwh765yR
echo $random->base58(24); // qoXcgmw4A9dys26HaNEdCRj9
echo $random->base58(7);  // 774SJD3vgP
```

If `$len` is not specified, 16 is assumed. It may be larger in future. Throws `\Phalcon\Security\Exception` if secure random number generator is not available or unexpected partial read.

Refs #10804
