### PR TITLE
Port from:  fix modifyColumn #11437

### DIFF
--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -207,6 +207,7 @@ class Postgresql extends Dialect
 
 		let columnDefinition = this->getColumnDefinition(column);
 		let sqlAlterTable = "ALTER TABLE " . this->prepareTable(tableName, schemaName);
+		let currentColumn = currentColumn == null ? column : currentColumn; 
 
 		//Rename
 		if column->getName() != currentColumn->getName() {


### PR DESCRIPTION
If currentColumn is missing use column parametr.

prevent:

```
ERROR: RuntimeException Object
(
    [message:protected] => Trying to call method getname on a non-object
...
)
```
