### PR TITLE
Require at least php 5.4 (composer)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "high load"
     ],
     "require": {
-        "php": "~5.3"
+        "php": "~5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Since support for php 5.3 has been deprecated, we should not allow it to be used.
