### PR TITLE
Fixes #11224: Ensure return type is set to static.

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -832,7 +832,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * </code>
 	 *
 	 * @param string|array parameters
-	 * @return \Phalcon\Mvc\Model
+	 * @return static
 	 */
 	public static function findFirst(var parameters = null) -> <Model>
 	{

--- a/phalcon/mvc/modelinterface.zep
+++ b/phalcon/mvc/modelinterface.zep
@@ -151,7 +151,7 @@ interface ModelInterface
 	 * Allows to query the first record that match the specified conditions
 	 *
 	 * @param array parameters
-	 * @return \Phalcon\Mvc\ModelInterface
+	 * @return static
 	 */
 	public static function findFirst(parameters = null);
 


### PR DESCRIPTION
Allows extending Model instances to be recognized within IDEs.

Reference: https://github.com/phpDocumentor/fig-standards/blob/master/proposed/phpdoc.md#715-return
