### PR TITLE
adding FULLTEXT index support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `Phalcon\Mvc\Model\Criteria::getGroup` renamed to `Phalcon\Mvc\Model\Criteria::getGroupBy`
 - Added method getOption() in `Phalcon\Mvc\Model\RelationInterface`
 - Added ability to spoof HTTP request method
+- Added FULLTEXT index type to `Phalcon\Db\Adapter\Pdo\Mysql` 
 
 # [2.0.10](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.10) (2015-XX-XX)
 - ORM: Added support for DATE columns in Oracle

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -358,11 +358,12 @@ class Mysql extends PdoAdapter implements AdapterInterface
 	 */
 	public function describeIndexes(string! table, schema = null) -> <IndexInterface[]>
 	{
-		var indexes, index, keyName, indexObjects, columns, name;
+		var indexes, index, keyName, indexType, indexObjects, columns, name;
 
 		let indexes = [];
 		for index in this->fetchAll(this->_dialect->describeIndexes(table, schema), Db::FETCH_ASSOC) {
 			let keyName = index["Key_name"];
+			let indexType = index["Index_type"];
 
 			if !isset indexes[keyName] {
 				let indexes[keyName] = [];
@@ -379,6 +380,8 @@ class Mysql extends PdoAdapter implements AdapterInterface
 
 			if keyName == "PRIMARY" {
 				let indexes[keyName]["type"] = "PRIMARY";
+			} elseif indexType == "FULLTEXT" {
+				let indexes[keyName]["type"] = "FULLTEXT";
 			} elseif index["Non_unique"] == 0 {
 				let indexes[keyName]["type"] = "UNIQUE";
 			} else {

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -110,6 +110,7 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 			'index2' => new Index("index2", array('column1', 'column2')),
 			'PRIMARY' => new Index("PRIMARY", array('column3')),
 			'index4' => new Index("index4", array('column4'), 'UNIQUE'),
+			'index5' => new Index("index5", array('column7'), 'FULLTEXT'),
 		);
 	}
 
@@ -307,6 +308,11 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($index4->getName(), 'index4');
 		$this->assertEquals($index4->getColumns(), array('column4'));
 		$this->assertEquals($index4->getType(), 'UNIQUE');
+
+		$index5 = $indexes['index5'];
+		$this->assertEquals($index5->getName(), 'index5');
+		$this->assertEquals($index5->getColumns(), array('column7'));
+		$this->assertEquals($index5->getType(), 'FULLTEXT');
 
 	}
 


### PR DESCRIPTION
This is to fix an issue that was reported over in the devtools that required FULLTEXT indexes:
https://github.com/phalcon/phalcon-devtools/issues/585

Im not sure what version in the changelog to change? 2.1 or 2.0.10?

Can anyone think of any major issues in adding this in now? Is there a reason we didn't have fulltext indexes?
