### PR TITLE
Sqlite data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - Added `Phalcon\Assets\Manager::exists()` to check if collection exists
 - `Phalcon\Mvc\Model\Manager::load()` now can load models from aliased namespaces
 - `Phalcon\Mvc\Model\Transaction\Manager` now correctly keeps account of transactions [#11554](https://github.com/phalcon/cphalcon/issues/11554)
+- `Phalcon\Db\Dialect\Sqlite` now maps additional column types to SQLite columns equivalents.
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -54,6 +54,9 @@ class Sqlite extends Dialect
 			let type = column->getTypeReference();
 		}
 
+		// SQLite has dynamic column typing. The conversion below maximizes
+		// compatibility with other DBMS's while following the type affinity
+		// rules: http://www.sqlite.org/datatype3.html.
 		switch type {
 
 			case Column::TYPE_INTEGER:
@@ -107,9 +110,57 @@ class Sqlite extends Dialect
 				}
 				break;
 
+			case Column::TYPE_BOOLEAN:
+				if empty columnSql {
+					let columnSql .= "TINYINT";
+				}
+				break;
+
 			case Column::TYPE_FLOAT:
 				if empty columnSql {
 					let columnSql .= "FLOAT";
+				}
+				break;
+
+			case Column::TYPE_DOUBLE:
+				if empty columnSql {
+					let columnSql .= "DOUBLE";
+				}
+				if column->isUnsigned() {
+					let columnSql .= " UNSIGNED";
+				}
+				break;
+
+			case Column::TYPE_BIGINTEGER:
+				if empty columnSql {
+					let columnSql .= "BIGINT";
+				}
+				if column->isUnsigned() {
+					let columnSql .= " UNSIGNED";
+				}
+				break;
+
+			case Column::TYPE_TINYBLOB:
+				if empty columnSql {
+					let columnSql .= "TINYBLOB";
+				}
+				break;
+
+			case Column::TYPE_BLOB:
+				if empty columnSql {
+					let columnSql .= "BLOB";
+				}
+				break;
+
+			case Column::TYPE_MEDIUMBLOB:
+				if empty columnSql {
+					let columnSql .= "MEDIUMBLOB";
+				}
+				break;
+
+			case Column::TYPE_LONGBLOB:
+				if empty columnSql {
+					let columnSql .= "LONGBLOB";
 				}
 				break;
 
@@ -483,7 +534,7 @@ class Sqlite extends Dialect
 		string sql;
 
 		let sql = "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = ". this->escape(table) ." COLLATE NOCASE";
-		
+
 		if keyName {
 			let sql .= " AND name = ". this->escape(keyName) ." COLLATE NOCASE";
 		}

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -101,6 +101,32 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 				'notNull' => true,
 				'default' => 'CURRENT_TIMESTAMP',
 			)),
+			'column14' => new Column("column14", array(
+				'type' => Column::TYPE_TINYBLOB,
+				'notNull' => true
+			)),
+			'column15' => new Column("column15", array(
+				'type' => Column::TYPE_MEDIUMBLOB,
+				'notNull' => true
+			)),
+			'column16' => new Column("column16", array(
+				'type' => Column::TYPE_BLOB,
+				'notNull' => true
+			)),
+			'column17' => new Column("column17", array(
+				'type' => Column::TYPE_LONGBLOB,
+				'notNull' => true
+			)),
+			'column18' => new Column("column18", array(
+				'type' => Column::TYPE_BOOLEAN,
+			)),
+			'column19' => new Column("column19", array(
+				'type' => Column::TYPE_DOUBLE,
+			)),
+			'column20' => new Column("column20", array(
+				'type' => Column::TYPE_DOUBLE,
+				'unsigned' => true
+			))
 		);
 	}
 
@@ -286,6 +312,47 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($column13->getType(), Column::TYPE_TIMESTAMP);
 		$this->assertTrue($column13->isNotNull());
 		$this->assertEquals($column13->getDefault(), 'CURRENT_TIMESTAMP');
+
+		//Tinyblob column
+		$column14 = $columns['column14'];
+		$this->assertEquals($column14->getName(), 'column14');
+		$this->assertEquals($column14->getType(), Column::TYPE_TINYBLOB);
+		$this->assertTrue($column14->isNotNull());
+
+		//Mediumblob column
+		$column15 = $columns['column15'];
+		$this->assertEquals($column15->getName(), 'column15');
+		$this->assertEquals($column15->getType(), Column::TYPE_MEDIUMBLOB);
+		$this->assertTrue($column15->isNotNull());
+
+		//Blob column
+		$column16 = $columns['column16'];
+		$this->assertEquals($column16->getName(), 'column16');
+		$this->assertEquals($column16->getType(), Column::TYPE_BLOB);
+		$this->assertTrue($column16->isNotNull());
+
+		//Longblob column
+		$column17 = $columns['column17'];
+		$this->assertEquals($column17->getName(), 'column17');
+		$this->assertEquals($column17->getType(), Column::TYPE_LONGBLOB);
+		$this->assertTrue($column17->isNotNull());
+
+		//Boolean column
+		$column18 = $columns['column18'];
+		$this->assertEquals($column18->getName(), 'column18');
+		$this->assertEquals($column18->getType(), Column::TYPE_BOOLEAN);
+
+		//Double column
+		$column19 = $columns['column19'];
+		$this->assertEquals($column19->getName(), 'column19');
+		$this->assertEquals($column19->getType(), Column::TYPE_DOUBLE);
+		$this->assertFalse($column19->isUnsigned());
+
+		//Unsigned double column
+		$column20 = $columns['column20'];
+		$this->assertEquals($column20->getName(), 'column20');
+		$this->assertEquals($column20->getType(), Column::TYPE_DOUBLE);
+		$this->assertTrue($column20->isUnsigned());
 	}
 
 	public function testIndexes()
@@ -835,6 +902,13 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($dialect->getColumnDefinition($columns['column9']), 'VARCHAR(10)');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column10']), 'INTEGER');
 		$this->assertEquals($dialect->getColumnDefinition($columns['column13']), 'TIMESTAMP');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column14']), 'TINYBLOB');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column15']), 'MEDIUMBLOB');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column16']), 'BLOB');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column17']), 'LONGBLOB');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column18']), 'TINYINT');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column19']), 'DOUBLE');
+		$this->assertEquals($dialect->getColumnDefinition($columns['column20']), 'DOUBLE UNSIGNED');
 
 		//Add Columns
 		$this->assertEquals($dialect->addColumn('table', null,     $columns['column1']), 'ALTER TABLE "table" ADD COLUMN "column1" VARCHAR(10)');
@@ -859,6 +933,20 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column10']), 'ALTER TABLE "schema"."table" ADD COLUMN "column10" INTEGER DEFAULT "10"');
 		$this->assertEquals($dialect->addColumn('table', null,     $columns['column13']), 'ALTER TABLE "table" ADD COLUMN "column13" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL');
 		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column13']), 'ALTER TABLE "schema"."table" ADD COLUMN "column13" TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column14']), 'ALTER TABLE "table" ADD COLUMN "column14" TINYBLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column14']), 'ALTER TABLE "schema"."table" ADD COLUMN "column14" TINYBLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column15']), 'ALTER TABLE "table" ADD COLUMN "column15" MEDIUMBLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column15']), 'ALTER TABLE "schema"."table" ADD COLUMN "column15" MEDIUMBLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column16']), 'ALTER TABLE "table" ADD COLUMN "column16" BLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column16']), 'ALTER TABLE "schema"."table" ADD COLUMN "column16" BLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column17']), 'ALTER TABLE "table" ADD COLUMN "column17" LONGBLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column17']), 'ALTER TABLE "schema"."table" ADD COLUMN "column17" LONGBLOB NOT NULL');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column18']), 'ALTER TABLE "table" ADD COLUMN "column18" TINYINT');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column18']), 'ALTER TABLE "schema"."table" ADD COLUMN "column18" TINYINT');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column19']), 'ALTER TABLE "table" ADD COLUMN "column19" DOUBLE');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column19']), 'ALTER TABLE "schema"."table" ADD COLUMN "column19" DOUBLE');
+		$this->assertEquals($dialect->addColumn('table', null,     $columns['column20']), 'ALTER TABLE "table" ADD COLUMN "column20" DOUBLE UNSIGNED');
+		$this->assertEquals($dialect->addColumn('table', 'schema', $columns['column20']), 'ALTER TABLE "schema"."table" ADD COLUMN "column20" DOUBLE UNSIGNED');
 
 		//Modify Columns
 		try {
@@ -1017,6 +1105,43 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		$expected .= ")";
 		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
 
+		$definition = array(
+			'columns' => array(
+				$columns['column14'],
+				$columns['column16'],
+			)
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	`column14` TINYBLOB NOT NULL,\n";
+		$expected .= "	`column16` BLOB NOT NULL\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
+
+		$definition = array(
+			'columns' => array(
+				$columns['column18'],
+			)
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	`column18` TINYINT\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
+
+		$definition = array(
+			'columns' => array(
+				$columns['column19'],
+				$columns['column20'],
+			)
+		);
+
+		$expected  = "CREATE TABLE \"table\" (\n";
+		$expected .= "	`column19` DOUBLE,\n";
+		$expected .= "	`column20` DOUBLE UNSIGNED\n";
+		$expected .= ")";
+		$this->assertEquals($dialect->createTable('table', null, $definition), $expected);
+
 		// issue 11359
 		$this->assertEquals($dialect->describeColumns('table', 'database.name.with.dots'), "PRAGMA table_info('table')");
 	}
@@ -1061,19 +1186,19 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 
     $this->assertEquals($dialect->listViews(), 'SELECT viewname AS view_name FROM pg_views WHERE schemaname = \'public\' ORDER BY view_name');
 
-		// SQLite
-		$dialect = new \Phalcon\Db\Dialect\Sqlite();
+	// SQLite
+	$dialect = new \Phalcon\Db\Dialect\Sqlite();
 
-		//Create View
-		$this->assertEquals($dialect->createView('test_view', $definition, null), 'CREATE VIEW "test_view" AS SELECT 1');
-		$this->assertEquals($dialect->createView('test_view', $definition, 'schema'), 'CREATE VIEW "schema"."test_view" AS SELECT 1');
+	//Create View
+	$this->assertEquals($dialect->createView('test_view', $definition, null), 'CREATE VIEW "test_view" AS SELECT 1');
+	$this->assertEquals($dialect->createView('test_view', $definition, 'schema'), 'CREATE VIEW "schema"."test_view" AS SELECT 1');
 
-		//Drop View
-		$this->assertEquals($dialect->dropView('test_view', null, false), 'DROP VIEW "test_view"');
-		$this->assertEquals($dialect->dropView('test_view', null, true), 'DROP VIEW IF EXISTS "test_view"');
-		$this->assertEquals($dialect->dropView('test_view', 'schema', false), 'DROP VIEW "schema"."test_view"');
-		$this->assertEquals($dialect->dropView('test_view', 'schema', true), 'DROP VIEW IF EXISTS "schema"."test_view"');
+	//Drop View
+	$this->assertEquals($dialect->dropView('test_view', null, false), 'DROP VIEW "test_view"');
+	$this->assertEquals($dialect->dropView('test_view', null, true), 'DROP VIEW IF EXISTS "test_view"');
+	$this->assertEquals($dialect->dropView('test_view', 'schema', false), 'DROP VIEW "schema"."test_view"');
+	$this->assertEquals($dialect->dropView('test_view', 'schema', true), 'DROP VIEW IF EXISTS "schema"."test_view"');
 
-		$this->assertEquals($dialect->listViews(), "SELECT tbl_name FROM sqlite_master WHERE type = 'view' ORDER BY tbl_name");
+	$this->assertEquals($dialect->listViews(), "SELECT tbl_name FROM sqlite_master WHERE type = 'view' ORDER BY tbl_name");
 	}
 }


### PR DESCRIPTION
The lists of column types has been extended. However, not all column types conversions exist for SQLite.

This PR adds support for the additional column types. While SQLite has no statically typed columns, they have dynamic typing and use the column name for determining the type affinity. The rules are explained in [Section 2.0](http://www.sqlite.org/datatype3.html). I have chosen column names that match MySQL the most, while still adhering to the type affinity rules. This way, as little as possible information is lost when converting from SQLite to another DBMS.

I also extended the dialect tests.

Together with https://github.com/phalcon/phalcon-devtools/pull/639, I have been using this patch for almost two weeks without problems. I successfully converted from MySQL -> Phalcon Devtool Migrations -> SQLite (clean migration).
