### PR TITLE
Firewall component, afterBinding in dispatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - Fixed `Filter::add` method handler [#11581](https://github.com/phalcon/cphalcon/issues/11581)
 - Removed `Phalcon\Session` [#11340](https://github.com/phalcon/cphalcon/issues/11340)
 - Phalcon\Tag::getTitle() shows a title depending on prependTitle and appendTitle
+- Added `Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl` and `Phalcon\Mvc\Dispatcher\Firewall\Adapter\Annotations`, built-in classes for securing controllers/actions
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -76,6 +76,8 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 	protected _modelBinding = false;
 
+	protected _boundModel = null;
+
 	const EXCEPTION_NO_DI = 0;
 
 	const EXCEPTION_CYCLIC_ROUTING = 1;
@@ -328,6 +330,14 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	}
 
 	/**
+	 * Gets a binded model
+	 */
+	public function getBoundModel() -> object
+	{
+		return this->_boundModel;
+	}
+
+	/**
 	 * Dispatches a handle action taking into account the routing parameters
 	 *
 	 * @return object
@@ -564,6 +574,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 									let modelName = call_user_func([handlerClass, "getModelName"]);
 									let bindModel = call_user_func_array([modelName, "findFirst"], [params[paramKey]]);
 									let params[paramKey] = bindModel;
+									let this->_boundModel = bindModel;
 									break;
 								}
 							}
@@ -572,10 +583,16 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 							if is_subclass_of(className, "Phalcon\\Mvc\\Model") {
 								let bindModel = call_user_func_array([className, "findFirst"], [params[paramKey]]);
 								let params[paramKey] = bindModel;
+								let this->_boundModel = bindModel;
 								break;
 							}
 						}
 					}
+				}
+			}
+			if typeof eventsManager == "object" {
+				if eventsManager->fire("dispatch:afterBinding", this) === false {
+					continue;
 				}
 			}
 

--- a/phalcon/mvc/dispatcher/firewall/adapter.zep
+++ b/phalcon/mvc/dispatcher/firewall/adapter.zep
@@ -1,0 +1,150 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+
+namespace Phalcon\Mvc\Dispatcher\Firewall;
+
+use Phalcon\Events\EventsAwareInterface;
+use Phalcon\Events\ManagerInterface;
+use Phalcon\Mvc\Dispatcher\Firewall\AdapterInterface;
+use Phalcon\Acl;
+use Phalcon\Mvc\Dispatcher;
+
+/**
+ * Phalcon\Mvc\Dispatcher\Firewall\Adapter
+ *
+ * Adapter for Phalcon\Mvc\Dispatcher\Firewall adapters
+ */
+abstract class Adapter implements AdapterInterface, EventsAwareInterface
+{
+	/**
+	 * Events manager
+	 * @var mixed
+	 */
+	protected _eventsManager;
+
+	/**
+	 * Default access
+	 * @var int
+	 */
+	protected _defaultAccess = Acl::DENY { get, set };
+
+	/**
+	 * Anonymous function for getting user identity - this function must return string, array or object implementing Phalcon\Acl\RoleAware
+	 * @var mixed
+	 */
+	protected _roleCallback;
+
+	/**
+	 * Dispatcher
+	 * @var mixed
+	 */
+	protected _dispatcher;
+
+	/**
+	 * Sets the events manager
+	 */
+	public function setEventsManager(<ManagerInterface> eventsManager)
+	{
+		let this->_eventsManager = eventsManager;
+	}
+
+	/**
+	 * Returns the internal event manager
+	 */
+	public function getEventsManager() -> <ManagerInterface>
+	{
+		return this->_eventsManager;
+	}
+
+	public function getDispatcher() -> <Dispatcher>
+	{
+		return this->_dispatcher;
+	}
+
+	/**
+	 * Sets role callback to fetch role name
+	 */
+	public function setRoleCallback(var callback)
+	{
+		if !is_callable(callback){
+			throw new Exception("Role callback must be function.");
+		}
+		let this->_roleCallback = callback;
+	}
+
+	/**
+	 * Gets role callback to fetch role name
+	 */
+	public function getRoleCallback()
+	{
+		return this->_roleCallback;
+	}
+
+	/**
+	 * Throws an internal exception
+	 */
+	protected function _throwFirewallException(string message, int exceptionCode = 0)
+	{
+		var exception;
+
+		let exception = new Exception(message, exceptionCode);
+
+		if this->_handleException(exception) === false {
+			return false;
+		}
+
+		throw exception;
+	}
+
+	/**
+	 * Handles a user exception
+	 */
+	protected function _handleException(<\Exception> exception)
+	{
+		var eventsManager;
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		if typeof eventsManager == "object" {
+			if eventsManager->fire("firewall:beforeException", this, exception) === false {
+				return false;
+			}
+		}
+	}
+
+	protected function fireEventOrThrowException(var role, string actionName, string controllerName, boolean access)
+	{
+		var eventsManager, roleName;
+		let eventsManager = this->_eventsManager;
+		if access {
+			if typeof eventsManager == "object" {
+				eventsManager->fire("firewall:afterCheck",this);
+			}
+		}
+		else {
+			if typeof role == "array" {
+				let roleName = implode(", ",role);
+			}
+			else {
+				let roleName = role;
+			}
+			return this->_throwFirewallException("Role name ".roleName." doesn't have access to action ".actionName." in controller ".controllerName,403);
+		}
+	}
+}

--- a/phalcon/mvc/dispatcher/firewall/adapter/acl.zep
+++ b/phalcon/mvc/dispatcher/firewall/adapter/acl.zep
@@ -1,0 +1,202 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+
+namespace Phalcon\Mvc\Dispatcher\Firewall\Adapter;
+
+use Phalcon\Mvc\Dispatcher\Firewall\Adapter;
+use Phalcon\Mvc\Dispatcher\Firewall\Exception;
+use Phalcon\Events\Event;
+use Phalcon\Acl\RoleAware;
+use Phalcon\Mvc\DispatcherInterface;
+use Phalcon\Di;
+use Phalcon\Events\ManagerInterface;
+
+/**
+ * Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl
+ *
+ * Firewall which depends on acl an dispatcher
+ */
+class Acl extends Adapter
+{
+	/**
+	 * Acl service name
+	 * @var string
+	 */
+	protected _aclServiceName { get, set };
+
+	/**
+	 * Name of parameter in function defined in isAllowed method - must be same for every function currently
+	 * @var string
+	 */
+	protected _boundModelParameterName { get, set};
+
+	/**
+	 * Bound model
+	 * @var object
+	 */
+	protected _boundModel = null;
+
+	/**
+	 * Parameter for using with multi module application
+	 * @var boolean
+	 */
+	protected _multiModuleConfiguration = false;
+
+	/**
+	 * Separator between module name and controller prefix
+	 * @var string
+	 */
+	protected _moduleSeparator = ":" {get, set};
+
+	/**
+	 * Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl constructor
+	 *
+	 * @param string aclServiceName
+	 * @param string boundModelParameterName
+	 */
+	public function __construct(string aclServiceName, string boundModelParameterName = null)
+	{
+		let this->_aclServiceName = aclServiceName;
+		let this->_boundModelParameterName = boundModelParameterName;
+	}
+
+	/**
+	 * Returns multiModuleConfiguration
+	 * @return boolean
+	 */
+	public function isMultiModuleConfiguration() -> boolean
+	{
+		return this->_multiModuleConfiguration;
+	}
+
+	/**
+	 * Sets multiModuleConfiguration
+	 */
+	public function useMultiModuleConfiguration(boolean multiModuleConfiguration)
+	{
+		let this->_multiModuleConfiguration = multiModuleConfiguration;
+		return this;
+	}
+
+	protected function afterBinding(<Event> event, <DispatcherInterface> dispatcher, var data)
+	{
+		if empty this->_boundModelParameterName {
+			throw new Exception("You need to set 'boundModelParameterName' to use ACL Firewall on dispatch:afterBinding event");
+		}
+		var boundModel;
+		let boundModel = dispatcher->getBoundModel();
+		if boundModel != null {
+			let this->_boundModel = boundModel;
+		}
+		let this->_dispatcher = dispatcher;
+		return this->handleDispatcher(dispatcher);
+	}
+
+	protected function beforeExecuteRoute(<Event> event, <DispatcherInterface> dispatcher, var data)
+	{
+		let this->_dispatcher = dispatcher;
+		return this->handleDispatcher(dispatcher);
+	}
+
+	protected function handleDispatcher(<DispatcherInterface> dispatcher)
+	{
+		var role, identity, actionName, eventsManager, acl, aclServiceName, aclRole, aclAccess, defaultAccess, parameters, boundModelParameterName, value, dependencyInjector, controllerName, moduleName, moduleSeparator;
+		string resourceName; // there were some seg fault when result from ucfirst was assigned to var
+		let dependencyInjector = dispatcher->getDI();
+		if typeof dependencyInjector != "object" {
+			throw new Exception("A dependency injector container is required to obtain ACL service");
+		}
+		let defaultAccess = (bool)this->_defaultAccess;
+		let parameters = [];
+		let identity = call_user_func(this->_roleCallback);
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		let controllerName = get_class(dispatcher->getActiveController());
+		if !this->_multiModuleConfiguration {
+			let resourceName = ucfirst(dispatcher->getControllerName());
+		}
+		else {
+			let moduleSeparator = this->_moduleSeparator;
+			let moduleName = dispatcher->getModuleName();
+			let resourceName = moduleName.moduleSeparator.ucfirst(dispatcher->getControllerName());
+		}
+		let actionName = dispatcher->getActionName();
+		if empty identity {
+			throw new Exception("Function defined as roleCallback must return something.");
+		}
+		if typeof identity == "string" {
+			let role = identity;
+		}
+		elseif typeof identity == "object" {
+			if !(identity instanceof RoleAware) {
+				throw new Exception("Role passed as object must implement 'Phalcon\\Acl\\RoleAware'");
+			}
+			let role = identity;
+		}
+		else {
+			throw new Exception("When using ACL service as firewall configuration you can only pass role as string or object implementing 'Phalcon\\Acl\\RoleAware'.");
+		}
+		let aclServiceName = this->_aclServiceName;
+		let acl = dependencyInjector->get(aclServiceName);
+		if typeof acl != "object" || !(acl instanceof \Phalcon\Acl\AdapterInterface) {
+			throw new Exception("You need to add acl service to dependency injector container which is implementing 'Phalcon\\Acl\\AdapterInterface'");
+		}
+		// handle role as object
+		if typeof identity == "object" {
+			let aclRole = role->getRoleName();
+		}
+		else {
+			let aclRole = role;
+		}
+		// check if role exist
+		if !acl->isRole(aclRole) {
+			throw new Exception("Role ".aclRole." doesn't exist in ACL");
+		}
+		// if resource doesn't exist check defaultAccess
+		if !acl->isResource(resourceName) {
+			let value = this->fireEventOrThrowException(aclRole, actionName, controllerName, defaultAccess);
+			if value === false {
+				return false;
+			}
+		}
+		if this->_boundModel != null {
+			let boundModelParameterName = this->_boundModelParameterName;
+			let parameters[boundModelParameterName] = this->_boundModel;
+		}
+		if empty parameters {
+			let aclAccess = acl->isAllowed(role, resourceName, actionName);
+		}
+		else {
+			let aclAccess = acl->isAllowed(role, resourceName, actionName, parameters);
+		}
+		if aclAccess {
+			if typeof eventsManager == "object" {
+				eventsManager->fire("firewall:afterCheck",this);
+			}
+		}
+		else {
+			// well, acl is returning false if actionName will not exist, so in this case we will check default access
+			let value = this->fireEventOrThrowException(aclRole, actionName, controllerName, defaultAccess);
+			if value === false {
+				return false;
+			}
+		}
+	}
+}

--- a/phalcon/mvc/dispatcher/firewall/adapter/annotations.zep
+++ b/phalcon/mvc/dispatcher/firewall/adapter/annotations.zep
@@ -1,0 +1,182 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+
+namespace Phalcon\Mvc\Dispatcher\Firewall\Adapter;
+
+use Phalcon\Mvc\Dispatcher\Firewall\Adapter;
+use Phalcon\Mvc\Dispatcher\Firewall\Exception;
+use Phalcon\Events\Event;
+use Phalcon\Acl\RoleAware;
+use Phalcon\Mvc\DispatcherInterface;
+use ReflectionClass;
+use Phalcon\Annotations\AdapterInterface;
+use Phalcon\Events\ManagerInterface;
+
+/**
+ * Phalcon\Mvc\Dispatcher\Firewall\Adapter\Annotations
+ *
+ * Firewall which depends on annotations and dispatcher
+ */
+class Annotations extends Adapter
+{
+	/**
+	 * Adapter for annotations
+	 * @var mixed
+	 */
+	protected _annotationsAdapter {get, set};
+
+	/**
+	 * Phalcon\Mvc\Dispatcher\Firewall\Adapter\Annotations constructor
+	 *
+	 * @param mixed annotationsAdapter
+	 */
+	public function __construct(<AdapterInterface> annotationsAdapter)
+	{
+		let this->_annotationsAdapter = annotationsAdapter;
+	}
+
+	protected function beforeExecuteRoute(<Event> event, <DispatcherInterface> dispatcher, var data)
+	{
+		var identity, role, controllerName, actionName, controllerAccess, actionAccess, defaultAccess, eventsManager, value;
+		let this->_dispatcher = dispatcher;
+		let defaultAccess = (bool)this->_defaultAccess;
+		let identity = call_user_func(this->_roleCallback);
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		let controllerName = get_class(dispatcher->getActiveController());
+		let actionName = dispatcher->getActionName();
+		if typeof identity == "string" || typeof identity == "array" {
+			let role = identity;
+		}
+		elseif typeof identity == "object" && identity instanceof RoleAware {
+			let role = identity->getRoleName();
+		}
+		else {
+			throw new Exception("When using firewall based on annotations you must pass role as string, array or object implementing 'RoleAware'.");
+		}
+		if this->_annotationsAdapter == null {
+			throw new Exception("You need to set annotations adapter for firewall based on annotations configurator to work");
+		}
+		if typeof eventsManager == "object" {
+			eventsManager->fire("firewall:beforeCheck",this);
+		}
+		let controllerAccess = this->checkControllerAnnotationAccess(controllerName, role);
+		if typeof controllerAccess == "boolean" {
+			let value = this->fireEventOrThrowException(role, actionName, controllerName, controllerAccess);
+			if value === false {
+				return false;
+			}
+		}
+		else {
+			let actionAccess = this->checkActionAnnotationAccess(controllerName, actionName, role);
+			if typeof actionAccess == "boolean" {
+				let value = this->fireEventOrThrowException(role, actionName, controllerName, actionAccess);
+				if value === false {
+					return false;
+				}
+			}
+			else {
+				let value = this->fireEventOrThrowException(role, actionName, controllerName, defaultAccess);
+				if value === false {
+					return false;
+				}
+			}
+		}
+	}
+
+	protected function checkControllerAnnotationAccess(string controllerName, var role)
+	{
+		var annotationsAdapter, reflector, annotations;
+		let annotationsAdapter = this->_annotationsAdapter;
+		let reflector = annotationsAdapter->get(controllerName);
+		let annotations = reflector->getClassAnnotations();
+		return this->_checkAnnotations(annotations, role);
+	}
+
+	protected function checkActionAnnotationAccess(string controllerName, string actionName, var role)
+	{
+		var annotationsAdapter, annotations;
+		let annotationsAdapter = this->_annotationsAdapter;
+		let annotations = annotationsAdapter->getMethod(controllerName, actionName."Action");
+		return this->_checkAnnotations(annotations, role);
+	}
+
+	protected function _checkAnnotations(var annotations, var role)
+	{
+		var returnAllow;
+		if !empty annotations {
+			if annotations->has("Allow") {
+				let returnAllow = this->_handleAnnotation(annotations->get("Allow"), true, role);
+				if typeof returnAllow == "boolean" {
+					return returnAllow;
+				}
+			}
+			if annotations->has("Deny") {
+				let returnAllow = this->_handleAnnotation(annotations->get("Deny"), false, role);
+				if typeof returnAllow == "boolean" {
+					return returnAllow;
+				}
+			}
+		}
+		return null;
+	}
+
+	protected function _handleAnnotation(var annotation, boolean access, var role)
+	{
+		var numberArguments, annotationRoles;
+		let numberArguments = annotation->numberArguments();
+		if numberArguments === 1 {
+			let annotationRoles = annotation->getArguments()[0];
+			if typeof annotationRoles == "array" {
+				if typeof role == "string" && in_array(role,annotationRoles) {
+					return access;
+				}
+				elseif typeof role == "array" && (boolean)array_intersect(role,annotationRoles) {
+					return access;
+				}
+				elseif access == false {
+					return true;
+				}
+				return null;
+			}
+			elseif typeof annotationRoles == "string" {
+				if typeof role == "string" && annotationRoles == role {
+					return access;
+				}
+				elseif typeof role == "array" && in_array(annotationRoles,role) {
+					return access;
+				}
+				elseif access == false {
+					return true;
+				}
+				return null;
+			}
+			else {
+				throw new Exception("Allowed or denied role must be provided as string or array of roles.");
+			}
+		}
+		elseif numberArguments === 0 {
+			return access;
+		}
+		else {
+			throw new Exception("Allow or deny annotation expect one or none arguments");
+		}
+	}
+}

--- a/phalcon/mvc/dispatcher/firewall/adapterinterface.zep
+++ b/phalcon/mvc/dispatcher/firewall/adapterinterface.zep
@@ -1,0 +1,56 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+
+namespace Phalcon\Mvc\Dispatcher\Firewall;
+
+use Phalcon\Mvc\DispatcherInterface;
+
+/**
+ * Phalcon\Mvc\Dispatcher\Firewall\AdapterInterface
+ *
+ * Interface for Phalcon\Mvc\Dispatcher\Firewall adapters
+ */
+interface AdapterInterface {
+	/**
+	 * Sets the default access level (Phalcon\Acl::ALLOW or Phalcon\Acl::DENY)
+	 */
+	public function setDefaultAccess(int defaultAccess);
+
+	/**
+	 * Returns the default ACL access level
+	 */
+	public function getDefaultAccess() -> int;
+
+	/**
+	 * Sets role callback to fetch role name
+	 */
+	public function setRoleCallback(var callback);
+
+	/**
+	 * Gets role callback to fetch role name
+	 */
+	public function getRoleCallback();
+
+	/**
+	 * Gets dispatcher
+	 */
+	public function getDispatcher() -> <DispatcherInterface>;
+}

--- a/phalcon/mvc/dispatcher/firewall/exception.zep
+++ b/phalcon/mvc/dispatcher/firewall/exception.zep
@@ -1,0 +1,31 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Mvc\Dispatcher\Firewall;
+
+/**
+ * Phalcon\Events\Exception
+ *
+ * Exceptions thrown in Phalcon\Mvc\Dispatcher\Firewall will use this class
+ */
+class Exception extends \Phalcon\Exception
+{
+
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/FirewallTest.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/FirewallTest.php
@@ -1,0 +1,463 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall;
+
+use Phalcon\Acl\Adapter\Memory;
+use Phalcon\Di;
+use Phalcon\Di\FactoryDefault;
+use Phalcon\Events\Manager;
+use Phalcon\Http\Response;
+use Phalcon\Mvc\Dispatcher;
+use Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl;
+use Phalcon\Mvc\Dispatcher\Firewall\Adapter\Annotations;
+use Phalcon\Test\Models\AlbumORama\Albums;
+use Phalcon\Test\Module\UnitTest;
+use Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\BindingRole;
+use Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\RoleObject;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\FirewallTest
+ * Tests the \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Mvc\Dispatcher\Firewall
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FirewallTest extends UnitTest
+{
+    /**
+     * Tests Phalcon\Mvc\Dispatcher\Firewall\Adapter\Annotations
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2016-03-24
+     */
+    public function testAnnotations()
+    {
+        $this->specify("Testing firewall with annotations configuration.", function () {
+            $di = new Di();
+            $response = new Response();
+            $di->set('response', $response);
+            $dispatcher = new Dispatcher;
+            $dispatcher->setDefaultNamespace('Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers');
+            $dispatcher->setDI($di);
+            $eventsManager = new Manager();
+            $eventsManager->attach('firewall:beforeException', function () {
+                return false;
+            });
+            $firewall = new Annotations(new \Phalcon\Annotations\Adapter\Memory());
+            $firewall->setEventsManager($eventsManager);
+            $firewall->setRoleCallback(function () use ($di) {
+                return $di->get('myrole');
+            });
+            $eventsManager = new Manager();
+            $eventsManager->attach('dispatch:beforeExecuteRoute', $firewall);
+            $dispatcher->setEventsManager($eventsManager);
+            expect($dispatcher->getDI())->isInstanceOf('Phalcon\Di');
+            $di->set('dispatcher', $dispatcher);
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE3");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE1"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE2"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE3"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE1"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE2"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE3"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", "ROLE1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", "ROLE2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", "ROLE3");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", new RoleObject("ROLE1"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", new RoleObjecT("ROLE2"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", new RoleObject("ROLE3"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstArray", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", "ROLE1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", "ROLE2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", new RoleObject("ROLE1"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", new RoleObject("ROLE2"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", new RoleObject("ROLE3"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondArray", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", "ROLE1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", "ROLE2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", new RoleObject("ROLE1"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", new RoleObject("ROLE2"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", new RoleObject("ROLE3"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "allowEveryone", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", "ROLE1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", "ROLE2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", "ROLE3");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", new RoleObject("ROLE1"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", new RoleObject("ROLE2"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", new RoleObject("ROLE3"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "denyEveryone", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", "ROLE1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", "ROLE2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", new RoleObject("ROLE1"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", new RoleObject("ROLE2"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", new RoleObject("ROLE3"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", "ROLE1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", "ROLE2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test12", "allow", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", "ROLE1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", "ROLE2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", "ROLE3");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", new RoleObject("ROLE1"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", new RoleObject("ROLE2"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", new RoleObject("ROLE3"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", ["ROLE1", "ROLE2"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", ["ROLE2", "ROLE3"]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test13", "deny", ["ROLE3", "ROLE4"]);
+            expect($returnedValue)->null();
+        });
+    }
+
+    /**
+     * @param $di
+     * @param Dispatcher $dispatcher
+     * @param $controllerName
+     * @param $actionName
+     * @param $roleName
+     * @param array $params
+     * @param string $moduleName
+     *
+     * @return mixed
+     */
+    private function getReturnedValueFor($di, $dispatcher, $controllerName, $actionName, $roleName, $params = null, $moduleName = null)
+    {
+        $dispatcher->setReturnedValue(null);
+        $this->changeRole($di, $roleName);
+        $dispatcher->setControllerName($controllerName);
+        $dispatcher->setActionName($actionName);
+        if (!empty($moduleName)) {
+            $dispatcher->setModuleName($moduleName);
+        }
+        if (!empty($params)) {
+            $dispatcher->setParams($params);
+        }
+        $dispatcher->dispatch();
+        return $dispatcher->getReturnedValue();
+    }
+
+    /**
+     * @param Di $di
+     * @param $role
+     */
+    private function changeRole($di, $role)
+    {
+        $di->set('myrole', function () use ($role) {
+            return $role;
+        });
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl when using it as beforeExecute in Dispatcher
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2016-03-24
+     */
+    public function testAclBeforeExecute()
+    {
+        $this->specify("Testing firewall with acl configuration and beforeExecute.", function () {
+            $di = new Di();
+            $response = new Response();
+            $di->set('response', $response);
+            $acl = new Memory();
+            $acl->addResource("Test11", ['firstRole', 'secondRole']);
+            $acl->addRole('ROLE1');
+            $acl->addRole('ROLE2');
+            $acl->addRole('ROLE3');
+            $acl->addRole('ROLE4');
+            $acl->allow('ROLE1', 'Test11', 'firstRole');
+            $acl->deny('ROLE1', 'Test11', 'secondRole');
+            $acl->deny('ROLE2', 'Test11', ['firstRole', 'secondRole']);
+            $acl->allow('ROLE3', 'Test11', ['firstRole', 'secondRole']);
+            $acl->deny('ROLE4', 'Test11', 'firstRole');
+            $acl->allow('ROLE4', 'Test11', 'secondRole');
+            $di->set('acl', $acl);
+            $dispatcher = new Dispatcher();
+            $dispatcher->setDefaultNamespace('Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers');
+            $dispatcher->setDI($di);
+            $eventsManager = new Manager();
+            $eventsManager->attach('firewall:beforeException', function () {
+                return false;
+            });
+            $firewall = new Acl("acl");
+            $firewall->setEventsManager($eventsManager);
+            $firewall->setRoleCallback(function () use ($di) {
+                return $di->get('myrole');
+            });
+            $eventsManager = new Manager();
+            $eventsManager->attach('dispatch:beforeExecuteRoute', $firewall);
+            $dispatcher->setEventsManager($eventsManager);
+            expect($dispatcher->getDI())->isInstanceOf('Phalcon\Di');
+            $di->set('dispatcher', $dispatcher);
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE4");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE1"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE2"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE3"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", new RoleObject("ROLE4"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE3");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE4");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE1"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE2"));
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE3"));
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", new RoleObject("ROLE4"));
+            expect($returnedValue)->equals("allowed");
+        });
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl when using it as afterBinding in Dispatcher
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2016-03-24
+     */
+    public function testAclAfterBinding()
+    {
+        $this->specify("Testing firewall with acl configuration and afterBinding.", function () {
+            $di = new FactoryDefault();
+            $response = new Response();
+            $di->set('response', $response);
+            $acl = new Memory();
+            $acl->addResource("Test14", ['first', 'second']);
+            $acl->addRole('ROLE1');
+            $acl->addRole('ROLE2');
+            $acl->allow('ROLE1', 'Test14', 'first');
+            $acl->allow('ROLE1', 'Test14', 'second');
+            $acl->allow('ROLE2', 'Test14', 'first', function (BindingRole $user, Albums $model) {
+                return $user->getId() == $model->artists_id;
+            });
+            $acl->allow('ROLE2', 'Test14', 'second');
+            $di->set('acl', $acl);
+            $dispatcher = new Dispatcher();
+            $dispatcher->setModelBinding(true);
+            $dispatcher->setDefaultNamespace('Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers');
+            $dispatcher->setDI($di);
+            $eventsManager = new Manager();
+            $eventsManager->attach('firewall:beforeException', function () {
+                return false;
+            });
+            $firewall = new Acl("acl", "model");
+            $firewall->setEventsManager($eventsManager);
+            $firewall->setRoleCallback(function () use ($di) {
+                return $di->get('myrole');
+            });
+            $eventsManager = new Manager();
+            $eventsManager->attach('dispatch:afterBinding', $firewall);
+            $dispatcher->setEventsManager($eventsManager);
+            expect($dispatcher->getDI())->isInstanceOf('Phalcon\Di');
+            $di->set('dispatcher', $dispatcher);
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "first", new BindingRole("ROLE1",1), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "first", new BindingRole("ROLE1",2), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "first", new BindingRole("ROLE2",1), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "first", new BindingRole("ROLE2",2), [0=>1]);
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "second", new BindingRole("ROLE1",1), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "second", new BindingRole("ROLE1",2), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "second", new BindingRole("ROLE2",1), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test14", "second", new BindingRole("ROLE2",2), [0=>1]);
+            expect($returnedValue)->equals("allowed");
+        });
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Dispatcher\Firewall\Adapter\Acl when using it as beforeExecute and multi-module application
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2016-03-24
+     */
+    public function testMultiModule()
+    {
+        $this->specify("Testing firewall with acl configuration and beforeExecute with multi-module application.", function () {
+            $di = new Di();
+            $response = new Response();
+            $di->set('response', $response);
+            $acl = new Memory();
+            $acl->addResource("Module1:Test11", ['firstRole', 'secondRole']);
+            $acl->addResource("Module2:Test11", ['firstRole', 'secondRole']);
+            $acl->addRole('ROLE1');
+            $acl->addRole('ROLE2');
+            $acl->allow('ROLE1', 'Module1:Test11', 'firstRole');
+            $acl->deny('ROLE1', 'Module1:Test11', 'secondRole');
+            $acl->deny('ROLE1', 'Module2:Test11', 'firstRole');
+            $acl->allow('ROLE1', 'Module2:Test11', 'secondRole');
+            $acl->deny('ROLE2', 'Module1:Test11', 'firstRole');
+            $acl->allow('ROLE2', 'Module1:Test11', 'secondRole');
+            $acl->allow('ROLE2', 'Module2:Test11', 'firstRole');
+            $acl->deny('ROLE2', 'Module2:Test11', 'secondRole');
+            $di->set('acl', $acl);
+            $dispatcher = new Dispatcher();
+            $dispatcher->setDefaultNamespace('Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers');
+            $dispatcher->setDI($di);
+            $eventsManager = new Manager();
+            $eventsManager->attach('firewall:beforeException', function () {
+                return false;
+            });
+            $firewall = new Acl("acl");
+            $firewall->setEventsManager($eventsManager);
+            $firewall->setRoleCallback(function () use ($di) {
+                return $di->get('myrole');
+            });
+            $firewall->useMultiModuleConfiguration(true);
+            $eventsManager = new Manager();
+            $eventsManager->attach('dispatch:beforeExecuteRoute', $firewall);
+            $dispatcher->setEventsManager($eventsManager);
+            expect($dispatcher->getDI())->isInstanceOf('Phalcon\Di');
+            $di->set('dispatcher', $dispatcher);
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE1", null, "Module1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE2", null, "Module1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE1", null, "Module1");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE2", null, "Module1");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE1", null, "Module2");
+            expect($returnedValue)->null();
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "firstRole", "ROLE2", null, "Module2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE1", null, "Module2");
+            expect($returnedValue)->equals("allowed");
+            $returnedValue = $this->getReturnedValueFor($di, $dispatcher, "test11", "secondRole", "ROLE2", null, "Module2");
+            expect($returnedValue)->null();
+        });
+    }
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/Helper/BindingRole.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/Helper/BindingRole.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Wojtek
+ * Date: 2016-04-29
+ * Time: 18:36
+ */
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper;
+
+use Phalcon\Acl\RoleAware;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\BindingRole
+ * Helper class extending Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\RoleObject for firewall tests
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class BindingRole extends RoleObject
+{
+    protected $id;
+
+    public function __construct($roleName, $id)
+    {
+        parent::__construct($roleName);
+        $this->id=$id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $id
+     *
+     * @return BindingRole
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+        return $this;
+    }
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test11Controller.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test11Controller.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers;
+
+use Phalcon\Mvc\Controller;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Test11Controller
+ * Helper controller for firewall tests
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Test11Controller extends Controller
+{
+	/**
+	 * @Allow("ROLE1")
+	 */
+	public function firstRoleAction()
+	{
+		return "allowed";
+	}
+
+	/**
+	 * @Deny("ROLE1")
+	 */
+	public function secondRoleAction()
+	{
+		return "allowed";
+	}
+	
+	/**
+	 * @Allow({"ROLE1","ROLE2"})
+	 */
+	public function firstArrayAction()
+	{
+		return "allowed";
+	}
+
+	/**
+	 * @Deny({"ROLE1","ROLE2"})
+	 */
+	public function secondArrayAction()
+	{
+		return "allowed";
+	}
+
+	/**
+	 * @Allow()
+	 */
+	public function allowEveryoneAction()
+	{
+		return "allowed";
+	}
+
+	/**
+	 * @Deny()
+	 */
+	public function denyEveryoneAction()
+	{
+		return "allowed";
+	}
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test12Controller.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test12Controller.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers;
+use Phalcon\Mvc\Controller;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Test12Controller
+ * Helper controller for firewall tests
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ * 
+ * @Allow()
+ */
+class Test12Controller extends Controller
+{
+	public function allowAction()
+	{
+		return "allowed";
+	}
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test13Controller.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test13Controller.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers;
+use Phalcon\Mvc\Controller;
+
+/**
+ * 
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Test13Controller
+ * Helper controller for firewall tests
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ * 
+ * @Deny()
+ */
+class Test13Controller extends Controller
+{
+	public function denyAction()
+	{
+		return "allowed";
+	}
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test14Controller.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/Helper/Controllers/Test14Controller.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Wojtek
+ * Date: 2016-04-29
+ * Time: 18:28
+ */
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Controllers;
+
+use Phalcon\Test\Models\AlbumORama\Albums;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\Test14Controller
+ * Helper controller for firewall tests
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Test14Controller
+{
+    public function firstAction(Albums $album)
+    {
+        return "allowed";
+    }
+
+    public function secondAction(Albums $album)
+    {
+        return "allowed";
+    }
+}

--- a/tests/unit/Mvc/Dispatcher/Firewall/Helper/RoleObject.php
+++ b/tests/unit/Mvc/Dispatcher/Firewall/Helper/RoleObject.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper;
+
+
+use Phalcon\Acl\RoleAware;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Dispatcher\Firewall\Helper\RoleObject
+ * Helper class implementing Phalcon\Acl\RoleAware for firewall tests
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class RoleObject implements RoleAware
+{
+	protected $roleName;
+	
+	public function __construct($roleName)
+	{
+		$this->roleName = $roleName;
+	}
+
+	public function getRoleName()
+	{
+		return $this->roleName;
+	}
+}


### PR DESCRIPTION
@sergeyklay @daison12006013 @valVk @SidRoberts

TODO, Requires discussion:
- [x] - After binding tests
- [x] - Discussion about `Phalcon\Firewall\Adapter::setRoleCallback()` - maybe diffrent name, maybe we could pass $di as parameter which will be get from dispatcher instead of writing use ($di), don't know if there is any performance difference ?
- [x] - `Phalcon\Firewall\Adapter\Acl` - what if we have controllers with same names(multi-module application i guess), maybe some convenient, standardized way of naming in acl service when we have multi-module application ? Like Module:Controller as resource name perhaps ?
- [x] - Check tests and classes, especially tests of `Phalcon\Firewall\Adapter\Annotations` - not sure if the current logic is fine(especially when we provide user roles as array and we have multiple roles in `@Deny` or `@Allow` and also if logic with controller/method checking is fine, for me it's obvious when i put `@Allow` before controller it means for me that i have access to whole controller
- [x] - Maybe whole Firewall namespace should be put into Phalcon\Mvc\Dispatcher, beacause it depends from this dispatcher ?
- ~~Methods in firewall to access current controller/action/user/role - for handling exception.~~

In future(or now) - implement firewall adapter on adding routes - not sure if we should add event manager to router, or just internally in router there should be calls into our firewall.
