### PR TITLE
Allow to set double encoding setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - Fixed the Session write callback [#11733](https://github.com/phalcon/cphalcon/issues/11733)
 - Added '\Phalcon\Loader::registerFiles' & '\Phalcon\Loader::getFiles'. This allows you to add files to the autoloader
 - Added `Phalcon\Security::hasLibreSsl` and `Phalcon\Security::getSslVersionNumber`
+- Added new setter `Phalcon\Escaper::setDoubleEncode()` - to allow setting/disabling double encoding
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/escaper.zep
+++ b/phalcon/escaper.zep
@@ -44,6 +44,8 @@ class Escaper implements EscaperInterface
 	protected _htmlEscapeMap = null;
 
 	protected _htmlQuoteType = 3;
+	
+	protected _doubleEncode = true;
 
 	/**
 	 * Sets the encoding to be used by the escaper
@@ -75,6 +77,18 @@ class Escaper implements EscaperInterface
 	public function setHtmlQuoteType(int quoteType) -> void
 	{
 		let this->_htmlQuoteType = quoteType;
+	}
+	
+	/**
+	 * Sets the double_encode to be used by the escaper
+	 *
+	 *<code>
+	 * $escaper->setDoubleEncode(false);
+	 *</code>
+	 */
+	public function setDoubleEncode(boolean doubleEncode) -> void
+	{
+		let this->_doubleEncode = doubleEncode;
 	}
 
 	/**
@@ -140,7 +154,7 @@ class Escaper implements EscaperInterface
 	 */
 	public function escapeHtml(string text) -> string
 	{
-		return htmlspecialchars(text, this->_htmlQuoteType, this->_encoding);
+		return htmlspecialchars(text, this->_htmlQuoteType, this->_encoding, this->_doubleEncode);
 	}
 
 	/**
@@ -148,7 +162,7 @@ class Escaper implements EscaperInterface
 	 */
 	public function escapeHtmlAttr(string attribute) -> string
 	{
-		return htmlspecialchars(attribute, ENT_QUOTES, this->_encoding);
+		return htmlspecialchars(attribute, ENT_QUOTES, this->_encoding, this->_doubleEncode);
 	}
 
 	/**


### PR DESCRIPTION
For some situations, double encoding causes problems (f.ex. &#39; becomes &amp;#39;). Being able to disable double encoding solves this problem.
