### PR TITLE
Phalcon\Mvc\Model\Criteria::getOrder renamed to Phalcon\Mvc\Model\Criteria::getOrderBy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Now `Phalcon\Events\Event` implements `Phalcon\Events\EventInterface`
 - `Phalcon\Events\Event::getCancelable` renamed to `Phalcon\Events\Event::isCancelable`
 - Removed `Phalcon\Events\Manager::dettachAll` in favor of `Phalcon\Events\Manager::detachAll`
+- `Phalcon\Mvc\Model\Criteria::getGroup` renamed to `Phalcon\Mvc\Model\Criteria::getGroupBy`
 
 # [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-09-19)
 - Added `Phalcon\Security\Random::base58` - to generate a random base58 string

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -638,7 +638,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	/**
 	 * Returns the order clause in the criteria
 	 */
-	public function getOrder() -> string | null
+	public function getOrderBy() -> string | null
 	{
 		var order;
 		if fetch order, this->_params["order"] {

--- a/phalcon/mvc/model/criteriainterface.zep
+++ b/phalcon/mvc/model/criteriainterface.zep
@@ -180,7 +180,7 @@ interface CriteriaInterface
 	 *
 	 * @return string|null
 	 */
-	public function getOrder();
+	public function getOrderBy();
 
 	/**
 	 * Returns all the parameters defined in the criteria

--- a/unit-tests/ModelsCriteriaTest.php
+++ b/unit-tests/ModelsCriteriaTest.php
@@ -220,6 +220,10 @@ class ModelsCriteriaTest extends PHPUnit_Framework_TestCase
 		$somePeople = $people->getFirst();
 		$this->assertEquals($somePersona->cedula, $somePeople->cedula);
 
+		$personas = Personas::query()
+			->orderBy("nombres");
+
+		$this->assertEquals($personas->getOrderBy(), "nombres");
 	}
 
 	protected function _executeTestsRenamed($di)


### PR DESCRIPTION
`Phalcon\Mvc\Model\Criteria::getGroup` renamed to `Phalcon\Mvc\Model\Criteria::getGroupBy`
