### PR TITLE
Messages in Forms\Element are now always available (#10953)

### DIFF
--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -64,6 +64,7 @@ abstract class Element implements ElementInterface
 		if typeof attributes == "array" {
 			let this->_attributes = attributes;
 		}
+		let this->_messages = new Group();
 	}
 
 	/**
@@ -484,16 +485,7 @@ abstract class Element implements ElementInterface
 	 */
 	public function getMessages() -> <Group>
 	{
-		var messages;
-
-		let messages = this->_messages;
-		if typeof messages == "object" {
-			return messages;
-		}
-
-		let messages = new Group(),
-			this->_messages = messages;
-		return messages;
+		return this->_messages;
 	}
 
 	/**
@@ -501,17 +493,7 @@ abstract class Element implements ElementInterface
 	 */
 	public function hasMessages() -> boolean
 	{
-		var messages;
-
-		/**
-		 * Get the related form
-		 */
-		let messages = this->_messages;
-		if typeof messages == "object" {
-			return count(messages) > 0;
-		}
-
-		return false;
+		return count(this->_messages) > 0;
 	}
 
 	/**
@@ -528,14 +510,7 @@ abstract class Element implements ElementInterface
 	 */
 	public function appendMessage(<MessageInterface> message) -> <ElementInterface>
 	{
-		var messages;
-
-		let messages = this->_messages;
-		if typeof messages != "object" {
-			let this->_messages = new Group();
-			let messages = this->_messages;
-		}
-		messages->appendMessage(message);
+		this->_messages->appendMessage(message);
 		return this;
 	}
 


### PR DESCRIPTION
Form Messages are now initialized in the constructor. #10953 
