### PR TITLE
Bugfix #10912 (Micro Middleware (before) does not stop operation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)
 - Fixed `Di::set`, `Di::setShared` to allow pass more than 10 arguments [#12299](https://github.com/phalcon/cphalcon/issues/12299)
 - Fixed `Phalcon\Mvc\Model\MetaData\Strategy\Annotations::getColumnMaps` where only renamed columns where returned if there was one
+- Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `before` handlers [#10931](https://github.com/phalcon/cphalcon/pull/10931)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -677,18 +677,22 @@ class Micro extends Injectable implements \ArrayAccess
 						}
 
 						/**
-						 * Call the before handler, if it returns false exit
+						 * Call the before handler
 						 */
-						if call_user_func(before) === false {
-							return false;
-						}
+						let status = call_user_func(before);
 
 						/**
-						 * Reload the 'stopped' status
+						 * break the execution if the middleware was stopped
 						 */
-						if this->_stopped {
-							return status;
+						if  this->_stopped {
+							break;
 						}
+					}
+					/**
+					 * Reload the 'stopped' status
+					 */
+					if this->_stopped {
+						return status;
 					}
 				}
 
@@ -843,6 +847,13 @@ class Micro extends Injectable implements \ArrayAccess
 						}
 
 						let status = call_user_func(after);
+
+						/**
+						 * break the execution if the middleware was stopped
+						 */
+						if this->_stopped {
+							break;
+						}
 					}
 				}
 


### PR DESCRIPTION
In this pull request is one important change.

before this change:
1. if `event` (before) is closure and return false -  [cancels the route execution](https://github.com/phalcon/cphalcon/blob/2.0.x/phalcon/mvc/micro.zep#L676-L678)
2. if `event` (before) is `MiddlewareInterface` object and return false/true/... - not cancels route execution

In this change:
1. if `event` (before) is closure and return false/true/... - **not** cancels route execution
2. if `event` (before) is `MiddlewareInterface` and return false/true/... - not cancels route execution

If you need to cancel execution on `event` (before) - in both cases **must be** called `$microApplication->stop();`

For example:

``` php
<?php
$app = new Phalcon\Mvc\Micro();
$app->before(function () use ($app) {
    if ($app['session']->get('auth') == false) {
        $app->stop();
        return false;
    }
    return true;
});
$app->handle();
```

or

``` php
<?php
class Auth implements Phalcon\Mvc\Micro\MiddlewareInterface
{
    public function call(Phalcon\Mvc\Micro $app)
    {
         if ($app['session']->get('auth') == false) {
            $app->stop();
            return false;
        }
        return true;
    }
}
$app = new Phalcon\Mvc\Micro();
$app->before(new Access());
$app->handle();
```
