### PR TITLE
Added ability for loading aliased namespaces in manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Default encrypt algorithm in `Phalcon\Crypt` is now changed to `AES-256-CFB`
 - Removed methods setMode(), getMode(), getAvailableModes() in `Phalcon\CryptInterface`
 - Added `Phalcon\Assets\Manager::exists()` to check if collection exists
+- `Phalcon\Mvc\Model\Manager::load()` now can load models from aliased namespaces
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -271,7 +271,19 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	public function load(string! modelName, boolean newInstance = false) -> <ModelInterface>
 	{
-		var model;
+		var model, colonPos, namespaceName, namespaceAlias, className;
+
+		/**
+		 * Check if a modelName is an alias
+		 */
+		let colonPos = strpos(modelName, ":");
+
+		if colonPos !== false {
+			let className = substr(modelName,colonPos+1);
+			let namespaceAlias = substr(modelName,0,colonPos);
+			let namespaceName = this->getNamespaceAlias(namespaceAlias);
+			let modelName = namespaceName."\\".className;
+		}
 
 		/**
 		 * Check if a model with the same is already loaded

--- a/tests/_data/models/AlbumORama/Albums.php
+++ b/tests/_data/models/AlbumORama/Albums.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phalcon\Test\Models\AlbumORama;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * \Phalcon\Test\Models\AlbumORama\Albums.php
+ * Albums model class
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @package   Phalcon\Test\Models\AlbumORama\Albums
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Albums extends Model
+{
+	public function initialize()
+	{
+		$this->belongsTo('artists_id', 'AlbumORama:Artists', 'id', array(
+			'alias' => 'artist'
+		));
+	}
+}

--- a/tests/_data/models/AlbumORama/Artists.php
+++ b/tests/_data/models/AlbumORama/Artists.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Phalcon\Test\Models\AlbumORama;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * \Phalcon\Test\Models\AlbumORama\Artists.php
+ * Artists model class
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @package   Phalcon\Test\Models\AlbumORama\Albums
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Artists extends Model
+{
+	public function initialize()
+	{
+		$this->hasMany('id', 'AlbumORama:Albums', 'artists_id', array(
+			'alias' => 'albums'
+		));
+	}
+}

--- a/tests/unit/Mvc/Model/ManagerTest.php
+++ b/tests/unit/Mvc/Model/ManagerTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: Wojtek
+ * Date: 2016-04-09
+ * Time: 20:03
+ */
+
+namespace Phalcon\Test\Unit\Mvc\Model;
+
+use Phalcon\Mvc\Model\Manager;
+use Phalcon\Test\Models\AlbumORama\Albums;
+use Phalcon\Test\Module\UnitTest;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Model\ManagerTest
+ * Tests the Phalcon\Mvc\Model\Manager component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Mvc\Model
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class ManagerTest extends UnitTest
+{
+    /**
+     * @var Manager
+     */
+    private $modelsManager;
+
+    protected function _before()
+    {
+        parent::_before();
+        $module = $this->getModule('Phalcon');
+
+        /** @var \Phalcon\Mvc\Application $app */
+        $app = $module->getApplication();
+
+        $this->modelsManager = $app->getDI()->getShared('modelsManager');
+    }
+    
+    public function testAliasedNamespacesRelations()
+    {
+        $this->specify(
+            "Aliased namespaces should work in relations",
+            function () {
+                $this->modelsManager->registerNamespaceAlias('AlbumORama','Phalcon\Test\Models\AlbumORama');
+                $albums = Albums::find();
+                foreach($albums as $album){
+                    expect($album->artist)->isInstanceOf('Phalcon\Test\Models\AlbumORama\Artists');
+                }
+            }
+        );
+    }
+}


### PR DESCRIPTION
With this ability we can define our relations using namespace aliases.

It's just loading proper models instead of throwing that some class don't exists.
