### PR TITLE
Mcrypt is replaced with openssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@
 - Added `Phalcon\Cache\Backend\Memcache::addServers` to enable pool of servers for memcache
 - Added `setLastModified` method to `Phalcon\Http\Response`
 - Added `Phalcon\Validation\Validator\Date`
+- Mcrypt is replaced with openssl in `Phalcon\Crypt`
+- Removed methods setMode(), getMode(), getAvailableModes() in `Phalcon\CryptInterface`
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -45,9 +45,7 @@ class Crypt implements CryptInterface
 
 	protected _padding = 0;
 
-	protected _mode = "cfb";
-
-	protected _cipher = "rijndael-256";
+	protected _cipher = "aes-256-cfb";
 
 	const PADDING_DEFAULT = 0;
 
@@ -87,23 +85,6 @@ class Crypt implements CryptInterface
 	public function getCipher() -> string
 	{
 		return this->_cipher;
-	}
-
-	/**
-	 * Sets the encrypt/decrypt mode
-	 */
-	public function setMode(string! mode) -> <Crypt>
-	{
-		let this->_mode = mode;
-		return this;
-	}
-
-	/**
-	 * Returns the current encryption mode
-	 */
-	public function getMode() -> string
-	{
-		return this->_mode;
 	}
 
 	/**
@@ -295,8 +276,8 @@ class Crypt implements CryptInterface
 	{
 		var encryptKey, ivSize, iv, cipher, mode, blockSize, paddingType, padded;
 
-		if !function_exists("mcrypt_get_iv_size") {
-			throw new Exception("mcrypt extension is required");
+		if !function_exists("openssl_cipher_iv_length") {
+			throw new Exception("openssl extension is required");
 		}
 
 		if key === null {
@@ -309,24 +290,21 @@ class Crypt implements CryptInterface
 			throw new Exception("Encryption key cannot be empty");
 		}
 
-		let cipher = this->_cipher, mode = this->_mode;
-
-		let ivSize = mcrypt_get_iv_size(cipher, mode);
-
-		if strlen(encryptKey) > ivSize {
-			throw new Exception("Size of key is too large for this algorithm");
+		let cipher = this->_cipher;
+		let mode = strtolower(substr(cipher, strrpos(cipher, "-") - strlen(cipher)));
+		
+		if !in_array(cipher, openssl_get_cipher_methods()) {
+			throw new Exception("Cipher algorithm is unknown");
+		}
+		
+		let ivSize = openssl_cipher_iv_length(cipher);
+		if ivSize > 0 {
+			let blockSize = ivSize;
+		} else {
+			let blockSize = openssl_cipher_iv_length(str_ireplace("-" . mode, "", cipher));
 		}
 
-		let iv = mcrypt_create_iv(ivSize, MCRYPT_RAND);
-		if typeof iv != "string" {
-			let iv = strval(iv);
-		}
-
-		let blockSize = mcrypt_get_block_size(cipher, mode);
-		if typeof blockSize != "integer" {
-			let blockSize = intval(blockSize);
-		}
-
+		let iv = openssl_random_pseudo_bytes(ivSize);
 		let paddingType = this->_padding;
 
 		if paddingType != 0 && (mode == "cbc" || mode == "ecb") {
@@ -335,7 +313,7 @@ class Crypt implements CryptInterface
 			let padded = text;
 		}
 
-		return iv . mcrypt_encrypt(cipher, encryptKey, padded, mode, iv);
+		return iv . openssl_encrypt(padded, cipher, encryptKey, OPENSSL_RAW_DATA, iv);
 	}
 
 	/**
@@ -347,10 +325,10 @@ class Crypt implements CryptInterface
 	 */
 	public function decrypt(string! text, key = null) -> string
 	{
-		var decryptKey, ivSize, cipher, mode, keySize, length, blockSize, paddingType, decrypted;
+		var decryptKey, ivSize, cipher, mode, blockSize, paddingType, decrypted;
 
-		if !function_exists("mcrypt_get_iv_size") {
-			throw new Exception("mcrypt extension is required");
+		if !function_exists("openssl_cipher_iv_length") {
+			throw new Exception("openssl extension is required");
 		}
 
 		if key === null {
@@ -363,23 +341,22 @@ class Crypt implements CryptInterface
 			throw new Exception("Decryption key cannot be empty");
 		}
 
-		let cipher = this->_cipher, mode = this->_mode;
-
-		let ivSize = mcrypt_get_iv_size(cipher, mode);
-
-		let keySize = strlen(decryptKey);
-		if keySize > ivSize {
-			throw new Exception("Size of key is too large for this algorithm");
+		let cipher = this->_cipher;
+		let mode = strtolower(substr(cipher, strrpos(cipher, "-") - strlen(cipher)));
+		
+		if !in_array(cipher, openssl_get_cipher_methods()) {
+			throw new Exception("Cipher algorithm is unknown");
 		}
 
-		let length = strlen(text);
-		if keySize > length {
-			throw new Exception("Size of IV is larger than text to decrypt. Are you trying to decrypt an uncrypted text?");
+		let ivSize = openssl_cipher_iv_length(cipher);
+		if ivSize > 0 {
+			let blockSize = ivSize;
+		} else {
+			let blockSize = openssl_cipher_iv_length(str_ireplace("-" . mode, "", cipher));
 		}
 
-		let decrypted = mcrypt_decrypt(cipher, decryptKey, substr(text, ivSize), mode, substr(text, 0, ivSize));
+		let decrypted = openssl_decrypt(substr(text, ivSize), cipher, decryptKey, OPENSSL_RAW_DATA, substr(text, 0, ivSize));
 
-		let blockSize = mcrypt_get_block_size(cipher, mode);
 		let paddingType = this->_padding;
 
 		if mode == "cbc" || mode == "ecb" {
@@ -412,18 +389,10 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Returns a list of available cyphers
+	 * Returns a list of available ciphers
 	 */
 	public function getAvailableCiphers() -> array
 	{
-		return mcrypt_list_algorithms();
-	}
-
-	/**
-	 * Returns a list of available modes
-	 */
-	public function getAvailableModes() -> array
-	{
-		return mcrypt_list_modes();
+		return openssl_get_cipher_methods();
 	}
 }

--- a/phalcon/cryptinterface.zep
+++ b/phalcon/cryptinterface.zep
@@ -38,16 +38,6 @@ interface CryptInterface
 	public function getCipher() -> string;
 
 	/**
-	 * Sets the encrypt/decrypt mode
-	 */
-	public function setMode(string! mode) -> <CryptInterface>;
-
-	/**
-	 * Returns the current encryption mode
-	 */
-	public function getMode() -> string;
-
-	/**
 	 * Sets the encryption key
 	 */
 	public function setKey(string! key) -> <CryptInterface>;
@@ -82,8 +72,4 @@ interface CryptInterface
 	 */
 	public function getAvailableCiphers() -> array;
 
-	/**
-	 * Returns a list of available modes
-	 */
-	public function getAvailableModes() -> array;
 }

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -28,8 +28,8 @@ class CryptTest extends UnitTest
     {
         parent::_before();
 
-        if (!extension_loaded('mcrypt')) {
-            $this->markTestSkipped('Warning: mcrypt extension is not loaded');
+        if (!extension_loaded('openssl')) {
+            $this->markTestSkipped('Warning: openssl extension is not loaded');
         }
     }
 
@@ -72,19 +72,18 @@ class CryptTest extends UnitTest
                     time().time()            => str_shuffle('abcdefeghijklmnopqrst'),
                     'le$ki12432543543543543' => null,
                 ];
-                $modes = [
-                    MCRYPT_MODE_ECB,
-                    MCRYPT_MODE_CBC,
-                    MCRYPT_MODE_CFB,
-                    MCRYPT_MODE_CFB,
-                    MCRYPT_MODE_NOFB
+                $ciphers = [
+                    'AES-128-ECB',
+                    'AES-128-CBC',
+                    'AES-128-CFB',
+                    'AES-128-OFB',
                 ];
 
                 $crypt = new Crypt();
 
-                foreach ($modes as $mode) {
+                foreach ($ciphers as $cipher) {
 
-                    $crypt->setMode($mode);
+                    $crypt->setCipher($cipher);
 
                     foreach ($tests as $key => $test) {
 
@@ -124,7 +123,11 @@ class CryptTest extends UnitTest
 
                 $texts = [''];
                 $key   = '0123456789ABCDEF0123456789ABCDEF';
-                $modes = ['ecb', 'cbc', 'cfb'];
+                $ciphers = [
+                    'AES-256-ECB',
+                    'AES-256-CBC',
+                    'AES-256-CFB',
+                ];
                 $pads  = [
                     Crypt::PADDING_ANSI_X_923,
                     Crypt::PADDING_PKCS7,
@@ -139,16 +142,15 @@ class CryptTest extends UnitTest
                 }
 
                 $crypt = new Crypt();
-                $crypt->setCipher(MCRYPT_RIJNDAEL_256)
-                    ->setKey(substr($key, 0, 16));
+                $crypt->setKey(substr($key, 0, 32));
 
                 foreach ($pads as $padding) {
 
                     $crypt->setPadding($padding);
 
-                    foreach ($modes as $mode) {
+                    foreach ($ciphers as $cipher) {
 
-                        $crypt->setMode($mode);
+                        $crypt->setCipher($cipher);
 
                         foreach ($texts as $text) {
 


### PR DESCRIPTION
Mcrypt is replaced with openssl in `Phalcon\Crypt`. (https://github.com/phalcon/cphalcon/issues/11486)
Removed methods `setMode()`, `getMode()`, `getAvailableModes()` as not applicable to the openssl in `Phalcon\CryptInterface`.
Unfortunately, the reverse compatibility was lost for the reason that cryptography techniques are called differently in mcrypt and openssl libraries. Moreover, the algorithm of rijndael-256 used by default doesn't have changeover in openssl. I hope, it is not too heavy payment for transition to faster, safe and modern cryptography library.
There were some difficulties which are generally connected to distinctions of implementations of similar algorithms in mcrypt and openssl, and also imperfection of the current implementation of `Phalcon\Crypt`. I will be glad if someone undertakes carrying out additional tests.
