### PR TITLE
Refactored Phalcon\Http\Request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,9 @@
 - Fixed `Phalcon\Config::merge` for working with php7
 - Added ability to use custom delimiter for `Phalcon\Text::camelize` and `Phalcon\Text::uncamelize` [#10396](https://github.com/phalcon/cphalcon/issues/10396)
 - Added support of `CONNECT`, `TRACE` and `PURGE`  HTTP methods
-- Refactored `Phalcon\Http\Request::getHttpHost`. Now it always return host name or empty string. Optionally validates and clean host name.
+- Refactored `Phalcon\Http\Request::getHttpHost`. Now it always return host name or empty string. Optionally validates and clean host name [#2573](https://github.com/phalcon/cphalcon/issues/2573)
 - Added `Phalcon\Http\Request::getPort`. To get information about the port on which the request is made.
+- Added `Phalcon\Http\Request::setStrictHostCheck` and `Phalcon\Http\Request::isStrictHostCheck` to manage strict validation of host name.
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Fixed `Phalcon\Config::merge` for working with php7
 - Added ability to use custom delimiter for `Phalcon\Text::camelize` and `Phalcon\Text::uncamelize` [#10396](https://github.com/phalcon/cphalcon/issues/10396)
 - Added support of `CONNECT`, `TRACE` and `PURGE`  HTTP methods
+- Refactored `Phalcon\Http\Request::getHttpHost`. Now it always return host name or empty string. Optionally validates and clean host name.
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@
 - Added ability to use custom delimiter for `Phalcon\Text::camelize` and `Phalcon\Text::uncamelize` [#10396](https://github.com/phalcon/cphalcon/issues/10396)
 - Added support of `CONNECT`, `TRACE` and `PURGE`  HTTP methods
 - Refactored `Phalcon\Http\Request::getHttpHost`. Now it always return host name or empty string. Optionally validates and clean host name.
+- Added `Phalcon\Http\Request::getPort`. To get information about the port on which the request is made.
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -396,9 +396,9 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 * - `$_SERVER['SERVER_ADDR']`
 	 *
 	 * Optionally `Request::getHttpHost` validates and clean host name.
-	 * The `$strict` value can be used force validation if the `Request::_strictHostCheck` field set to `false`.
+	 * The `Request::$_strictHostCheck` can be used to validate host name.
 	 *
-	 * Note: validation and cleaning has a negative performance impact because they uses regular expressions.
+	 * Note: validation and cleaning have a negative performance impact because they use regular expressions.
 	 *
 	 * <code>
 	 * use Phalcon\Http\Request;
@@ -411,15 +411,6 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 * $_SERVER['HTTP_HOST'] = 'example.com:8080';
 	 * $request->getHttpHost(); // example.com:8080
 	 *
-	 * $_SERVER['HTTP_HOST'] = 'example.com:8080';
-	 * $request->getHttpHost(true); // example.com
-	 *
-	 * $_SERVER['HTTP_HOST'] = 'ExAmPlE.com';
-	 * $request->getHttpHost(true); // example.com
-	 *
-	 * $_SERVER['HTTP_HOST'] = 'ex=am~ple.com';
-	 * $request->getHttpHost(true); // UnexpectedValueException
-	 *
 	 * $request->setStrictHostCheck(true);
 	 * $_SERVER['HTTP_HOST'] = 'ex=am~ple.com';
 	 * $request->getHttpHost(); // UnexpectedValueException
@@ -428,11 +419,11 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 * $request->getHttpHost(); // example.com
 	 * </code>
 	 */
-	public function getHttpHost(bool strict = false) -> string
+	public function getHttpHost() -> string
 	{
-		var host, globalStrict;
+		var host, strict;
 
-		let globalStrict = this->_strictHostCheck;
+		let strict = this->_strictHostCheck;
 
 		/**
 		 * Get the server name from _SERVER['HTTP_HOST']
@@ -452,7 +443,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 			}
 		}
 
-		if host && (strict || globalStrict) {
+		if host && strict {
 			/**
 			 * Cleanup. Force lowercase as per RFC 952/2181
 			 */
@@ -496,7 +487,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 */
 	public function getPort() -> int
 	{
-		var host, port, pos;
+		var host, pos;
 
 		/**
 		 * Get the server name from _SERVER['HTTP_HOST']

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -410,7 +410,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 			}
 		}
 
-		if strict {
+		if strict && host {
 			/**
 			 * Cleanup. Force lowercase as per RFC 952/2181
 			 */
@@ -425,7 +425,33 @@ class Request implements RequestInterface, InjectionAwareInterface
 			}
 		}
 
-		return host;
+		return (string) host;
+	}
+
+	/**
+	 * Gets information about the port on which the request is made.
+	 */
+	public function getPort() -> int
+	{
+		var host, port, pos;
+
+		/**
+		 * Get the server name from _SERVER['HTTP_HOST']
+		 */
+		let host = this->getServer("HTTP_HOST");
+		if host {
+			if memstr(host, ":") {
+				let pos = strrpos(host, "");
+
+				if false !== pos {
+					return (int) substr(host, pos + 1);
+				}
+			}
+
+			return "https" === $this->getScheme() ? 443 : 80;
+		}
+
+		return (int) this->getServer("SERVER_PORT");
 	}
 
 	/**

--- a/phalcon/http/requestinterface.zep
+++ b/phalcon/http/requestinterface.zep
@@ -133,7 +133,7 @@ interface RequestInterface
 	/**
 	 * Gets host name used by the request
 	 */
-	public function getHttpHost(bool strict = false) -> string;
+	public function getHttpHost() -> string;
 
 	/**
 	 * Gets information about the port on which the request is made

--- a/phalcon/http/requestinterface.zep
+++ b/phalcon/http/requestinterface.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -131,9 +131,14 @@ interface RequestInterface
 	public function getServerName() -> string;
 
 	/**
-	 * Gets information about schema, host and port used by the request
+	 * Gets host name used by the request
 	 */
-	public function getHttpHost() -> string;
+	public function getHttpHost(bool strict = false) -> string;
+
+	/**
+	 * Gets information about the port on which the request is made
+	 */
+	public function getPort() -> int;
 
 	/**
 	 * Gets most possibly client IPv4 Address. This methods search in $_SERVER['REMOTE_ADDR'] and optionally in $_SERVER['HTTP_X_FORWARDED_FOR']
@@ -187,6 +192,21 @@ interface RequestInterface
 	 * Checks whether HTTP method is OPTIONS. if $_SERVER['REQUEST_METHOD']=='OPTIONS'
 	 */
 	public function isOptions() -> boolean;
+
+	/**
+	 * Checks whether HTTP method is PURGE (Squid and Varnish support). if _SERVER["REQUEST_METHOD"]==="PURGE"
+	 */
+	public function isPurge() -> boolean;
+
+	/**
+	 * Checks whether HTTP method is TRACE. if _SERVER["REQUEST_METHOD"]==="TRACE"
+	 */
+	public function isTrace() -> boolean;
+
+	/**
+	 * Checks whether HTTP method is CONNECT. if _SERVER["REQUEST_METHOD"]==="CONNECT"
+	 */
+	public function isConnect() -> boolean;
 
 	/**
 	 * Checks whether request include attached files

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -3278,7 +3278,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 			}
 
 			/**
-			 * By defaut use use 3600 seconds (1 hour) as cache lifetime
+			 * By default use use 3600 seconds (1 hour) as cache lifetime
 			 */
 			if !fetch lifetime, cacheOptions["lifetime"] {
 				let lifetime = 3600;

--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -422,7 +422,7 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 				/**
 				 * No HTTP_HOST, maybe in CLI mode?
 				 */
-				if typeof currentHostName == "null" || currentHostName === ":" {
+				if !currentHostName {
 					continue;
 				}
 

--- a/tests/_proxies/Http/Request.php
+++ b/tests/_proxies/Http/Request.php
@@ -109,9 +109,24 @@ class Request extends PhRequest
         return parent::getServerName();
     }
 
-    public function getHttpHost($strict = false)
+    public function getHttpHost()
     {
-        return parent::getHttpHost($strict);
+        return parent::getHttpHost();
+    }
+
+    public function getPort()
+    {
+        return parent::getPort();
+    }
+
+    public function setStrictHostCheck($flag = true)
+    {
+        return parent::setStrictHostCheck($flag);
+    }
+
+    public function isStrictHostCheck()
+    {
+        return parent::isStrictHostCheck();
     }
 
     public function getClientAddress($trustForwardedHeader = false)

--- a/tests/_proxies/Http/Request.php
+++ b/tests/_proxies/Http/Request.php
@@ -109,9 +109,9 @@ class Request extends PhRequest
         return parent::getServerName();
     }
 
-    public function getHttpHost()
+    public function getHttpHost($strict = false)
     {
-        return parent::getHttpHost();
+        return parent::getHttpHost($strict);
     }
 
     public function getClientAddress($trustForwardedHeader = false)

--- a/tests/unit/Http/RequestTest.php
+++ b/tests/unit/Http/RequestTest.php
@@ -318,6 +318,29 @@ class RequestTest extends HttpBase
     public function testHttpRequestHttpHost()
     {
         $this->specify(
+            "http host without required server values does not return empty string",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTP_HOST', '');
+                $this->setServerVar('SERVER_NAME', '');
+                $this->setServerVar('SERVER_ADDR', '');
+
+                expect(is_string($request->getHttpHost()))->true();
+                expect($request->getHttpHost())->equals('');
+            }
+        );
+
+        $this->specify(
+            "http host with strict param does not return does not return valid host name",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('SERVER_NAME', 'LOCALHOST:80');
+
+                expect($request->getHttpHost(true))->equals('localhost');
+            }
+        );
+
+        $this->specify(
             "http host without http does not contain correct data",
             function () {
                 $request = $this->getRequestObject();
@@ -350,6 +373,42 @@ class RequestTest extends HttpBase
                 $this->setServerVar('SERVER_PORT', 443);
 
                 expect($request->getHttpHost())->equals('localhost');
+            }
+        );
+
+        $this->specify(
+            "http host with SERVER_ADDR value does not return expected host name",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTP_HOST', '');
+                $this->setServerVar('SERVER_NAME', '');
+                $this->setServerVar('SERVER_ADDR', '8.8.8.8');
+
+                expect($request->getHttpHost())->equals('8.8.8.8');
+            }
+        );
+
+        $this->specify(
+            "http host with SERVER_NAME value does not return expected host name",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTP_HOST', '');
+                $this->setServerVar('SERVER_NAME', 'some.domain');
+                $this->setServerVar('SERVER_ADDR', '8.8.8.8');
+
+                expect($request->getHttpHost())->equals('some.domain');
+            }
+        );
+
+        $this->specify(
+            "http host with HTTP_HOST value does not return expected host name",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTP_HOST', 'example.com');
+                $this->setServerVar('SERVER_NAME', 'some.domain');
+                $this->setServerVar('SERVER_ADDR', '8.8.8.8');
+
+                expect($request->getHttpHost())->equals('example.com');
             }
         );
     }

--- a/tests/unit/Http/RequestTest.php
+++ b/tests/unit/Http/RequestTest.php
@@ -318,7 +318,7 @@ class RequestTest extends HttpBase
     public function testHttpRequestHttpHost()
     {
         $this->specify(
-            "http host without required server values does not return empty string",
+            "http host with empty server values does not return empty string",
             function () {
                 $request = $this->getRequestObject();
                 $this->setServerVar('HTTP_HOST', '');
@@ -331,12 +331,23 @@ class RequestTest extends HttpBase
         );
 
         $this->specify(
-            "http host with strict param does not return does not return valid host name",
+            "http host without required server values does not return empty string",
             function () {
                 $request = $this->getRequestObject();
-                $this->setServerVar('SERVER_NAME', 'LOCALHOST:80');
+                unset($_SERVER['HTTP_HOST'],$_SERVER['SERVER_NAME'], $_SERVER['SERVER_ADDR']);
 
-                expect($request->getHttpHost(true))->equals('localhost');
+                expect(is_string($request->getHttpHost()))->true();
+                expect($request->getHttpHost())->equals('');
+            }
+        );
+
+        $this->specify(
+            "The Request::getHttpHost without strict validation does not return expected host",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('SERVER_NAME', 'host@name');
+
+                expect($request->getHttpHost())->equals('host@name');
             }
         );
 
@@ -410,6 +421,134 @@ class RequestTest extends HttpBase
 
                 expect($request->getHttpHost())->equals('example.com');
             }
+        );
+    }
+
+    /**
+     * Tests strict host check
+     *
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2016-06-26
+     */
+    public function testHttpStrictHostCheck()
+    {
+        $this->specify(
+            "http host with strict param does not return does not return valid host name",
+            function () {
+                $request = $this->getRequestObject();
+                $request->setStrictHostCheck(true);
+                $this->setServerVar('SERVER_NAME', 'LOCALHOST:80');
+
+                expect($request->getHttpHost())->equals('localhost');
+            }
+        );
+
+        $this->specify(
+            "http host with strict param does not return does not return valid host name",
+            function () {
+                $request = $this->getRequestObject();
+                $request->setStrictHostCheck(false);
+                $this->setServerVar('SERVER_NAME', 'LOCALHOST:80');
+
+                expect($request->getHttpHost())->equals('LOCALHOST:80');
+            }
+        );
+
+        $this->specify(
+            "The Request::isStrictHostCheck does not return expected value",
+            function () {
+                $request = $this->getRequestObject();
+
+                expect($request->isStrictHostCheck())->false();
+
+                $request->setStrictHostCheck(true);
+                expect($request->isStrictHostCheck())->true();
+
+                $request->setStrictHostCheck(false);
+                expect($request->isStrictHostCheck())->false();
+            }
+        );
+    }
+
+    /**
+     * Tests Request::getPort
+     *
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2016-06-26
+     */
+    public function testHttpRequestPort()
+    {
+        $this->specify(
+            "http host with https on does not return expected port",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTPS', 'on');
+                $this->setServerVar('HTTP_HOST', 'example.com');
+
+                expect($request->getPort())->equals(443);
+            }
+        );
+
+        $this->specify(
+            "http host with https off does not return expected port",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTPS', 'off');
+                $this->setServerVar('HTTP_HOST', 'example.com');
+
+                expect($request->getPort())->equals(80);
+            }
+        );
+
+        $this->specify(
+            "http host with port on HTTP_HOST does not return expected port",
+            function () {
+                $request = $this->getRequestObject();
+                $this->setServerVar('HTTPS', 'off');
+                $this->setServerVar('HTTP_HOST', 'example.com:8080');
+
+                expect($request->getPort())->equals(8080);
+
+                $this->setServerVar('HTTPS', 'on');
+                $this->setServerVar('HTTP_HOST', 'example.com:8081');
+
+                expect($request->getPort())->equals(8081);
+
+                unset($_SERVER['HTTPS']);
+                $this->setServerVar('HTTP_HOST', 'example.com:8082');
+
+                expect($request->getPort())->equals(8082);
+            }
+        );
+    }
+
+    /**
+     * Tests getHttpHost by using invalid host
+     *
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2016-06-26
+     */
+    public function testInvalidHttpRequestHttpHost()
+    {
+        $this->specify(
+            "The Request::getHttpHost does not throws exception on strict host validation",
+            function ($host) {
+                $request = $this->getRequestObject();
+                $request->setStrictHostCheck(true);
+
+                $this->setServerVar('HTTP_HOST', $host);
+                $request->getHttpHost();
+            }, [
+                'throws' => 'UnexpectedValueException',
+                'examples' => [
+                    ['foo±bar±baz'  ],
+                    ['foo~bar~baz'  ],
+                    ['<foo-bar-baz>'],
+                    ['foo=bar=baz'  ],
+                    ['foobar/baz'   ],
+                    ['foo@bar'      ],
+                ]
+            ]
         );
     }
 

--- a/tests/unit/Http/RequestTest.php
+++ b/tests/unit/Http/RequestTest.php
@@ -337,7 +337,7 @@ class RequestTest extends HttpBase
                 $this->setServerVar('SERVER_NAME', 'localhost');
                 $this->setServerVar('SERVER_PORT', 80);
 
-                expect($request->getHttpHost())->equals('localhost:80');
+                expect($request->getHttpHost())->equals('localhost');
             }
         );
 


### PR DESCRIPTION
- Now `Request::getHttpHost` always return host name or empty string
- Optionally `Request::getHttpHost` can validate and clean host name
- Added `Request::getPort`. To get information about the port on which the request is made
- Added `Request::setStrictHostCheck` and `Request::isStrictHostCheck` to manage strict validation of host name
- Updated `Phalcon\Http\RequestInterface`

`Request::getHttpHost` trying to find host name in following order:
- `$_SERVER['HTTP_HOST']`
- `$_SERVER['SERVER_NAME']`
- `$_SERVER['SERVER_ADDR']`

<br>_**Note**: validation and cleaning has a negative performance impact because they uses regular expressions._

``` php
use Phalcon\Http\Request;

$request = new Request;

$_SERVER['HTTP_HOST'] = 'example.com';
$request->getHttpHost(); // example.com

$_SERVER['HTTP_HOST'] = 'example.com:8080';
$request->getHttpHost(); // example.com:8080

$request->setStrictHostCheck(true);
$_SERVER['HTTP_HOST'] = 'ex=am~ple.com';
$request->getHttpHost(); // throws UnexpectedValueException

// The Request::_strictHostCheck is still true
$_SERVER['HTTP_HOST'] = 'ExAmPlE.com';
$request->getHttpHost(); // example.com

$request->setStrictHostCheck(false);
$_SERVER['HTTP_HOST'] = 'ExAmPlE.com';
$request->getHttpHost(); // ExAmPlE.com
```

<hr>

Fixes #2573
