### PR TITLE
Fix notice in _exists method of model

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -1056,11 +1056,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		 */
 		let num = connection->fetchOne(
 			"SELECT COUNT(*) \"rowcount\" FROM " . connection->escapeIdentifier(table) . " WHERE " . uniqueKey,
-			null,
+			\Phalcon\Db::FETCH_ASSOC,
 			uniqueParams,
 			uniqueTypes
 		);
-		if num["rowcount"] {
+		if num && num["rowcount"] {
 			let this->_dirtyState = self::DIRTY_STATE_PERSISTENT;
 			return true;
 		} else {


### PR DESCRIPTION
In some cases fetchOne return false.  The _exists method should handle that condition and should be more explicit in what the return type from fetchOne.
