### PR TITLE
Added ability to check whether element has been defined in a form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - Fixed `Phalcon\Session\Flash::getMessages`. Now it returns an empty array in case of non existent message type request [#11941](https://github.com/phalcon/cphalcon/issues/11941)
 - Amended `Phalcon\Mvc\RouterInterface` and `Phalcon\Mvc\Router`. Added missed `addPurge`, `addTrace` and `addConnect` methods
 - Fixed incorrect query when using NULL fields with `Phalcon\Validation\Validator\Uniqueness`
+- Added ability to check whether element has been defined in `Phalcon\Forms\Form`
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -710,4 +710,14 @@ class Form extends Injectable implements \Countable, \Iterator
 	{
 		return isset this->_elementsIndexed[this->_position];
 	}
+
+	/**
+	 * checks whether element with such a name exists in form definition
+	 *
+	 * @param string $name
+	 */
+	public function hasField(string name) -> boolean
+	{
+		return isset this->_elements[name];
+	}
 }

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -101,6 +101,9 @@ class FormTest extends UnitTest
                 expect($form->hasMessagesFor("telephone"))->true();
 
                 expect($form->hasMessagesFor("address"))->false();
+
+                expect($form->hasField("address"))->true();
+                expect($form->hasField("falseTest"))->false();
             }
         );
     }


### PR DESCRIPTION
Lets say we have a form for adding a product. Now this product has a type, and based on the type some of the fields are used, other are not. What I do is create 1 form class no matter what the type is and currently we have to perform the same check twice :

```
if ($product_type === "whatever" ) {
//add the field in the form
}

.... 

and then the same in our view
if ($product_type === "whatever" ) {
//display the field
}
```

probably you are saying yo yourself that we have to do the same with this implementation, and you are right, but we can skip cases like this :

```
if ($product_type === "car"  || $product_type === "bike"  || $product_type === "boat")
```

after half of out fields in our form. Also the display of the form can be dictated from form class only.
