### PR TITLE
[2.1.x] Disable storing of cache keys per default. Performance regression

### DIFF
--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -84,7 +84,8 @@ class Libmemcached extends Backend implements BackendInterface
 		}
 
 		if !isset options["statsKey"] {
-			let options["statsKey"] = "_PHCM";
+			// Disable tracking of cached keys per default
+			let options["statsKey"] = "";
 		}
 
 		parent::__construct(frontend, options);
@@ -319,7 +320,7 @@ class Libmemcached extends Backend implements BackendInterface
 		}
 
 		if specialKey == "" {
-			throw new Exception("Cached keys were disabled (options['statsKey'] == ''), you shouldn't use this function");
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
 		}
 
 		/**
@@ -458,7 +459,7 @@ class Libmemcached extends Backend implements BackendInterface
 		}
 
 		if specialKey == "" {
-			throw new Exception("Cached keys were disabled (options['statsKey'] == ''), flush of memcached phalcon-related keys isn't implemented for now");
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
 		}
 
 		/**

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -226,7 +226,7 @@ class Memcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey != "null" {
+		if specialKey != "" {
 			/**
 			 * Update the stats key
 			 */

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -83,7 +83,8 @@ class Memcache extends Backend implements BackendInterface
 		}
 
 		if !isset options["statsKey"] {
-			let options["statsKey"] = "_PHCM";
+			// Disable tracking of cached keys per default
+			let options["statsKey"] = "";
 		}
 
 		parent::__construct(frontend, options);
@@ -276,11 +277,13 @@ class Memcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		let keys = memcache->get(specialKey);
+		if specialKey != "" {
+			let keys = memcache->get(specialKey);
 
-		if typeof keys == "array" {
-			unset keys[prefixedKey];
-			memcache->set(specialKey, keys);
+			if typeof keys == "array" {
+				unset keys[prefixedKey];
+				memcache->set(specialKey, keys);
+			}
 		}
 
 		/**
@@ -311,6 +314,10 @@ class Memcache extends Backend implements BackendInterface
 
 		if !fetch specialKey, options["statsKey"] {
 			throw new Exception("Unexpected inconsistency in options");
+		}
+
+		if specialKey == "" {
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
 		}
 
 		/**
@@ -448,6 +455,10 @@ class Memcache extends Backend implements BackendInterface
 
 		if !fetch specialKey, options["statsKey"] {
 			throw new \Phalcon\Cache\Exception("Unexpected inconsistency in options");
+		}
+
+		if specialKey == "" {
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
 		}
 
 		/**

--- a/phalcon/cache/backend/xcache.zep
+++ b/phalcon/cache/backend/xcache.zep
@@ -63,7 +63,8 @@ class Xcache extends Backend implements BackendInterface
 		}
 
 		if !isset options["statsKey"] {
-			let options["statsKey"] = "_PHCX";
+			// Disable tracking of cached keys per default
+			let options["statsKey"] = "";
 		}
 
 		parent::__construct(frontend, options);
@@ -169,17 +170,19 @@ class Xcache extends Backend implements BackendInterface
 				throw new Exception("Unexpected inconsistency in options");
 			}
 
-			/**
-			 * xcache_list() is available only to the administrator (unless XCache was
-			 * patched). We have to update the list of the stored keys.
-			 */
-			let keys = xcache_get(specialKey);
-			if typeof keys != "array" {
-				let keys = [];
-			}
+			if specialKey != "" {
+				/**
+				 * xcache_list() is available only to the administrator (unless XCache was
+				 * patched). We have to update the list of the stored keys.
+				 */
+				let keys = xcache_get(specialKey);
+				if typeof keys != "array" {
+					let keys = [];
+				}
 
-			let keys[lastKey] = tt1;
-			xcache_set(specialKey, keys);
+				let keys[lastKey] = tt1;
+				xcache_set(specialKey, keys);
+			}
 		}
 	}
 
@@ -199,14 +202,16 @@ class Xcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		let keys = xcache_get(specialKey);
-		if typeof keys != "array" {
-			let keys = [];
+		if specialKey != "" {
+			let keys = xcache_get(specialKey);
+			if typeof keys != "array" {
+				let keys = [];
+			}
+
+			unset keys[prefixedKey];
+
+			xcache_set(specialKey, keys);
 		}
-
-		unset keys[prefixedKey];
-
-		xcache_set(specialKey, keys);
 	}
 
 	/**
@@ -229,6 +234,10 @@ class Xcache extends Backend implements BackendInterface
 
 		if !fetch specialKey, this->_options["statsKey"] {
 			throw new Exception("Unexpected inconsistency in options");
+		}
+
+		if specialKey == "" {
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
 		}
 
 		let retval = [];
@@ -348,6 +357,10 @@ class Xcache extends Backend implements BackendInterface
 
 		if !fetch specialKey, this->_options["statsKey"] {
 			throw new Exception("Unexpected inconsistency in options");
+		}
+
+		if specialKey == "" {
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
 		}
 
 		let keys = xcache_get(specialKey);

--- a/unit-tests/CacheTest.php
+++ b/unit-tests/CacheTest.php
@@ -1298,7 +1298,8 @@ class CacheTest extends PHPUnit_Framework_TestCase
 
 		$cache = new Phalcon\Cache\Backend\Memcache($frontCache, array(
 			'host' => '127.0.0.1',
-			'port' => '11211'
+			'port' => '11211',
+            'statsKey' => '_PHCM'
 		));
 
 		$cache->save('data', "1");
@@ -1370,7 +1371,9 @@ class CacheTest extends PHPUnit_Framework_TestCase
 			return false;
 		}
 
-		$cache = new Phalcon\Cache\Backend\Xcache($frontCache);
+		$cache = new Phalcon\Cache\Backend\Xcache($frontCache, array(
+            'statsKey' => '_PHCM'
+        ));
 
 		$cache->save('data', "1");
 		$cache->save('data2', "2");
@@ -1398,6 +1401,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 					'port' => '11211',
 					'weight' => '1'),
 			),
+            'statsKey' => '_PHCM',
 			'client' => array(
 				Memcached::OPT_PREFIX_KEY => 'prefix.',
 			)
@@ -1579,6 +1583,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$frontCache = new Phalcon\Cache\Frontend\Data();
 		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
 			'host' => 'localhost',
+            'statsKey' => '_PHCM',
 			'port' => 6379
 		));
 

--- a/unit-tests/CacheTest.php
+++ b/unit-tests/CacheTest.php
@@ -482,6 +482,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 
 		$cache = new Phalcon\Cache\Backend\Memcache($frontCache, array(
 			'host' => '127.0.0.1',
+			'statsKey' => '_PHCM',
 			'port' => '11211'
 		));
 
@@ -862,7 +863,9 @@ class CacheTest extends PHPUnit_Framework_TestCase
 			'lifetime' => 2
 		));
 
-		$cache = new Phalcon\Cache\Backend\Xcache($frontCache);
+		$cache = new Phalcon\Cache\Backend\Xcache($frontCache, array(
+			'statsKey' => '_PHCM'
+		));
 
 		ob_start();
 
@@ -1143,7 +1146,8 @@ class CacheTest extends PHPUnit_Framework_TestCase
 					'host' => '127.0.0.1',
 					'port' => '11211',
 					'weight' => '1'),
-			)
+			),
+			'statsKey' => '_PHCM'
 		));
 
 		$keys = $cache->queryKeys();
@@ -1299,7 +1303,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$cache = new Phalcon\Cache\Backend\Memcache($frontCache, array(
 			'host' => '127.0.0.1',
 			'port' => '11211',
-            'statsKey' => '_PHCM'
+			'statsKey' => '_PHCM'
 		));
 
 		$cache->save('data', "1");
@@ -1372,8 +1376,8 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		}
 
 		$cache = new Phalcon\Cache\Backend\Xcache($frontCache, array(
-            'statsKey' => '_PHCM'
-        ));
+			'statsKey' => '_PHCM'
+		));
 
 		$cache->save('data', "1");
 		$cache->save('data2', "2");
@@ -1401,7 +1405,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 					'port' => '11211',
 					'weight' => '1'),
 			),
-            'statsKey' => '_PHCM',
+			'statsKey' => '_PHCM',
 			'client' => array(
 				Memcached::OPT_PREFIX_KEY => 'prefix.',
 			)
@@ -1487,6 +1491,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$frontCache = new Phalcon\Cache\Frontend\Output(array('lifetime' => 2));
 		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
 			'host' => 'localhost',
+			'statsKey' => '_PHCM',
 			'port' => 6379
 		));
 
@@ -1542,6 +1547,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$frontCache = new Phalcon\Cache\Frontend\Data();
 		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
 			'host' => 'localhost',
+			'statsKey' => '_PHCM',
 			'port' => 6379
 		));
 
@@ -1583,7 +1589,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$frontCache = new Phalcon\Cache\Frontend\Data();
 		$cache = new Phalcon\Cache\Backend\Redis($frontCache, array(
 			'host' => 'localhost',
-            'statsKey' => '_PHCM',
+			'statsKey' => '_PHCM',
 			'port' => 6379
 		));
 


### PR DESCRIPTION
Disable options["statsKey"] in cache backends per default. It is required for flush() or queryKeys() which are probably rarely used in production.
It was also not possible to disable statKey in redis and xcache. Memcache issued some notices.

Mentioned previously in #10343, [forum 3310](https://forum.phalconphp.com/discussion/3310/how-to-disable-phcm-store-all-the-keys-when-using-libmemcached-)

Unit-tests may fail as I do not run all cache backend on my vagrant box
