### PR TITLE
Collection: don't keep the raw keys when converting to array

### DIFF
--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -430,7 +430,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 		 * Requesting a complete resultset
 		 */
 		let collections = [];
-		for document in iterator_to_array(documentsCursor) {
+		for document in iterator_to_array(documentsCursor, false) {
 
 			/**
 			 * Assign the values to the base object


### PR DESCRIPTION
These keys are not used anywhere further in the code. 
With the default setting as true and the use of array in MongoDb ids (as allowed through the use of `Phalcon\Mvc\Collection->useImplicitObjectIds` ), it can lead to an "Array to string conversion" notice.
See also #11134 and [the comment about the use_keys parameter](http://php.net/iterator_to_array#use_keys).
