### PR TITLE
Comment updated

### DIFF
--- a/phalcon/http/request/file.zep
+++ b/phalcon/http/request/file.zep
@@ -125,7 +125,7 @@ class File implements FileInterface
 	}
 
 	/**
-	 * Returns the temporal name of the uploaded file
+	 * Returns the temporary name of the uploaded file
 	 */
 	public function getTempName() -> string
 	{


### PR DESCRIPTION
getTempName() is the _temporary_ name, not the _temporal_ name
