### PR TITLE
Fixed SQL error in Paginator when the query builder has set groupBy() specified by string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed `Phalcon\Http\Response::redirect` bug[#11324](https://github.com/phalcon/cphalcon/issues/11324). Incorrect initialization local array of status codes
 - Fixed cache backends bug[#11322](https://github.com/phalcon/cphalcon/issues/11322) related to saving number 0
 - Fixed `Phalcon\Db\Dialect::escape` bug[#11359](https://github.com/phalcon/cphalcon/issues/11359). Added ability to use the database name with dots.
+- Fixed SQL error in `Paginator` when the query builder has set `groupBy()` specified by string
 
 # [2.0.9](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.9) (2015-11-24)
 - Fixed bug that double serializes data using Redis adapter

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -167,7 +167,14 @@ class QueryBuilder extends Adapter implements AdapterInterface
 		 */
 		var groups = totalBuilder->getGroupBy();
 		if !empty groups {
-			var groupColumn = implode(", ", groups);
+			var groupColumn;
+
+			if typeof groups === "string" {
+				let groupColumn = groups;
+			} else {
+				let groupColumn = implode(", ", groups);
+			}
+
 			totalBuilder->groupBy(null)->columns(["COUNT(DISTINCT ".groupColumn.") AS rowcount"]);
 		}
 

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -536,5 +536,21 @@ class PaginatorTest extends PHPUnit_Framework_TestCase
 		$queryBuilder = $paginator->getQueryBuilder();
 		$this->assertEquals($builder2, $queryBuilder);
 		$this->assertEquals($setterResult, $paginator);
+
+		$builder = $di['modelsManager']->createBuilder()
+			->from('Personnes')
+			->groupBy('cedula');
+
+		$paginator = new Phalcon\Paginator\Adapter\QueryBuilder(array(
+			'builder' => $builder,
+			'limit'   => 10,
+			'page'    => 1
+		));
+
+		$page = $paginator->getPaginate();
+
+		$this->assertEquals(get_class($page), 'stdClass');
+
+		$this->assertEquals(count($page->items), 10);
 	}
 }


### PR DESCRIPTION
### Code to reproduce:

``` php
$di['modelsManager']->createBuilder()
    ->columns('cedula, nombres')
    ->from('Personnes')
    ->groupBy('email');
```
### Get error

``` sql
Exception SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error 
in your SQL syntax; check the manual that corresponds to your MySQL server version 
for the right syntax to use near ') AS `rowcount` FROM
```
