### PR TITLE
Fixes for building on windows

### DIFF
--- a/build/_resource/Phalcon/Build/Generator/Safe.php
+++ b/build/_resource/Phalcon/Build/Generator/Safe.php
@@ -37,9 +37,9 @@ class Generator_Safe
     /**
      * Generator for config.m4 or config.w32
      *
-     * @var Generator_File_ConfigM4|Generator_File_ConfigW32
+     * @var array
      */
-    protected $config;
+    protected $configs = array();
 
     /**
      * Generator for Makefile.frag
@@ -62,10 +62,10 @@ class Generator_Safe
         $this->phalconH = new Generator_File_PhalconH($this->sourceDir, $outputDir);
         $this->phalconC = new Generator_File_PhalconC($rootDir, $this->sourceDir, $configDir, $outputDir);
 
+        $this->configs[] = new Generator_File_ConfigM4($this->sourceDir, $outputDir);
+        
         if (preg_match('/^WIN/', PHP_OS)) {
-            $this->config = new Generator_File_ConfigW32($this->sourceDir, $outputDir);
-        } else {
-            $this->config = new Generator_File_ConfigM4($this->sourceDir, $outputDir);
+            $this->configs[] = new Generator_File_ConfigW32($this->sourceDir, $outputDir);
         }
     }
 
@@ -89,8 +89,10 @@ class Generator_Safe
     {
         $includedHeaderFiles = $this->phalconH->generate();
         $this->phalconC->generate($includedHeaderFiles);
-
-        $this->config->generate();
+        
+        foreach($this->configs as $config) {
+            $config->generate();
+        }
 
         copy($this->sourceDir . '/php_phalcon.h', $this->outputDir . '/php_phalcon.h');
         $this->processKernelGlobals();


### PR DESCRIPTION
I'm sorry to say that I had some misunderstanding in my previous commit. (#11278)
I realized that config.m4 is required file when installing the extension from source code.

so, I changed the rule to generate config.w32 file on windows only.

Thanks.
