### PR TITLE
Fix di array access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Added `Phalcon\Cli\DispatcherInterface`, `Phalcon\Cli\TaskInterface`, `Phalcon\Cli\RouterInterface` and `Phalcon\Cli\Router\RouteInterface`.
 - Added methods update(), create() and createIfNotExist(array criteria) to `Phalcon\Mvc\Collection`
 - Removed `__construct` from all interfaces [#11410](https://github.com/phalcon/cphalcon/issues/11410)
+- Changed `offsetSet()` and `offsetGet()` in `Phalcon\Di`, now you can set if service is shared using array-access syntax, also `offsetGet()` is using `get()` instead of `getShared()`
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -329,7 +329,7 @@ class Di implements DiInterface
 	}
 
 	/**
-	 * Allows to register a shared service using the array syntax
+	 * Allows to register a service using the array syntax
 	 *
 	 *<code>
 	 *	$di["request"] = new \Phalcon\Http\Request();
@@ -341,12 +341,23 @@ class Di implements DiInterface
 	 */
 	public function offsetSet(string! name, var definition) -> boolean
 	{
-		this->setShared(name, definition);
+		var def, shared;
+		if typeof definition == "array" {
+			let def = definition[0];
+			let shared = true;
+			if isset definition[1] {
+				let shared = definition[1];
+			}
+			this->set(name, def, shared);
+		}
+		else{
+			this->setShared(name, definition);
+		}
 		return true;
 	}
 
 	/**
-	 * Allows to obtain a shared service using the array syntax
+	 * Allows to obtain a service using the array syntax
 	 *
 	 *<code>
 	 *	var_dump($di["request"]);
@@ -354,7 +365,7 @@ class Di implements DiInterface
 	 */
 	public function offsetGet(string! name) -> var
 	{
-		return this->getShared(name);
+		return this->get(name);
 	}
 
 	/**


### PR DESCRIPTION
This is related to this problem on forum : https://forum.phalconphp.com/discussion/10583/set-service-to-be-not-shared#C30309

I think it adds some consistency for array syntax and option to set if service should be shared or not.

Also i guess i could possibly do PR for 2.0.x.
