### PR TITLE
Added ability to change document class to be returned in ODM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added `strict` option for ExclusionIn validator
 - Added `Phalcon\Text::underscore` - to make a phrase underscored instead of spaced
 - Added `Phalcon\Text::humanize` - to make an underscored or dashed phrase human-readable
+- Added ability to change document class to be returned in ODM through `class` option
 
 # [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-09-19)
 - Added `Phalcon\Security\Random::base58` - to generate a random base58 string

--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -341,7 +341,20 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 	protected static function _getResultset(var params, <CollectionInterface> collection, connection, boolean unique)
 	{
 		var source, mongoCollection, conditions, base, documentsCursor,
-			fields, skip, limit, sort, document, collections;
+			fields, skip, limit, sort, document, collections, className;
+
+		/**
+		 * Check if "class" clause was defined
+		 */
+		if fetch className, params["class"] {
+			let base = new {className}();
+
+			if !(base instanceof CollectionInterface || base instanceof Collection\Document) {
+				throw new Exception("Object of class '" . className . "' must be an implementation of Phalcon\\Mvc\\CollectionInterface or an instance of Phalcon\\Mvc\\Collection\\Document");
+			}
+		} else {
+			let base = collection;
+		}
 
 		let source = collection->getSource();
 		if empty source {
@@ -395,15 +408,6 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 		 */
 		if fetch skip, params["skip"] {
 			documentsCursor->skip(skip);
-		}
-
-		/**
-		 * If a group of specific fields are requested we use a Phalcon\Mvc\Collection\Document instead
-		 */
-		if isset params["fields"] {
-			let base = new Document();
-		} else {
-			let base = collection;
 		}
 
 		if unique === true {

--- a/unit-tests/CollectionsClassChangeTest.php
+++ b/unit-tests/CollectionsClassChangeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use Bookshelf\Books;
+
+class CollectionsClassChangeTest extends PHPUnit_Framework_TestCase
+{
+	/** @var Books */
+	protected $_book;
+
+	public function __construct()
+	{
+		spl_autoload_register(array($this, 'collectionsAutoloader'));
+	}
+
+	public function __destruct()
+	{
+		spl_autoload_unregister(array($this, 'collectionsAutoloader'));
+	}
+
+	public function collectionsAutoloader($className)
+	{
+		$className = str_replace('\\', '/', $className);
+		if (file_exists('unit-tests/collections/' . $className . '.php')) {
+			require 'unit-tests/collections/' . $className . '.php';
+		}
+	}
+
+	public static function setUpBeforeClass() {
+		Phalcon\DI::reset();
+
+		$di = new Phalcon\DI();
+
+		$di->set('mongo', function(){
+			$mongo = new MongoClient();
+			return $mongo->phalcon_test;
+		});
+
+		$di->set('collectionManager', function(){
+			return new Phalcon\Mvc\Collection\Manager();
+		});
+	}
+
+	public function setUp() {
+		$book = new Books();
+		$book->title = 'book';
+		$book->save();
+
+		$this->_book = $book;
+	}
+
+	public function testCollectionsClassChange() {
+		if (!class_exists('Mongo')) {
+			$this->markTestSkipped("Mongo class does not exist, test skipped");
+			return;
+		}
+
+		$book = Books::findFirst([['_id' => $this->_book->getId()]]);
+		$this->assertInstanceOf('\Bookshelf\Books', $book);
+
+		$magazine = Books::findFirst([
+			['_id'   => $this->_book->getId()],
+			'class' => '\Bookshelf\Magazines'
+		]);
+		$this->assertInstanceOf('\Bookshelf\Magazines', $magazine);
+
+		$document = Books::findFirst([
+			['_id'   => $this->_book->getId()],
+			'class' => '\Phalcon\Mvc\Collection\Document'
+		]);
+		$this->assertInstanceOf('\Phalcon\Mvc\Collection\Document', $document);
+	}
+
+	public function testCollectionsClassChangeExceptionOnWrongClass() {
+		if (!class_exists('Mongo')) {
+			$this->markTestSkipped("Mongo class does not exist, test skipped");
+			return;
+		}
+
+		$this->setExpectedException('Exception', 'must be an implementation of Phalcon\\Mvc\\CollectionInterface');
+
+		Books::findFirst([
+			['_id'   => $this->_book->getId()],
+			'class' => '\Bookshelf\NotACollection'
+		]);
+
+	}
+
+	public function tearDown() {
+		$this->_book->delete();
+	}
+
+}

--- a/unit-tests/collections/Bookshelf/Books.php
+++ b/unit-tests/collections/Bookshelf/Books.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Bookshelf;
+
+use Phalcon\Mvc\Collection;
+
+class Books extends Collection {}

--- a/unit-tests/collections/Bookshelf/Magazines.php
+++ b/unit-tests/collections/Bookshelf/Magazines.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Bookshelf;
+
+use Phalcon\Mvc\Collection;
+
+class Magazines extends Collection {}

--- a/unit-tests/collections/Bookshelf/NotACollection.php
+++ b/unit-tests/collections/Bookshelf/NotACollection.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Bookshelf;
+
+class NotACollection {}

--- a/unit-tests/phpunit.xml
+++ b/unit-tests/phpunit.xml
@@ -22,6 +22,7 @@
 			<file>unit-tests/CollectionsBehaviorsTest.php</file>
 			<file>unit-tests/CollectionsEventsTest.php</file>
 			<file>unit-tests/CollectionsSerializeTest.php</file>
+			<file>unit-tests/CollectionsChangeClassTest.php</file>
 			<file>unit-tests/CollectionsTest.php</file>
 			<file>unit-tests/ConfigTest.php</file>
 			<file>unit-tests/ConsoleCliTest.php</file>


### PR DESCRIPTION
issue #11031
Usage:

``` PHP
Robots::find(); //returns Robots
Robots::find(['class' => 'Books']); // you get Books
Robots::find(['class' => 'Phalcon\Mvc\Collection\Document']); // you get Documents
Robots::find(['class' => 'UnknowClass']); // you get php error "Class 'UnknownClass' not found"
Robots::find(['class' => 'KnownClassNotImplementingInterface']); // you get phalcon exception "Object of class 'KnownClassNotImplementingInterface' must be an implementation of Phalcon\Mvc\CollectionInterface or an instance of Phalcon\Mvc\Collection\Document"
```

In case when exception must be thrown all other check become useless waste of time and that is why class check is made so early.
