### PR TITLE
allow pass string as arguments so router can handle it with custom rules

### DIFF
--- a/phalcon/cli/console.zep
+++ b/phalcon/cli/console.zep
@@ -141,7 +141,7 @@ class Console implements InjectionAwareInterface, EventsAwareInterface
 	/**
 	 * Handle the whole command-line tasks
 	 */
-	public function handle(array arguments = null)
+	public function handle(arguments = null)
 	{
 		var dependencyInjector, router, eventsManager,
 			moduleName, modules, module, path, className,


### PR DESCRIPTION
arguments are restricted as an array and passed to router directly, so router cannot handle it with custom rules.

```
         */
        public function handle(arguments = null)
        {
                var moduleName, taskName, actionName,
                        params, route, parts, pattern, routeFound, matches, paths,
                        beforeMatch, converters, converter, part, position, matchPosition,
                        strParams;

                let routeFound = false,
                        parts = [],
                        params = [],
                        matches = null,
                        this->_wasMatched = false,
                        this->_matchedRoute = null;

                if typeof arguments != "array" {

                        if typeof arguments != "string" && typeof arguments != "null" {
                                throw new Exception("Arguments must be an array or string");
                        }

                        for route in reverse this->_routes {
                         ............
```
