### PR TITLE
Mcrypt is replaced with openssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 - Added `Phalcon\Cache\Backend\Memcache::addServers` to enable pool of servers for memcache
 - Added `setLastModified` method to `Phalcon\Http\Response`
 - Added `Phalcon\Validation\Validator\Date`
+- Mcrypt is replaced with openssl in `Phalcon\Crypt`
+- Removed methods setMode(), getMode(), getAvailableModes() in `Phalcon\CryptInterface`
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -325,7 +325,7 @@ class Crypt implements CryptInterface
 	 */
 	public function decrypt(string! text, key = null) -> string
 	{
-		var decryptKey, ivSize, cipher, mode, keySize, length, blockSize, paddingType, decrypted;
+		var decryptKey, ivSize, cipher, mode, blockSize, paddingType, decrypted;
 
 		if !function_exists("openssl_cipher_iv_length") {
 			throw new Exception("openssl extension is required");
@@ -353,12 +353,6 @@ class Crypt implements CryptInterface
 			let blockSize = ivSize;
 		} else {
 			let blockSize = openssl_cipher_iv_length(str_ireplace("-" . mode, "", cipher));
-		}
-
-		let keySize = strlen(decryptKey);
-		let length = strlen(text);
-		if keySize > length {
-			throw new Exception("Size of IV is larger than text to decrypt. Are you trying to decrypt an uncrypted text?");
 		}
 
 		let decrypted = openssl_decrypt(substr(text, ivSize), cipher, decryptKey, OPENSSL_RAW_DATA, substr(text, 0, ivSize));

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -280,10 +280,6 @@ class Crypt implements CryptInterface
 			throw new Exception("openssl extension is required");
 		}
 		
-		if !in_array(cipher, openssl_get_cipher_methods()) {
-			throw new Exception("Cipher algorithm is unknown");
-		}
-		
 		if key === null {
 			let encryptKey = this->_key;
 		} else {
@@ -296,6 +292,11 @@ class Crypt implements CryptInterface
 
 		let cipher = this->_cipher;
 		let mode = strtolower(substr(cipher, strrpos(cipher, "-") - strlen(cipher)));
+		
+		if !in_array(cipher, openssl_get_cipher_methods()) {
+			throw new Exception("Cipher algorithm is unknown");
+		}
+		
 		let ivSize = openssl_cipher_iv_length(cipher);
 
 		if strlen(encryptKey) > ivSize {

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -298,16 +298,17 @@ class Crypt implements CryptInterface
 		}
 		
 		let ivSize = openssl_cipher_iv_length(cipher);
-
-		if strlen(encryptKey) > ivSize {
-			throw new Exception("Size of key is too large for this algorithm");
+		if ivSize > 0 {
+			let blockSize = ivSize;
+		} else {
+			let blockSize = openssl_cipher_iv_length(str_ireplace("-" . mode, "", cipher));
 		}
 
 		let iv = openssl_random_pseudo_bytes(ivSize);
 		let paddingType = this->_padding;
 
 		if paddingType != 0 && (mode == "cbc" || mode == "ecb") {
-			let padded = this->_cryptPadText(text, mode, ivSize, paddingType);
+			let padded = this->_cryptPadText(text, mode, blockSize, paddingType);
 		} else {
 			let padded = text;
 		}
@@ -348,12 +349,13 @@ class Crypt implements CryptInterface
 		}
 
 		let ivSize = openssl_cipher_iv_length(cipher);
-
-		let keySize = strlen(decryptKey);
-		if keySize > ivSize {
-			throw new Exception("Size of key is too large for this algorithm");
+		if ivSize > 0 {
+			let blockSize = ivSize;
+		} else {
+			let blockSize = openssl_cipher_iv_length(str_ireplace("-" . mode, "", cipher));
 		}
 
+		let keySize = strlen(decryptKey);
 		let length = strlen(text);
 		if keySize > length {
 			throw new Exception("Size of IV is larger than text to decrypt. Are you trying to decrypt an uncrypted text?");
@@ -364,7 +366,7 @@ class Crypt implements CryptInterface
 		let paddingType = this->_padding;
 
 		if mode == "cbc" || mode == "ecb" {
-			return this->_cryptUnpadText(decrypted, mode, ivSize, paddingType);
+			return this->_cryptUnpadText(decrypted, mode, blockSize, paddingType);
 		}
 
 		return decrypted;

--- a/phalcon/cryptinterface.zep
+++ b/phalcon/cryptinterface.zep
@@ -38,16 +38,6 @@ interface CryptInterface
 	public function getCipher() -> string;
 
 	/**
-	 * Sets the encrypt/decrypt mode
-	 */
-	public function setMode(string! mode) -> <CryptInterface>;
-
-	/**
-	 * Returns the current encryption mode
-	 */
-	public function getMode() -> string;
-
-	/**
 	 * Sets the encryption key
 	 */
 	public function setKey(string! key) -> <CryptInterface>;
@@ -82,8 +72,4 @@ interface CryptInterface
 	 */
 	public function getAvailableCiphers() -> array;
 
-	/**
-	 * Returns a list of available modes
-	 */
-	public function getAvailableModes() -> array;
 }

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -28,8 +28,8 @@ class CryptTest extends UnitTest
     {
         parent::_before();
 
-        if (!extension_loaded('mcrypt')) {
-            $this->markTestSkipped('Warning: mcrypt extension is not loaded');
+        if (!extension_loaded('openssl')) {
+            $this->markTestSkipped('Warning: openssl extension is not loaded');
         }
     }
 
@@ -72,19 +72,22 @@ class CryptTest extends UnitTest
                     time().time()            => str_shuffle('abcdefeghijklmnopqrst'),
                     'le$ki12432543543543543' => null,
                 ];
-                $modes = [
-                    MCRYPT_MODE_ECB,
-                    MCRYPT_MODE_CBC,
-                    MCRYPT_MODE_CFB,
-                    MCRYPT_MODE_CFB,
-                    MCRYPT_MODE_NOFB
+                $ciphers = [
+                    'AES-256-ECB',
+                    'AES-256-CBC',
+                    'AES-256-CFB',
+                    'AES-256-OFB',
+                    'AES-128-ECB',
+                    'AES-128-CBC',
+                    'AES-128-CFB',
+                    'AES-128-OFB',
                 ];
 
                 $crypt = new Crypt();
 
-                foreach ($modes as $mode) {
+                foreach ($ciphers as $cipher) {
 
-                    $crypt->setMode($mode);
+                    $crypt->setCipher($cipher);
 
                     foreach ($tests as $key => $test) {
 
@@ -124,7 +127,11 @@ class CryptTest extends UnitTest
 
                 $texts = [''];
                 $key   = '0123456789ABCDEF0123456789ABCDEF';
-                $modes = ['ecb', 'cbc', 'cfb'];
+                $ciphers = [
+                    'AES-256-ECB',
+                    'AES-256-CBC',
+                    'AES-256-CFB',
+                ];
                 $pads  = [
                     Crypt::PADDING_ANSI_X_923,
                     Crypt::PADDING_PKCS7,
@@ -139,16 +146,15 @@ class CryptTest extends UnitTest
                 }
 
                 $crypt = new Crypt();
-                $crypt->setCipher(MCRYPT_RIJNDAEL_256)
-                    ->setKey(substr($key, 0, 16));
+                $crypt->setKey(substr($key, 0, 16));
 
                 foreach ($pads as $padding) {
 
                     $crypt->setPadding($padding);
 
-                    foreach ($modes as $mode) {
+                    foreach ($ciphers as $cipher) {
 
-                        $crypt->setMode($mode);
+                        $crypt->setCipher($cipher);
 
                         foreach ($texts as $text) {
 

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -73,10 +73,6 @@ class CryptTest extends UnitTest
                     'le$ki12432543543543543' => null,
                 ];
                 $ciphers = [
-                    'AES-256-ECB',
-                    'AES-256-CBC',
-                    'AES-256-CFB',
-                    'AES-256-OFB',
                     'AES-128-ECB',
                     'AES-128-CBC',
                     'AES-128-CFB',
@@ -146,7 +142,7 @@ class CryptTest extends UnitTest
                 }
 
                 $crypt = new Crypt();
-                $crypt->setKey(substr($key, 0, 16));
+                $crypt->setKey(substr($key, 0, 32));
 
                 foreach ($pads as $padding) {
 


### PR DESCRIPTION
Mcrypt is replaced with openssl in `Phalcon\Crypt`. (https://github.com/phalcon/cphalcon/issues/11486)
Removed methods `setMode()`, `getMode()`, `getAvailableModes()` as not applicable to the openssl in `Phalcon\CryptInterface`.
Unfortunately, the reverse compatibility was lost for the reason that cryptography techniques are called differently in mcrypt and openssl libraries. Moreover, the algorithm of rijndael-256 used by default doesn't have changeover in openssl. I hope, it is not too heavy payment for transition to faster, safe and modern cryptography library.
