### PR TITLE
add an hard limit to libmemcached adapter lifetime

### DIFF
--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -52,7 +52,9 @@ use Phalcon\Cache\Frontend\Data as FrontendData;
  */
 class Libmemcached extends Adapter implements AdapterInterface
 {
-
+	
+	const NATIVE_MAX_LIFETIME = 2592000;
+	
 	protected _libmemcached = null { get };
 
 	protected _lifetime = 8600 { get };
@@ -76,7 +78,7 @@ class Libmemcached extends Adapter implements AdapterInterface
 			let lifetime = 8600;
 		}
 
-		let this->_lifetime = max(lifetime, 2592000);
+		let this->_lifetime = max(lifetime, self::NATIVE_MAX_LIFETIME);
 
 		if !fetch prefix, options["prefix"] {
 			let prefix = null;

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -76,7 +76,7 @@ class Libmemcached extends Adapter implements AdapterInterface
 			let lifetime = 8600;
 		}
 
-		let this->_lifetime = lifetime;
+		let this->_lifetime = max(lifetime, 2592000);
 
 		if !fetch prefix, options["prefix"] {
 			let prefix = null;


### PR DESCRIPTION
Memcache has an internal lifetime limit of 30 days, see http://stackoverflow.com/questions/1418324/memcache-maximum-key-expiration-time
Setting something upper to this limit leads to having blank writes with no error, breaking the purpose of the session.
