### PR TITLE
Implement #11235, Resourceable and Roleable, Function in allow

### DIFF
--- a/phalcon/acl/adapterinterface.zep
+++ b/phalcon/acl/adapterinterface.zep
@@ -78,17 +78,17 @@ interface AdapterInterface
 	/**
 	 * Allow access to a role on a resource
 	 */
-	public function allow(string roleName, string resourceName, access);
+	public function allow(string roleName, string resourceName, access, func = null);
 
 	/**
 	 * Deny access to a role on a resource
 	 */
-	public function deny(string roleName, string resourceName, access);
+	public function deny(string roleName, string resourceName, access, func = null);
 
 	/**
 	 * Check whether a role is allowed to access an action from a resource
 	 */
-	public function isAllowed(string roleName, string resourceName, access) -> boolean;
+	public function isAllowed(roleName, resourceName, access) -> boolean;
 
 	/**
 	 * Returns the role which the list is checking if it's allowed to certain resource/access

--- a/phalcon/acl/resourceable.zep
+++ b/phalcon/acl/resourceable.zep
@@ -1,0 +1,33 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Acl;
+
+/**
+ * Phalcon\Acl\Resource
+ *
+ * Interface for classes which could be used in allow method as RESOURCE, ResourceInterface need __construct method so i decided to do this simple interface
+ */
+interface Resourceable
+{
+    /**
+     * Returns the role name
+    */
+    public function getResourceName() -> string;
+}

--- a/phalcon/acl/roleable.zep
+++ b/phalcon/acl/roleable.zep
@@ -1,0 +1,33 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Acl;
+
+/**
+ * Phalcon\Acl\Roleable
+ *
+ * Interface for classes which could be used in allow method as ROLE, RoleInterace need __construct method so i decided to do this simple interface
+ */
+interface Roleable
+{
+    /**
+     * Returns the role name
+    */
+    public function getRoleName() -> string;
+}


### PR DESCRIPTION
Add option to add function in allow method in Phalcon\Acl\Adapter\Memory like this:

``` php
$acl->allow('SomeRole','SomeResource','update',function(TestResource $user,TestModel $model){
    return $user->getId() == $model->getUser();
});
```

 Where we can put class implemting Roleable as first argument, and Resourceable as second argument. Then when we do

``` php
$acl->isAllowed($roleable,$resourcable,'update');
```

It will call our defined method in allow if there is any.
