### PR TITLE
Fixed Route::handle

### DIFF
--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -422,7 +422,7 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 				/**
 				 * No HTTP_HOST, maybe in CLI mode?
 				 */
-				if typeof currentHostName == "null" {
+				if typeof currentHostName == "null" || currentHostName === ":" {
 					continue;
 				}
 


### PR DESCRIPTION
In some cases (for example when `PHP_SAPI === cli`) the `Request::getHttpHost` can return only `:`
