### PR TITLE
Reset variables(params and matches) between loops in Router::handle()

### DIFF
--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -365,6 +365,8 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 		 * Routes are traversed in reversed order
 		 */
 		for route in reverse this->_routes {
+			let params = [],
+				matches = null;
 
 			/**
 			 * Look for HTTP method constraints


### PR DESCRIPTION
params and matches are bind to each route, they should not suvive a loop, which may interfere in next loop
