### PR TITLE
Micro LazyLoader now has a getter for the definition property

### DIFF
--- a/phalcon/mvc/micro/lazyloader.zep
+++ b/phalcon/mvc/micro/lazyloader.zep
@@ -28,7 +28,9 @@ class LazyLoader
 {
 	protected _handler;
 
-	protected _definition;
+	protected _definition {
+		get
+	};
 
 	/**
 	 * Phalcon\Mvc\Micro\LazyLoader constructor


### PR DESCRIPTION
As per issue #11940 I have added a getter to get definition, for the LazyLoader (Phalcon\Mvc\Micro\LazyLoader) class
