### PR TITLE
Adds mixed return type to session adapter get method

### DIFF
--- a/phalcon/session/adapter.zep
+++ b/phalcon/session/adapter.zep
@@ -126,7 +126,7 @@ abstract class Adapter
 	 *	$session->get('auth', 'yes');
 	 *</code>
 	 */
-	public function get(string index, var defaultValue = null, boolean remove = false)
+	public function get(string index, var defaultValue = null, boolean remove = false) -> var
 	{
 		var value, key, uniqueId;
 


### PR DESCRIPTION
This is so that php IDEs do not see the get method as returning void.
![screenshot_2](https://cloud.githubusercontent.com/assets/3328823/9764442/14c185a0-5707-11e5-83c3-4ef7c342c517.png)
