### PR TITLE
Add firing of 'afterConnect' event to PDO adapter.

### DIFF
--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -85,8 +85,11 @@ abstract class Pdo extends Adapter
 	 */
 	public function connect(descriptor = null)
 	{
-		var username, password, dsnParts, dsnAttributes,
+		var eventsManager,
+			username, password, dsnParts, dsnAttributes,
 			persistent, options, key, value;
+
+		let eventsManager = <ManagerInterface> this->_eventsManager;
 
 		if descriptor === null {
 			let descriptor = this->_descriptor;
@@ -153,6 +156,13 @@ abstract class Pdo extends Adapter
 		 * Create the connection using PDO
 		 */
 		let this->_pdo = new \Pdo(this->_type . ":" . dsnAttributes, username, password, options);
+
+		/**
+		 * Execute the afterQuery event if a EventsManager is available
+		 */
+		if typeof eventsManager == "object" {
+			eventsManager->fire("db:afterQuery", this);
+		}
 	}
 
 	/**


### PR DESCRIPTION
The event still is not able to be listened to because the `connect` function is called in the adapter constructor and so the events manager is unable to catch this early event.  This event is being fired in the correct place though so future commits should be able to resolve this.
