### PR TITLE
Fix issue #11358

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Added `Phalcon\Dispatcher::hasParam()`.
 - `Phalcon\Cli\Console` and `Phalcon\Mvc\Application` now inherit `Phalcon\Application`.
 - Fixed `afterFetch` event not being sent to behaviors
+- Fixed issue with radio not being checked when default value is 0 [#11358] (https://github.com/phalcon/cphalcon/issues/11358)
 - Fixed issue with `Model::__set` that was setting hidden attributes directly instead of calling setters [#11286](https://github.com/phalcon/cphalcon/issues/11286)
 - Added `Phalcon\Cli\DispatcherInterface`, `Phalcon\Cli\TaskInterface`, `Phalcon\Cli\RouterInterface` and `Phalcon\Cli\Router\RouteInterface`.
 - Added methods update(), create() and createIfNotExist(array criteria) to `Phalcon\Mvc\Collection`

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -527,7 +527,7 @@ class Tag
 
 			let value = self::getValue(id, params);
 
-			if value && currentValue == value {
+			if value != null && currentValue == value {
 				let params["checked"] = "checked";
 			}
 			let params["value"] = currentValue;
@@ -537,7 +537,7 @@ class Tag
 			/**
 			* Evaluate the value in POST
 			*/
-			if value {
+			if value != null {
 				let params["checked"] = "checked";
 			}
 

--- a/unit-tests/TagTest.php
+++ b/unit-tests/TagTest.php
@@ -172,4 +172,29 @@ HTML;
 		$html = Phalcon\Tag::linkTo(array('signup/register', 'Register Here!', 'class' => 'btn-primary', 'query' => array('from' => 'github', 'token' => '123456')));
 		$this->assertEquals($html, '<a href="/signup/register?from=github&amp;token=123456" class="btn-primary">Register Here!</a>');
 	}
+
+	public function testIssue11358()
+	{
+        // Without default set.
+		$html = <<<HTML
+<input type="radio" id="channel" name="channel" value="0" />
+HTML;
+
+		$di = new Phalcon\DI\FactoryDefault();
+		Tag::setDefault("channel", null);
+		Tag::setDI($di);
+		$ret = Tag::radioField(['channel', 'value' => 0]);
+
+		$this->assertEquals($ret, $html);
+
+        // With default set.
+		$html = <<<HTML
+<input type="radio" id="channel" name="channel" value="0" checked="checked" />
+HTML;
+
+		Tag::setDefault("channel", "0");
+		$ret = Tag::radioField(['channel', 'value' => 0]);
+
+		$this->assertEquals($ret, $html);
+	}
 }


### PR DESCRIPTION
Since `value` comes from `Tag::getValue`, which returns `null` if it's not set, then we can test that value is not null, and we should still be able to allow for falsy values.
