### PR TITLE
Removed unnecessary gc from Mongo cache.

### DIFF
--- a/phalcon/cache/backend/mongo.zep
+++ b/phalcon/cache/backend/mongo.zep
@@ -438,10 +438,6 @@ class Mongo extends Backend implements BackendInterface
 	{
 		this->_getCollection()->remove();
 
-		if (int) rand() % 100 == 0 {
-			this->gc();
-		}
-
 		return true;
 	}
 }


### PR DESCRIPTION
`flush()` removes everything anyway so we don't need to collect any garbage.
