### PR TITLE
Improvements for Phalcon\Db\Dialect\Sqlite

### DIFF
--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -58,7 +58,7 @@ class Sqlite extends Dialect
 
 			case Column::TYPE_INTEGER:
 				if empty columnSql {
-					let columnSql .= "INT";
+					let columnSql .= "INTEGER";
 				}
 				break;
 
@@ -84,7 +84,7 @@ class Sqlite extends Dialect
 
 			case Column::TYPE_DATETIME:
 				if empty columnSql {
-					let columnSql .= "TIMESTAMP";
+					let columnSql .= "DATETIME";
 				}
 				break;
 
@@ -256,7 +256,119 @@ class Sqlite extends Dialect
 	 */
 	public function createTable(string! tableName, string! schemaName, array! definition) -> string
 	{
-		throw new Exception("Not implemented yet");
+		var columns, table, temporary, options, createLines, columnLine, column,
+			indexes, index, indexName, indexType, references, reference, defaultValue,
+			referenceSql, onDelete, onUpdate, sql, hasPrimary;
+
+		let table = this->prepareTable(tableName, schemaName);
+
+		let temporary = false;
+		if fetch options, definition["options"] {
+			fetch temporary, options["temporary"];
+		}
+
+		if !fetch columns, definition["columns"] {
+			throw new Exception("The index 'columns' is required in the definition array");
+		}
+
+		/**
+		 * Create a temporary or normal table
+		 */
+		if temporary {
+			let sql = "CREATE TEMPORARY TABLE " . table . " (\n\t";
+		} else {
+			let sql = "CREATE TABLE " . table . " (\n\t";
+		}
+
+		let hasPrimary = false;
+		let createLines = [];
+
+		for column in columns {
+			let columnLine = "`" . column->getName() . "` " . this->getColumnDefinition(column);
+
+			/**
+			 * Mark the column as primary key
+			 */
+			if column->isPrimary() && !hasPrimary {
+				let columnLine .= " PRIMARY KEY";
+				let hasPrimary = true;
+			}
+
+			/**
+			 * Add an AUTOINCREMENT clause
+			 */
+			if column->isAutoIncrement() && hasPrimary {
+				let columnLine .= " AUTOINCREMENT";
+			}
+
+			/**
+			 * Add a NOT NULL clause
+			 */
+			if column->isNotNull() {
+				let columnLine .= " NOT NULL";
+			}
+
+			/**
+			 * Add a Default clause
+			 */
+			if column->hasDefault() {
+				let defaultValue = column->getDefault();
+				if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") {
+					let columnLine .= " DEFAULT CURRENT_TIMESTAMP";
+				} else {
+					let columnLine .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
+				}
+			}
+
+			let createLines[] = columnLine;
+		}
+
+		/**
+		 * Create related indexes
+		 */
+		if fetch indexes, definition["indexes"] {
+
+			for index in indexes {
+
+				let indexName = index->getName();
+				let indexType = index->getType();
+
+				/**
+				 * If the index name is primary we add a primary key
+				 */
+				if indexName == "PRIMARY" && !hasPrimary {
+					let createLines[] = "PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
+				} elseif !empty indexType && memstr(strtoupper(indexType), "UNIQUE") {
+					let createLines[] = "UNIQUE (" . this->getColumnList(index->getColumns()) . ")";
+				}
+			}
+		}
+
+		/**
+		 * Create related references
+		 */
+		if fetch references, definition["references"] {
+			for reference in references {
+				let referenceSql = "CONSTRAINT `" . reference->getName() . "` FOREIGN KEY (" . this->getColumnList(reference->getColumns()) . ")"
+					. " REFERENCES `" . reference->getReferencedTable() . "`(" . this->getColumnList(reference->getReferencedColumns()) . ")";
+
+				let onDelete = reference->getOnDelete();
+				if !empty onDelete {
+					let referenceSql .= " ON DELETE " . onDelete;
+				}
+
+				let onUpdate = reference->getOnUpdate();
+				if !empty onUpdate {
+					let referenceSql .= " ON UPDATE " . onUpdate;
+				}
+
+				let createLines[] = referenceSql;
+			}
+		}
+
+		let sql .= join(",\n\t", createLines) . "\n)";
+
+		return sql;
 	}
 
 	/**

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -302,13 +302,6 @@ class Sqlite extends Dialect
 			}
 
 			/**
-			 * Add a NOT NULL clause
-			 */
-			if column->isNotNull() {
-				let columnLine .= " NOT NULL";
-			}
-
-			/**
 			 * Add a Default clause
 			 */
 			if column->hasDefault() {
@@ -318,6 +311,13 @@ class Sqlite extends Dialect
 				} else {
 					let columnLine .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
 				}
+			}
+
+			/**
+			 * Add a NOT NULL clause
+			 */
+			if column->isNotNull() {
+				let columnLine .= " NOT NULL";
 			}
 
 			let createLines[] = columnLine;


### PR DESCRIPTION
- **SQLite INTEGER datetype fixes**

`AUTOINCREMENT` is only allowed on an `INTEGER PRIMARY KEY`.

**Wrong**:

``` sql
CREATE TABLE "tbl1" (`id` INT PRIMARY KEY AUTOINCREMENT NOT NULL);
```

**Correct**

``` sql
CREATE TABLE "tbl1" (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL);
```
- **SQLite DATETIME datetype fixes**

Fixed `Column::TYPE_DATETIME` constant value now it  `DATETIME`.
For `TIMESTAMP` datatype need use `Column::TYPE_TIMESTAMP` constant.
- **Fixed SQLite tests for DATETIME datetype**
- **Added SQLite test for creating table**
- **Added timestamp test for all dialects**
- **New feature**:  implemented `Phalcon\Db\Dialect\Sqlite::createTable` (see below):

**PHP**

``` php
<?php
use Phalcon\Db\Reference;
use Phalcon\Db\Index;
use Phalcon\Db\Dialect\Sqlite;
use Phalcon\Db\Column;

$dialect = new Sqlite;

$id = new Column(
    'id',
    [
        'type'          => Column::TYPE_INTEGER,
        'primary'       => true,
        'notNull'       => true,
        'autoIncrement' => true,
        'first'         => true
    ]
);

$name = new Column(
    'name',
    [
        'type'    => Column::TYPE_VARCHAR,
        'notNull' => true,
        'size'    => 80,
        'after'   => 'id'
    ]
);

$status = new Column(
    'status',
    [
        'type'    => Column::TYPE_CHAR,
        'notNull' => true,
        'size'    => 1,
        'default' => 'y',
        'default' => true
    ]
);

$ref = new Reference(
    'profiles_ibfk_1',
    [
        'referencedSchema'  => 'test',
        'referencedTable'   => 'users',
        'columns'           => ['id'],
        'referencedColumns' => ['id']
    ]
);

$sql = $dialect->createTable(
     'profiles',
     'test',
     [
         'columns' => [$id, $name, $status],
         'indexes' =>
         [
             new Index('name', ['name'], "UNIQUE"),
         ],
         'references' => [
            $ref
         ]
     ]
);

echo $sql, PHP_EOL;
```

**SQL**

``` sql
CREATE TABLE "test"."profiles" (
    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
    `name` VARCHAR(80) NOT NULL,
    `status` CHARACTER(1) NOT NULL DEFAULT "1",
    UNIQUE ("name"),
    CONSTRAINT `profiles_ibfk_1` FOREIGN KEY ("id") REFERENCES `users`("id")
)
```

**Note** if you declare 2 times primary, 1 will be used:

``` php
$id = new Column(
    'id',
    [
        'type'          => Column::TYPE_INTEGER,
        'primary'       => true, // primary here
        'notNull'       => true,
        'autoIncrement' => true,
        'first'         => true
    ]
);

// ...

$sql = $dialect->createTable(
     'profiles',
     'test',
     [
         'columns' => [$id, $name, $status],
         'indexes' =>
         [
             new Index('PRIMARY', ['id']), // primary here
             new Index('name', ['name'], "UNIQUE"),
         ],
         'references' => [
            $ref
         ]
     ]
);

echo $sql, PHP_EOL;
```

**Output**:

``` sql
CREATE TABLE "test"."profiles" (
    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
    `name` VARCHAR(80) NOT NULL,
    `status` CHARACTER(1) NOT NULL DEFAULT "1",
    UNIQUE ("name"),
    CONSTRAINT `profiles_ibfk_1` FOREIGN KEY ("id") REFERENCES `users`("id")
)
```

Also you can use `table-constraint` like syntax for determining primary indexes:

``` php
$id = new Column(
    'id',
    [
        'type'          => Column::TYPE_INTEGER,
        'notNull'       => true,
        // Please note, this will not be used now
        // AUTOINCREMENT is only allowed on an INTEGER PRIMARY KEY
        'autoIncrement' => true,
        'first'         => true
    ]
);

// ...

$sql = $dialect->createTable(
     'profiles',
     'test',
     [
         'columns' => [$id, $name, $status],
         'indexes' =>
         [
             new Index('PRIMARY', ['id']),
             new Index('', ['name'], "UNIQUE"), // You can omit first param if it is not PRIMARY
         ],
         'references' => [
            $ref
         ]
     ]
);


echo $sql, PHP_EOL;
```

**Output**:

``` sql
CREATE TABLE "test"."profiles" (
    `id` INTEGER NOT NULL,
    `name` VARCHAR(80) NOT NULL,
    `status` CHARACTER(1) NOT NULL DEFAULT "1",
    PRIMARY KEY ("id"),
    UNIQUE ("name"),
    CONSTRAINT `profiles_ibfk_1` FOREIGN KEY ("id") REFERENCES `users`("id")
)
```
