### PR TITLE
Close cursor on $fetch function

### DIFF
--- a/phalcon/db/result/pdo.zep
+++ b/phalcon/db/result/pdo.zep
@@ -116,7 +116,13 @@ class Pdo implements ResultInterface
 	 */
 	public function $fetch(var fetchStyle = null, var cursorOrientation = null, var cursorOffset = null)
 	{
-		return this->_pdoStatement->$fetch(fetchStyle, cursorOrientation, cursorOffset);
+		var result;
+
+		let result = this->_pdoStatement->$fetch(fetchStyle, cursorOrientation, cursorOffset);
+
+		this->_pdoStatement->closeCursor();
+
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
SQLSTATE[24000]: Invalid cursor state: 0 [FreeTDS][SQL Server]Invalid cursor state

When create a SQL Server adapter, using odbc
