### PR TITLE
Update view.zep

### DIFF
--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -714,11 +714,9 @@ class View extends Injectable implements ViewInterface
 					break;
 				}
 			}
+		}
 
-			if notExists === false {
-				break;
-			}
-
+		if notExists === true {
 			/**
 			 * Notify about not found views
 			 */


### PR DESCRIPTION
Finally!

Ok - this fixes an issue with multiple view paths. As it was, if a resource was not found in the first view path, then and error was raised and the other paths were not checked. Now - a resource (partial / whatever) is marked as 'found' if it exists in ANY of the multiple view paths.
