### PR TITLE
Added ability to add files using \Phalcon\Loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 - Fixed `Phalcon\Mvc\Model\Resultset::update()` - removed endless loop queries
 - The cache backend adapters now returns boolean on call `Phalcon\Cache\BackendInterface::save`
 - Fixed the Session write callback [#11733](https://github.com/phalcon/cphalcon/issues/11733)
+- Added '\Phalcon\Loader::registerFiles' & '\Phalcon\Loader::getFiles'. This allows you to add files to the autoloader
 - Added `Phalcon\Security::hasLibreSsl` and `Phalcon\Security::getSslVersionNumber`
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)

--- a/tests/README.md
+++ b/tests/README.md
@@ -87,6 +87,7 @@ export TEST_MC_HOST="127.0.0.1"
 export TEST_MC_PORT="11211"
 
 # MySQL
+export TEST_DB_MYSQL_DSN="mysql:host=localhost;dbname=phalcon_test"
 export TEST_DB_MYSQL_HOST="127.0.0.1"
 export TEST_DB_MYSQL_PORT="3306"
 export TEST_DB_MYSQL_USER="root"

--- a/tests/_data/vendor/Example/Other/NoClass.php
+++ b/tests/_data/vendor/Example/Other/NoClass.php
@@ -1,0 +1,11 @@
+<?php
+
+function noClassFoo()
+{
+
+}
+
+function noClassBar()
+{
+
+}

--- a/tests/_data/vendor/Example/Other/NoClass1.php
+++ b/tests/_data/vendor/Example/Other/NoClass1.php
@@ -1,0 +1,11 @@
+<?php
+
+function noClass1Foo()
+{
+
+}
+
+function noClass1Bar()
+{
+
+}

--- a/tests/_data/vendor/Example/Other/NoClass2.php
+++ b/tests/_data/vendor/Example/Other/NoClass2.php
@@ -1,0 +1,11 @@
+<?php
+
+function noClass2Foo()
+{
+
+}
+
+function noClass2Bar()
+{
+
+}

--- a/tests/_proxies/Loader.php
+++ b/tests/_proxies/Loader.php
@@ -64,6 +64,16 @@ class Loader extends PhLoader
         return parent::getDirs();
     }
 
+    public function registerFiles(array $files, $merge = false)
+    {
+        return parent::registerFiles($files, $merge);
+    }
+
+    public function getFiles()
+    {
+        return parent::getFiles();
+    }
+
     public function registerClasses(array $classes, $merge = false)
     {
         return parent::registerClasses($classes, $merge);

--- a/tests/unit/LoaderTest.php
+++ b/tests/unit/LoaderTest.php
@@ -64,7 +64,6 @@ class LoaderTest extends UnitTest
         set_include_path($this->includePath);
     }
 
-
     public function testNamespaces()
     {
         $this->specify(
@@ -144,6 +143,45 @@ class LoaderTest extends UnitTest
                 expect(new \Example\Adapter\LeCoolSome())->isInstanceOf('Example\Adapter\LeCoolSome');
 
                 $loader->unregister();
+            }
+        );
+    }
+
+    public function testFiles()
+    {
+        $this->specify(
+            "The loader does not load files correctly when using the files strategy",
+            function () {
+                // TEST CASE : Register the file and check if functions in the file is accessible
+                expect(function_exists('noClassFoo'))->false();
+                expect(function_exists('noClassBar'))->false();
+                expect(function_exists('noClass1Foo'))->false();
+                expect(function_exists('noClass1Bar'))->false();
+                expect(function_exists('noClass2Foo'))->false();
+                expect(function_exists('noClass2Bar'))->false();
+                $loader = new Loader();
+                $loader->registerFiles([
+                    PATH_DATA . 'vendor/Example/Other/NoClass.php',
+                    PATH_DATA . 'vendor/Example/Other/NoClass1.php'
+                ]);
+                $loader->registerFiles([
+                    PATH_DATA . 'vendor/Example/Other/NoClass2.php'
+                ], true);
+                $loader->register();
+                expect(function_exists('noClassFoo'))->true();
+                expect(function_exists('noClassBar'))->true();
+                expect(function_exists('noClass1Foo'))->true();
+                expect(function_exists('noClass1Bar'))->true();
+                expect(function_exists('noClass2Foo'))->true();
+                expect(function_exists('noClass2Bar'))->true();
+                // TEST CASE : We are going to un-register it, but the functions should still be accessible
+                $loader->unregister();
+                expect(function_exists('noClassFoo'))->true();
+                expect(function_exists('noClassBar'))->true();
+                expect(function_exists('noClass1Foo'))->true();
+                expect(function_exists('noClass1Bar'))->true();
+                expect(function_exists('noClass2Foo'))->true();
+                expect(function_exists('noClass2Bar'))->true();
             }
         );
     }


### PR DESCRIPTION
There are cases where you have helper files which don't have any classes. In composer, you add something like this to add them - 

``` javascript
{
...
     "autoload": {
         "files": ["src/blah.php"],
     },
...
}
```

The changes below will allow something like this - 

``` php
$loader = new Loader();
$loader->registerFiles(['src/blah.php']);
```

`blah.php` will added using require and all the contents will be usable as normal.

This indirectly addresses -
https://github.com/phalcon/cphalcon/issues/2533
https://github.com/guzzle/guzzle/issues/707
