### PR TITLE
Allow implicit joins to be disabled in the global settings.

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4489,6 +4489,13 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		}
 
 		/**
+		 * Enables/Disables implicit join condition based on defined relationship
+		 */
+		if fetch enableImplicitJoins, options["enableImplicitJoins"] {
+			globals_set("orm.enable_implicit_joins", enableImplicitJoins);
+		}
+
+		/**
 		 * Enables/Disables automatic cast to original types on hydration
 		 */
 		if fetch castOnHydrate, options["castOnHydrate"] {


### PR DESCRIPTION
Some time ago I added the ability to disable implicit joins on the query level and this completes that work by allowing it to be globally disabled.
