### PR TITLE
Removed redundant validity checks DI and ModelsManager in Mvc\Model.

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -206,13 +206,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		let metaData = this->_modelsMetaData;
 		if typeof metaData != "object" {
 
-			/**
-			 * Check if the DI is valid
-			 */
 			let dependencyInjector = <DiInterface> this->_dependencyInjector;
-			if typeof dependencyInjector != "object" {
-				throw new Exception("A dependency injector container is required to obtain the services related to the ORM");
-			}
 
 			/**
 			 * Obtain the models-metadata service from the DI


### PR DESCRIPTION
The DI and the Models Manager are set in the constructor so we don't need to check if they are objects. See https://github.com/phalcon/cphalcon/blob/master/phalcon/mvc/model.zep#L134 and https://github.com/phalcon/cphalcon/blob/master/phalcon/mvc/model.zep#L145.
