### PR TITLE
Fix view selection when multiple view directories have been set

### DIFF
--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -726,7 +726,7 @@ class View extends Injectable implements ViewInterface
 			}
 
 			if !silence {
-				throw new Exception("View '" . viewsDirPath . "' was not found in the views directory");
+				throw new Exception("View '" . viewPath . "' was not found in any of the views directory");
 			}
 		}
 	}

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -1336,7 +1336,18 @@ class View extends Injectable implements ViewInterface
 	 */
 	public function getActiveRenderPath() -> string | array
 	{
-		return this->_activeRenderPaths;
+		var activeRenderPath;
+		int viewsDirsCount;
+
+		let viewsDirsCount = count(this->getViewsDirs());
+
+		if viewsDirsCount === 1 {
+			let activeRenderPath = this->_activeRenderPaths[0];
+		} else {
+			let activeRenderPath = this->_activeRenderPaths;
+		}
+
+		return activeRenderPath;
 	}
 
 	/**

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -139,7 +139,7 @@ class View extends Injectable implements ViewInterface
 
 	protected _cacheLevel = 0;
 
-	protected _activeRenderPath;
+	protected _activeRenderPaths;
 
 	protected _disabled = false;
 
@@ -613,12 +613,13 @@ class View extends Injectable implements ViewInterface
 		int renderLevel, cacheLevel;
 		var key, lifetime, viewsDir, basePath, viewsDirPath,
 			viewOptions, cacheOptions, cachedView, viewParams, eventsManager,
-			extension, engine, viewEnginePath;
+			extension, engine, viewEnginePath, viewEnginePaths;
 
 		let notExists = true,
 			basePath = this->_basePath,
 			viewParams = this->_viewParams,
-			eventsManager = <ManagerInterface> this->_eventsManager;
+			eventsManager = <ManagerInterface> this->_eventsManager,
+			viewEnginePaths = [];
 
 		for viewsDir in this->getViewsDirs() {
 
@@ -696,7 +697,7 @@ class View extends Injectable implements ViewInterface
 					 * Call beforeRenderView if there is a events manager available
 					 */
 					if typeof eventsManager == "object" {
-						let this->_activeRenderPath = viewEnginePath;
+						let this->_activeRenderPaths = [viewEnginePath];
 						if eventsManager->fire("view:beforeRenderView", this, viewEnginePath) === false {
 							continue;
 						}
@@ -713,6 +714,8 @@ class View extends Injectable implements ViewInterface
 					}
 					break;
 				}
+
+				let viewEnginePaths[] = viewEnginePath;
 			}
 		}
 
@@ -721,7 +724,7 @@ class View extends Injectable implements ViewInterface
 			 * Notify about not found views
 			 */
 			if typeof eventsManager == "object" {
-				let this->_activeRenderPath = viewEnginePath;
+				let this->_activeRenderPaths = viewEnginePaths;
 				eventsManager->fire("view:notFoundView", this, viewEnginePath);
 			}
 
@@ -1329,11 +1332,11 @@ class View extends Injectable implements ViewInterface
 	}
 
 	/**
-	 * Returns the path of the view that is currently rendered
+	 * Returns the path (or paths) of the views that are currently rendered
 	 */
-	public function getActiveRenderPath() -> string
+	public function getActiveRenderPath() -> string | array
 	{
-		return this->_activeRenderPath;
+		return this->_activeRenderPaths;
 	}
 
 	/**


### PR DESCRIPTION
The problem was that when the target view was not found in the very first views directory, the search was aborted and an exception got thrown. This meant that the views were never searched for in the other views directories.

I am not completely sure, how the `view:notFoundView` event should be handled here -- should it fire for every view not found or only when no views are found?
