### PR TITLE
Add firing of 'afterConnect' event to PDO adapter.

### DIFF
--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -59,7 +59,6 @@ abstract class Pdo extends Adapter
 	 */
 	public function __construct(array! descriptor)
 	{
-		this->connect(descriptor);
 		parent::__construct(descriptor);
 	}
 
@@ -177,7 +176,9 @@ abstract class Pdo extends Adapter
 	 */
 	public function prepare(string! sqlStatement) -> <\PDOStatement>
 	{
-		return this->_pdo->prepare(sqlStatement);
+		var pdo;
+		let pdo = this->getInternalHandler();
+		return pdo->prepare(sqlStatement);
 	}
 
 	/**
@@ -312,7 +313,7 @@ abstract class Pdo extends Adapter
 			}
 		}
 
-		let pdo = <\Pdo> this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof bindParams == "array" {
 			let statement = pdo->prepare(sqlStatement);
 			if typeof statement == "object" {
@@ -367,7 +368,7 @@ abstract class Pdo extends Adapter
 		 */
 		let affectedRows = 0;
 
-		let pdo = <\Pdo> this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof bindParams == "array" {
 			let statement = pdo->prepare(sqlStatement);
 			if typeof statement == "object" {
@@ -446,7 +447,9 @@ abstract class Pdo extends Adapter
 	 */
 	public function escapeString(string str) -> string
 	{
-		return this->_pdo->quote(str);
+		var pdo;
+		let pdo = this->getInternalHandler();
+		return pdo->quote(str);
 	}
 
 	/**
@@ -513,7 +516,7 @@ abstract class Pdo extends Adapter
 	public function lastInsertId(sequenceName = null) -> int | boolean
 	{
 		var pdo;
-		let pdo = this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof pdo != "object" {
 			return false;
 		}
@@ -527,7 +530,7 @@ abstract class Pdo extends Adapter
 	{
 		var pdo, transactionLevel, eventsManager, savepointName;
 
-		let pdo = this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof pdo != "object" {
 			return false;
 		}
@@ -585,7 +588,7 @@ abstract class Pdo extends Adapter
 	{
 		var pdo, transactionLevel, eventsManager, savepointName;
 
-		let pdo = this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof pdo != "object" {
 			return false;
 		}
@@ -659,7 +662,7 @@ abstract class Pdo extends Adapter
 	{
 		var pdo, transactionLevel, eventsManager, savepointName;
 
-		let pdo = this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof pdo != "object" {
 			return false;
 		}
@@ -743,7 +746,7 @@ abstract class Pdo extends Adapter
 	public function isUnderTransaction() -> boolean
 	{
 		var pdo;
-		let pdo = this->_pdo;
+		let pdo = this->getInternalHandler();
 		if typeof pdo == "object" {
 			return pdo->inTransaction();
 		}
@@ -755,6 +758,11 @@ abstract class Pdo extends Adapter
 	 */
 	public function getInternalHandler() -> <\Pdo>
 	{
+		var pdo;
+		let pdo = this->_pdo;
+		if typeof pdo != "object" {
+			this->connect();
+		}
 		return this->_pdo;
 	}
 
@@ -765,6 +773,8 @@ abstract class Pdo extends Adapter
 	 */
 	public function getErrorInfo()
 	{
-		return this->_pdo->errorInfo();
+		var pdo;
+		let pdo = this->getInternalHandler();
+		return pdo->errorInfo();
 	}
 }

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -156,6 +156,8 @@ abstract class Pdo extends Adapter
 		 */
 		let this->_pdo = new \Pdo(this->_type . ":" . dsnAttributes, username, password, options);
 
+		error_log("connect");
+
 		/**
 		 * Execute the afterConnect event if a EventsManager is available
 		 */
@@ -301,6 +303,8 @@ abstract class Pdo extends Adapter
 
 		let eventsManager = <ManagerInterface> this->_eventsManager;
 
+		let pdo = this->getInternalHandler();
+
 		/**
 		 * Execute the beforeQuery event if a EventsManager is available
 		 */
@@ -313,7 +317,6 @@ abstract class Pdo extends Adapter
 			}
 		}
 
-		let pdo = this->getInternalHandler();
 		if typeof bindParams == "array" {
 			let statement = pdo->prepare(sqlStatement);
 			if typeof statement == "object" {
@@ -350,6 +353,8 @@ abstract class Pdo extends Adapter
 	{
 		var eventsManager, affectedRows, pdo, newStatement, statement;
 
+		let pdo = this->getInternalHandler();
+
 		/**
 		 * Execute the beforeQuery event if a EventsManager is available
 		 */
@@ -368,7 +373,6 @@ abstract class Pdo extends Adapter
 		 */
 		let affectedRows = 0;
 
-		let pdo = this->getInternalHandler();
 		if typeof bindParams == "array" {
 			let statement = pdo->prepare(sqlStatement);
 			if typeof statement == "object" {
@@ -746,7 +750,7 @@ abstract class Pdo extends Adapter
 	public function isUnderTransaction() -> boolean
 	{
 		var pdo;
-		let pdo = this->getInternalHandler();
+		let pdo = this->_pdo;
 		if typeof pdo == "object" {
 			return pdo->inTransaction();
 		}
@@ -761,9 +765,11 @@ abstract class Pdo extends Adapter
 		var pdo;
 		let pdo = this->_pdo;
 		if typeof pdo != "object" {
+			error_log(typeof pdo);
 			this->connect();
+			let pdo = this->_pdo;
 		}
-		return this->_pdo;
+		return pdo;
 	}
 
 	/**

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -85,8 +85,11 @@ abstract class Pdo extends Adapter
 	 */
 	public function connect(descriptor = null)
 	{
-		var username, password, dsnParts, dsnAttributes,
+		var eventsManager,
+			username, password, dsnParts, dsnAttributes,
 			persistent, options, key, value;
+
+		let eventsManager = <ManagerInterface> this->_eventsManager;
 
 		if descriptor === null {
 			let descriptor = this->_descriptor;
@@ -153,6 +156,13 @@ abstract class Pdo extends Adapter
 		 * Create the connection using PDO
 		 */
 		let this->_pdo = new \Pdo(this->_type . ":" . dsnAttributes, username, password, options);
+
+		/**
+		 * Execute the afterConnect event if a EventsManager is available
+		 */
+		if typeof eventsManager == "object" {
+			eventsManager->fire("db:afterConnect", this);
+		}
 	}
 
 	/**

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -156,8 +156,6 @@ abstract class Pdo extends Adapter
 		 */
 		let this->_pdo = new \Pdo(this->_type . ":" . dsnAttributes, username, password, options);
 
-		error_log("connect");
-
 		/**
 		 * Execute the afterConnect event if a EventsManager is available
 		 */
@@ -765,7 +763,6 @@ abstract class Pdo extends Adapter
 		var pdo;
 		let pdo = this->_pdo;
 		if typeof pdo != "object" {
-			error_log(typeof pdo);
 			this->connect();
 			let pdo = this->_pdo;
 		}


### PR DESCRIPTION
The event still is not able to be listened to because the connect function is called in the adapter constructor and so the events manager is unable to catch this early event. This event is being fired in the correct place though so future commits should be able to resolve this.
