### PR TITLE
NPE in Phalcon\Form\Element::appendMessage - missing statement

### DIFF
--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -533,6 +533,7 @@ abstract class Element implements ElementInterface
 		let messages = this->_messages;
 		if typeof messages != "object" {
 			let this->_messages = new Group();
+			let messages = this->_messages;
 		}
 		messages->appendMessage(message);
 		return this;

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -25,7 +25,8 @@ use
 	Phalcon\Forms\Element\Radio,
 	Phalcon\Validation\Validator\PresenceOf,
 	Phalcon\Validation\Validator\StringLength,
-	Phalcon\Validation\Validator\Regex;
+	Phalcon\Validation\Validator\Regex,
+	Phalcon\Validation\Message;
 
 class ContactFormPublicProperties
 {
@@ -532,5 +533,11 @@ class FormsTest extends PHPUnit_Framework_TestCase
 		$element->addOption('value');
 
 		$this->assertEquals('<select id="test-select" name="test-select"><option value="0">value</option></select>', preg_replace('/[[:cntrl:]]/', '', $element->render()));
+	}
+
+	public function testElementAppendMessage()
+	{
+		$element = new Select('test-select');
+		$element->appendMessage(new Message(''));
 	}
 }


### PR DESCRIPTION
There was a missing statement in appendMessage of Phalcon\Form\Element. Before this patch, the unit test I added:

```
There was 1 error:

1) FormsTest::testElementAppendMessage
RuntimeException: Trying to call method appendmessage on a non-object

.../cphalcon-olivier/unit-tests/FormsTest.php:541
```

With this patch, the unit test is working.
