### PR TITLE
Fix segfault on PHP 7

### DIFF
--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -205,7 +205,7 @@ class Di implements DiInterface
 	 */
 	public function get(string! name, parameters = null) -> var
 	{
-		var service, eventsManager, instance = null;
+		var service, eventsManager, reflection, instance = null;
 
 		let eventsManager = <ManagerInterface> this->_eventsManager;
 
@@ -232,7 +232,12 @@ class Di implements DiInterface
 				}
 
 				if typeof parameters == "array" && count(parameters) {
-					let instance = create_instance_params(name, parameters);
+					if is_php_version("5.6") || is_php_version("7.0") {
+						let reflection = new \ReflectionClass(name),
+							instance = reflection->newInstanceArgs(parameters);
+					} else {
+						let instance = create_instance_params(name, parameters);
+					}
 				} else {
 					let instance = create_instance(name);
 				}


### PR DESCRIPTION
Back porting some code from 2.0.0 branch, and including an update for PHP 7.0.

Current implementation results in a SEGFAULT when run under PHP 7.0, stemming from the below code in `mvc/model/query/builder.zep`

```
let query = <QueryInterface> dependencyInjector->get("Phalcon\\Mvc\\Model\\Query", [phql, dependencyInjector]);
```

I could potentially fix through `create_instance_params`, but I can't find where that function is defined - nor `is_php_version` for that matter.

No unit tests since PHP 7 is not running on travis.
