### PR TITLE
Adds the missing code property of validation\message

### DIFF
--- a/phalcon/validation/message.zep
+++ b/phalcon/validation/message.zep
@@ -34,19 +34,18 @@ class Message implements MessageInterface
 	protected _message;
 
 	protected _field;
+	
+	protected _code;
 
 	/**
 	 * Phalcon\Validation\Message constructor
-	 *
-	 * @param string message
-	 * @param string field
-	 * @param string type
 	 */
-	public function __construct(string! message, field = null, type = null)
+	public function __construct(string! message, string field = null, string type = null, int code = null)
 	{
 		let this->_message = message,
 			this->_field = field,
-			this->_type = type;
+			this->_type = type,
+			this->_code = code;
 	}
 
 	/**
@@ -100,6 +99,23 @@ class Message implements MessageInterface
 	public function getField()
 	{
 		return this->_field;
+	}
+	
+	/**
+	 * Sets code for the message
+	 */
+	public function setCode(int code) -> <Message>
+	{
+		let this->_code = code;
+		return this;
+	}
+
+	/**
+	 * Returns the message code
+	 */
+	public function getCode() -> int
+	{
+		return this->_code;
 	}
 
 	/**


### PR DESCRIPTION
Adds the code property which was present in 1.3, but is currently missing in 2.0.x.
ref #10819
