### PR TITLE
Update view.zep

### DIFF
--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -714,22 +714,22 @@ class View extends Injectable implements ViewInterface
 					break;
 				}
 			}
+		}
 
-			if notExists === false {
-				break;
-			}
+		if notExists === false {
+			break;
+		}
 
-			/**
-			 * Notify about not found views
-			 */
-			if typeof eventsManager == "object" {
-				let this->_activeRenderPath = viewEnginePath;
-				eventsManager->fire("view:notFoundView", this, viewEnginePath);
-			}
+		/**
+		 * Notify about not found views
+		 */
+		if typeof eventsManager == "object" {
+			let this->_activeRenderPath = viewEnginePath;
+			eventsManager->fire("view:notFoundView", this, viewEnginePath);
+		}
 
-			if !silence {
-				throw new Exception("View '" . viewsDirPath . "' was not found in the views directory");
-			}
+		if !silence {
+			throw new Exception("View '" . viewsDirPath . "' was not found in the views directory");
 		}
 	}
 


### PR DESCRIPTION
Where you have multiple view paths/directories ... searching for anything (partial etc) fails (errors out) if the first path it tests does not have the item.

Perhaps this is expected behaviour but it seems to me that the error should only rise if the item is not in ANY of the multiple paths.

If so, then the fix is simple as seen.
