### PR TITLE
Added ability to call afterFetch method in Simple::toArray(), always call afterFetch even when select columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Default encrypt algorithm in `Phalcon\Crypt` is now changed to `AES-256-CFB`
 - Removed methods setMode(), getMode(), getAvailableModes() in `Phalcon\CryptInterface`
 - Added `Phalcon\Assets\Manager::exists()` to check if collection exists
+- Added `fireAfterFetch` key in parameters of `Phalcon\Mvc\Model::find()`, `Phalcon\Mvc\Model::findFirst()` and method `Phalcon\Mvc\Model\Query::setFireAfterFetch()`. It will call `Phalcon\Mvc\Model::afterFetch()` even with columns. Also working on `Phalcon\Mvc\Model\Resultset\Simple::toArray()` method. Also `Phalcon\Mvc\Model\Resultset\Simple::toArray()` accepts additional parameter which will remove additional columns when `afterFetch()` is called.
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -102,6 +102,8 @@ class Query implements QueryInterface, InjectionAwareInterface
 
 	protected _sharedLock;
 
+	protected _fireAfterFetch = false;
+
 	static protected _irPhqlCache;
 
 	const TYPE_SELECT = 309;
@@ -2800,7 +2802,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 			/**
 			 * Simple resultsets contains only complete objects
 			 */
-			return new Simple(simpleColumnMap, resultObject, resultData, cache, isKeepingSnapshots);
+			return new Simple(simpleColumnMap, resultObject, resultData, cache, isKeepingSnapshots, model, this->_fireAfterFetch);
 		}
 
 		/**
@@ -3491,6 +3493,29 @@ class Query implements QueryInterface, InjectionAwareInterface
 		let this->_sharedLock = sharedLock;
 
 		return this;
+	}
+
+	/**
+	 * Set fire after fetch
+	 */
+	public function setFireAfterFetch(boolean fireAfterFetch = false) -> <Query>
+	{
+		if strpos("JOIN", this->_phql) !== false {
+			throw new Exception("Fireing after fetch is not implemented for joins.");
+		}
+		let this->_fireAfterFetch = fireAfterFetch;
+
+		return this;
+	}
+
+	/**
+	 * Returns fire after fetch
+	 *
+	 * @return bool
+	 */
+	public function getFireAfterFetch()
+	{
+		return this->_fireAfterFetch;
 	}
 
 	/**

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -91,6 +91,8 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 
 	protected _hiddenParamNumber = 0;
 
+	protected _fireAfterFetch;
+
 	/**
 	 * Phalcon\Mvc\Model\Query\Builder constructor
 	 */
@@ -101,7 +103,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 			singleConditionArray, limit, offset, fromClause,
 			mergedConditions, mergedParams, mergedTypes,
 			singleCondition, singleParams, singleTypes,
-			with, distinct, bind, bindTypes;
+			with, distinct, bind, bindTypes, fireAfterFetch;
 
 		if typeof params == "array" {
 
@@ -262,6 +264,13 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 			 */
 			if fetch sharedLock, params["shared_lock"] {
 				let this->_sharedLock = sharedLock;
+			}
+
+			/**
+			 * Assign FIRE AFTER FETCH
+			 */
+			if fetch fireAfterFetch, params["fireAfterFetch"] {
+				let this->_fireAfterFetch = fireAfterFetch;
 			}
 		} else {
 			if typeof params == "string" && params !== "" {
@@ -1407,6 +1416,10 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 
 		if typeof this->_sharedLock === "boolean" {
 			query->setSharedLock(this->_sharedLock);
+		}
+
+		if typeof this->_fireAfterFetch === "boolean" {
+			query->setFireAfterFetch(this->_fireAfterFetch);
 		}
 
 		return query;

--- a/tests/_data/models/TestAfterFetchRobots.php
+++ b/tests/_data/models/TestAfterFetchRobots.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Wojtek
+ * Date: 2016-04-09
+ * Time: 23:07
+ */
+
+namespace Phalcon\Test\Models;
+
+use DateTime;
+use Phalcon\Mvc\Model;
+
+/**
+ * \Phalcon\Test\Models\TestAfterFetchRobots.php
+ * TestAfterFetchRobots model class
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Models
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class TestAfterFetchRobots extends Model
+{
+    public function getSource()
+    {
+        return 'robots';
+    }
+    
+    public function afterFetch()
+    {
+        $this->datetime = new DateTime($this->datetime);
+        $this->text = "texttexttext";
+    }
+}

--- a/tests/unit/Mvc/Model/Resultset/SimpleTest.php
+++ b/tests/unit/Mvc/Model/Resultset/SimpleTest.php
@@ -1,0 +1,135 @@
+<?php
+use Phalcon\Test\Models\TestAfterFetchRobots;
+use Phalcon\Test\Module\UnitTest;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Model\Resultset\SimpleTest
+ * Tests the Phalcon\Mvc\Model\Resultset\Simple component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Mvc\Model\Resultset
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class SimpleTest extends UnitTest
+{
+    public function testToArrayAfterFetchRemoveColumns()
+    {
+        $this->specify(
+            "After fetch should be fired on toArray method and should remove columns",
+            function () {
+                $expectedRobots = [
+                    ['datetime'=>new DateTime('1972-01-01 00:00:00')],
+                    ['datetime'=>new DateTime('1952-01-01 00:00:00')],
+                    ['datetime'=>new DateTime('2029-01-01 00:00:00')]
+                ];
+                
+                $actualRobots = TestAfterFetchRobots::find([
+                    'columns'=>['datetime'],
+                    'fireAfterFetch'=>true
+                ])->toArray(true);
+                expect($actualRobots)->equals($expectedRobots);
+            }
+        );
+    }
+
+    public function testToArrayAfterFetch()
+    {
+        $this->specify(
+            "After fetch should be fired on toArray method",
+            function () {
+                $expectedRobots = [
+                    ['datetime'=>new DateTime('1972-01-01 00:00:00'),'text'=>'texttexttext'],
+                    ['datetime'=>new DateTime('1952-01-01 00:00:00'),'text'=>'texttexttext'],
+                    ['datetime'=>new DateTime('2029-01-01 00:00:00'),'text'=>'texttexttext']
+                ];
+
+                $actualRobots = TestAfterFetchRobots::find([
+                    'columns'=>['datetime'],
+                    'fireAfterFetch'=>true
+                ])->toArray();
+                expect($actualRobots)->equals($expectedRobots);
+            }
+        );
+    }
+
+    public function testAfterFetch()
+    {
+        $this->specify(
+            "After fetch should be fired on Row",
+            function () {
+                $expectedRobot = ['datetime'=>new DateTime('1972-01-01 00:00:00'),'text'=>'texttexttext'];
+
+                $actualRobot = TestAfterFetchRobots::findFirst([
+                    'conditions'=>'id = 1',
+                    'columns'=>['datetime','text'],
+                    'fireAfterFetch'=>true
+                ])->toArray();
+                expect($actualRobot)->equals($expectedRobot);
+            }
+        );
+    }
+
+    public function testAfterFetchRemoveColumns()
+    {
+        $this->specify(
+            "After fetch should return remove columns if there are additional columns on Row",
+            function () {
+                $expectedRobot = ['datetime'=>new DateTime('1972-01-01 00:00:00')];
+
+                $actualRobot = TestAfterFetchRobots::findFirst([
+                    'conditions'=>'id = 1',
+                    'columns'=>['datetime'],
+                    'fireAfterFetch'=>true
+                ])->toArray();
+                expect($actualRobot)->equals($expectedRobot);
+            }
+        );
+    }
+
+    public function testAfterFetchFalse()
+    {
+        $this->specify(
+            "After fetch should not be fired when false",
+            function () {
+                $expectedRobot = ['datetime'=>'1972-01-01 00:00:00'];
+
+                $actualRobot = TestAfterFetchRobots::findFirst([
+                    'conditions'=>'id = 1',
+                    'columns'=>['datetime'],
+                    'fireAfterFetch'=>false
+                ])->toArray();
+                expect($actualRobot)->equals($expectedRobot);
+            }
+        );
+    }
+
+    public function testToArrayAfterFetchFalse()
+    {
+        $this->specify(
+            "After fetch should not be fired when false on toArray method",
+            function () {
+                $expectedRobots = [
+                    ['datetime'=>'1972-01-01 00:00:00'],
+                    ['datetime'=>'1952-01-01 00:00:00'],
+                    ['datetime'=>'2029-01-01 00:00:00']
+                ];
+
+                $actualRobots = TestAfterFetchRobots::find([
+                    'columns'=>['datetime'],
+                    'fireAfterFetch'=>false
+                ])->toArray();
+                expect($actualRobots)->equals($expectedRobots);
+            }
+        );
+    }
+}


### PR DESCRIPTION
Added ability to call afterFetch method in:
- `Phalcon\Mvc\Model\Resultset\Simple::toArray()`
- `Phalcon\Mvc\Model::find` when searching with columns
- `Phalcon\Mvc\Model::findFirst` when searching with columns
- `Phalcon\Mvc\Model\Query\Builder` when searching with columns(but without joins)

It's using reflectionMethod and stdClass, it's not actually creating object of our model(and using then to Array() method from it), well acutally we have to create it once(to retrieve closure) - actual way is pretty fast(like 5 times than `cloneResultMap`).

**What is important it's not working for joins. Maybe i will implement this some day if there will be need for it.**

If casting object type to array in zephir would work, we could possibly save some time. Right now it's using ArrayObject class.

**Also what is important if unset could work on dynamic properties we could save some time in current() method.**
