### PR TITLE
Fix method's argument in Phalcon\Flash [2.0.x]

### DIFF
--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -117,7 +117,7 @@ abstract class Flash
 	 * $flash->success('The process was finished successfully');
 	 *</code>
 	 */
-	public function success(string message) -> string
+	public function success(var message) -> string
 	{
 		return this->{"message"}("success", message);
 	}


### PR DESCRIPTION
In the current implementation Phalcon\Flash it is impossible to transfer an array to the method `success()`. It is the strange and differs from behavior of other methods. This patch corrects it.
Just as the https://github.com/phalcon/cphalcon/pull/11761
