### PR TITLE
ORM: Case-insensitive column map option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 - Using a settable variable for the Mongo Connection Service name instead of a hard coded string [#11725](https://github.com/phalcon/cphalcon/issues/11725)
 - Added new getter `Phalcon\Mvc\Model\Query\Builder::getJoins()` - to get join parts from query builder
 - Fixed `Phalcon\Db\Dialect\Oracle::prepareTable()` to correctly generate SQL for table aliases [#11799](https://github.com/phalcon/cphalcon/issues/11799)
+- Added global setting `orm.try_ci_column_map` to attempt to find value in the column map case-insensitively if it is not found, what is a real fix for many possible bugs with Oracle column capitalization. Can be also enabled by setting `tryCIColumnMap` key in `\Phalcon\Mvc\Model::setup()`.
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Phalcon\Tag::getTitle() shows a title depending on prependTitle and appendTitle
 - Using a settable variable for the Mongo Connection Service name instead of a hard coded string [#11725](https://github.com/phalcon/cphalcon/issues/11725)
 - Added new getter `Phalcon\Mvc\Model\Query\Builder::getJoins()` - to get join parts from query builder
+- Added global setting `orm.try_ci_column_map` to attempt to find value in the column map case-insensitively if it is not found, what is a real fix for many possible bugs with Oracle column capitalization. Can be also enabled by setting `tryCIColumnMap` key in `\Phalcon\Mvc\Model::setup()`.
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/config.json
+++ b/config.json
@@ -99,7 +99,11 @@
         "orm.ignore_unknown_columns": {
             "type": "bool",
             "default": false
-        }
+        },
+		"orm.try_ci_column_map": {
+			"type": "bool",
+			"default": false
+		}
     },
     "destructors": {
         "request": [

--- a/config.json
+++ b/config.json
@@ -100,10 +100,10 @@
             "type": "bool",
             "default": false
         },
-		"orm.try_ci_column_map": {
-			"type": "bool",
-			"default": false
-		}
+        "orm.try_ci_column_map": {
+            "type": "bool",
+            "default": false
+        }
     },
     "destructors": {
         "request": [

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -494,6 +494,20 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	}
 
 	/**
+	 * Attempts to find key case-insensitively
+	 */
+	private static function columnMapCIResolve(var columnMap, var key) -> string
+	{
+		var cmKey;
+		for cmKey in array_keys(columnMap) {
+			if strtolower(cmKey) == strtolower(key) {
+				return cmKey;
+			}
+		}
+		return key;
+	}
+	
+	/**
 	 * Assigns values to a model from an array returning a new model.
 	 *
 	 *<code>
@@ -530,6 +544,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 					continue;
 				}
 
+				// Try to find case-insensitive key variant
+				if !isset columnMap[key] && globals_get("orm.try_ci_column_map") {
+					let key = self::columnMapCIResolve(columnMap, key);
+				}
+				
 				// Every field must be part of the column map
 				if !fetch attribute, columnMap[key] {
 					if !globals_get("orm.ignore_unknown_columns") {
@@ -638,6 +657,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 			if typeof key == "string" {
 				if typeof columnMap == "array" {
 
+					// Try to find case-insensitive key variant
+					if !isset columnMap[key] && globals_get("orm.try_ci_column_map") {
+						let key = self::columnMapCIResolve(columnMap, key);
+					}
+				
 					/**
 					 * Every field must be part of the column map
 					 */
@@ -3612,6 +3636,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 					continue;
 				}
 
+				// Try to find case-insensitive key variant
+				if !isset columnMap[key] && globals_get("orm.try_ci_column_map") {
+					let key = self::columnMapCIResolve(columnMap, key);
+				}
+				
 				/**
 				 * Every field must be part of the column map
 				 */
@@ -4406,6 +4435,12 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 			 * Check if the columns must be renamed
 			 */
 			if typeof columnMap == "array" {
+				
+				// Try to find case-insensitive attribute variant
+				if !isset columnMap[attribute] && globals_get("orm.try_ci_column_map") {
+					let attribute = self::columnMapCIResolve(columnMap, attribute);
+				}
+				
 				if !fetch attributeField, columnMap[attribute] {
 					if !globals_get("orm.ignore_unknown_columns") {
 						throw new Exception("Column '" . attribute . "' doesn't make part of the column map");
@@ -4454,7 +4489,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	{
 		var disableEvents, columnRenaming, notNullValidations,
 			exceptionOnFailedSave, phqlLiterals, virtualForeignKeys,
-			lateStateBinding, castOnHydrate, ignoreUnknownColumns;
+			lateStateBinding, castOnHydrate, ignoreUnknownColumns,
+			tryCIColumnMap;
 
 		/**
 		 * Enables/Disables globally the internal events
@@ -4517,6 +4553,13 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		 */
 		if fetch ignoreUnknownColumns, options["ignoreUnknownColumns"] {
 			globals_set("orm.ignore_unknown_columns", ignoreUnknownColumns);
+		}
+		
+		/**
+		 * Allows to try to find attributes in column map case-insensitively (needed for Oracle)
+		 */
+		if fetch tryCIColumnMap, options["tryCIColumnMap"] {
+			globals_set("orm.try_ci_column_map", tryCIColumnMap);
 		}
 	}
 


### PR DESCRIPTION
Added a global ORM setting that allows to try to find a key in column map case-insensitively if it was not found by an exact match at first time. Can be a real fix for many Oracle bugs, because Phalcon does not expect that column names are converted to uppercase by Oracle in the query result.

This is a real fix for #10532, because orm.ignore_unknown_columns just suppresses error, while _groupResult will return NULL which may have unintended consequences, and of course Model::count() will not work in this case. This may be a fix for #1652, #760, #10490, but did not check all those cases yet.
