### PR TITLE
[2.1.x] [NFR] Improving adapter session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@
 - Method `isSetOption` in `Phalcon\Validation\ValidatorInterface` marked as deprecated, please use `hasOption`
 - Added internal check "allowEmpty" before calling a validator. If it option is true and the value of empty, the validator is skipped
 - Added default header: `Content-Type: "application/json; charset=UTF-8"` in method `Phalcon\Http\Response::setJsonContent`
+- `Phalcon\Session`:
+   - Added public method (with support PHP 5.4):
+      - `getOption()`, `getCookieParams()`, `setCookieParams()`, `reset()`, `commit()`, `abort()`, `clear()`, `encode()`, `decode()`
+   - Added protected method:
+      - `configure()`
+   - Added options:
+      - name, cookie_lifetime, cookie_path, cookie_domain, cookie_secure, cookie_httponly
+   - `Phalcon\Session\Adapter\Files` added options: savePath
 
 # [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-09-19)
 - Added `Phalcon\Security\Random::base58` - to generate a random base58 string

--- a/phalcon/session/adapter/files.zep
+++ b/phalcon/session/adapter/files.zep
@@ -19,7 +19,6 @@
 
 namespace Phalcon\Session\Adapter;
 
-use Phalcon\Session\AdapterInterface;
 use Phalcon\Session\Adapter;
 
 /**
@@ -29,7 +28,14 @@ use Phalcon\Session\Adapter;
  *
  *<code>
  * $session = new \Phalcon\Session\Adapter\Files(array(
- *    'uniqueId' => 'my-private-app'
+ *    'uniqueId' => 'my-private-app',
+ *    'savePath' => 'session-save-path',
+ *    'name' => 'session-name',
+ *    'cookie_lifetime' => 'session-cookie-lifetime',
+ *    'cookie_path' => 'session-cookie-path',
+ *    'cookie_domain' => 'session-cookie-domain',
+ *    'cookie_secure' => 'session-cookie-secure',
+ *    'cookie_httponly' => 'session-cookie-httponly'
  * ));
  *
  * $session->start();
@@ -39,7 +45,30 @@ use Phalcon\Session\Adapter;
  * echo $session->get('var');
  *</code>
  */
-class Files extends Adapter implements AdapterInterface
+class Files extends Adapter
 {
+	/**
+	 * Reads the session data from the session storage, and returns the results.
+	 * Note: SessionHandlerInterface::open() is called immediately before this function.
+	 */
+	public function read(string session_id) -> var
+	{
+		var session_file;
+		let session_file = session_save_path() . DIRECTORY_SEPARATOR . "sess_" . session_id;
+		return is_file(session_file) ? file_get_contents(session_file) : "";
+	}
 
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure() -> void
+	{
+		var path = this->getOption("savePath");
+
+		if path {
+			session_save_path(path);
+		}
+
+		parent::configure();
+	}
 }

--- a/phalcon/session/adapter/memcache.zep
+++ b/phalcon/session/adapter/memcache.zep
@@ -20,7 +20,6 @@
 namespace Phalcon\Session\Adapter;
 
 use Phalcon\Session\Adapter;
-use Phalcon\Session\AdapterInterface;
 use Phalcon\Cache\Backend\Memcache;
 use Phalcon\Cache\Frontend\Data as FrontendData;
 
@@ -36,7 +35,14 @@ use Phalcon\Cache\Frontend\Data as FrontendData;
  *    'port' => 11211,
  *    'persistent' => true,
  *    'lifetime' => 3600,
- *    'prefix' => 'my_'
+ *    'prefix' => 'my_',
+ *
+ *    'name' => 'session-name',
+ *    'cookie_lifetime' => 'session-cookie-lifetime',
+ *    'cookie_path' => 'session-cookie-path',
+ *    'cookie_domain' => 'session-cookie-domain',
+ *    'cookie_secure' => 'session-cookie-secure',
+ *    'cookie_httponly' => 'session-cookie-httponly'
  * ));
  *
  * $session->start();
@@ -46,7 +52,7 @@ use Phalcon\Cache\Frontend\Data as FrontendData;
  * echo $session->get('var');
  *</code>
  */
-class Memcache extends Adapter implements AdapterInterface
+class Memcache extends Adapter implements \SessionHandlerInterface
 {
 
 	protected _memcache = null { get };
@@ -54,96 +60,79 @@ class Memcache extends Adapter implements AdapterInterface
 	protected _lifetime = 8600 { get };
 
 	/**
-	 * Phalcon\Session\Adapter\Memcache constructor
+	 * Re-initialize existing session, or creates a new one.
 	 */
-	public function __construct(array options = [])
+	public function open(string save_path, string session_name) -> boolean
 	{
-		var lifetime;
+		return true;
+	}
 
-		if !isset options["host"] {
-			let options["host"] = "127.0.0.1";
+	/**
+	 * Closes the current session.
+	 */
+	public function close() -> boolean
+	{
+		return true;
+	}
+
+	/**
+	 * Reads the session data from the session storage, and returns the results.
+	 * Note: SessionHandlerInterface::open() is called immediately before this function.
+	 */
+	public function read(string session_id) -> var
+	{
+		return this->_memcache->get(session_id, this->_lifetime);
+	}
+
+	/**
+	 * Writes the session data to the session storage.
+	 * Note: SessionHandlerInterface::close() is called immediately after this function.
+	 */
+	public function write(string session_id, var session_data) -> boolean
+	{
+		this->_memcache->save(session_id, session_data, this->_lifetime);
+		return true;
+	}
+
+	/**
+	 * Destroys the session data in the session storage.
+	 */
+	public function destroy(string session_id = null) -> boolean
+	{
+		return this->_memcache->delete(session_id ? session_id : this->getId());
+	}
+
+	/**
+	 * Cleans up expired sessions.
+	 */
+	public function gc(string maxlifetime) -> boolean
+	{
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setOptions(array! options) -> void
+	{
+		if isset options["lifetime"] {
+			let this->_lifetime = options["lifetime"];
 		}
 
-		if !isset options["port"] {
-			let options["port"] = 11211;
-		}
+		parent::setOptions(options);
+	}
 
-		if !isset options["persistent"] {
-			let options["persistent"] = 0;
-		}
-
-		if fetch lifetime, options["lifetime"] {
-			let this->_lifetime = lifetime;
-		}
-
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function configure() -> void
+	{
 		let this->_memcache = new Memcache(
 			new FrontendData(["lifetime": this->_lifetime]),
-			options
+			this->getOptions()
 		);
 
-		session_set_save_handler(
-			[this, "open"],
-			[this, "close"],
-			[this, "read"],
-			[this, "write"],
-			[this, "destroy"],
-			[this, "gc"]
-		);
-
-		parent::__construct(options);
-	}
-
-	public function open()
-	{
-		return true;
-	}
-
-	public function close()
-	{
-		return true;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param string sessionId
-	 * @return mixed
-	 */
-	public function read(sessionId)
-	{
-		return this->_memcache->get(sessionId, this->_lifetime);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param string sessionId
-	 * @param string data
-	 */
-	public function write(sessionId, data)
-	{
-		this->_memcache->save(sessionId, data, this->_lifetime);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param  string  sessionId
-	 * @return boolean
-	 */
-	public function destroy(sessionId = null) -> boolean
-	{
-		if sessionId === null {
-			let sessionId = this->getId();
-		}
-		return this->_memcache->delete(sessionId);
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function gc()
-	{
-		return true;
+		session_set_save_handler(this);
+		parent::configure();
 	}
 }

--- a/phalcon/session/adapterinterface.zep
+++ b/phalcon/session/adapterinterface.zep
@@ -14,6 +14,7 @@
  +------------------------------------------------------------------------+
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
  |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
  +------------------------------------------------------------------------+
  */
 
@@ -30,12 +31,24 @@ interface AdapterInterface
 	/**
 	 * Starts session, optionally using an adapter
 	 */
-	public function start();
+	public function start() -> boolean;
+
+	/**
+	 * Gets the session cookie parameters
+	 * @see http://php.net/manual/en/function.session-get-cookie-params.php
+	 */
+	public function getCookieParams() -> array;
+
+	/**
+	 * Sets the session cookie parameters
+	 * @see http://php.net/manual/en/function.session-set-cookie-params.php
+	 */
+	public function setCookieParams(int! lifetime, string path, string domain, bool secure = false, bool httpOnly = false) -> void;
 
 	/**
 	 * Sets session options
 	 */
-	public function setOptions(array! options);
+	public function setOptions(array! options) -> void;
 
 	/**
 	 * Get internal options
@@ -43,14 +56,20 @@ interface AdapterInterface
 	public function getOptions() -> array;
 
 	/**
+	 * Returns an option in the session's options
+	 * Returns defaultValue if the option hasn't set
+	 */
+	public function getOption(string key, var defaultValue = null) -> var;
+
+	/**
 	 * Gets a session variable from an application context
 	 */
-	public function get(string index, var defaultValue = null);
+	public function get(string index, var defaultValue = null) -> var;
 
 	/**
 	 * Sets a session variable in an application context
 	 */
-	public function set(string index, var value);
+	public function set(string index, var value) -> void;
 
 	/**
 	 * Check whether a session variable is set in an application context
@@ -60,7 +79,17 @@ interface AdapterInterface
 	/**
 	 * Removes a session variable from an application context
 	 */
-	public function remove(string index);
+	public function remove(string index) -> void;
+
+	/**
+	 * Set the current session id
+	 * Returns the previous name
+	 *
+	 * <code>
+	 *    $session->setId($id);
+	 * </code>
+	 */
+	public function setId(string id) -> string;
 
 	/**
 	 * Returns active session id
@@ -78,17 +107,59 @@ interface AdapterInterface
 	public function destroy(boolean removeData = false) -> boolean;
 
 	/**
-	 * Regenerate session's id
+	 * Update the current session id with a newly generated one.
+	 * Returns NEW session ID on success or FALSE on failure.
+	 * @see http://php.net/manual/en/function.session-regenerate-id.php
 	 */
-	public function regenerateId(bool deleteOldSession = true) -> <AdapterInterface>;
+	public function regenerateId(bool deleteOldSession = false) -> string | boolean;
 
 	/**
-	 * Set session name
+	 * Sets the current session name and return the old session name
+	 * Returns the previous name
+	 *
+	 * @see http://php.net/manual/en/function.session-name.php
 	 */
-	public function setName(string name);
+	public function setName(string name) -> string;
 
 	/**
-	 * Get session name
+	 * Gets the current session name
+	 * @see http://php.net/manual/en/function.session-name.php
 	 */
 	public function getName() -> string;
+
+	/**
+	 * Write session data and end session
+	 * @see http://php.net/manual/en/function.session-write-close.php
+	 */
+	public function commit() -> void;
+
+	/**
+	 * Discard session array changes and finish session
+	 * @see http://php.net/manual/en/function.session-abort.php
+	 */
+	public function abort() -> void;
+
+	/**
+	 * Returns the current session status (const: SESSION_DISABLED, SESSION_NONE, SESSION_ACTIVE)
+	 * @see http://php.net/manual/en/function.session-status.php
+	 */
+	public function status() -> int;
+
+	/**
+	 * Clear all session variables
+	 * @see http://php.net/manual/en/function.session-unset.php
+	 */
+	public function clear() -> void;
+
+	/**
+	 * Encodes the current session data as a session encoded string
+	 * @see http://php.net/manual/en/function.session-encode.php
+	 */
+	public function encode() -> string;
+
+	/**
+	 * Decodes session data from a session encoded string
+	 * @see http://php.net/manual/en/function.session-encode.php
+	 */
+	public function decode(string data) -> boolean;
 }

--- a/tests/PhalconTest/Session/Adapter/Libmemcached.php
+++ b/tests/PhalconTest/Session/Adapter/Libmemcached.php
@@ -31,10 +31,10 @@ class Libmemcached extends PhLibmemcached
     {
         return parent::__construct($options);
     }
-    
-    public function open()
+
+    public function open($save_path, $session_name)
     {
-        return parent::open();
+        return parent::open($save_path, $session_name);
     }
 
     public function close()
@@ -42,24 +42,24 @@ class Libmemcached extends PhLibmemcached
         return parent::close();
     }
 
-    public function read($sessionId)
+    public function read($session_id)
     {
-        return parent::read($sessionId);
+        return parent::read($session_id);
     }
 
-    public function write($sessionId, $data)
+    public function write($session_id, $session_data)
     {
-        return parent::write($sessionId, $data);
+        return parent::write($session_id, $session_data);
     }
 
-    public function destroy($sessionId = null)
+    public function destroy($session_id = null)
     {
-        return parent::destroy($sessionId);
+        return parent::destroy($session_id);
     }
 
-    public function gc()
+    public function gc($maxlifetime)
     {
-        return parent::gc();
+        return parent::gc($maxlifetime);
     }
 
 

--- a/tests/PhalconTest/Session/Adapter/Memcache.php
+++ b/tests/PhalconTest/Session/Adapter/Memcache.php
@@ -32,9 +32,9 @@ class Memcache extends PhMemcache
         return parent::__construct($options);
     }
     
-    public function open()
+    public function open($save_path, $session_name)
     {
-        return parent::open();
+        return parent::open($save_path, $session_name);
     }
 
     public function close()
@@ -42,24 +42,24 @@ class Memcache extends PhMemcache
         return parent::close();
     }
 
-    public function read($sessionId)
+    public function read($session_id)
     {
-        return parent::read($sessionId);
+        return parent::read($session_id);
     }
 
-    public function write($sessionId, $data)
+    public function write($session_id, $session_data)
     {
-        return parent::write($sessionId, $data);
+        return parent::write($session_id, $session_data);
     }
 
-    public function destroy($sessionId = null)
+    public function destroy($session_id = null)
     {
-        return parent::destroy($sessionId);
+        return parent::destroy($session_id);
     }
 
-    public function gc()
+    public function gc($maxlifetime)
     {
-        return parent::gc();
+        return parent::gc($maxlifetime);
     }
 
 

--- a/tests/PhalconTest/Session/Adapter/Redis.php
+++ b/tests/PhalconTest/Session/Adapter/Redis.php
@@ -31,10 +31,10 @@ class Redis extends PhRedis
     {
         return parent::__construct($options);
     }
-    
-    public function open()
+
+    public function open($save_path, $session_name)
     {
-        return parent::open();
+        return parent::open($save_path, $session_name);
     }
 
     public function close()
@@ -42,24 +42,24 @@ class Redis extends PhRedis
         return parent::close();
     }
 
-    public function read($sessionId)
+    public function read($session_id)
     {
-        return parent::read($sessionId);
+        return parent::read($session_id);
     }
 
-    public function write($sessionId, $data)
+    public function write($session_id, $session_data)
     {
-        return parent::write($sessionId, $data);
+        return parent::write($session_id, $session_data);
     }
 
-    public function destroy($sessionId = null)
+    public function destroy($session_id = null)
     {
-        return parent::destroy($sessionId);
+        return parent::destroy($session_id);
     }
 
-    public function gc()
+    public function gc($maxlifetime)
     {
-        return parent::gc();
+        return parent::gc($maxlifetime);
     }
 
 

--- a/unit-tests/SessionTest.php
+++ b/unit-tests/SessionTest.php
@@ -15,133 +15,159 @@
 	+------------------------------------------------------------------------+
 	| Authors: Andres Gutierrez <andres@phalconphp.com>                      |
 	|          Eduar Carvajal <eduar@phalconphp.com>                         |
+	|          Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
 	+------------------------------------------------------------------------+
 */
 
+use Phalcon\Session\Adapter as SessionAdapter;
+use Phalcon\Session\AdapterInterface as SessionAdapterInterface;
+
+/**
+ * Class SessionTest
+ */
 class SessionTest extends PHPUnit_Framework_TestCase
 {
-
 	protected $stack = array();
 
-	protected function setUp()
-	{
+	/**
+	 * @var SessionAdapterInterface
+	 */
+	protected $session;
 
+	public static function setUpBeforeClass()
+	{
+		@session_unset();
+		@session_destroy();
+		@session_write_close();
+
+		session_save_path(__DIR__ . '/cache');
+	}
+
+	public function setUp()
+	{
 		$this->stack = array(
 			'save_handler' => ini_get('session.save_handler'),
 			'save_path' => ini_get('session.save_path'),
-			'serialize_handler' => ini_get('session.serialize_handler'),
+			'serialize_handler' => ini_get('session.serialize_handler')
 		);
 
+		$this->session = $this->createAdapter();
 	}
 
-	protected function tearDown()
+	public function tearDown()
 	{
-		@session_write_close();
+		@$this->sessionStart();
+		@$this->session->clear();
+		@$this->session->destroy();
+		$this->session = null;
 
 		foreach ($this->stack as $key => $val) {
 			@ini_set($key, $val);
 		}
-
 	}
 
-	public function testSessionFiles()
+	/**
+	 * Test method getOptions, getOption
+	 * @throws Exception
+	 */
+	public function testSessionGetOptions()
 	{
+		$options = array(
+			'option1' => 'test-value-1',
+			'option2' => 'test-value-2'
+		);
 
-		$session = new Phalcon\Session\Adapter\Files();
+		$session = $this->createAdapter($options);
 
-		$this->assertFalse($session->start());
-		$this->assertFalse($session->isStarted());
+		$this->assertEquals($session->getOptions(), $options);
 
-		@session_start();
+		$this->assertEquals($session->getOption('option1'), 'test-value-1');
+		$this->assertEquals($session->getOption('option2'), 'test-value-2');
 
-		$session->set('some', 'value');
-
-		$this->assertEquals($session->get('some'), 'value');
-		$this->assertTrue($session->has('some'));
-		$this->assertEquals($session->get('undefined', 'my-default'), 'my-default');
-
-		// Automatically deleted after reading
-		$this->assertEquals($session->get('some', NULL, TRUE), 'value');
-		$this->assertFalse($session->has('some'));
-
-		// Issue 10238
-		$session->set('some', 0);
-		$this->assertEquals($session->get('some'), 0);
+		// Test getOption default value
+		$this->assertEquals($session->getOption('option3'), null);
+		$this->assertEquals($session->getOption('option4', 'test-value-4'), 'test-value-4');
 	}
 
-	public function testSessionFilesWrite()
+
+	/**
+	 * Test method setOptions
+	 * @throws Exception
+	 */
+	public function testSessionSetOptions()
 	{
+		$options = array(
+			'option-1' => 'test-value-1',
+			'option-2' => 'test-value-2'
+		);
 
-		$session_path =  __DIR__ . '/cache';
-		ini_set('session.save_handler', 'files');
-		ini_set('session.save_path', $session_path);
-		ini_set('session.serialize_handler', 'php');
+		$session = $this->createAdapter();
+		$session->setOptions($options);
 
-		// Write
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
+		$this->assertEquals($session->getOptions(), $options);
 
-		$session->set('some', 'write-value');
+		$this->assertEquals($session->getOption('option-1'), 'test-value-1');
+		$this->assertEquals($session->getOption('option-2'), 'test-value-2');
 
-		$this->assertEquals($session->get('some'), 'write-value');
-		$this->assertTrue($session->has('some'));
+		// Test getOption default value
+		$this->assertEquals($session->getOption('option-3'), null);
+		$this->assertEquals($session->getOption('option-4', 'test-value-4'), 'test-value-4');
+	}
 
-		$session_id = $session->getId();
+	/**
+	 * Test gets\sets session id
+	 * @throws Exception
+	 */
+	public function testSessionSetId()
+	{
+		$this->sessionStart();
+
+		$session_id = $this->session->getId();
 		$this->assertNotEmpty($session_id);
 
-		session_write_close();
-		unset($session);
-
-		// Check session file
-		$session_file = $session_path . '/sess_' . $session_id;
-		$this->assertTrue(is_file($session_file));
-		$this->assertNotEmpty(@file_get_contents($session_file));
-
-		// Read
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
-
-		$session->setId($session_id);
-
-		$this->assertTrue($session->has('some'));
-		$this->assertEquals($session->get('some'), 'write-value');
-
-		$session->remove('some');
-		$this->assertFalse($session->has('some'));
-
-		@session_write_close();
-		unset($session);
-
-		// Check session file
-		$this->assertTrue(is_file($session_file));
-		$this->assertEmpty(@file_get_contents($session_file));
-		@unlink($session_file);
-
+		$this->session->setId($session_id_new = md5($session_id));
+		$this->assertEquals($this->session->getId(), $session_id_new);
 	}
 
-	public function testSessionFilesWriteMagicMethods()
+	/**
+	 * Test gets\sets session name
+	 * @throws Exception
+	 */
+	public function testSessionSetName()
 	{
+		$this->sessionStart();
 
-		$session_path =  __DIR__ . '/cache';
-		ini_set('session.save_handler', 'files');
-		ini_set('session.save_path', $session_path);
-		ini_set('session.serialize_handler', 'php');
+		$session_name = $this->session->getName();
+		$this->assertNotEmpty($session_name);
 
-		// Write
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
+		$this->assertEquals($this->session->setName('some-name'), $session_name);
+		$this->assertEquals($this->session->getName(), 'some-name');
+	}
 
-		$session->some = 'write-magic-value';
+	/**
+	 * Test adapter Phalcon\Session\Adapter\File, option savePath
+	 * @throws Exception
+	 */
+	public function testSessionAdapterFilesOptionSavePath()
+	{
+		$session_path_old = session_save_path();
 
-		$this->assertEquals($session->some, 'write-magic-value');
-		$this->assertTrue(isset($session->some));
+		$session_path = __DIR__ . '/cache/session';
+
+		if (!is_dir($session_path)) {
+			@mkdir($session_path, 0777, true);
+		}
+
+		$session = $this->createAdapter(array(
+			'savePath' => $session_path
+		));
+
+		$this->sessionStart();
+		$session->set('some', 'write-value');
 
 		$session_id = $session->getId();
 
-		@session_write_close();
+		$session->commit();
 		unset($session);
 
 		// Check session file
@@ -149,38 +175,384 @@ class SessionTest extends PHPUnit_Framework_TestCase
 		$this->assertTrue(is_file($session_file));
 		$this->assertNotEmpty(@file_get_contents($session_file));
 
-		// Read
-		$session = new Phalcon\Session\Adapter\Files();
-		$session->start();
-		@session_start();
-
-		$session->setId($session_id);
-
-		$this->assertTrue(isset($session->some));
-		$this->assertEquals($session->some, 'write-magic-value');
-
-		unset($session->some);
-		$this->assertFalse(isset($session->some));
-
-		@session_write_close();
-		unset($session);
-
-		// Check session file
-		$this->assertTrue(is_file($session_file));
-		$this->assertEmpty(@file_get_contents($session_file));
 		@unlink($session_file);
+		@rmdir($session_path);
 
+		session_save_path($session_path_old);
 	}
 
-    public function testSessionName()
-    {
-        $session = new Phalcon\Session\Adapter\Files();
-        $session->setName('NAMEFOO');
-        $this->assertEquals('NAMEFOO', $session->getName());
-        $this->assertEquals('NAMEFOO', session_name());
+	/**
+	 * Test session start, start force and status
+	 *
+	 * @throws Exception
+	 */
+	public function testSessionStart()
+	{
+		$this->assertEquals($this->session->status(), SessionAdapter::SESSION_NONE);
 
-        session_name('NAMEBAR');
-        $this->assertEquals('NAMEBAR', $session->getName());
-    }
+		// Test not force start
+		$this->assertFalse($this->session->start());
+		$this->assertFalse($this->session->isStarted());
+		$this->assertEquals($this->session->status(), SessionAdapter::SESSION_NONE);
 
+		// Test force start
+		$this->assertFalse($this->session->start());
+		$this->assertFalse($this->session->isStarted());
+
+		@session_start();
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertEquals($this->session->status(), SessionAdapter::SESSION_ACTIVE);
+	}
+
+
+	/**
+	 * Test session, getters, setters, has, remove
+	 * @throws Exception
+	 */
+	public function testSessionMethodsManipulate()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some', 'write-value');
+
+		// Test gets and sets method
+		$this->assertEquals($this->session->get('some'), 'write-value');
+		$this->assertTrue($this->session->has('some'));
+
+		// Test gets default value
+		$this->assertEquals($this->session->get('undefined-key', 'default-value'), 'default-value');
+
+		// Automatically deleted after reading
+		$this->assertEquals($this->session->get('some', null, true), 'write-value');
+		$this->assertFalse($this->session->has('some'));
+
+		// Test remove key
+		$this->session->set('some2', 'write-value');
+		$this->session->remove('some2');
+		$this->assertFalse($this->session->has('some'));
+
+		// Issue 10238
+		$this->session->set('some', 0);
+		$this->assertEquals($this->session->get('some'), 0);
+	}
+
+	/**
+	 * Test session magic methods
+	 * @throws Exception
+	 */
+	public function testSessionMagicMethodsManipulate()
+	{
+		$this->sessionStart();
+
+		$this->session->some = 'write-magic-value';
+
+		$this->assertEquals($this->session->some, 'write-magic-value');
+		$this->assertTrue(isset($this->session->some));
+
+		$this->session->some2 = 'write-magic-value';
+		unset($this->session->some2);
+		$this->assertFalse(isset($this->session->some2));
+	}
+
+
+	/**
+	 * Test session regenerate id
+	 * @throws Exception
+	 */
+	public function testSessionRegenerateId()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->assertTrue($this->session->has('some-key-1'));
+
+		$this->assertNotEmpty($session_id = $this->session->getId());
+
+		$newId = @$this->session->regenerateId();
+		$this->assertNotEquals($newId, $session_id);
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+	}
+
+	/**
+	 * Test session commit
+	 * @throws Exception
+	 */
+	public function testSessionCommit()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+		$this->session->commit();
+
+		$this->assertFalse($this->session->isStarted());
+
+		if (method_exists($this->session, 'read')) {
+			$this->assertNotEmpty($data = $this->session->read($this->session->getId()));
+		}
+
+		// The value of the session should not be updated after the start
+		$this->session->set('some-key-3', 'some-value-3');
+
+		$this->sessionStart();
+		$this->assertFalse($this->session->has('some-key-3'));
+	}
+
+	/**
+	 * Test session reset
+	 * @throws Exception
+	 */
+	public function testSessionReset()
+	{
+		$this->sessionStart();
+
+		/**
+		 * Test, reset to empty data
+		 */
+		$this->session->set('some-key-1', 'some-value-1');
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		$this->session->reset();
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertFalse($this->session->has('some-key-1'));
+
+
+		/**
+		 * Test, reset to previous data
+		 */
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+		$this->session->commit();
+
+		$this->assertFalse($this->session->isStarted());
+
+		$this->sessionStart();
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->session->set('some-key-2', 'some-value-22');
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-22');
+
+		// test key3
+		$this->session->set('some-key-3', 'some-value-3');
+		$this->assertTrue($this->session->has('some-key-3'));
+		$this->assertEquals($this->session->get('some-key-3'), 'some-value-3');
+
+		// Reset
+		$this->session->reset();
+
+		$this->assertTrue($this->session->isStarted());
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertFalse($this->session->has('some-key-3'));
+
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+	}
+
+	public function testSessionAbort()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		$this->session->commit();
+		$this->assertFalse($this->session->isStarted());
+
+		// Session start
+		$this->sessionStart();
+
+		// Change session data
+		$this->session->set('some-key-2', 'some-value-22');
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-22');
+
+		$this->session->set('some-key-3', 'some-value-3');
+		$this->assertTrue($this->session->has('some-key-3'));
+		$this->assertEquals($this->session->get('some-key-3'), 'some-value-3');
+
+		/**
+		 * Test abort session
+		 */
+		$this->session->abort();
+		$this->assertFalse($this->session->isStarted());
+
+		$this->sessionStart();
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		$this->assertFalse($this->session->has('some-key-3'));
+	}
+
+
+	/**
+	 * Test session clear
+	 * @throws Exception
+	 */
+	public function testSessionClear()
+	{
+		$this->sessionStart();
+
+		$session_id = $this->session->getId();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		/**
+		 * Test session clear
+		 */
+		$this->session->clear();
+
+		$this->assertTrue($this->session->isStarted());
+		$this->assertEquals($this->session->getId(), $session_id);
+
+		$this->assertFalse($this->session->has('some-key-1'));
+		$this->assertFalse($this->session->has('some-key-2'));
+	}
+
+	/**
+	 * Test session clear
+	 * @throws Exception
+	 */
+	public function testSessionDestroy()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		/**
+		 * Test session clear
+		 */
+		$this->assertTrue($this->session->destroy());
+
+		$this->assertFalse($this->session->isStarted());
+		$this->assertEquals($this->session->getId(), '');
+
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertTrue($this->session->has('some-key-2'));
+
+		$this->sessionStart();
+
+		$this->assertFalse($this->session->has('some-key-1'));
+		$this->assertFalse($this->session->has('some-key-2'));
+	}
+
+	/**
+	 * Test session clear
+	 * @throws Exception
+	 */
+	public function testSessionEncodeDecode()
+	{
+		$this->sessionStart();
+
+		$this->session->set('some-key-1', 'some-value-1');
+		$this->session->set('some-key-2', 'some-value-2');
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		/**
+		 * Test session encode
+		 */
+		$this->assertNotEmpty($session_data = $this->session->encode());
+
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertTrue($this->session->has('some-key-2'));
+
+		// test key3
+		$this->session->set('some-key-3', 'some-value-3');
+		$this->assertTrue($this->session->has('some-key-3'));
+		$this->assertEquals($this->session->get('some-key-3'), 'some-value-3');
+
+		// clear current session
+		$this->session->clear();
+
+		$this->assertFalse($this->session->has('some-key-1'));
+		$this->assertFalse($this->session->has('some-key-2'));
+		$this->assertFalse($this->session->has('some-key-3'));
+
+		/**
+		 * Test session decode
+		 */
+		$this->assertTrue($this->session->decode($session_data));
+
+		// test key1
+		$this->assertTrue($this->session->has('some-key-1'));
+		$this->assertEquals($this->session->get('some-key-1'), 'some-value-1');
+
+		// test key2
+		$this->assertTrue($this->session->has('some-key-2'));
+		$this->assertEquals($this->session->get('some-key-2'), 'some-value-2');
+
+		// test key3
+		$this->assertFalse($this->session->has('some-key-3'));
+	}
+
+	protected function sessionStart()
+	{
+		if (!$this->session->start()) {
+			@session_start();
+		}
+
+		$this->assertTrue($this->session->isStarted());
+	}
+
+	/**
+	 * @param array $options
+	 * @return SessionAdapter\Files
+	 */
+	protected function createAdapter(Array $options = null)
+	{
+		return new Phalcon\Session\Adapter\Files($options);
+	}
 }


### PR DESCRIPTION
Update `Phalcon\Session\Adapter`, `Phalcon\Session\AdapterInterface` and also full coverage of the tests... And more improvements...

_Added public method:_
- `getOption()`
- `getCookieParams()`
- `setCookieParams()`
- `reset()`
- `commit()`
- `abort()`
- `clear()`
- `encode()`
- `decode()`

_Added protected method_
- `configure()`

_Added options:_
- name (session name) 
- cookie_lifetime
- cookie_path
- cookie_domain
- cookie_secure
- cookie_httponly

_`Phalcon\Session\Adapter\Files` added options:_
- savePath
