### PR TITLE
Flash\Session::getMessages with type and removal fix

### DIFF
--- a/phalcon/flash/session.zep
+++ b/phalcon/flash/session.zep
@@ -55,9 +55,9 @@ class Session extends FlashBase implements FlashInterface, InjectionAwareInterfa
 	/**
 	 * Returns the messages stored in session
 	 */
-	protected function _getSessionMessages(boolean remove) -> array
+	protected function _getSessionMessages(boolean remove, type = null) -> array
 	{
-		var dependencyInjector, session, messages;
+		var dependencyInjector, session, messages, returnMessages;
 
 		let dependencyInjector = <DiInterface> this->_dependencyInjector;
 		if typeof dependencyInjector != "object" {
@@ -66,6 +66,17 @@ class Session extends FlashBase implements FlashInterface, InjectionAwareInterfa
 
 		let session = <SessionInterface> dependencyInjector->getShared("session");
 		let messages = session->get("_flashMessages");
+
+		if typeof type == "string" && isset(messages[type]) {
+			if !fetch returnMessages, messages[type] {
+				let returnMessages = [];
+			}
+			if remove === true {
+				unset(messages[type]);
+				session->set("_flashMessages", messages);
+			}
+			return returnMessages;
+		}
 
 		if remove === true {
 			session->remove("_flashMessages");
@@ -132,19 +143,7 @@ class Session extends FlashBase implements FlashInterface, InjectionAwareInterfa
 	 */
 	public function getMessages(type = null, boolean remove = true) -> array
 	{
-		var messages, returnMessages;
-
-		let messages = this->_getSessionMessages(remove);
-
-		if typeof type != "string" {
-			return messages;
-		}
-
-		if !fetch returnMessages, messages[type] {
-			return [];
-		}
-
-		return returnMessages;
+		return this->_getSessionMessages(remove, type);
 	}
 
 	/**

--- a/tests/unit/Phalcon/Flash/Direct/Helper/FlashBase.php
+++ b/tests/unit/Phalcon/Flash/Direct/Helper/FlashBase.php
@@ -3,7 +3,7 @@
  * FlashBase.php
  * \Phalcon\Flash\Direct\Helper\FlashBase
  *
- * Tests the \Phalcon\Tag component
+ * Tests the \Phalcon\Flash\Direct component
  *
  * PhalconPHP Framework
  *
@@ -40,9 +40,9 @@ class FlashBase extends TBase
 
     /**
      * Sets the custom classes for the tests
-     * 
+     *
      * @param $classes
-     * 
+     *
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
      * @since  2014-10-04
      */

--- a/tests/unit/Phalcon/Flash/Session/FlashSessionDefaultTest.php
+++ b/tests/unit/Phalcon/Flash/Session/FlashSessionDefaultTest.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * InMemorySession.php
+ * \Phalcon\Flash\Session\FlashSessionDefaultTest
+ *
+ * Tests Phalcon\Flash\Session
+ *
+ * PhalconPHP Framework
+ *
+ * @author    Iván Guillén <zeopix@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+namespace Phalcon\Tests\unit\Phalcon\Flash\Session;
+
+
+use \PhalconTest\Flash\Session as PhFlash;
+
+use \Phalcon\Tests\unit\Phalcon\_Helper\TestsBase as TBase;
+
+use \Phalcon\DI as PhDI;
+
+
+class FlashSessionDefaultTest extends TBase
+{
+    /**
+     * @var array
+     */
+    protected $classes = [
+        'success' => 'successMessage',
+        'notice'  => 'noticeMessage',
+        'warning' => 'warningMessage',
+        'error'   => 'errorMessage',
+    ];
+
+    /**
+     * Return flash instance
+     */
+    protected function getFlash()
+    {
+        $flash = new PhFlash($this->classes);
+        $di = new PhDI();
+        $di->set('session', new Helper\InMemorySession(), true);
+        $flash->setDI($di);
+        return $flash;
+    }
+
+    /**
+     * Test getMessages with specified type and removal
+     * activated, only removes the retreived messages.
+     */
+    public function testGetMessagesTypeRemoveMessages()
+    {
+        $flash = $this->getFlash();
+
+        $flash->success('sample success');
+        $flash->error('sample error');
+
+        $expectedSuccessMessages = ['sample success'];
+        $actualSuccessMessages = $flash->getMessages('success');
+        expect($actualSuccessMessages)->equals($expectedSuccessMessages);
+
+        $expectedErrorMessages = ['sample error'];
+        $actualErrorMessages = $flash->getMessages('error');
+        expect($actualErrorMessages)->equals($expectedErrorMessages);
+
+        expect(null)->equals($flash->getMessages());
+    }
+
+    /**
+     * Tests clear method
+     */
+    public function testClear()
+    {
+        $flash = $this->getFlash();
+
+        ob_start();
+        $flash->output();
+        $flash->success('sample message');
+        $flash->clear();
+        $actual = ob_get_contents();
+        ob_end_clean();
+        $expected = '';
+
+        expect($actual)->equals($expected);
+    }
+
+    /**
+     * @dataProvider testStringDataProvider
+     */
+    public function testString($function)
+    {
+        $flash = $this->getFlash();
+        $template = ' class="%s"';
+        $class = sprintf($template, $this->classes[$function]);
+
+        $template = '<div%s>%s</div>' . PHP_EOL;
+        $message  = 'sample message';
+
+        $expected = sprintf($template, $class, $message);
+        ob_start();
+        $flash->$function($message);
+        $flash->output();
+        $actual = ob_get_contents();
+        ob_end_clean();
+
+        expect($actual)->equals($expected);
+    }
+
+
+    /**
+     * testString dataProvider
+     */
+    public function testStringDataProvider()
+    {
+        return array(
+            'error' => array(
+                'function' => 'error'
+            ),
+            'success' => array(
+                'function' => 'success'
+            ),
+            'notice' => array(
+                'function' => 'notice'
+            )
+        );
+    }
+}

--- a/tests/unit/Phalcon/Flash/Session/Helper/InMemorySession.php
+++ b/tests/unit/Phalcon/Flash/Session/Helper/InMemorySession.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * InMemorySession.php
+ * \Phalcon\Flash\Session\Helper\InMemorySession
+ *
+ * in memory implementation for Phalcon\Session\Adapter
+ *
+ * PhalconPHP Framework
+ *
+ * @author    Iván Guillén <zeopix@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+namespace Phalcon\Tests\unit\Phalcon\Flash\Session\Helper;
+
+use Phalcon\Session\AdapterInterface;
+
+class InMemorySession implements AdapterInterface
+{
+    /**
+     * @var array
+     */
+    protected $memory;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * @var string
+     */
+    protected $sessionId;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var bool
+     */
+    protected $started;
+
+    public function __construct()
+    {
+        $this->sessionId = $this->generateId();
+        $this->started = false;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function start()
+    {
+        $this->memory = [];
+        $this->started = true;
+    }
+    /**
+     * @inheritdoc
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+    /**
+     * @inheritdoc
+     */
+    public function get($index, $defaultValue = null)
+    {
+        return $this->memory[$index] ?: $defaultValue;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function set($index, $value)
+    {
+        $this->memory[$index] = $value;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function has($index)
+    {
+        return isset($this->memory[$index]);
+    }
+    /**
+     * Removes a session variable from an application context
+     *
+     * @param string $index
+     */
+    public function remove($index)
+    {
+        if (isset($this->memory[$index])) {
+            unset($this->memory[$index]);
+        }
+    }
+    /**
+     * Returns active session id
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->sessionId;
+    }
+    /**
+     * Check whether the session has been started
+     *
+     * @return bool
+     */
+    public function isStarted()
+    {
+        return $this->started;
+    }
+
+    /**
+     * Destroys the active session
+     *
+     * @inheritdoc
+     */
+    public function destroy($removeData = NULL)
+    {
+        if ($removeData) {
+            $this->memory = [];
+        }
+        $this->started = false;
+    }
+
+    /**
+     *
+     * @inheritdoc
+     */
+    public function regenerateId($deleteOldSession = true)
+    {
+        $this->sessionId = $this->generateId();
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    private function generateId()
+    {
+        return md5(time());
+    }
+}


### PR DESCRIPTION
1. Fixed getMessages in Session Flash Adapter. When retriving messages for a specific type, all messages get removed, so method usage is misleading, see: FlashSessionDefaultTest::testGetMessagesTypeRemoveMessages.
2. Added test cases for Session Adapter, which slightly differs from Direct implementaiton.
3. Added a InMemory mock helper for session adapter.
