### PR TITLE
Modify cache redis backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 - Default encrypt algorithm in `Phalcon\Crypt` is now changed to `AES-256-CFB`
 - Removed methods setMode(), getMode(), getAvailableModes() in `Phalcon\CryptInterface`
 - Added `Phalcon\Assets\Manager::exists()` to check if collection exists
+- Modify and refactor redis cache backend. Now redis cache backend supports `client` option which is a connected redis object; `_PHCR` prefix is deleted, and it is used as `statsKeys` by default
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)


### PR DESCRIPTION
# Changes
1. Modify cache redis backend, delete _PHCR
2. Cache redis backend supports "client" option, now you can pass a redis client
3. Redis's `set` method supports `ttl`,the call of `settimeout` is removed
4. Redis has `exists`method to check if a key exists, the previous implementation uses `get` which is wrong
# Why
1. The redis cache backend use a special key _PHCR to store all keys used by cache. There is a issue: #10905 .According to @Green-Cat ,it is disabled in 2.0.x branch which is not true. If use _PHCR, every time we set a cache, we have to run sAdd and set commands. Store all keys in `_PHCR` will cause it expands quickly and this will influence performance.
2. The previous implementation mixes `statsKey` and `prefix`, it uses `_PHCR` as super prefix which is not needed.
3. The cache backend doesn't support redis option which means that we can not pass a redis connection. So if we use modelsCache and modelsMetadata, there will be two redis connections. So I modify this part and let redis option be supported, and through the lifetime of a request we can use one redis connection.
