### PR TITLE
Fixed notice in query builder paginator when totalQuery result is empty

### DIFF
--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -177,7 +177,7 @@ class QueryBuilder extends Adapter implements AdapterInterface
 		 */
 		let result = totalQuery->execute(),
 			row = result->getFirst(),
-			rowcount = intval(row->rowcount),
+			rowcount = row ? intval(row->rowcount) : 0,
 			totalPages = intval(ceil(rowcount / limit));
 
 		if numberPage < totalPages {


### PR DESCRIPTION
issue #11049 
