### PR TITLE
Form validation : fetch elements after "bind" and "beforeValidation" have been called

### DIFF
--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -270,11 +270,6 @@ class Form extends Injectable implements \Countable, \Iterator
 			validators, name, preparedValidators, filters,
 			validator, validation, elementMessages;
 
-		let elements = this->_elements;
-		if typeof elements != "array" {
-			return true;
-		}
-
 		/**
 		 * If the data is not an array use the one passed previously
 		 */
@@ -299,7 +294,12 @@ class Form extends Injectable implements \Countable, \Iterator
 				return false;
 			}
 		}
-
+		
+		let elements = this->_elements;
+		if typeof elements != "array" {
+			return true;
+		}
+		
 		let notFailed = true,
 			messages = [];
 

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -296,9 +296,6 @@ class Form extends Injectable implements \Countable, \Iterator
 		}
 		
 		let elements = this->_elements;
-		if typeof elements != "array" {
-			return true;
-		}
 		
 		let notFailed = true,
 			messages = [];


### PR DESCRIPTION
They are called from form->isValid() method, and can be custom methods. Any use of form->remove or form->add inside one of this function can change the set of elements to be validated.
Moving the elements fetch after they are called remove the case where the elements being valdated are not the actual stored ones.
