### PR TITLE
[2.1.x] Added new feature for pagination and also optional sets the aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Method `isSetOption` in `Phalcon\Validation\ValidatorInterface` marked as deprecated, please use `hasOption`
 - Added internal check "allowEmpty" before calling a validator. If it option is true and the value of empty, the validator is skipped
 - Added default header: `Content-Type: "application/json; charset=UTF-8"` in method `Phalcon\Http\Response::setJsonContent`
-- Added `Phalcon\Paginator\RepositoryInterface` for repository the current state of `paginator` and also optional sets the aliases for properties repository
+- Added `Phalcon\Paginator\RepositoryInterface` for repository the current state of `paginator` and also optional sets the aliases for properties repository [#10985](https://github.com/phalcon/cphalcon/pull/10985)
 
 # [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-09-19)
 - Added `Phalcon\Security\Random::base58` - to generate a random base58 string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Method `isSetOption` in `Phalcon\Validation\ValidatorInterface` marked as deprecated, please use `hasOption`
 - Added internal check "allowEmpty" before calling a validator. If it option is true and the value of empty, the validator is skipped
 - Added default header: `Content-Type: "application/json; charset=UTF-8"` in method `Phalcon\Http\Response::setJsonContent`
+- Added `Phalcon\Paginator\RepositoryInterface` for repository the current state of `paginator` and also optional sets the aliases for properties repository
 
 # [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-09-19)
 - Added `Phalcon\Security\Random::base58` - to generate a random base58 string

--- a/phalcon/paginator/adapter.zep
+++ b/phalcon/paginator/adapter.zep
@@ -22,7 +22,7 @@ namespace Phalcon\Paginator;
 /**
  * Phalcon\Paginator\Adapter
  */
-abstract class Adapter
+abstract class Adapter implements AdapterInterface
 {
 
 	/**
@@ -34,6 +34,30 @@ abstract class Adapter
 	 * Current page in paginate
 	 */
 	protected _page = null;
+
+	/**
+	 * Repository for pagination
+	 * @var RepositoryInterface
+	 */
+	private _repository;
+
+	/**
+	 * Phalcon\Paginator\Adapter\Model constructor
+	 */
+	public function __construct(array! config)
+	{
+		if isset config["limit"] {
+			this->setLimit(config["limit"]);
+		}
+
+		if isset config["page"] {
+			this->setCurrentPage(config["page"]);
+		}
+
+		if isset config["repository"] {
+			this->setRepository(config["repository"]);
+		}
+	}
 
 	/**
 	 * Set the current page number
@@ -59,5 +83,30 @@ abstract class Adapter
 	public function getLimit() -> int
 	{
 		return this->_limitRows;
+	}
+
+	/**
+	 * Sets current repository for pagination
+	 */
+	public function setRepository(<RepositoryInterface> repository) -> <Adapter>
+	{
+		let this->_repository = repository;
+		return this;
+	}
+
+	/**
+	 * Gets current repository for pagination
+	 */
+	protected function getRepository(array properties = null) -> <RepositoryInterface>
+	{
+		if !this->_repository {
+			let this->_repository = new Repository();
+		}
+
+		if properties !== null {
+			this->_repository->setProperties(properties);
+		}
+
+		return this->_repository;
 	}
 }

--- a/phalcon/paginator/adapter/model.zep
+++ b/phalcon/paginator/adapter/model.zep
@@ -22,7 +22,7 @@ namespace Phalcon\Paginator\Adapter;
 
 use Phalcon\Paginator\Exception;
 use Phalcon\Paginator\Adapter;
-use Phalcon\Paginator\AdapterInterface;
+use Phalcon\Paginator\RepositoryInterface;
 
 /**
  * Phalcon\Paginator\Adapter\Model
@@ -40,7 +40,7 @@ use Phalcon\Paginator\AdapterInterface;
  *  $paginate = $paginator->getPaginate();
  *</code>
  */
-class Model extends Adapter implements AdapterInterface
+class Model extends Adapter
 {
 
 	/**
@@ -53,25 +53,16 @@ class Model extends Adapter implements AdapterInterface
 	 */
 	public function __construct(array! config)
 	{
-		var page, limit;
-
+		parent::__construct(config);
 		let this->_config = config;
-
-		if fetch limit, config["limit"] {
-			let this->_limitRows = limit;
-		}
-
-		if fetch page, config["page"] {
-			let this->_page = page;
-		}
 	}
 
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <\stdclass>
+	public function getPaginate() -> <RepositoryInterface>
 	{
-		var config, items, pageItems, page;
+		var config, items, pageItems;
 		int pageNumber, show, n, start, lastShowPage,
 			i, next, totalPages, before;
 
@@ -139,17 +130,16 @@ class Model extends Adapter implements AdapterInterface
 			let before = 1;
 		}
 
-		let page = new \stdClass(),
-			page->items = pageItems,
-			page->first = 1,
-			page->before =  before,
-			page->current = pageNumber,
-			page->last = totalPages,
-			page->next = next,
-			page->total_pages = totalPages,
-			page->total_items = n,
-			page->limit = this->_limitRows;
-
-		return page;
+		return this->getRepository([
+			RepositoryInterface::PROPERTY_ITEMS 		: pageItems,
+			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
+			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: n,
+			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
+			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : before,
+			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: pageNumber,
+			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
+			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages
+		]);
 	}
 }

--- a/phalcon/paginator/adapter/nativearray.zep
+++ b/phalcon/paginator/adapter/nativearray.zep
@@ -21,7 +21,7 @@ namespace Phalcon\Paginator\Adapter;
 
 use Phalcon\Paginator\Exception;
 use Phalcon\Paginator\Adapter;
-use Phalcon\Paginator\AdapterInterface;
+use Phalcon\Paginator\RepositoryInterface;
 
 /**
  * Phalcon\Paginator\Adapter\NativeArray
@@ -45,7 +45,7 @@ use Phalcon\Paginator\AdapterInterface;
  *</code>
  *
  */
-class NativeArray extends Adapter implements AdapterInterface
+class NativeArray extends Adapter
 {
 
 	/**
@@ -56,27 +56,18 @@ class NativeArray extends Adapter implements AdapterInterface
 	/**
 	 * Phalcon\Paginator\Adapter\NativeArray constructor
 	 */
-	public function __construct(array config)
+	public function __construct(array! config)
 	{
-		var page, limit;
-
+		parent::__construct(config);
 		let this->_config = config;
-
-		if fetch limit, config["limit"] {
-			let this->_limitRows = limit;
-		}
-
-		if fetch page, config["page"] {
-			let this->_page = page;
-		}
 	}
 
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <\stdClass>
+	public function getPaginate() -> <RepositoryInterface>
 	{
-		var config, items, page;
+		var config, items;
 		int show, pageNumber, totalPages, number, before, next;
 		double roundedTotal;
 
@@ -123,17 +114,16 @@ class NativeArray extends Adapter implements AdapterInterface
 			let before = 1;
 		}
 
-		let page = new \stdClass(),
-			page->items = items,
-			page->first = 1,
-			page->before =  before,
-			page->current = pageNumber,
-			page->last = totalPages,
-			page->next = next,
-			page->total_pages = totalPages,
-			page->total_items = number,
-			page->limit = this->_limitRows;
-
-		return page;
+		return this->getRepository([
+			RepositoryInterface::PROPERTY_ITEMS 		: items,
+			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
+			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: number,
+			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
+			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : before,
+			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: pageNumber,
+			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
+			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages
+		]);
 	}
 }

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -21,7 +21,7 @@ namespace Phalcon\Paginator\Adapter;
 
 use Phalcon\Mvc\Model\Query\Builder;
 use Phalcon\Paginator\Adapter;
-use Phalcon\Paginator\AdapterInterface;
+use Phalcon\Paginator\RepositoryInterface;
 use Phalcon\Paginator\Exception;
 
 /**
@@ -42,7 +42,7 @@ use Phalcon\Paginator\Exception;
  *  ));
  *</code>
  */
-class QueryBuilder extends Adapter implements AdapterInterface
+class QueryBuilder extends Adapter
 {
 	/**
 	 * Configuration of paginator by model
@@ -59,24 +59,18 @@ class QueryBuilder extends Adapter implements AdapterInterface
 	 */
 	public function __construct(array config)
 	{
-		var builder, limit, page;
-
+		parent::__construct(config);
 		let this->_config = config;
 
-		if !fetch builder, config["builder"] {
+		if !isset config["builder"] {
 			throw new Exception("Parameter 'builder' is required");
 		}
 
-		if !fetch limit, config["limit"] {
+		if !isset config["limit"] {
 			throw new Exception("Parameter 'limit' is required");
 		}
 
-		this->setQueryBuilder(builder);
-		this->setLimit(limit);
-
-		if fetch page, config["page"] {
-			this->setCurrentPage(page);
-		}
+		this->setQueryBuilder(config["builder"]);
 	}
 
 	/**
@@ -108,10 +102,10 @@ class QueryBuilder extends Adapter implements AdapterInterface
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <\stdClass>
+	public function getPaginate() -> <RepositoryInterface>
 	{
 		var originalBuilder, builder, totalBuilder, totalPages,
-			limit, numberPage, number, query, page, before, items, totalQuery,
+			limit, numberPage, number, query, before, items, totalQuery,
 			result, row, rowcount, next;
 
 		let originalBuilder = this->_builder;
@@ -186,18 +180,17 @@ class QueryBuilder extends Adapter implements AdapterInterface
 			let next = totalPages;
 		}
 
-		let page = new \stdClass(),
-			page->items = items,
-			page->first = 1,
-			page->before = before,
-			page->current = numberPage,
-			page->last = totalPages,
-			page->next = next,
-			page->total_pages = totalPages,
-			page->total_items = rowcount,
-			page->limit = this->_limitRows;
-
-		return page;
+		return this->getRepository([
+			RepositoryInterface::PROPERTY_ITEMS 		: items,
+			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
+			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: rowcount,
+			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
+			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : before,
+			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: numberPage,
+			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
+			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages
+		]);
 	}
 
 }

--- a/phalcon/paginator/adapterinterface.zep
+++ b/phalcon/paginator/adapterinterface.zep
@@ -40,7 +40,7 @@ interface AdapterInterface
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <\stdClass>;
+	public function getPaginate() -> <PaginateInterface>;
 
 	/**
 	 * Set current rows limit

--- a/phalcon/paginator/repository.zep
+++ b/phalcon/paginator/repository.zep
@@ -1,0 +1,183 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
+ +------------------------------------------------------------------------+
+ */
+namespace Phalcon\Paginator;
+
+/**
+ * Phalcon\Paginator\Repository
+ *
+ * Repository of current state Phalcon\Paginator\AdapterInterface::getPaginate()
+ */
+class Repository implements RepositoryInterface
+{
+	protected _properties = [];
+	protected _aliases = [];
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setProperties(array properties) -> <Repository>
+	{
+		let this->_properties = properties;
+		return this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setAliases(array aliases) -> <Repository>
+	{
+		let this->_aliases = aliases;
+		return this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getAliases() -> array
+	{
+		return this->_aliases;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getItems() -> var
+	{
+		return this->getProperty(self::PROPERTY_ITEMS, null);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getTotalPages() -> int
+	{
+		return this->getProperty(self::PROPERTY_TOTAL_PAGES, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getTotalItems() -> int
+	{
+		return this->getProperty(self::PROPERTY_TOTAL_ITEMS, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getLimit() -> int
+	{
+		return this->getProperty(self::PROPERTY_LIMIT, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFirstPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_FIRST_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getPreviousPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_PREVIOUS_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getCurrentPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_CURRENT_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getNextPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_NEXT_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getLastPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_LAST_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __get(string property)
+	{
+		var method;
+		let method = "get" . camelize(this->getRealNameProperty(property));
+
+		if method_exists(this, method) {
+			return this->{method}();
+		}
+
+		/**
+		 * A notice is shown if the property is not defined
+		 */
+		trigger_error("Access to undefined property " . get_class(this) . "::" . property);
+		return null;
+	}
+
+	/**
+	 * Gets value of property by name
+	 */
+	protected function getProperty(string property, var defaultValue = null) -> var
+	{
+		return isset this->_properties[property] ? this->_properties[property] : defaultValue;
+	}
+
+	/**
+	 * Resolve legacy alias for compatibility with version 2.0.x
+	 */
+	protected function getRealNameProperty(string property) -> string
+	{
+		var aliases;
+		let aliases = this->getAliases();
+
+		if isset aliases[property] {
+			return aliases[property];
+		}
+
+		/**
+		 * Resolve legacy alias to maintain compatibility with version 2.0.x
+		 */
+		array legacyAliases = [
+			"first" 	: self::PROPERTY_FIRST_PAGE,
+			"before" 	: self::PROPERTY_PREVIOUS_PAGE,
+			"current" 	: self::PROPERTY_CURRENT_PAGE,
+			"next" 		: self::PROPERTY_NEXT_PAGE,
+			"last" 		: self::PROPERTY_LAST_PAGE
+		];
+
+		if isset legacyAliases[property] {
+			return legacyAliases[property];
+		}
+
+		return property;
+	}
+}

--- a/phalcon/paginator/repositoryinterface.zep
+++ b/phalcon/paginator/repositoryinterface.zep
@@ -1,0 +1,95 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
+ +------------------------------------------------------------------------+
+ */
+namespace Phalcon\Paginator;
+
+/**
+ * Phalcon\Paginator\RepositoryInterface
+ *
+ * Interface for the repository of current state Phalcon\Paginator\AdapterInterface::getPaginate()
+ */
+interface RepositoryInterface
+{
+	const PROPERTY_ITEMS            = "items";
+	const PROPERTY_TOTAL_PAGES      = "total_pages";
+	const PROPERTY_TOTAL_ITEMS      = "total_items";
+	const PROPERTY_LIMIT            = "limit";
+	const PROPERTY_FIRST_PAGE       = "first_page";
+	const PROPERTY_PREVIOUS_PAGE    = "previous_page";
+	const PROPERTY_CURRENT_PAGE     = "current_page";
+	const PROPERTY_NEXT_PAGE        = "next_page";
+	const PROPERTY_LAST_PAGE        = "last_page";
+
+	/**
+	 * Sets values for properties of the repository
+	 */
+	public function setProperties(array properties) -> <RepositoryInterface>;
+
+	/**
+	 * Sets the aliases for properties repository
+	 */
+	public function setAliases(array aliases) -> <RepositoryInterface>;
+
+	/**
+	 * Gets the aliases for properties repository
+	 */
+	public function getAliases() -> array;
+
+	/**
+	 * Gets the items on the current page
+	 */
+	public function getItems() -> var;
+
+	/**
+	 * Gets the total number of pages
+	 */
+	public function getTotalPages() -> int;
+
+	/**
+	 * Gets the total number of items
+	 */
+	public function getTotalItems() -> int;
+
+	/**
+	 * Gets current rows limit
+	 */
+	public function getLimit() -> int;
+
+	/**
+	 * Gets number of the first page
+	 */
+	public function getFirstPage() -> int;
+
+	/**
+	 * Gets number of the previous page
+	 */
+	public function getPreviousPage() -> int;
+
+	/**
+	 * Gets number of the current page
+	 */
+	public function getCurrentPage() -> int;
+
+	/**
+		 * Gets number of the next page
+	 */
+	public function getNextPage() -> int;
+
+	/**
+	 * Gets number of the last page
+	 */
+	public function getLastPage() -> int;
+}

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -158,7 +158,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		//First Page
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 3);
 
@@ -174,7 +174,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$paginator->setCurrentPage(4);
 
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 3);
 
@@ -196,7 +196,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		));
 
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 25);
 
@@ -211,7 +211,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$paginator->setCurrentPage(2);
 
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 5);
 
@@ -243,7 +243,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		//First Page
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -259,7 +259,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$paginator->setCurrentPage(50);
 
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -274,7 +274,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$paginator->setCurrentPage(218);
 
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -283,7 +283,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($page->last, 218);
 
 		$this->assertEquals($page->current, 218);
-		$this->assertEquals($page->total_pages, 218);
+		$this->assertEquals($page->totalPages, 218);
 	}
 
 	public function testModelPaginatorBind()
@@ -311,7 +311,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		//First Page
 		$page = $paginator->getPaginate();
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -347,7 +347,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		$page = $paginator->getPaginate();
 
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -367,7 +367,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		$page = $paginator->getPaginate();
 
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -386,7 +386,7 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 
 		$page = $paginator->getPaginate();
 
-		$this->assertEquals(get_class($page), 'stdClass');
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
 
 		$this->assertEquals(count($page->items), 10);
 
@@ -429,4 +429,67 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($setterResult, $paginator);
 	}
 
+	public function testRepositoryPaginator()
+	{
+		$paginatorRepository = new \Phalcon\Paginator\Repository();
+		$paginatorRepository->setAliases(array(
+			'myFirstPage'   => $paginatorRepository::PROPERTY_FIRST_PAGE,
+			'myLastPage'    => $paginatorRepository::PROPERTY_LAST_PAGE,
+			'myCurrentPage' => $paginatorRepository::PROPERTY_CURRENT_PAGE,
+			'myTotalPages'  => $paginatorRepository::PROPERTY_TOTAL_PAGES,
+			'myLimit' 	    => $paginatorRepository::PROPERTY_LIMIT
+		));
+
+		$paginator = new \Phalcon\Paginator\Adapter\NativeArray(array(
+			'data' => array_fill(0, 30, 'banana'),
+			'limit'=> 25,
+			'page' => 1,
+			'repository' => $paginatorRepository
+		));
+
+		$page = $paginator->getPaginate();
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
+
+		// Test getters
+		$this->assertEquals(count($page->getItems()), 25);
+
+		$this->assertEquals($page->getPreviousPage(), 1);
+		$this->assertEquals($page->getNextPage(), 2);
+		$this->assertEquals($page->getLastPage(), 2);
+		$this->assertEquals($page->getLimit(), 25);
+
+		$this->assertEquals($page->getCurrentPage(), 1);
+		$this->assertEquals($page->getTotalPages(), 2);
+
+		// Test aliases
+		$this->assertEquals($page->myLastPage, 2);
+		$this->assertEquals($page->myLimit, 25);
+
+		$this->assertEquals($page->myCurrentPage, 1);
+		$this->assertEquals($page->myTotalPages, 2);
+
+		$paginator->setCurrentPage(2);
+
+		$page = $paginator->getPaginate();
+
+		$this->assertEquals(get_class($page), 'Phalcon\Paginator\Repository');
+
+		// Test magic getters
+		$this->assertEquals(count($page->items), 5);
+
+		$this->assertEquals($page->previousPage, 1);
+		$this->assertEquals($page->previous_page, 1);
+		$this->assertEquals($page->nextPage, 2);
+		$this->assertEquals($page->lastPage, 2);
+
+		$this->assertEquals($page->currentPage, 2);
+		$this->assertEquals($page->totalPages, 2);
+
+		// Test aliases
+		$this->assertEquals($page->myLastPage, 2);
+		$this->assertEquals($page->myLimit, 25);
+
+		$this->assertEquals($page->myCurrentPage, 2);
+		$this->assertEquals($page->myTotalPages, 2);
+	}
 }


### PR DESCRIPTION
**Maintain compatibility with version 2.0.x**
see  #10957 

``` php
$repository = new \Phalcon\Paginator\Repository();
$repository->setAliases(array(
    'myFirstPage' => $repository::PROPERTY_FIRST_PAGE,
    'myLastPage' => $repository::PROPERTY_LAST_PAGE,
    'myCurrentPage' => $repository::PROPERTY_CURRENT_PAGE
));

$paginator = new \Phalcon\Paginator\Adapter\NativeArray(array(
    'data' => array_fill(0, 30, 'banana'),
    'limit'=> 25,
    'page' => 1,
    'repository' => $repository
));

$page = $paginator->getPaginate();

// First page
echo $page->first . PHP_EOL; // compatibility with version 2.0.x
echo $page->getFirstPage() . PHP_EOL; // Getter
echo $page->firstPage . PHP_EOL; // Magic getter
echo $page->myFirstPage . PHP_EOL; // Alias

// Current page
echo $page->current . PHP_EOL; // compatibility with version 2.0.x
echo $page->getCurrentPage() . PHP_EOL; // Getter
echo $page->currentPage . PHP_EOL; // Magic getter
echo $page->myCurrentPage . PHP_EOL; // Alias

// Last page
echo $page->last . PHP_EOL; // compatibility with version 2.0.x
echo $page->getLastPage() . PHP_EOL; // Getter
echo $page->lastPage . PHP_EOL; // Magic getter
echo $page->myLastPage . PHP_EOL; // Alias
```
