### PR TITLE
Restore setTrackingKey and getTrackingKey methods on Memcache and Libmemcached backends

### DIFF
--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -479,9 +479,11 @@ class Libmemcached extends Backend implements BackendInterface
 	 * Stores special memcached key use internally to store all memcache keys
 	 * @param string|null key
 	 */
-	public function setTrackingKey(var key) -> void
+	public function setTrackingKey(var key) -> <Libmemcached>
 	{
 		let this->_options["statsKey"] = key;
+
+		return this;
 	}
 
 	/**

--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -229,7 +229,7 @@ class Libmemcached extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey != "null" {
+		if specialKey != "" {
 			/**
 			 * Update the stats key
 			 */
@@ -280,7 +280,7 @@ class Libmemcached extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey != "null" {
+		if specialKey != "" {
 			let keys = memcache->get(specialKey);
 			if typeof keys == "array" {
 				unset keys[prefixedKey];
@@ -311,7 +311,7 @@ class Libmemcached extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey == "null" {
+		if specialKey == "" {
 			return;
 		}
 
@@ -457,7 +457,7 @@ class Libmemcached extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey != "null" {
+		if specialKey != "" {
 			/**
 			 * Get the key from memcached
 			 */
@@ -477,9 +477,9 @@ class Libmemcached extends Backend implements BackendInterface
 
 	/**
 	 * Stores special memcached key use internally to store all memcache keys
-	 * @param string|null key
+	 * @param string key
 	 */
-	public function setTrackingKey(var key) -> <Libmemcached>
+	public function setTrackingKey(string! key) -> <Libmemcached>
 	{
 		let this->_options["statsKey"] = key;
 

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -473,9 +473,11 @@ class Memcache extends Backend implements BackendInterface
 	 * Stores special memcached key use internally to store all memcache keys
 	 * @param string|null key
 	 */
-	public function setTrackingKey(var key) -> void
+	public function setTrackingKey(var key) -> <Memcache>
 	{
 		let this->_options["statsKey"] = key;
+
+		return this;
 	}
 
 	/**

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -225,7 +225,7 @@ class Memcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey != "null" {
+		if specialKey != "" {
 			/**
 			 * Update the stats key
 			 */
@@ -276,7 +276,7 @@ class Memcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey != "null" {
+		if specialKey != "" {
 			let keys = memcache->get(specialKey);
 
 			if typeof keys == "array" {
@@ -308,7 +308,7 @@ class Memcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		if typeof specialKey == "null" {
+		if specialKey == "" {
 			return;
 		}
 
@@ -456,24 +456,27 @@ class Memcache extends Backend implements BackendInterface
 			throw new \Phalcon\Cache\Exception("Unexpected inconsistency in options");
 		}
 
-		/**
-		 * Get the key from memcached
-		 */
-		let keys = memcache->get(specialKey);
-		if typeof keys == "array" {
-			for key, _ in keys {
-				memcache->delete(key);
+		if specialKey != "" {
+			/**
+			 * Get the key from memcached
+			 */
+			let keys = memcache->get(specialKey);
+			if typeof keys == "array" {
+				for key, _ in keys {
+					memcache->delete(key);
+				}
+				memcache->set(specialKey, keys);
 			}
-			memcache->set(specialKey, keys);
 		}
+
 		return true;
 	}
 
 	/**
 	 * Stores special memcached key use internally to store all memcache keys
-	 * @param string|null key
+	 * @param string key
 	 */
-	public function setTrackingKey(var key) -> <Memcache>
+	public function setTrackingKey(string! key) -> <Memcache>
 	{
 		let this->_options["statsKey"] = key;
 

--- a/phalcon/cache/backend/memcache.zep
+++ b/phalcon/cache/backend/memcache.zep
@@ -276,11 +276,13 @@ class Memcache extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
-		let keys = memcache->get(specialKey);
+		if typeof specialKey != "null" {
+			let keys = memcache->get(specialKey);
 
-		if typeof keys == "array" {
-			unset keys[prefixedKey];
-			memcache->set(specialKey, keys);
+			if typeof keys == "array" {
+				unset keys[prefixedKey];
+				memcache->set(specialKey, keys);
+			}
 		}
 
 		/**
@@ -294,23 +296,27 @@ class Memcache extends Backend implements BackendInterface
 	 * Query the existing cached keys
 	 *
 	 * @param string prefix
-	 * @return array
+	 * @return array|void
 	 */
-	public function queryKeys(prefix = null) -> array
+	public function queryKeys(prefix = null)
 	{
 		var memcache, options, keys, specialKey, key, realKey;
+
+		let options = this->_options;
+
+		if !fetch specialKey, options["statsKey"] {
+			throw new Exception("Unexpected inconsistency in options");
+		}
+
+		if typeof specialKey == "null" {
+			return;
+		}
 
 		let memcache = this->_memcache;
 
 		if typeof memcache != "object" {
 			this->_connect();
 			let memcache = this->_memcache;
-		}
-
-		let options = this->_options;
-
-		if !fetch specialKey, options["statsKey"] {
-			throw new Exception("Unexpected inconsistency in options");
 		}
 
 		/**
@@ -463,4 +469,29 @@ class Memcache extends Backend implements BackendInterface
 		return true;
 	}
 
+	/**
+	 * Stores special memcached key use internally to store all memcache keys
+	 * @param string|null key
+	 */
+	public function setTrackingKey(var key) -> void
+	{
+		let this->_options["statsKey"] = key;
+	}
+
+	/**
+	 * Returns special memcached key.
+	 * @return string|null
+	 */
+	public function getTrackingKey()
+	{
+		var options, specialKey;
+
+		let options = this->_options;
+
+		if !fetch specialKey, options["statsKey"] {
+			return null;
+		}
+
+		return specialKey;
+	}
 }


### PR DESCRIPTION
In 1.3.x, setTrackingKey and getTrackingKey methods were available on Phalcon\Cache\Backend\Memcache and Phalcon\Cache\Backend\Libmemcached.

Restore also the 1.3.x behaviour of queryKeys() method : 
If there was no statsKey defined, queryKeys() method returns void instead of throwing an exception as in 2.0.x
