### PR TITLE
JsonSerialize Interface for mvc\model

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4339,6 +4339,20 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		return data;
 	}
 
+    /**
+    * Serializes the object for json_encode
+    *
+	*<code>
+	* echo json_encode($robot->jsonSerialize());
+	*</code>
+    *
+    * @return array
+    */
+	public function jsonSerialize() -> array
+	{
+	    return this->toArray();
+	}
+
 	/**
 	 * Enables/disables options in the ORM
 	 */

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4343,7 +4343,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
     * Serializes the object for json_encode
     *
 	*<code>
-	* echo json_encode($robot->jsonSerialize());
+	* echo json_encode($robot);
 	*</code>
     *
     * @return array

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -76,7 +76,7 @@ use Phalcon\Events\ManagerInterface as EventsManagerInterface;
  * </code>
  *
  */
-abstract class Model implements EntityInterface, ModelInterface, ResultInterface, InjectionAwareInterface, \Serializable
+abstract class Model implements EntityInterface, ModelInterface, ResultInterface, InjectionAwareInterface, \Serializable, \JsonSerializable
 {
 
 	protected _dependencyInjector;

--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -564,7 +564,7 @@ abstract class Resultset
      *
      *<code>
      * $robots = Robots::find();
-     * echo json_encode($robots->jsonSerialize());
+     * echo json_encode($robots);
      *</code>
      *
      * @return array

--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -558,4 +558,28 @@ abstract class Resultset
 
 		return records;
 	}
+
+    /**
+     * Returns serialised model objects as array for json_encode. Calls jsonSerialize on each object if present
+     *
+     *<code>
+     * $robots = Robots::find();
+     * echo json_encode($robots->jsonSerialize());
+     *</code>
+     *
+     * @return array
+     */
+    public function jsonSerialize() -> array
+    {
+        var records, current;
+        let records = [];
+        for current in iterator(this) {
+        	if typeof current == "object" && method_exists(current, "jsonSerialize") {
+        		let records[] = current->{"jsonSerialize"}();
+        	} else {
+        	    let records[] = current;
+        	}
+        }
+        return records;
+    }
 }

--- a/phalcon/mvc/model/resultset.zep
+++ b/phalcon/mvc/model/resultset.zep
@@ -53,7 +53,7 @@ use Phalcon\Mvc\Model\ResultsetInterface;
  * </code>
  */
 abstract class Resultset
-	implements ResultsetInterface, \Iterator, \SeekableIterator, \Countable, \ArrayAccess, \Serializable
+	implements ResultsetInterface, \Iterator, \SeekableIterator, \Countable, \ArrayAccess, \Serializable, \JsonSerializable
 {
 
 	/**

--- a/phalcon/mvc/model/row.zep
+++ b/phalcon/mvc/model/row.zep
@@ -131,4 +131,14 @@ class Row implements EntityInterface, ResultInterface, \ArrayAccess
 	{
 		return get_object_vars(this);
 	}
+
+    /**
+    * Serializes the object for json_encode
+    *
+    * @return array
+    */
+	public function jsonSerialize() -> array
+	{
+	    return this->toArray();
+	}
 }

--- a/phalcon/mvc/model/row.zep
+++ b/phalcon/mvc/model/row.zep
@@ -30,7 +30,7 @@ use Phalcon\Mvc\Model\ResultInterface;
  * This component allows Phalcon\Mvc\Model to return rows without an associated entity.
  * This objects implements the ArrayAccess interface to allow access the object as object->x or array[x].
  */
-class Row implements EntityInterface, ResultInterface, \ArrayAccess
+class Row implements EntityInterface, ResultInterface, \ArrayAccess, \JsonSerializable
 {
 
 	/**

--- a/unit-tests/ModelsSerializeTest.php
+++ b/unit-tests/ModelsSerializeTest.php
@@ -39,7 +39,7 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
 		}
 	}
 
-	protected function _prepareDI()
+	protected function _getDI()
 	{
 		Phalcon\DI::reset();
 
@@ -58,6 +58,8 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
 			return new Phalcon\Db\Adapter\Pdo\Mysql($configMysql);
 		}, true);
 
+        return $di;
+
 	}
 
 	public function testSerialize()
@@ -68,7 +70,7 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
 			return;
 		}
 
-		$this->_prepareDI();
+		$this->_getDI();
 
 		$robot = Robots::findFirst();
 
@@ -78,5 +80,46 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue($robot->save());
 
 	}
+
+    public function testJsonSerialize()
+    {
+        require 'unit-tests/config.db.php';
+        if (empty($configMysql)) {
+            $this->markTestSkipped('Test skipped');
+            return;
+        }
+
+        $di = $this->_getDI();
+
+        // Single model object json serialization
+        $robot = Robots::findFirst();
+        $json = json_encode($robot->jsonSerialize());
+        $this->assertTrue(is_string($json));
+        $this->assertTrue(strlen($json) > 10); // make sure result is not "{ }"
+        $array = json_decode($json, true);
+        $this->assertEquals($robot->toArray(), $array);
+
+        // Result-set serialization
+        $robots = Robots::find();
+        $json = json_encode($robots->jsonSerialize());
+        $this->assertTrue(is_string($json));
+        $this->assertTrue(strlen($json) > 50); // make sure result is not "{ }"
+        $array = json_decode($json, true);
+        $this->assertEquals($robots->toArray(), $array);
+
+        // Single row serialization
+        $result = $di->get('modelsManager')->executeQuery('SELECT id FROM Robots LIMIT 1');
+        $this->assertEquals(get_class($result), 'Phalcon\Mvc\Model\Resultset\Simple');
+        foreach ($result as $row) {
+            $this->assertEquals(get_class($row), 'Phalcon\Mvc\Model\Row');
+            $this->assertEquals($row->id, $robot->id);
+            $json = json_encode($row->jsonSerialize());
+            $this->assertTrue(is_string($json));
+            $this->assertTrue(strlen($json) > 5); // make sure result is not "{ }"
+            $array = json_decode($json, true);
+            $this->assertEquals($row->toArray(), $array);
+        }
+
+    }
 
 }

--- a/unit-tests/ModelsSerializeTest.php
+++ b/unit-tests/ModelsSerializeTest.php
@@ -93,7 +93,7 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
 
         // Single model object json serialization
         $robot = Robots::findFirst();
-        $json = json_encode($robot->jsonSerialize());
+        $json = json_encode($robot);
         $this->assertTrue(is_string($json));
         $this->assertTrue(strlen($json) > 10); // make sure result is not "{ }"
         $array = json_decode($json, true);
@@ -101,7 +101,7 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
 
         // Result-set serialization
         $robots = Robots::find();
-        $json = json_encode($robots->jsonSerialize());
+        $json = json_encode($robots);
         $this->assertTrue(is_string($json));
         $this->assertTrue(strlen($json) > 50); // make sure result is not "{ }"
         $array = json_decode($json, true);
@@ -113,7 +113,7 @@ class ModelsSerializeTest extends PHPUnit_Framework_TestCase
         foreach ($result as $row) {
             $this->assertEquals(get_class($row), 'Phalcon\Mvc\Model\Row');
             $this->assertEquals($row->id, $robot->id);
-            $json = json_encode($row->jsonSerialize());
+            $json = json_encode($row);
             $this->assertTrue(is_string($json));
             $this->assertTrue(strlen($json) > 5); // make sure result is not "{ }"
             $array = json_decode($json, true);


### PR DESCRIPTION
Implements `jsonSerialize()` in mvc\model+row+result-set and `JsonSerializable` interface.  `jsonSerialize()` is called by `json_encode()` automatically.

See  #10273 

Syntax:

``` php
$robots = Robots::find();
echo json_encode( $robots );
```

Rebased from 2.0.x and dropped PHP 5.3 compatibility (#10320)
