### PR TITLE
Use is_callable instead of method_exists on Dispatcher

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -428,7 +428,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			// Check if the method exists in the handler
 			let actionMethod = actionName . actionSuffix;
 
-			if !is_callable(handler, actionMethod) {
+			if !is_callable([handler, actionMethod]) {
 
 				// Call beforeNotFoundAction
 				if typeof eventsManager == "object" {

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -428,7 +428,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			// Check if the method exists in the handler
 			let actionMethod = actionName . actionSuffix;
 
-			if !method_exists(handler, actionMethod) {
+			if !is_callable(handler, actionMethod) {
 
 				// Call beforeNotFoundAction
 				if typeof eventsManager == "object" {


### PR DESCRIPTION
Using `is_callable` we can overload `__call` on Controllers, and catch generic action methods on controllers.

Use case:
Errors controllers where we want to define generic error actions
CMS where we want to use `__call` to check for the content instead using a `beforeException` as a plugin
etc...
