### PR TITLE
[2.0.x] setLogLevel method to Multiple Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Added a `prepareSave` event to model saving 
 - Added support for OnUpdate and OnDelete foreign key events to the MySQL adapter
+- Added ability to setLogLevel on multiple logs [#10429](https://github.com/phalcon/cphalcon/pull/10429)
 
 # [2.0.10](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.10) (2016-02-04)
 - ORM: Added support for DATE columns in Oracle

--- a/phalcon/logger/multiple.zep
+++ b/phalcon/logger/multiple.zep
@@ -36,6 +36,8 @@ class Multiple
 
 	protected _formatter { get };
 
+	protected _logLevel { get };
+
 	/**
 	 * Pushes a logger to the logger tail
 	 */
@@ -58,6 +60,22 @@ class Multiple
 			}
 		}
 		let this->_formatter = formatter;
+	}
+
+	/**
+	 * Sets a global level
+	 */
+	public function setLogLevel(int level)
+	{
+		var loggers, logger;
+
+		let loggers = this->_loggers;
+		if typeof loggers == "array" {
+			for logger in loggers {
+				logger->setLogLevel(level);
+			}
+		}
+		let this->_logLevel = level;
 	}
 
 	/**

--- a/unit-tests/LoggerTest.php
+++ b/unit-tests/LoggerTest.php
@@ -116,4 +116,44 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 			$result = $logger->format("msg", \Phalcon\Logger::INFO, 0);
 			$this->assertEquals($result, '[Thu, 01 Jan 70 00:00:00 +0000][INFO] msg'.PHP_EOL);
 	}
+
+	public function testIssues10429()
+	{
+		$logfile1 = "unit-tests/logs/file.log";
+		$logfile2 = "unit-tests/logs/multiple.log";
+
+		@unlink($logfile1);
+		@unlink($logfile2);
+
+		$logger = new \Phalcon\Logger\Multiple();
+		$logger->push(new \Phalcon\Logger\Adapter\File($logfile1));
+		$logger->push(new \Phalcon\Logger\Adapter\File($logfile2));
+		$logger->setFormatter(new \Phalcon\Logger\Formatter\Json());
+		$logger->setLogLevel(\Phalcon\Logger::WARNING);
+		$logger->log('This is a warning');
+		$logger->log("This is an error", \Phalcon\Logger::ERROR);
+		$logger->error("This is another error");
+		$logger->setLogLevel(\Phalcon\Logger::DEBUG);
+		$logger->log('This is a debug');
+
+		$loggerType = array('WARNING', 'ERROR', 'ERROR', 'DEBUG');
+		$loggerMessage = array('This is a warning', 'This is an error', 'This is another error', 'This is a debug');
+
+		$lines = file($logfile1);
+		$this->assertEquals(count($lines), 4);
+		foreach($lines as $key => $line) {
+			$line = json_decode($line, true);
+			$this->assertEquals($line['type'], $loggerType[$key]);
+			$this->assertEquals($line['message'], $loggerMessage[$key]);
+		}
+
+		unset($lines);
+		$lines = file($logfile2);
+		$this->assertEquals(count($lines), 4);
+		foreach($lines as $key => $line) {
+			$line = json_decode($line, true);
+			$this->assertEquals($line['type'], $loggerType[$key]);
+			$this->assertEquals($line['message'], $loggerMessage[$key]);
+		}
+	}
 }

--- a/unit-tests/LoggerTest.php
+++ b/unit-tests/LoggerTest.php
@@ -125,22 +125,23 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 		@unlink($logfile1);
 		@unlink($logfile2);
 
+		// Show the first debug message is ignored.
 		$logger = new \Phalcon\Logger\Multiple();
 		$logger->push(new \Phalcon\Logger\Adapter\File($logfile1));
 		$logger->push(new \Phalcon\Logger\Adapter\File($logfile2));
 		$logger->setFormatter(new \Phalcon\Logger\Formatter\Json());
 		$logger->setLogLevel(\Phalcon\Logger::WARNING);
-		$logger->log('This is a warning');
-		$logger->log("This is an error", \Phalcon\Logger::ERROR);
-		$logger->error("This is another error");
+		$logger->log('This is an ignored debug');
+		$logger->log("This is a warning", \Phalcon\Logger::WARNING);
+		$logger->error("This is an error");
 		$logger->setLogLevel(\Phalcon\Logger::DEBUG);
 		$logger->log('This is a debug');
 
-		$loggerType = array('WARNING', 'ERROR', 'ERROR', 'DEBUG');
-		$loggerMessage = array('This is a warning', 'This is an error', 'This is another error', 'This is a debug');
+		$loggerType = array('WARNING', 'ERROR', 'DEBUG');
+		$loggerMessage = array('This is a warning', 'This is an error', 'This is a debug');
 
 		$lines = file($logfile1);
-		$this->assertEquals(count($lines), 4);
+		$this->assertEquals(count($lines), 3);
 		foreach($lines as $key => $line) {
 			$line = json_decode($line, true);
 			$this->assertEquals($line['type'], $loggerType[$key]);
@@ -149,7 +150,7 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 
 		unset($lines);
 		$lines = file($logfile2);
-		$this->assertEquals(count($lines), 4);
+		$this->assertEquals(count($lines), 3);
 		foreach($lines as $key => $line) {
 			$line = json_decode($line, true);
 			$this->assertEquals($line['type'], $loggerType[$key]);


### PR DESCRIPTION
Port setLogLevel to multiple as was done by tmihkil but gone stale. Add unit tests to verify the default log level is applied across multiple logs.

https://github.com/phalcon/cphalcon/pull/10429 went stale. So I recreated it and added a unit-test.
