### PR TITLE
Improves the logic of `Model`

### DIFF
--- a/config.json
+++ b/config.json
@@ -96,6 +96,14 @@
         "orm.ignore_unknown_columns": {
             "type": "bool",
             "default": false
+        },
+        "orm.check_existing_record_before_save": {
+            "type": "bool",
+            "default": false
+        },
+        "orm.use_write_connection_on_save": {
+            "type": "bool",
+            "default": true
         }
     },
     "destructors": {


### PR DESCRIPTION
I think there're some issues to work with `Model` in my project.
so, I tried to improve `Model` for me. I hope it would be valuable to others.

Please let me know If you have an another opinion or idea.
- It's related to #11106, #11117
## 1. Only use write connection on save.

I usually prefer write(master) connection rather than read(slave) connection while the processes to save data. That's because it's possibility to have unexpected network latency between master and slave servers.

I just want to use write connection selectively.
- global config

```
phalcon.orm.use_write_connection_on_save = On (default : On)
```
- example for Model::setup()

```
Model::setup(array(
    'useWriteConnectionOnSave' => false
));
```
## 2. Not check if the record exists.

I don't want to check the existing record before create or update function.
It's just for performance. and, I think it's often unnecessary in most cases.
- global config

```
phalcon.orm.check_existing_record_before_save = Off (default : Off)
```
- example for Model::setup()

```
Model::setup(array(
    'checkExistingRecordBeforeSave' => true
));
```
## 3. Fixed for checking the unique key.

Sometimes, `Model` has unnecessary select queries in specific case. (#11106)
If the field is AUTO_INCREMENT and NULL, It would not occur additional select query.
## 4. Tidied up the code a little bit.
