### PR TITLE
Fix notice in _exists method of model

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -1054,7 +1054,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		 */
 		let num = connection->fetchOne(
 			"SELECT COUNT(*) \"rowcount\" FROM " . connection->escapeIdentifier(table) . " WHERE " . uniqueKey,
-			null,
+			\Phalcon\Db::FETCH_ASSOC,
 			uniqueParams,
 			uniqueTypes
 		);


### PR DESCRIPTION
In the _exists method of model the fetchOne call can return false.  That condition should not throw notices.  It should also be explicit to fetchOne for the return type.
