### PR TITLE
Fixed bug in `Http\Request::isValidHttpMethod()`

### DIFF
--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -535,11 +535,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 */
 	public function isValidHttpMethod(string method) -> boolean
 	{
-		var lowerMethod;
-
-		let lowerMethod = strtoupper(method);
-
-		switch method {
+		switch strtoupper(method) {
 
 			case "GET":
 			case "POST":


### PR DESCRIPTION
Previously, `$request->isValidHttpMethod("get")` would have returned false.
