### PR TITLE
Phalcon\Validation\Validator\Alpha now correctly validates non-ASCII characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,9 @@
 - Added `Phalcon\Security::hasLibreSsl` and `Phalcon\Security::getSslVersionNumber`
 - Added new setter `Phalcon\Escaper::setDoubleEncode()` - to allow setting/disabling double encoding
 - Added  `Phalcon\Cache\Frontend\Msgpack` - Added Msgpack Support for Frontend Cache
-- `Phalcon\Debug\Dump` skip debuging di, fix detecting private/protected properties
+- `Phalcon\Debug\Dump` skip debugging di, fix detecting private/protected properties
 - Added option to validate multiple fields with one validator(fix uniqueness validator as well), also removes unnecessary `model => $this` in `Phalcon\Validation\Validator\Uniqueness`.
+- `Phalcon\Validation\Validator\Alpha` now correctly validates non-ASCII characters
 
 # [2.0.11](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.11) (????-??-??)
 - Fix Model magic set functionality to maintain variable visibility and utilize setter methods.[#11286](https://github.com/phalcon/cphalcon/issues/11286)

--- a/phalcon/validation/validator/alpha.zep
+++ b/phalcon/validation/validator/alpha.zep
@@ -45,7 +45,6 @@ use Phalcon\Validation\Validator;
  */
 class Alpha extends Validator
 {
-
 	/**
 	 * Executes the validation
 	 */
@@ -55,7 +54,7 @@ class Alpha extends Validator
 
 		let value = validation->getValue(field);
 
-		if !ctype_alpha(value) {
+		if preg_match("/[^[:alpha:]]/imu", value) {
 
 			let label = this->getOption("label");
 			if typeof label == "array" {

--- a/tests/_proxies/Validation/Validator/Alpha.php
+++ b/tests/_proxies/Validation/Validator/Alpha.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Phalcon\Test\Proxy\Validation\Validator;
+
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Alpha as PhAlpha;
+
+/**
+ * \Phalcon\Test\Proxy\Validation\Validator\Alpha
+ * A proxy class for \Phalcon\Validation\Validator\Alpha
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Proxy\Validation\Validator
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Alpha extends PhAlpha
+{
+    public function validate(Validation $validation, $field)
+    {
+        return parent::validate($validation, $field);
+    }
+}


### PR DESCRIPTION
Fixed issue #11386
