### PR TITLE
Fixed Logger\FormatterInterface inheritance

### DIFF
--- a/phalcon/logger/formatter.zep
+++ b/phalcon/logger/formatter.zep
@@ -26,7 +26,7 @@ use Phalcon\Logger;
  *
  * This is a base class for logger formatters
  */
-abstract class Formatter
+abstract class Formatter implements FormatterInterface
 {
 
 	/**

--- a/phalcon/logger/formatter/firephp.zep
+++ b/phalcon/logger/formatter/firephp.zep
@@ -22,14 +22,13 @@ namespace Phalcon\Logger\Formatter;
 
 use Phalcon\Logger;
 use Phalcon\Logger\Formatter;
-use Phalcon\Logger\FormatterInterface;
 
 /**
  * Phalcon\Logger\Formatter\Firephp
  *
  * Formats messages so that they can be sent to FirePHP
  */
-class Firephp extends Formatter implements FormatterInterface
+class Firephp extends Formatter
 {
 	protected _showBacktrace = true;
 

--- a/phalcon/logger/formatter/json.zep
+++ b/phalcon/logger/formatter/json.zep
@@ -20,14 +20,13 @@
 namespace Phalcon\Logger\Formatter;
 
 use Phalcon\Logger\Formatter;
-use Phalcon\Logger\FormatterInterface;
 
 /**
  * Phalcon\Logger\Formatter\Json
  *
  * Formats messages using JSON encoding
  */
-class Json extends Formatter implements FormatterInterface
+class Json extends Formatter
 {
 
 	/**

--- a/phalcon/logger/formatter/line.zep
+++ b/phalcon/logger/formatter/line.zep
@@ -20,14 +20,13 @@
 namespace Phalcon\Logger\Formatter;
 
 use Phalcon\Logger\Formatter;
-use Phalcon\Logger\FormatterInterface;
 
 /**
  * Phalcon\Logger\Formatter\Line
  *
  * Formats messages using an one-line string
  */
-class Line extends Formatter implements FormatterInterface
+class Line extends Formatter
 {
 
 	/**

--- a/phalcon/logger/formatter/syslog.zep
+++ b/phalcon/logger/formatter/syslog.zep
@@ -20,14 +20,13 @@
 namespace Phalcon\Logger\Formatter;
 
 use Phalcon\Logger\Formatter;
-use Phalcon\Logger\FormatterInterface;
 
 /**
  * Phalcon\Logger\Formatter\Syslog
  *
  * Prepares a message to be used in a Syslog backend
  */
-class Syslog extends Formatter implements FormatterInterface
+class Syslog extends Formatter
 {
 
 	/**


### PR DESCRIPTION
Now, a class that extends `\Phalcon\Logger\Formatter` is forced to implement methods in the interface.
