### PR TITLE
[2.1.x] Memcached persistent connection pool for cache and session backends.

### DIFF
--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -57,36 +57,6 @@ use Phalcon\Cache\Exception;
  * $data = $cache->get('my-data');
  *
  *</code>
- *
- * For multiple memcached servers please make sure to enable proper fail-over and timeouts.
- * The following settings could be used in a fast local network environment.
- * Shared environments with higher latencies require different settings.
- *
- *<code>
- *$cache = new \Phalcon\Cache\Backend\Libmemcached($frontCache, [
- *  "server" => $servers,
- *  "persistent_id" => "phalcon_cache",
- *  "client" => [
- *    // Ensure correct mapping of keys for failed servers
- *    Memcached::OPT_DISTRIBUTION => Memcached::DISTRIBUTION_CONSISTENT,
- *    // Remove failed servers from connection pool
- *    Memcached::OPT_REMOVE_FAILED_SERVERS => true,
- *    // Number of connection failures after a server is considered down
- *    Memcached::OPT_SERVER_FAILURE_LIMIT => 2,
- *    // Retry failed servers every 1 second
- *    Memcached::OPT_RETRY_TIMEOUT => 1,
- *    // Can not initially connect within 20ms -> consider offline
- *    Memcached::OPT_POLL_TIMEOUT => 20,
- *    // An open connection does not respond to polling within 20ms -> consider offline
- *    Memcached::OPT_CONNECT_TIMEOUT => 20,
- *    // Binary transfer is marginally faster than ascii transfer
- *    Memcached::OPT_BINARY_PROTOCOL => true,
- *    // Asynchronous I/O is supposedly the fastest transport
- *    Memcached::OPT_NO_BLOCK => true,
- *    // Don't queue network packages. Send as fast as possible
- *    Memcached::OPT_TCP_NODELAY => true
- *]]);
- *</code>
  */
 class Libmemcached extends Backend implements BackendInterface
 {

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -62,7 +62,7 @@ class Libmemcached extends Adapter implements AdapterInterface
 	 */
 	public function __construct(array options)
 	{
-		var servers, client, lifetime, prefix, statsKey;
+		var servers, client, lifetime, prefix, statsKey, persistentId;
 
 		if !fetch servers, options["servers"] {
 			throw new Exception("No servers given in options");
@@ -83,7 +83,11 @@ class Libmemcached extends Adapter implements AdapterInterface
 		}
 
 		if !fetch statsKey, options["statsKey"] {
-			let statsKey = null;
+			let statsKey = "";
+		}
+
+		if !fetch persistentId, options["persistent_id"] {
+			let persistentId = "phalcon-session";
 		}
 
 		let this->_libmemcached = new Libmemcached(
@@ -92,7 +96,8 @@ class Libmemcached extends Adapter implements AdapterInterface
 				"servers":  servers,
 				"client":   client,
 				"prefix":   prefix,
-				"statsKey": statsKey
+				"statsKey": statsKey,
+				"persistent_id": persistentId
 			]
 		);
 

--- a/unit-tests/CacheTest.php
+++ b/unit-tests/CacheTest.php
@@ -1201,6 +1201,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 					'port' => '11211',
 					'weight' => '1'),
 			),
+            'persistent_id' => 'new_connection_pool_with_prefix',
 			'client' => array(
 				Memcached::OPT_PREFIX_KEY => 'prefix.',
 			)
@@ -1222,6 +1223,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($cachedUnserialize, $data);
 
 		//Memcached Option None
+        //A new persistent_id is required, otherwise new options are not applied
 		$cache2 = new Phalcon\Cache\Backend\Libmemcached($frontCache, array(
 			'servers' => array(
 				array(
@@ -1229,6 +1231,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 					'port' => '11211',
 					'weight' => '1'),
 			),
+            'persistent_id' => 'new_connection_pool_without_prefix',
 			'client' => array(),
 		));
 
@@ -1406,6 +1409,7 @@ class CacheTest extends PHPUnit_Framework_TestCase
 					'weight' => '1'),
 			),
 			'statsKey' => '_PHCM',
+            'persistent_id' => 'new_connection_pool_with_prefix',
 			'client' => array(
 				Memcached::OPT_PREFIX_KEY => 'prefix.',
 			)


### PR DESCRIPTION
Memcached persistent connection pool for cache and session backends. Enabled per default. Cache and Session can share the same connection pool as long as `$server` and `$client` are equal.

``` php
$cache = new \Phalcon\Cache\Backend\Libmemcached($frontCache, [ 
  "server" => $servers,
  "persistent_id" => "my_pool",
  "client" => $client_settings
]);
$session = new Phalcon\Session\Adapter\Libmemcached([ 
  "lifetime" => 3600,
  "server" => $servers,
  "persistent_id" => "my_pool",
  "client" => $client_settings
]);
```

2x Unit-Tests updated accordingly to 'purge' client settings.
I've been using persistent memcached pool since my statsKey performance regression #10343.
