### PR TITLE
Adding beforeException on Application. implement _handleException on getModule

### DIFF
--- a/phalcon/mvc/application.zep
+++ b/phalcon/mvc/application.zep
@@ -145,6 +145,22 @@ class Application extends Injectable
 	{
 		return this->_modules;
 	}
+	
+	/**
+	 * Handles a user exception
+	 */
+	protected function _handleException(<\Exception> exception)
+	{
+		var eventsManager;
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		if typeof eventsManager == "object" {
+			if eventsManager->fire("application:beforeException", this, exception) === false {
+				return false;
+			} else {
+				throw exception;
+			}
+		}
+	}
 
 	/**
 	 * Gets the module definition registered in the application via module name
@@ -157,7 +173,8 @@ class Application extends Injectable
 		var module;
 
 		if !fetch module, this->_modules[name] {
-			throw new Exception("Module '" . name . "' isn't registered in the application container");
+			exception = new Exception("Module '" . name . "' isn't registered in the application container");
+			this->_handleException(exception);
 		}
 
 		return module;


### PR DESCRIPTION
Actually it's is not possible to handle the module not defined exception except for a catch on application launch. 
The new _handleException is a copy from dispatcher. If an exception is needed the application will launch an event: application:beforeException where it will be possible to override the default behaviour (throw the exception)
