### PR TITLE
Throw exception when calling appendMessage outside of validators

### DIFF
--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -343,6 +343,10 @@ class Validation extends Injectable implements ValidationInterface
 	 */
 	public function appendMessage(<MessageInterface> message) -> <Validation>
 	{
+		if empty this->_messages {
+			throw new Exception("You can only append messages from validators");
+		}
+		
 		this->_messages->appendMessage(message);
 		return this;
 	}


### PR DESCRIPTION
This is a quick fix for issue #10405. Please check if we should use `empty` or `isset`.
