### PR TITLE
[NFR] getJoins() method in \Phalcon\Mvc\Model\Query\Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@
 - Added `Phalcon\Text::underscore` - to make a phrase underscored instead of spaced
 - Added `Phalcon\Text::humanize` - to make an underscored or dashed phrase human-readable
 - Added ability to change document class to be returned in ODM through `class` option
+- Added new getter `Phalcon\Mvc\Model\Query\Builder::getJoins()` - to get join parts from query builder
 
 # [2.0.8](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.8) (2015-09-19)
 - Added `Phalcon\Security\Random::base58` - to generate a random base58 string

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -1,4 +1,3 @@
-
 /*
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
@@ -498,6 +497,16 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	{
 		let this->_joins[] = [model, conditions, alias, "RIGHT"];
 		return this;
+	}
+
+	/**
+	 * Return join parts of the query
+	 *
+	 * @return array
+	 */
+	public function getJoins()
+	{
+		return this->_joins;
 	}
 
 	/**

--- a/phalcon/mvc/model/query/builderinterface.zep
+++ b/phalcon/mvc/model/query/builderinterface.zep
@@ -1,4 +1,3 @@
-
 /*
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
@@ -109,6 +108,13 @@ interface BuilderInterface
 	 * @return \Phalcon\Mvc\Model\Query\Builder
 	 */
 	public function rightJoin(model, conditions = null, alias = null);
+
+	/**
+	 * Return join parts of the query
+	 *
+	 * @return array
+	 */
+	public function getJoins();
 
 	/**
 	 * Sets conditions for the query


### PR DESCRIPTION
In some cases it's useful to have `getJoins()` method in Query Builder to check which joins are already present in Builder. 

Usage:

``` php
$queryBuilder = new Phalcon\Mvc\Model\Query\Builder();
$queryBuilder->from(Robots::class);
$queryBuilder->leftJoin(Parts::class,sprintf('%s.id = %s.robot_id',Robots::class,Parts::class));

...

$queryBuilder->leftJoin(Parts::class,sprintf('%s.id = %s.robot_id',Robots::class,Parts::class)); 
$result = $queryBuilder->getQuery()->execute(); // ooops... it will be error here

```

Therefore we can use `getJoins()` to see which joins are present in Builder to avoid this situation.
