### PR TITLE
Fixed destroy() method bug of Phalcon\Session\Adapter\Libmemcached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Removed `__construct` from all interfaces [#11410](https://github.com/phalcon/cphalcon/issues/11410)
 - Fires the dispatch:beforeException event when there is any exception during dispatching [#11458](https://github.com/phalcon/cphalcon/issues/11458)
 - Added `OR` operator for `Phalcon\Mvc\Model\Query\Builder` methods: betweenWhere, notBetweenWhere, inWhere and notInWhere
+- Fixed bug of `destroy` method of `Phalcon\Session\Adapter\Libmemcached`
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -147,15 +147,18 @@ class Libmemcached extends Adapter
 	 */
 	public function destroy(string sessionId = null) ->boolean
 	{
-		var id;
+		var id, key;
 
 		if sessionId === null {
 			let id = this->getId();
 		} else {
 			let id = sessionId;
 		}
-
-		return this->_libmemcached->delete(id);
+		
+		for key, _ in _SESSION {
+			unset _SESSION[key];			
+		}
+		return this->_libmemcached->delete(id);		
 	}
 
 	/**


### PR DESCRIPTION
It is fix of the issue mentioned in the following link:

https://github.com/phalcon/cphalcon/issues/2778
