### PR TITLE
#11042 - Fix setting relation should not always cause dirty state change

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4089,17 +4089,21 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	public function __set(string property, value)
 	{
 		var lowerProperty, related, modelName, manager, lowerKey,
-			relation, referencedModel, key, item;
+			relation, referencedModel, key, item, dirtyState;
 
 		/**
 		 * Values are probably relationships if they are objects
 		 */
 		if typeof value == "object" {
 			if value instanceof ModelInterface {
+				let dirtyState = this->_dirtyState;
+				if (value->getDirtyState() != dirtyState) {
+					let dirtyState = self::DIRTY_STATE_TRANSIENT;
+				}
 				let lowerProperty = strtolower(property),
 					this->{lowerProperty} = value,
 					this->_related[lowerProperty] = value,
-					this->_dirtyState = self::DIRTY_STATE_TRANSIENT;
+					this->_dirtyState = dirtyState;
 				return value;
 			}
 		}

--- a/unit-tests/ModelsRelationsTest.php
+++ b/unit-tests/ModelsRelationsTest.php
@@ -75,6 +75,7 @@ class ModelsRelationsTest extends PHPUnit_Framework_TestCase
 		$this->_executeTestsNormal($di);
 		$this->_executeTestsRenamed($di);
 		$this->_testIssue938($di);
+		$this->_testIssue11042();
 	}
 
 	public function testModelsPostgresql()
@@ -94,6 +95,7 @@ class ModelsRelationsTest extends PHPUnit_Framework_TestCase
 
 		$this->_executeTestsNormal($di);
 		$this->_executeTestsRenamed($di);
+		$this->_testIssue11042();
 
 	}
 
@@ -115,6 +117,7 @@ class ModelsRelationsTest extends PHPUnit_Framework_TestCase
 		$this->_executeTestsNormal($di);
 		$this->_executeTestsRenamed($di);
 		$this->_testIssue938($di);
+		$this->_testIssue11042();
 	}
 
 	public function _executeTestsNormal($di)
@@ -366,5 +369,21 @@ class ModelsRelationsTest extends PHPUnit_Framework_TestCase
 			$this->assertEquals($rp[$i]->parts_id, $parts[$i]->id);
 			$this->assertEquals($rp[$i]->robots_id, $robot->id);
 		}
+	}
+
+	protected function _testIssue11042()
+	{
+		$robot = RelationsRobots::findFirst();
+		$this->assertNotEquals($robot, false);
+		$this->assertEquals($robot->getDirtyState(), $robot::DIRTY_STATE_PERSISTENT);
+
+		$robotsParts = $robot->getRelationsRobotsParts();
+		$this->assertEquals($robot->getDirtyState(), $robot::DIRTY_STATE_PERSISTENT);
+
+		$robot = RelationsRobots::findFirst();
+		$this->assertNotEquals($robot, false);
+
+		$robotsParts = $robot->relationsRobotsParts;
+		$this->assertEquals($robot->getDirtyState(), $robot::DIRTY_STATE_PERSISTENT);
 	}
 }


### PR DESCRIPTION
This should fix #11042 although I have no real way of testing it. Hope my style follows conventions. This time for 2.0.x branch
