### PR TITLE
Proxies fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require-dev": {
         "mustache/mustache": "~2.10",
         "twig/twig": "~1.24",
-        "codeception/codeception": "~2.1",
+        "codeception/codeception": "~2.2",
         "codeception/verify": "~0.3",
         "codeception/specify": "~0.4"
     },

--- a/tests/_proxies/Assets/Collection.php
+++ b/tests/_proxies/Assets/Collection.php
@@ -3,6 +3,7 @@
 namespace Phalcon\Test\Proxy\Assets;
 
 use Phalcon\Assets\Collection as PhCollection;
+use Phalcon\Assets\FilterInterface;
 
 /**
  * \Phalcon\Test\Proxy\Assets\Collection
@@ -23,12 +24,12 @@ use Phalcon\Assets\Collection as PhCollection;
  */
 class Collection extends PhCollection
 {
-    public function add($resource)
+    public function add(\Phalcon\Assets\Resource $resource)
     {
         return parent::add($resource);
     }
 
-    public function addInline($code)
+    public function addInline(\Phalcon\Assets\Inline $code)
     {
         return parent::addInline($code);
     }
@@ -108,12 +109,12 @@ class Collection extends PhCollection
         return parent::setLocal($local);
     }
 
-    public function setAttributes($attributes)
+    public function setAttributes(array $attributes)
     {
         return parent::setAttributes($attributes);
     }
 
-    public function setFilters($filters)
+    public function setFilters(array $filters)
     {
         return parent::setFilter($filters);
     }
@@ -133,7 +134,7 @@ class Collection extends PhCollection
         return parent::getRealTargetPath($basePath);
     }
 
-    public function addFilter($filter)
+    public function addFilter(FilterInterface $filter)
     {
         return parent::addFilter($filter);
     }

--- a/tests/_proxies/Assets/Inline.php
+++ b/tests/_proxies/Assets/Inline.php
@@ -33,7 +33,7 @@ class Inline extends PhInline
         return parent::setFilter($filter);
     }
 
-    public function setAttributes($attributes)
+    public function setAttributes(array $attributes)
     {
         return parent::setAttributes($attributes);
     }

--- a/tests/_proxies/Assets/Manager.php
+++ b/tests/_proxies/Assets/Manager.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Proxy\Assets;
 
+use Phalcon\Assets\Inline;
 use Phalcon\Assets\Manager as PhManager;
 
 /**
@@ -23,7 +24,7 @@ use Phalcon\Assets\Manager as PhManager;
  */
 class Manager extends PhManager
 {
-    public function setOptions($options)
+    public function setOptions(array $options)
     {
         return parent::setOptions($options);
     }
@@ -58,27 +59,27 @@ class Manager extends PhManager
         parent::addInlineJs($content, $filter, $attributes);
     }
 
-    public function addResourceByType($type, $resource)
+    public function addResourceByType($type, \Phalcon\Assets\Resource $resource)
     {
         parent::addResourceByType($type, $resource);
     }
 
-    public function addInlineCodeByType($type, $code)
+    public function addInlineCodeByType($type, \Phalcon\Assets\Inline $code)
     {
         parent::addInlineCodeByType($type, $code);
     }
 
-    public function addResource($resource)
+    public function addResource(\Phalcon\Assets\Resource $resource)
     {
         parent::addResource($resource);
     }
 
-    public function addInlineCode($code)
+    public function addInlineCode(Inline $code)
     {
         parent::addInlineCode($code);
     }
 
-    public function set($id, $collection)
+    public function set($id, \Phalcon\Assets\Collection $collection)
     {
         return parent::set($id, $collection);
     }
@@ -103,12 +104,12 @@ class Manager extends PhManager
         return parent::collection($name);
     }
 
-    public function output($collection, $callback, $type)
+    public function output(\Phalcon\Assets\Collection $collection, $callback, $type)
     {
         return parent::output($collection, $callback, $type);
     }
 
-    public function outputInline($collection, $type)
+    public function outputInline(\Phalcon\Assets\Collection $collection, $type)
     {
         return parent::outputInline($collection, $type);
     }

--- a/tests/_proxies/Assets/Resource.php
+++ b/tests/_proxies/Assets/Resource.php
@@ -83,7 +83,7 @@ class Resource extends PhResource
         return parent::setFilter($filter);
     }
 
-    public function setAttributes($attributes)
+    public function setAttributes(array $attributes)
     {
         return parent::setAttributes($attributes);
     }

--- a/tests/_proxies/Config.php
+++ b/tests/_proxies/Config.php
@@ -53,7 +53,7 @@ class Config extends PhConfig
         parent::offsetUnset($index);
     }
 
-    public function merge(Config $config)
+    public function merge(PhConfig $config)
     {
         return parent::merge($config);
     }
@@ -68,7 +68,7 @@ class Config extends PhConfig
         return parent::count();
     }
 
-    public static function __set_state($data)
+    public static function __set_state(array $data)
     {
         return parent::__set_state($data);
     }

--- a/tests/_proxies/Di/Service.php
+++ b/tests/_proxies/Di/Service.php
@@ -59,7 +59,7 @@ class Service extends PhService
         return parent::resolve($parameters, $dependencyInjector);
     }
 
-    public function setParameter($position, $parameter)
+    public function setParameter($position, array $parameter)
     {
         return parent::setParameter($position, $parameter);
     }
@@ -74,7 +74,7 @@ class Service extends PhService
         return parent::isResolved();
     }
 
-    public static function __set_state($attributes)
+    public static function __set_state(array $attributes)
     {
         return parent::__set_state($attributes);
     }

--- a/tests/_proxies/Flash/Direct.php
+++ b/tests/_proxies/Flash/Direct.php
@@ -33,7 +33,7 @@ class Direct extends PhDirect
         parent::setAutomaticHtml($automaticHtml);
     }
 
-    public function setCssClasses($cssClasses)
+    public function setCssClasses(array $cssClasses)
     {
         return parent::setCssClasses($cssClasses);
     }

--- a/tests/_proxies/Flash/Session.php
+++ b/tests/_proxies/Flash/Session.php
@@ -54,7 +54,7 @@ class Session extends PhSession
         return parent::setAutomaticHtml($automaticHtml);
     }
 
-    public function setCssClasses($cssClasses)
+    public function setCssClasses(array $cssClasses)
     {
         return parent::setCssClasses($cssClasses);
     }

--- a/tests/_proxies/Http/Request.php
+++ b/tests/_proxies/Http/Request.php
@@ -94,7 +94,7 @@ class Request extends PhRequest
         return parent::getRawBody();
     }
 
-    public function getJsonRawBody()
+    public function getJsonRawBody($associative = false)
     {
         return parent::getJsonRawBody();
     }

--- a/tests/_proxies/Http/Response.php
+++ b/tests/_proxies/Http/Response.php
@@ -39,7 +39,7 @@ class Response extends PhResponse
         return parent::setStatusCode($code, $message);
     }
 
-    public function setHeaders($headers)
+    public function setHeaders(PhResponse\HeadersInterface $headers)
     {
         return parent::setHeaders($headers);
     }
@@ -49,7 +49,7 @@ class Response extends PhResponse
         return parent::getHeaders();
     }
 
-    public function setCookies($cookies)
+    public function setCookies(PhResponse\CookiesInterface $cookies)
     {
         return parent::setCookies($cookies);
     }

--- a/tests/_proxies/Loader.php
+++ b/tests/_proxies/Loader.php
@@ -34,7 +34,7 @@ class Loader extends PhLoader
         return parent::getEventsManager();
     }
 
-    public function setExtensions($extensions)
+    public function setExtensions(array $extensions)
     {
         return parent::setExtensions($extensions);
     }
@@ -44,7 +44,7 @@ class Loader extends PhLoader
         return parent::getExtensions();
     }
 
-    public function registerNamespaces($namespaces, $merge = false)
+    public function registerNamespaces(array $namespaces, $merge = false)
     {
         return parent::registerNamespaces($namespaces, $merge);
     }
@@ -54,7 +54,7 @@ class Loader extends PhLoader
         return parent::getNamespaces();
     }
 
-    public function registerDirs($directories, $merge = false)
+    public function registerDirs(array $directories, $merge = false)
     {
         return parent::registerDirs($directories, $merge);
     }
@@ -64,7 +64,7 @@ class Loader extends PhLoader
         return parent::getDirs();
     }
 
-    public function registerClasses($classes, $merge = false)
+    public function registerClasses(array $classes, $merge = false)
     {
         return parent::registerClasses($classes, $merge);
     }

--- a/tests/_proxies/Logger/Adapter/File.php
+++ b/tests/_proxies/Logger/Adapter/File.php
@@ -38,7 +38,7 @@ class File extends PhFile
         return parent::getFormatter();
     }
 
-    public function logInternal($message, $type, $time, $context)
+    public function logInternal($message, $type, $time, array $context)
     {
         parent::logInternal($message, $type, $time, $context);
     }

--- a/tests/_proxies/Logger/Adapter/Firephp.php
+++ b/tests/_proxies/Logger/Adapter/Firephp.php
@@ -31,7 +31,7 @@ class Firephp extends PhFirephp
         return parent::getFormatter();
     }
 
-    public function logInternal($message, $type, $time, $context)
+    public function logInternal($message, $type, $time, array $context)
     {
         parent::logInternal($message, $type, $time, $context);
     }

--- a/tests/_proxies/Logger/Multiple.php
+++ b/tests/_proxies/Logger/Multiple.php
@@ -55,47 +55,47 @@ class Multiple extends PhMultiple
         parent::setLogLevel($level);
     }
 
-    public function log($type, $message = null, $context = null)
+    public function log($type, $message = null, array $context = null)
     {
         parent::log($type, $message, $context);
     }
 
-    public function critical($message, $context = null)
+    public function critical($message, array $context = null)
     {
         parent::critical($message, $context);
     }
 
-    public function emergency($message, $context = null)
+    public function emergency($message, array $context = null)
     {
         parent::emergency($message, $context);
     }
 
-    public function debug($message, $context = null)
+    public function debug($message, array $context = null)
     {
         parent::debug($message, $context);
     }
 
-    public function error($message, $context = null)
+    public function error($message, array $context = null)
     {
         parent::error($message, $context);
     }
 
-    public function info($message, $context = null)
+    public function info($message, array $context = null)
     {
         parent::info($message, $context);
     }
 
-    public function notice($message, $context = null)
+    public function notice($message, array $context = null)
     {
         parent::notice($message, $context);
     }
 
-    public function warning($message, $context = null)
+    public function warning($message, array $context = null)
     {
         parent::warning($message, $context);
     }
 
-    public function alert($message, $context = null)
+    public function alert($message, array $context = null)
     {
         parent::alert($message, $context);
     }

--- a/tests/_proxies/Mvc/Collection.php
+++ b/tests/_proxies/Mvc/Collection.php
@@ -137,7 +137,7 @@ class Collection extends PhCollection
         return parent::create();
     }
 
-    public function createIfNotExist($criteria)
+    public function createIfNotExist(array $criteria)
     {
         return parent::createIfNotExist($criteria);
     }
@@ -167,7 +167,7 @@ class Collection extends PhCollection
         return parent::count($parameters);
     }
 
-    public static function aggregate($parameters = null)
+    public static function aggregate(array $parameters = null)
     {
         return parent::aggregate($parameters);
     }

--- a/tests/_proxies/Queue/Beanstalk.php
+++ b/tests/_proxies/Queue/Beanstalk.php
@@ -33,7 +33,7 @@ class Beanstalk extends PhBeanstalk
         return parent::connect();
     }
 
-    public function put($data, $options = null)
+    public function put($data, array $options = null)
     {
         return parent::put($data, $options);
     }

--- a/tests/_proxies/Security.php
+++ b/tests/_proxies/Security.php
@@ -44,9 +44,9 @@ class Security extends PhSecurity
         return parent::getRandomBytes();
     }
 
-    public function getSaltBytes()
+    public function getSaltBytes($numberBytes = 0)
     {
-        return parent::getSaltBytes();
+        return parent::getSaltBytes($numberBytes);
     }
 
     public function hash($password, $workFactor = 0)
@@ -74,9 +74,9 @@ class Security extends PhSecurity
         return parent::getToken($numberBytes);
     }
 
-    public function checkToken($tokenKey = null, $tokenValue = null)
+    public function checkToken($tokenKey = null, $tokenValue = null, $destroyIfValid = true)
     {
-        return parent::checkToken($tokenKey, $tokenValue);
+        return parent::checkToken($tokenKey, $tokenValue, $destroyIfValid);
     }
 
     public function getSessionToken()

--- a/tests/_proxies/Tag.php
+++ b/tests/_proxies/Tag.php
@@ -24,12 +24,12 @@ use Phalcon\DiInterface;
  */
 class Tag extends PhTag
 {
-    public static function getEscaper($params)
+    public static function getEscaper(array $params)
     {
         return parent::getEscaper($params);
     }
 
-    public static function renderAttributes($code, $attributes)
+    public static function renderAttributes($code, array $attributes)
     {
         return parent::renderAttributes($code, $attributes);
     }
@@ -64,7 +64,7 @@ class Tag extends PhTag
         parent::setDefault($id, $value);
     }
 
-    public static function setDefaults($values, $merge = false)
+    public static function setDefaults(array $values, $merge = false)
     {
         parent::setDefaults($values, $merge);
     }

--- a/tests/_proxies/Text.php
+++ b/tests/_proxies/Text.php
@@ -53,14 +53,14 @@ class Text extends PhText
         return parent::endsWith($str, $end, $ignoreCase);
     }
 
-    public static function lower($str)
+    public static function lower($str, $encoding = "UTF-8")
     {
-        return parent::lower($str);
+        return parent::lower($str, $encoding);
     }
 
-    public static function upper($str)
+    public static function upper($str, $encoding = "UTF-8")
     {
-        return parent::upper($str);
+        return parent::upper($str, $encoding);
     }
 
     public static function reduceSlashes($str)

--- a/tests/_support/Helper/Unit.php
+++ b/tests/_support/Helper/Unit.php
@@ -3,8 +3,8 @@
 namespace Helper;
 
 use Codeception\Module;
-use Codeception\TestCase;
 use Codeception\Specify\Config as SpecifyConfig;
+use Codeception\TestInterface;
 use Phalcon\Tag;
 
 /**
@@ -18,16 +18,16 @@ use Phalcon\Tag;
 class Unit extends Module
 {
     /**
-     * @var \Codeception\TestCase
+     * @var \Codeception\TestInterface
      */
     protected $test;
 
     /**
      * Executed before each test.
      *
-     * @param \Codeception\TestCase $test
+     * @param \Codeception\TestInterface $test
      */
-    public function _before(TestCase $test)
+    public function _before(TestInterface $test)
     {
         $this->test = $test;
 
@@ -37,9 +37,9 @@ class Unit extends Module
     /**
      * Executed after each test.
      *
-     * @param \Codeception\TestCase $test
+     * @param \Codeception\TestInterface $test
      */
-    public function _after(TestCase $test)
+    public function _after(TestInterface $test)
     {
     }
 

--- a/tests/integration.suite.yml
+++ b/tests/integration.suite.yml
@@ -5,7 +5,7 @@ class_name: IntegrationTester
 modules:
     enabled:
         - Helper\Integration
-        - Phalcon2
+        - Phalcon
     config:
-        Phalcon2:
+        Phalcon:
             bootstrap: 'tests/_config/bootstrap.php'

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -9,7 +9,7 @@ modules:
         - Asserts
         - Db
         - Filesystem
-        - Phalcon2
+        - Phalcon
     config:
-        Phalcon2:
+        Phalcon:
             bootstrap: 'tests/_config/bootstrap.php'

--- a/tests/unit/Mvc/CollectionTest.php
+++ b/tests/unit/Mvc/CollectionTest.php
@@ -38,8 +38,8 @@ class CollectionTest extends UnitTest
             $this->markTestSkipped('Warning: mongo extension is not loaded');
         }
 
-        /** @var \Codeception\Module\Phalcon2 $module */
-        $module = $this->getModule('Phalcon2');
+        /** @var \Codeception\Module\Phalcon $module */
+        $module = $this->getModule('Phalcon');
 
         /** @var \Phalcon\Mvc\Application $app */
         $app = $module->getApplication();


### PR DESCRIPTION
If someone wonder how i found broken classes:

``` php
$path = "_proxies/";
$fqcns = array();

$allFiles = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path));
$phpFiles = new RegexIterator($allFiles, '/\.php$/');
foreach ($phpFiles as $phpFile) {
    $content = file_get_contents($phpFile->getRealPath());
    $tokens = token_get_all($content);
    $namespace = '';
    for ($index = 0; isset($tokens[$index]); $index++) {
        if (!isset($tokens[$index][0])) {
            continue;
        }
        if (T_NAMESPACE === $tokens[$index][0]) {
            $index += 2; // Skip namespace keyword and whitespace
            while (isset($tokens[$index]) && is_array($tokens[$index])) {
                $namespace .= $tokens[$index++][1];
            }
        }
        if (T_CLASS === $tokens[$index][0]) {
            $index += 2; // Skip class keyword and whitespace
            $fqcns[] = $namespace.'\\'.$tokens[$index][1];
        }
    }
}

foreach($fqcns as $class)
{
    $reflection = new ReflectionClass($class);
    if ($reflection->isInstantiable()){
        try {
            $reflection->newInstanceWithoutConstructor();
        }
        catch(Exception $e){
            var_dump($e->getMessage());
        }
    }
}
```
