### PR TITLE
Update view.zep

### DIFF
--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -714,11 +714,9 @@ class View extends Injectable implements ViewInterface
 					break;
 				}
 			}
+		}
 
-			if notExists === false {
-				break;
-			}
-
+		if notExists === false {
 			/**
 			 * Notify about not found views
 			 */


### PR DESCRIPTION
Allows multiple view directories where, as long as an item is found in any one of them, it is found. Currently, if it fails before it succeeds (in the loop) an error rises. Patch fixes this so, for example, a partial is 'found' if it exists in ANY of the paths.
