### PR TITLE
Fix bug with uppercase controller name

### DIFF
--- a/phalcon/mvc/application.zep
+++ b/phalcon/mvc/application.zep
@@ -392,7 +392,7 @@ class Application extends Injectable
 							 * Automatic render based on the latest controller executed
 							 */
 							view->render(
-								dispatcher->getControllerName(),
+								strtolower(dispatcher->getControllerName()),
 								dispatcher->getActionName(),
 								dispatcher->getParams()
 							);


### PR DESCRIPTION
If you register Route like this

``` php
$router->add('/reset-password/{code}/{email}/{id}/', array(
    'controller' => 'Auth',
    'action' => 'reset'
))
```

Application is working but it cant render View via it's Auth not auth

Not errors, no excepions...
