### PR TITLE
Improved test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
     - TEST_DB_MYSQL_PASSWD=""
     - TEST_DB_MYSQL_NAME="phalcon_test"
     - TEST_DB_MYSQL_CHARSET="utf8"
+    - TEST_DB_MYSQL_DSN="mysql:host=127.0.0.1;dbname=phalcon_test"
     - TEST_DB_MONGO_HOST="127.0.0.1"
     - TEST_DB_MONGO_PORT="27017"
     - TEST_DB_MONGO_USER="admin"

--- a/codeception.yml
+++ b/codeception.yml
@@ -24,12 +24,7 @@ coverage:
 extensions:
     enabled:
         - Codeception\Extension\RunFailed
-modules:
-    config:
-        Db:
-            dsn: 'mysql:host=localhost;dbname=phalcon_test'
-            user: 'root'
-            password: ''
-            populate: true
-            cleanup: false
-            dump: tests/_data/schemas/mysql/mysql.dump.sql
+
+params:
+    # get params drom environment vars
+    - env

--- a/tests/unit.suite.yml
+++ b/tests/unit.suite.yml
@@ -13,3 +13,14 @@ modules:
     config:
         Phalcon:
             bootstrap: 'tests/_config/bootstrap.php'
+        Db:
+            # get params drom environment vars
+            # Create it before running tests. For example:
+            # export TEST_DB_MYSQL_DSN="mysql:host=10.1.0.3.;dbname=phalcon_test"
+            # ...
+            dsn: %TEST_DB_MYSQL_DSN%
+            user: %TEST_DB_MYSQL_USER%
+            password: %TEST_DB_MYSQL_PASSWD%
+            populate: true
+            cleanup: false
+            dump: tests/_data/schemas/mysql/mysql.dump.sql


### PR DESCRIPTION
See: https://github.com/Codeception/Codeception/issues/2779
And: http://codeception.com/03-05-2016/codeception-2.2.-upcoming-features.html#params

How to test Phalcon by using Docker containers? Example:

``` sh
#!/usr/bin/env bash

docker_bin="$(which docker.io 2> /dev/null || which docker 2> /dev/null)"

#  1) Create Phalcon Network
#  docker network create --driver bridge phalcon_nw

[ -z "$PHP_VERSION" ] && echo "Need to set PHP_VERSION variable. Fox example: 'export PHP_VERSION=7'" && exit 1;
[ -z "$TRAVIS_BUILD_DIR" ] && TRAVIS_BUILD_DIR=$(cd $(dirname "$1") && pwd -P)/$(basename "$1")

#  2) Run required containers inside Phalcon Network (--net=phalcon_nw)
#  and get the corresponding names of their hosts
[ -z "$TEST_DB_MYSQL_HOST" ] && TEST_DB_MYSQL_HOST="phalcon_mysql"
[ -z "$TEST_RS_HOST" ] && TEST_RS_HOST="phalcon_redis"
[ -z "$TEST_MC_HOST" ] && TEST_MC_HOST="phalcon_memcached"
[ -z "$TEST_BT_HOST" ] && TEST_BT_HOST="phalcon_beanstalk"
[ -z "$TEST_DB_MONGO_HOST" ] && TEST_DB_MONGO_HOST="phalcon_mongo"

chmod +x ${TRAVIS_BUILD_DIR}/tests/_ci/entrypoint.sh

#  3) Run tests
${docker_bin} run -it --rm \
    --entrypoint /entrypoint.sh \
    --privileged=true \
    --net=phalcon_nw \
    --name test-phalcon-${PHP_VERSION} \
    -e TEST_DB_MYSQL_DSN="mysql:host=${TEST_DB_MYSQL_HOST};dbname=phalcon_test" \
    -e TEST_DB_MYSQL_HOST="${TEST_DB_MYSQL_HOST}" \
    -e TEST_DB_MYSQL_PORT=3306 \
    -e TEST_DB_MYSQL_USER="root" \
    -e TEST_DB_MYSQL_PASSWD="" \
    -e TEST_DB_MYSQL_NAME="phalcon_test" \
    -e TEST_DB_MYSQL_CHARSET="utf8" \
    -e TEST_RS_HOST="${TEST_RS_HOST}" \
    -e TEST_RS_PORT=6379 \
    -e TEST_MC_HOST="${TEST_MC_HOST}" \
    -e TEST_MC_PORT=11211 \
    -e TEST_BT_HOST="${TEST_BT_HOST}" \
    -e TEST_BT_PORT=11300 \
    -e TEST_DB_MONGO_HOST="${TEST_DB_MONGO_HOST}" \
    -e TEST_DB_MONGO_PORT=27017 \
    -e TEST_DB_MONGO_USER='admin' \
    -e TEST_DB_MONGO_PASSWD='' \
    -e TEST_DB_MONGO_NAME='phalcon_test' \
    -e PHP_VERSION="${PHP_VERSION}" \
    -v ${TRAVIS_BUILD_DIR}/tests/_ci/backtrace.sh:/backtrace.sh \
    -v ${TRAVIS_BUILD_DIR}/tests/_ci/entrypoint.sh:/entrypoint.sh \
    -v ${TRAVIS_BUILD_DIR}/vendor:/app/vendor \
    -v ${TRAVIS_BUILD_DIR}/codeception.yml:/app/codeception.yml \
    -v ${TRAVIS_BUILD_DIR}/tests:/app/tests \
    -v ${TRAVIS_BUILD_DIR}/ext/modules/phalcon.so:/ext/phalcon.so \
    phalconphp/php:${PHP_VERSION} bash

```

**entrypoint.sh**:

``` sh
#!/usr/bin/env bash

PURPLE="\e[0;35m"
GREEN="\033[0;32m"
YELLOW="\e[1;33m"
NC="\033[0m"

echo -e "\nWelcome to the Docker testing container."

mkdir -p /tmp/phalcon
echo "/tmp/phalcon/core-%e.%p" | tee /proc/sys/kernel/core_pattern &> /dev/null

ulimit -c unlimited

export PHP_EXTENSION_DIR=`php-config --extension-dir`

echo -e "If a Segmentation Fault is happens use: ${PURPLE}bash /backtrace.sh${NC}"
echo -e "PHP extension path: ${PURPLE}${PHP_EXTENSION_DIR}${NC}\n"

ln -s /ext/phalcon.so ${PHP_EXTENSION_DIR}/phalcon.so
[[ "$PHP_VERSION" == "7" ]] || ln -s /app/tests/_ci/phalcon.ini /etc/php5/cli/conf.d/50-phalcon.ini;
[[ "$PHP_VERSION" != "7" ]] || ln -s /app/tests/_ci/phalcon.ini /etc/php/7.0/cli/conf.d/50-phalcon.ini;

export PHALCON_VERSION=`php --ri phalcon | grep "Version =" | awk '{print $3}'`

echo -e "${GREEN}Phalcon${NC}     version ${YELLOW}${PHALCON_VERSION}${NC}"
/app/vendor/bin/codecept --version

/app/vendor/bin/codecept build &> /dev/null

echo -e ""
/app/vendor/bin/codecept run -v

result_codecept=$?

if [ ${result_codecept} -ne 0 ]; then
  bash /backtrace.sh
  [[ "$PHP_VERSION" == "7" ]] || exit 1;
  # Allow failures for PHP 7
  [[ "$PHP_VERSION" != "7" ]] || exit 0;
fi

exit 0;
```

**backtrace.sh**:

``` sh
#!/usr/bin/env bash

shopt -s nullglob
export LC_ALL=C

for i in /tmp/phalcon/core-*.*; do
    if [ -f "$i" -a "$(file "$i" | grep -o 'core file')" ]; then
        gdb -q $(which php) "$i" <<EOF
set pagination 0
backtrace full
info registers
x/16i \$pc
thread apply all backtrace
quit
EOF
    fi
done
```

![selection_166](https://cloud.githubusercontent.com/assets/1256298/14536877/3fff5d6a-027d-11e6-8a9b-f8b1b30162b5.png)
