### PR TITLE
Get messages from getter method on ValidationFailed exception launch

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2881,7 +2881,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 				/**
 				 * Launch a Phalcon\Mvc\Model\ValidationFailed to notify that the save failed
 				 */
-				throw new \Phalcon\Mvc\Model\ValidationFailed(this, this->_errorMessages);
+				throw new \Phalcon\Mvc\Model\ValidationFailed(this, this->getMessages());
 			}
 
 			return false;


### PR DESCRIPTION
This change allow get translated messages in Exception, overriding the model's getMessages method, as suggested in the documentation (https://docs.phalconphp.com/pt/latest/reference/models.html#validation-messages) .
