### PR TITLE
Remove "AS" in prepareTable for Oracle dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Phalcon\Tag::getTitle() shows a title depending on prependTitle and appendTitle
 - Using a settable variable for the Mongo Connection Service name instead of a hard coded string [#11725](https://github.com/phalcon/cphalcon/issues/11725)
 - Added new getter `Phalcon\Mvc\Model\Query\Builder::getJoins()` - to get join parts from query builder
+- Fixed `Phalcon\Db\Dialect\Oracle::prepareTable()` to correctly generate SQL for table aliases [#11799](https://github.com/phalcon/cphalcon/issues/11799)
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/db/dialect/oracle.zep
+++ b/phalcon/db/dialect/oracle.zep
@@ -391,11 +391,25 @@ class Oracle extends Dialect
 	 */
 	protected function prepareTable(string! table, string schema = null, string alias = null, string escapeChar = null) -> string
 	{
-		return parent::prepareTable(
-			Text::upper(table),
-			Text::upper(schema),
-			alias,
-			escapeChar
-		);
+		let table = Text::upper(table);
+		let schema = Text::upper(schema);
+	
+		let table = this->escape(table, escapeChar);
+
+		/**
+		 * Schema
+		 */
+		if schema != "" {
+			let table = this->escapeSchema(schema, escapeChar) . "." . table;
+		}
+
+		/**
+		 * Alias
+		 */
+		if alias != "" {
+			let table = table . " " . this->escape(alias, escapeChar);
+		}
+
+		return table;
 	}
 }


### PR DESCRIPTION
In oracle dialect it is "TABLE alias", without the AS. AS is only used for variable aliasing.
I don't think it is possible without copying code from parent, because you need to remove the "AS" part.
