### PR TITLE
Parameters in CLI tasks are now consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `Phalcon\Acl\AdapterInterface::allow` and `Phalcon\Acl\AdapterInterface::deny` have 4th argument - function, which will be called when using `Phalcon\Acl\AdapterInterface::isAllowed`
 - `Phalcon\Acl\AdapterInterface::isAllowed` have 4th argument - parameters, you can pass arguments for function defined in `Phalcon\Acl\AdapterInterface:allow` or `Phalcon\Acl\AdapterInterface::deny` as associative array where key is argument name
 - Added method getActionSuffix() in `Phalcon\DispatcherInterface`
+- CLI parameters are now handled consistently.
 - Added `Phalcon\Mvc\Controller\BindModelInterface` and associated model type hint loading through dispatcher.
 - Added `Phalcon\Dispatcher::hasParam()`.
 - `Phalcon\Cli\Console` and `Phalcon\Mvc\Application` now inherit `Phalcon\Application`.

--- a/phalcon/cli/dispatcher.zep
+++ b/phalcon/cli/dispatcher.zep
@@ -152,7 +152,7 @@ class Dispatcher extends \Phalcon\Dispatcher
 		return this->_options;
 	}
 
-	public function callActionMethod(handler, actionMethod, params)
+	public function callActionMethod(handler, string actionMethod, array! params = [])
 	{
 		return call_user_func_array([handler, actionMethod], [params]);
 	}

--- a/phalcon/cli/dispatcher.zep
+++ b/phalcon/cli/dispatcher.zep
@@ -151,4 +151,9 @@ class Dispatcher extends \Phalcon\Dispatcher
 	{
 		return this->_options;
 	}
+
+	public function callActionMethod(handler, actionMethod, params)
+	{
+		return call_user_func_array([handler, actionMethod], [params]);
+	}
 }

--- a/phalcon/cli/router.zep
+++ b/phalcon/cli/router.zep
@@ -351,23 +351,19 @@ class Router implements \Phalcon\Di\InjectionAwareInterface
 		/**
 		 * Check for an parameters
 		 */
-		if routeFound {
-			if fetch params, parts["params"] {
-				if typeof params != "array" {
-					let strParams = substr((string)params, 1);
-					if strParams {
-						let params = explode(Route::getDelimiter(), strParams);
-					} else {
-						let params = [];
-					}
+		if fetch params, parts["params"] {
+			if typeof params != "array" {
+				let strParams = substr((string)params, 1);
+				if strParams {
+					let params = explode(Route::getDelimiter(), strParams);
+				} else {
+					let params = [];
 				}
-				unset parts["params"];
 			}
-			if count(params) {
-				let params = array_merge(params, parts);
-			} else {
-				let params = parts;
-			}
+			unset parts["params"];
+		}
+		if count(params) {
+			let params = array_merge(params, parts);
 		} else {
 			let params = parts;
 		}

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -561,7 +561,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			try {
 
 				// We update the latest value produced by the latest handler
-				let this->_returnedValue = call_user_func_array([handler, actionMethod], params),
+				let this->_returnedValue = this->callActionMethod(handler, actionMethod, params),
 					this->_lastHandler = handler;
 
 			} catch \Exception, e {
@@ -701,6 +701,11 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		}
 
 		return handlerClass;
+	}
+
+	public function callActionMethod(handler, actionMethod, params)
+	{
+		return call_user_func_array([handler, actionMethod], params);
 	}
 
 	/**

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -703,7 +703,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		return handlerClass;
 	}
 
-	public function callActionMethod(handler, actionMethod, params)
+	public function callActionMethod(handler, string actionMethod, array! params = [])
 	{
 		return call_user_func_array([handler, actionMethod], params);
 	}

--- a/unit-tests/DispatcherCliTest.php
+++ b/unit-tests/DispatcherCliTest.php
@@ -127,4 +127,21 @@ class DispatcherCliTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($dispatcher->getReturnedValue(), '$param[0] is the same as $this->dispatcher->getParam(0)');
 	}
 
+	public function testCallActionMethod()
+	{
+		$di = new \Phalcon\DI\FactoryDefault\CLI();
+
+		$dispatcher = new \Phalcon\CLI\Dispatcher();
+
+		$di->setShared("dispatcher", $dispatcher);
+
+		$dispatcher->setDI($di);
+
+		$mainTask = new MainTask();
+		$mainTask->setDI($di);
+
+		$this->assertEquals($dispatcher->callActionMethod($mainTask, 'mainAction', []), 'mainAction');
+		$this->assertEquals($dispatcher->callActionMethod($mainTask, 'helloAction', ['World']), 'Hello World!');
+		$this->assertEquals($dispatcher->callActionMethod($mainTask, 'helloAction', ['World', '.']), 'Hello World.');
+	}
 }

--- a/unit-tests/DispatcherCliTest.php
+++ b/unit-tests/DispatcherCliTest.php
@@ -112,17 +112,19 @@ class DispatcherCliTest extends PHPUnit_Framework_TestCase
 
 		$dispatcher->setDI($di);
 
+		// Test $this->dispatcher->getParams()
 		$dispatcher->setTaskName('params');
 		$dispatcher->setActionName('params');
 		$dispatcher->setParams(array('This', 'Is', 'An', 'Example'));
 		$dispatcher->dispatch();
-		$this->assertEquals($dispatcher->getReturnedValue(), 'same');
+		$this->assertEquals($dispatcher->getReturnedValue(), '$params is the same as $this->dispatcher->getParams()');
 
+		// Test $this->dispatcher->getParam()
 		$dispatcher->setTaskName('params');
 		$dispatcher->setActionName('param');
 		$dispatcher->setParams(array('This', 'Is', 'An', 'Example'));
 		$dispatcher->dispatch();
-		$this->assertEquals($dispatcher->getReturnedValue(), 'same');
+		$this->assertEquals($dispatcher->getReturnedValue(), '$param[0] is the same as $this->dispatcher->getParam(0)');
 	}
 
 }

--- a/unit-tests/DispatcherCliTest.php
+++ b/unit-tests/DispatcherCliTest.php
@@ -102,4 +102,27 @@ class DispatcherCliTest extends PHPUnit_Framework_TestCase
 
 	}
 
+	public function testCliParameters()
+	{
+		$di = new \Phalcon\DI\FactoryDefault\CLI();
+
+		$dispatcher = new \Phalcon\CLI\Dispatcher();
+
+		$di->setShared("dispatcher", $dispatcher);
+
+		$dispatcher->setDI($di);
+
+		$dispatcher->setTaskName('params');
+		$dispatcher->setActionName('params');
+		$dispatcher->setParams(array('This', 'Is', 'An', 'Example'));
+		$dispatcher->dispatch();
+		$this->assertEquals($dispatcher->getReturnedValue(), 'same');
+
+		$dispatcher->setTaskName('params');
+		$dispatcher->setActionName('param');
+		$dispatcher->setParams(array('This', 'Is', 'An', 'Example'));
+		$dispatcher->dispatch();
+		$this->assertEquals($dispatcher->getReturnedValue(), 'same');
+	}
+
 }

--- a/unit-tests/DispatcherMvcTest.php
+++ b/unit-tests/DispatcherMvcTest.php
@@ -238,4 +238,20 @@ class DispatcherMvcTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals('Foo\IndexController', $value);
 	}
 
+	public function testCallActionMethod()
+	{
+		$di = new \Phalcon\DI\FactoryDefault();
+
+		$dispatcher = new \Phalcon\Mvc\Dispatcher();
+
+		$di->setShared("dispatcher", $dispatcher);
+
+		$dispatcher->setDI($di);
+
+		$mainTask = new Test2Controller();
+		$mainTask->setDI($di);
+
+		$this->assertEquals($dispatcher->callActionMethod($mainTask, 'anotherTwoAction', [1, 2]), 3);
+	}
+
 }

--- a/unit-tests/TasksCliTest.php
+++ b/unit-tests/TasksCliTest.php
@@ -56,7 +56,7 @@ class TasksCliTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals($task->requestRegistryAction(), 'data');
 		$this->assertEquals($task->helloAction(), 'Hello !');
-		$this->assertEquals($task->helloAction('World'), 'Hello World!');
+		$this->assertEquals($task->helloAction(array('World')), 'Hello World!');
 
 		$task2 = new EchoTask();
 		$task2->setDI($di);

--- a/unit-tests/tasks/MainTask.php
+++ b/unit-tests/tasks/MainTask.php
@@ -13,8 +13,11 @@ class MainTask extends \Phalcon\CLI\Task
         return $this->di['registry']->data;
     }
 
-    public function helloAction($world = "", $symbol = "!")
+    public function helloAction($params = array())
     {
+        $world  = @$params[0] ?: "";
+        $symbol = @$params[1] ?: "!";
+
         return "Hello " . $world . $symbol;
     }
 }

--- a/unit-tests/tasks/MainTask.php
+++ b/unit-tests/tasks/MainTask.php
@@ -15,8 +15,8 @@ class MainTask extends \Phalcon\CLI\Task
 
     public function helloAction($params = array())
     {
-        $world  = @$params[0] ?: "";
-        $symbol = @$params[1] ?: "!";
+        $world  = isset($params[0]) ? $params[0] : "";
+        $symbol = isset($params[1]) ? $params[1] : "!";
 
         return "Hello " . $world . $symbol;
     }

--- a/unit-tests/tasks/ParamsTask.php
+++ b/unit-tests/tasks/ParamsTask.php
@@ -1,0 +1,18 @@
+<?php
+
+class ParamsTask extends \Phalcon\CLI\Task
+{
+	public function paramsAction($params)
+	{
+		return ($params === $this->dispatcher->getParams())
+				? 'same'
+				: 'not same';
+	}
+
+	public function paramAction($params)
+	{
+		return ($params[0] === $this->dispatcher->getParam(0))
+				? 'same'
+				: 'not same';
+	}
+}

--- a/unit-tests/tasks/ParamsTask.php
+++ b/unit-tests/tasks/ParamsTask.php
@@ -5,14 +5,14 @@ class ParamsTask extends \Phalcon\CLI\Task
 	public function paramsAction($params)
 	{
 		return ($params === $this->dispatcher->getParams())
-				? 'same'
-				: 'not same';
+				? '$params is the same as $this->dispatcher->getParams()'
+				: '$params is not the same as $this->dispatcher->getParams()';
 	}
 
 	public function paramAction($params)
 	{
 		return ($params[0] === $this->dispatcher->getParam(0))
-				? 'same'
-				: 'not same';
+				? '$param[0] is the same as $this->dispatcher->getParam(0)'
+				: '$param[0] is not the same as $this->dispatcher->getParam(0)';
 	}
 }


### PR DESCRIPTION
Assuming I execute `php cli.php example main param1 param2 param3`, `$this->dispatcher->getParams()` and `$params` from the parameters return different things:

``` php
class ExampleTask extends \Phalcon\Cli\Task
{
    public function mainAction($params)
    {
        print_r($this->dispatcher->getParams());
        // Array
        // (
        //     [params] => Array
        //         (
        //             [0] => "param1"
        //             [1] => "param2"
        //             [2] => "param3"
        //         )
        // 
        // )

        print_r($params);
        // Array
        // (
        //     [0] => "param1"
        //     [1] => "param2"
        //     [2] => "param3"
        // )
    }
}
```

This PR fixes that so that it returns the same:

``` php
class ExampleTask extends \Phalcon\Cli\Task
{
    public function mainAction($params)
    {
        print_r($this->dispatcher->getParams());
        // Array
        // (
        //     [0] => "param1"
        //     [1] => "param2"
        //     [2] => "param3"
        // )

        print_r($params);
        // Array
        // (
        //     [0] => "param1"
        //     [1] => "param2"
        //     [2] => "param3"
        // )
    }
}
```

`$this->dispatcher->getParam($paramKey)` also works as expected.
