### PR TITLE
Removes php 5.3 BC layer from the FirePHP logger adapter

### DIFF
--- a/phalcon/logger/formatter/firephp.zep
+++ b/phalcon/logger/formatter/firephp.zep
@@ -120,11 +120,7 @@ class Firephp extends Formatter implements FormatterInterface
 
 		if this->_showBacktrace {
 			var param, backtraceItem, key;
-			let param = false;
-
-			if !version_compare(PHP_VERSION, "5.3.6", "<") {
-				let param = DEBUG_BACKTRACE_IGNORE_ARGS;
-			}
+			let param = DEBUG_BACKTRACE_IGNORE_ARGS;
 
 			let backtrace = debug_backtrace(param),
 				lastTrace = end(backtrace);


### PR DESCRIPTION
Since support for 5.3 is fully deprecated, this can be removed.
