### PR TITLE
Bugfix #10912 (Micro Middleware (before) does not stop operation)

### DIFF
--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -671,18 +671,22 @@ class Micro extends Injectable implements \ArrayAccess
 						}
 
 						/**
-						 * Call the before handler, if it returns false exit
+						 * Call the before handler
 						 */
-						if call_user_func(before) === false {
-							return false;
-						}
+						let status = call_user_func(before);
 
 						/**
-						 * Reload the 'stopped' status
+						 * break the execution if the middleware was stopped
 						 */
-						if this->_stopped {
-							return status;
+						if  this->_stopped {
+							break;
 						}
+					}
+					/**
+					 * Reload the 'stopped' status
+					 */
+					if this->_stopped {
+						return status;
 					}
 				}
 

--- a/unit-tests/MicroMvcEventsTest.php
+++ b/unit-tests/MicroMvcEventsTest.php
@@ -28,13 +28,15 @@ class MicroMvcEventsTest extends PHPUnit_Framework_TestCase
 
 		$app = new Phalcon\Mvc\Micro();
 
-		$app->before(function() use (&$trace) {
+		$app->before(function() use ($app, &$trace) {
 			$trace[] = 1;
+			$app->stop();
 			return false;
 		});
 
-		$app->before(function() use (&$trace) {
+		$app->before(function() use ($app, &$trace) {
 			$trace[] = 1;
+			$app->stop();
 			return false;
 		});
 

--- a/unit-tests/MicroMvcMiddlewareTest.php
+++ b/unit-tests/MicroMvcMiddlewareTest.php
@@ -117,7 +117,7 @@ class MicroMvcMiddlewareTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($middleware->getNumber(), 6);
 	}
 
-	public function testMicroStopMiddlewareClasses()
+	public function testMicroStopMiddlewareOnBeforeClasses()
 	{
 
 		$app = new Phalcon\Mvc\Micro();
@@ -139,7 +139,29 @@ class MicroMvcMiddlewareTest extends PHPUnit_Framework_TestCase
 
 		$app->handle('/api/site');
 
-		$this->assertEquals($middleware->getNumber(), 3);
+		$this->assertEquals($middleware->getNumber(), 1);
+	}
+
+	public function testMicroStopMiddlewareOnAfterAndFinishClasses()
+	{
+
+		$app = new Phalcon\Mvc\Micro();
+
+		$app->map('/api/site', function(){
+			return true;
+		});
+
+		$middleware = new MyMiddlewareStop();
+
+		$app->after($middleware);
+		$app->after($middleware);
+
+		$app->finish($middleware);
+		$app->finish($middleware);
+
+		$app->handle('/api/site');
+
+		$this->assertEquals($middleware->getNumber(), 2);
 	}
 
 }


### PR DESCRIPTION
In this pull request is one important change.

before this change:
1. if `event` (before) is closure and return false -  [cancels the route execution](https://github.com/phalcon/cphalcon/blob/2.0.x/phalcon/mvc/micro.zep#L676-L678)
2. if `event` (before) is `MiddlewareInterface` object and return false/true/... - not cancels route execution

In this change:
1. if `event` (before) is closure and return false/true/... - **not** cancels route execution
2. if `event` (before) is `MiddlewareInterface` and return false/true/... - not cancels route execution

If you need to cancel execution on `event` (before) - in both cases **must be** called `$microApplication->stop();`

For example:

``` php
<?php
$app = new Phalcon\Mvc\Micro();
$app->before(function () use ($app) {
    if ($app['session']->get('auth') == false) {
        $app->stop();
        return false;
    }
    return true;
});
$app->handle();
```

or

``` php
<?php
class Auth implements Phalcon\Mvc\Micro\MiddlewareInterface
{
    public function call(Phalcon\Mvc\Micro $app)
    {
         if ($app['session']->get('auth') == false) {
            $app->stop();
            return false;
        }
        return true;
    }
}
$app = new Phalcon\Mvc\Micro();
$app->before(new Access());
$app->handle();
```
