### PR TITLE
Fix for incorrect page counts when using group by with the query builder pagination

### DIFF
--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -175,10 +175,21 @@ class QueryBuilder extends Adapter implements AdapterInterface
 		/**
 		 * Obtain the result of the total query
 		 */
-		let result = totalQuery->execute(),
-			row = result->getFirst(),
-			rowcount = intval(row->rowcount),
-			totalPages = intval(ceil(rowcount / limit));
+		let result = totalQuery->execute();
+
+
+		/**
+		 * Check if the query has a 'GROUP BY' clause and if it does just get the row count
+		 */
+		if totalBuilder->getGroupBy() != null {
+			let rowcount = result->count();
+		} else {
+			let row = result->getFirst(),
+				rowcount = intval(row->rowcount);
+		}
+
+		let totalPages = intval(ceil(rowcount / limit));
+
 
 		if numberPage < totalPages {
 			let next = numberPage + 1;

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -427,6 +427,27 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$queryBuilder = $paginator->getQueryBuilder();
 		$this->assertEquals($builder2, $queryBuilder);
 		$this->assertEquals($setterResult, $paginator);
+
+
+		// -- Group by test --
+		$builderGroup = $di['modelsManager']->createBuilder()
+			->columns('cedula, nombres, tipo_documento_id')
+			->from('Personnes')
+			->orderBy('cedula')
+			->groupBy('tipo_documento_id');
+
+		$paginatorGroup = new Phalcon\Paginator\Adapter\QueryBuilder(array(
+			"builder" => $builderGroup,
+			"limit"=> 10,
+			"page" => 1
+		));
+
+
+		$pageGroup = $paginatorGroup->getPaginate();
+
+		$this->assertEquals(1, $pageGroup->total_pages);
+		$this->assertEquals(8, $pageGroup->total_items);
+		$this->assertEquals(8, $pageGroup->items->count());
 	}
 
 }


### PR DESCRIPTION
This is a temporary fix for issue #2411. This is where GROUP BY clauses cause an incorrect total item count and thus page count for the QueryBuilder

I appreciate that this is not the perfect fix as it doesn't use a count and a FROM subquery like it has in previous versions. However this is not a function that is supported by PHQL at this time so this fix was not possible.

Another fix I came up with involved moving the grouping into a COUNT(DISTINCT col) but it doesn't work with multiple group by clauses and is notoriously slow in older versions of MySQL.

I've opted for this solution as it doesn't really change the function that much but does correct the issue.
