### PR TITLE
Added ability to autoescape Flash messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - `Phalcon\Validation\Validator\Alpha` now correctly validates non-ASCII characters [#11386](https://github.com/phalcon/cphalcon/issues/11386)
 - `Phalcon\Validation\Validator\Digit` now correctly validates digits [#11374](https://github.com/phalcon/cphalcon/issues/11374)
 - Added `Phalcon\Validation\CombinedFieldsValidator`, validation will pass array of fields to this validator if needed
+- Added ability to autoescape Flash messages [#11448](https://github.com/phalcon/cphalcon/issues/11448)
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/phalcon/flash/direct.zep
+++ b/phalcon/flash/direct.zep
@@ -25,7 +25,7 @@ use Phalcon\Flash as FlashBase;
 /**
  * Phalcon\Flash\Direct
  *
- * This is a variant of the Phalcon\Flash that inmediately outputs any message passed to it
+ * This is a variant of the Phalcon\Flash that immediately outputs any message passed to it
  */
 class Direct extends FlashBase implements FlashInterface
 {

--- a/phalcon/flash/session.zep
+++ b/phalcon/flash/session.zep
@@ -42,7 +42,7 @@ class Session extends FlashBase implements FlashInterface
 		let dependencyInjector = <DiInterface> this->getDI();
 
 		let session = <SessionInterface> dependencyInjector->getShared("session"),
-		    messages = session->get("_flashMessages");
+			messages = session->get("_flashMessages");
 
 		if typeof type == "string" && isset(messages[type]) {
 			if !fetch returnMessages, messages[type] {
@@ -70,7 +70,7 @@ class Session extends FlashBase implements FlashInterface
 		var dependencyInjector, session;
 
 		let dependencyInjector = <DiInterface> this->getDI(),
-		    session = <SessionInterface> dependencyInjector->getShared("session");
+			session = <SessionInterface> dependencyInjector->getShared("session");
 
 		session->set("_flashMessages", messages);
 		return messages;

--- a/phalcon/flash/session.zep
+++ b/phalcon/flash/session.zep
@@ -22,7 +22,6 @@ namespace Phalcon\Flash;
 use Phalcon\Flash as FlashBase;
 use Phalcon\DiInterface;
 use Phalcon\FlashInterface;
-use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Flash\Exception;
 use Phalcon\Session\AdapterInterface as SessionInterface;
 
@@ -31,27 +30,8 @@ use Phalcon\Session\AdapterInterface as SessionInterface;
  *
  * Temporarily stores the messages in session, then messages can be printed in the next request
  */
-class Session extends FlashBase implements FlashInterface, InjectionAwareInterface
+class Session extends FlashBase implements FlashInterface
 {
-
-	protected _dependencyInjector;
-
-	/**
-	 * Sets the dependency injector
-	 */
-	public function setDI(<DiInterface> dependencyInjector)
-	{
-		let this->_dependencyInjector = dependencyInjector;
-	}
-
-	/**
-	 * Returns the internal dependency injector
-	 */
-	public function getDI() -> <DiInterface>
-	{
-		return this->_dependencyInjector;
-	}
-
 	/**
 	 * Returns the messages stored in session
 	 */
@@ -59,13 +39,10 @@ class Session extends FlashBase implements FlashInterface, InjectionAwareInterfa
 	{
 		var dependencyInjector, session, messages, returnMessages;
 
-		let dependencyInjector = <DiInterface> this->_dependencyInjector;
-		if typeof dependencyInjector != "object" {
-			throw new Exception("A dependency injection container is required to access the 'session' service");
-		}
+		let dependencyInjector = <DiInterface> this->getDI();
 
-		let session = <SessionInterface> dependencyInjector->getShared("session");
-		let messages = session->get("_flashMessages");
+		let session = <SessionInterface> dependencyInjector->getShared("session"),
+		    messages = session->get("_flashMessages");
 
 		if typeof type == "string" && isset(messages[type]) {
 			if !fetch returnMessages, messages[type] {
@@ -92,12 +69,9 @@ class Session extends FlashBase implements FlashInterface, InjectionAwareInterfa
 	{
 		var dependencyInjector, session;
 
-		let dependencyInjector = <DiInterface> this->_dependencyInjector;
-		if typeof dependencyInjector != "object" {
-			throw new Exception("A dependency injection container is required to access the 'session' service");
-		}
+		let dependencyInjector = <DiInterface> this->getDI(),
+		    session = <SessionInterface> dependencyInjector->getShared("session");
 
-		let session = <SessionInterface> dependencyInjector->getShared("session");
 		session->set("_flashMessages", messages);
 		return messages;
 	}

--- a/tests/_proxies/Flash.php
+++ b/tests/_proxies/Flash.php
@@ -1,19 +1,20 @@
 <?php
 
-namespace Phalcon\Test\Proxy\Flash;
+namespace Phalcon\Test\Proxy;
 
 use Phalcon\DiInterface;
-use Phalcon\Flash\Session as PhSession;
+use Phalcon\EscaperInterface;
+use Phalcon\Flash as PhFlash;
 
 /**
- * \Phalcon\Test\Proxy\Flash\Session
- * Flash Session proxy class for \Phalcon\Flash\Session
+ * \Phalcon\Test\Proxy\Flash
+ * Flash proxy class for \Phalcon\Flash
  *
  * @copyright (c) 2011-2016 Phalcon Team
  * @link      http://www.phalconphp.com
  * @author    Andres Gutierrez <andres@phalconphp.com>
- * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
- * @package   Phalcon\Test\Proxy\Flash
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Proxy
  *
  * The contents of this file are subject to the New BSD License that is
  * bundled with this package in the file docs/LICENSE.txt
@@ -22,16 +23,41 @@ use Phalcon\Flash\Session as PhSession;
  * through the world-wide-web, please send an email to license@phalconphp.com
  * so that we can send you a copy immediately.
  */
-class Session extends PhSession
+abstract class Flash extends PhFlash
 {
-    public function message($type, $message)
+    public function __construct($cssClasses = null)
     {
-        parent::message($type, $message);
+        parent::__construct($cssClasses);
     }
 
-    public function output($remove = true)
+    public function getAutoescape()
     {
-        parent::output($remove);
+        return parent::getAutoescape();
+    }
+
+    public function setAutoescape($autoescape)
+    {
+        return parent::setAutoescape($autoescape);
+    }
+
+    public function getEscaperService()
+    {
+        return parent::getEscaperService();
+    }
+
+    public function setEscaperService(EscaperInterface $escaperService)
+    {
+        return parent::setEscaperService($escaperService);
+    }
+
+    public function setDI(DiInterface $dependencyInjector)
+    {
+        return parent::setDI($dependencyInjector);
+    }
+
+    public function getDI()
+    {
+        return parent::getDI();
     }
 
     public function setImplicitFlush($implicitFlush)
@@ -44,7 +70,7 @@ class Session extends PhSession
         return parent::setAutomaticHtml($automaticHtml);
     }
 
-    public function setCssClasses(array $cssClasses)
+    public function setCssClasses($cssClasses)
     {
         return parent::setCssClasses($cssClasses);
     }
@@ -72,5 +98,10 @@ class Session extends PhSession
     public function outputMessage($type, $message)
     {
         return parent::outputMessage($type, $message);
+    }
+
+    public function clear()
+    {
+        parent::clear();
     }
 }

--- a/tests/unit/Flash/Direct/Helper/FlashBase.php
+++ b/tests/unit/Flash/Direct/Helper/FlashBase.php
@@ -4,6 +4,8 @@ namespace Phalcon\Test\Unit\Flash\Direct\Helper;
 
 use Phalcon\Test\Proxy\Flash\Direct;
 use Phalcon\Test\Module\UnitTest;
+use Phalcon\Di;
+use Phalcon\Escaper;
 
 /**
  * \Phalcon\Test\Unit\Flash\Direct\Helper\FlashBase
@@ -253,6 +255,27 @@ class FlashBase extends UnitTest
         $this->stringTest('warning');
         $this->notHtml     = false;
         $this->notImplicit = false;
+    }
+
+    /**
+     * Tests auto escaping
+     *
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @issue  11448
+     * @since  2016-06-15
+     */
+    public function testFlashDirectWithAutoEscaping()
+    {
+        $flash = new Direct($this->classes);
+
+        $flash->setAutomaticHtml(false);
+        $flash->setImplicitFlush(false);
+
+        expect($flash->success("<h1>Hello World!</h1>"))->equals('&lt;h1&gt;Hello World!&lt;/h1&gt;');
+
+        $flash->setAutoescape(false);
+
+        expect($flash->success("<h1>Hello World!</h1>"))->equals('<h1>Hello World!</h1>');
     }
 
     /**


### PR DESCRIPTION
Refs #11448
## Use case 1

``` php
$flash = new Phalcon\Flash\Session;

$di = new Phalcon\Di;
$di->setShared('escaper', new Phalcon\Escaper);

$flash->setDI($di);

$flash->success("<script>alert('This will execute as JavaScript!')</script>");
echo $flash->output();
// <div class="successMessage">&lt;script&gt;alert(&#039;This will execute as JavaScript!&#039;)&lt;/script&gt;</div>
```
## Use case 2

``` php
$flash = new Phalcon\Flash\Session;
$flash->setEscaperService(new Phalcon\Escaper);

$flash->success("<script>alert('This will execute as JavaScript!')</script>");
echo $flash->output();
// <div class="successMessage">&lt;script&gt;alert(&#039;This will execute as JavaScript!&#039;)&lt;/script&gt;</div>
```

<hr>

``` php
$flash->setAutoescape(true); // Enable the autoescape mode in generated html
$flash->setAutoescape(false); // Disable the autoescape mode in generated html
$flash->getAutoescape(); // Returns the autoescape mode in generated html

$flash->setEscaperService(Phalcon\EscaperInterface $escaperService); // Sets the Escaper Service
$flash->getEscaperService(); // Returns the Escaper Service (always)
```
