### PR TITLE
Fixed Validation::appendMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@
 - Added `Phalcon\Http\Request::setStrictHostCheck` and `Phalcon\Http\Request::isStrictHostCheck` to manage strict validation of host name.
 - Fixed matching host name by `Phalcon\Mvc\Route::handle` when using port on current host name [#2573](https://github.com/phalcon/cphalcon/issues/2573)
 - Fixed `Phalcon\Text:dynamic()` to allow custom separator [#11215](https://github.com/phalcon/cphalcon/issues/11215)
+- Fixed `Phalcon\Validation::appendMessage` to allow append message to the empty stack [#10405](https://github.com/phalcon/cphalcon/issues/10405)
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -446,7 +446,17 @@ class Validation extends Injectable implements ValidationInterface
 	 */
 	public function appendMessage(<MessageInterface> message) -> <Validation>
 	{
-		this->_messages->appendMessage(message);
+		var messages;
+
+		let messages = this->_messages;
+		if typeof messages != "object" {
+			let messages = new Group();
+		}
+
+		messages->appendMessage(message);
+
+		let this->_messages = messages;
+
 		return this;
 	}
 

--- a/tests/integration/ValidationCest.php
+++ b/tests/integration/ValidationCest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace  Phalcon\Test\Integration;
+
+use IntegrationTester;
+use Phalcon\Validation;
+use Phalcon\Validation\Message;
+use Phalcon\Validation\Validator\PresenceOf;
+use Phalcon\Validation\Message\Group;
+
+/**
+ * \Phalcon\Test\Integration\ValidationCest
+ * Tests the \Phalcon\Validation component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Integration
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class ValidationCest
+{
+    /**
+     * Tests the get
+     *
+     * @issue  10405
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2016-06-27
+     * @param IntegrationTester $I
+     */
+    public function appendValidationMessageToTheNonObject(IntegrationTester $I)
+    {
+        $myValidator = new PresenceOf();
+        $validation = new Validation();
+
+        $validation->bind(new \stdClass(),
+            [
+                'day'   => date('d'),
+                'month' => date('m'),
+                'year'  => date('Y') + 1
+            ]
+        );
+
+        $myValidator->validate($validation, 'foo');
+
+        $expectedMessages = Group::__set_state([
+            '_position' => 0,
+            '_messages' => [
+                new Message('Field foo is required', 'foo', 'PresenceOf', 0)
+            ],
+        ]);
+
+        $I->assertEquals($expectedMessages, $validation->getMessages());
+    }
+}


### PR DESCRIPTION
Fixed `Phalcon\Validation::appendMessage` to allow append message to the empty stack [#10405](https://github.com/phalcon/cphalcon/issues/10405)
