### PR TITLE
Added ability for loading aliased namespaces in manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Default encrypt algorithm in `Phalcon\Crypt` is now changed to `AES-256-CFB`
 - Removed methods setMode(), getMode(), getAvailableModes() in `Phalcon\CryptInterface`
 - Added `Phalcon\Assets\Manager::exists()` to check if collection exists
+- `Phalcon\Mvc\Model\Manager::load()` now can load models from aliased namespaces
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -271,7 +271,19 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	public function load(string! modelName, boolean newInstance = false) -> <ModelInterface>
 	{
-		var model;
+		var model, colonPos, namespaceName, namespaceAlias, className;
+
+		/**
+		 * Check if a modelName is an alias
+		 */
+		let colonPos = strpos(modelName, ":");
+
+		if colonPos !== false {
+			let className = substr(modelName,colonPos+1);
+			let namespaceAlias = substr(modelName,0,colonPos);
+			let namespaceName = this->getNamespaceAlias(namespaceAlias);
+			let modelName = namespaceName."\\".className;
+		}
 
 		/**
 		 * Check if a model with the same is already loaded


### PR DESCRIPTION
With this ability we can define our relations using namespace aliases.

It's just loading proper models instead of throwing that some class don't exists.
