### PR TITLE
The beforeException dispatcher event can now forward

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -581,8 +581,20 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 			let this->_lastHandler = handler;
 
-			// We update the latest value produced by the latest handler
-			let this->_returnedValue = this->callActionMethod(handler, actionMethod, params);
+			try {
+				// We update the latest value produced by the latest handler
+				let this->_returnedValue = this->callActionMethod(handler, actionMethod, params);
+			} catch \Exception, e {
+				let this->_lastHandler = handler;
+
+				if this->{"_handleException"}(e) === false {
+					if this->_finished === false {
+						continue;
+					}
+				} else {
+					throw e;
+				}
+			}
 
 			// Calling afterExecuteRoute
 			if typeof eventsManager == "object" {


### PR DESCRIPTION
If an Exception is thrown, it needs to be caught within the loop and be able to continue if we need it to.

Fixes #2851.
