### PR TITLE
Implement NFR #10798

### DIFF
--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -1408,6 +1408,7 @@ class Compiler implements InjectionAwareInterface
 			let compilation .= "<?php $" . prefixLevel . "iterator = " . exprCode . "; ";
 			let compilation .= "$" . prefixLevel . "incr = 0; ";
 			let compilation .= "$" . prefixLevel . "loop = new stdClass(); ";
+			let compilation .= "$" . prefixLevel . "loop->self = &$" . prefixLevel . "loop; ";
 			let compilation .= "$" . prefixLevel . "loop->length = count($" . prefixLevel . "iterator); ";
 			let compilation .= "$" . prefixLevel . "loop->index = 1; ";
 			let compilation .= "$" . prefixLevel . "loop->index0 = 1; ";

--- a/unit-tests/ViewEnginesVoltTest.php
+++ b/unit-tests/ViewEnginesVoltTest.php
@@ -1379,4 +1379,14 @@ Clearly, the song is: <?php echo $this->getContent(); ?>.
 
 		$this->assertEquals($view->getContent(), 'Length Array: 4Length Object: 4Length String: 5Length No String: 4Slice Array: 1,2,3,4Slice Array: 2,3Slice Array: 1,2,3Slice Object: 2,3,4Slice Object: 2,3Slice Object: 1,2Slice String: helSlice String: elSlice String: lloSlice No String: 123Slice No String: 23Slice No String: 34');
 	}
+
+	public function testVoltEngineLoopContext()
+	{
+		$volt = new Compiler();
+		$compiled = $volt->compileString('{% for i in 1..5 %}{{ loop.self.index }}{% endfor %}');
+		ob_start();
+		eval('?>'.$compiled);
+		$result = ob_get_clean();
+		$this->assertEquals('12345', $result);
+	}
 }


### PR DESCRIPTION
This is just an example for @lajosbencz

```
$ git clone git@github.com:phalcon/cphalcon.git
Cloning into 'cphalcon'...
Warning: Permanently added the RSA host key for IP address '192.30.252.129' to the list of known hosts.
remote: Counting objects: 95067, done.
remote: Total 95067 (delta 0), reused 0 (delta 0), pack-reused 95066
Receiving objects: 100% (95067/95067), 83.42 MiB | 27.00 KiB/s, done.
Resolving deltas: 100% (73916/73916), done.
Checking connectivity... done.

$ cd cphalcon/
$ git remote add lajosbencz git@github.com:lajosbencz/cphalcon.git
$ git checkout 2.1.x
Branch 2.1.x set up to track remote branch 2.1.x from origin.
Switched to a new branch '2.1.x'

// edit files ...

$ git status
On branch 2.1.x
Your branch is up-to-date with 'origin/2.1.x'.
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

    modified:   phalcon/mvc/view/engine/volt/compiler.zep
    modified:   unit-tests/ViewEnginesVoltTest.php

no changes added to commit (use "git add" and/or "git commit -a")

$ git checkout -b nfr_10798
M   phalcon/mvc/view/engine/volt/compiler.zep
M   unit-tests/ViewEnginesVoltTest.php
Switched to a new branch 'nfr_10798'
$ git add .
$ git commit -m 'Implement NFR #10798'
[nfr_10798 fc0b53c] Implement NFR #10798
 2 files changed, 11 insertions(+)
$ git push --set-upstream lajosbencz nfr_10798
Counting objects: 355, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (135/135), done.
Writing objects: 100% (355/355), 110.83 KiB | 0 bytes/s, done.
Total 355 (delta 287), reused 272 (delta 219)
To git@github.com:lajosbencz/cphalcon.git
 * [new branch]      nfr_10798 -> nfr_10798
```
