### PR TITLE
Proposed Fix for Issue #10800

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4246,6 +4246,12 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		let relation = <RelationInterface> manager->getRelationByAlias(modelName, lowerProperty);
 		if typeof relation == "object" {
 
+			/*
+			 Not fetch a relation if it is on CamelCase
+			 */
+			if isset this->{lowerProperty} && typeof this->{lowerProperty} == "object" {
+				return this->{lowerProperty};
+			}
 			/**
 			 * Get the related records
 			 */

--- a/tests/unit/Mvc/ModelTest.php
+++ b/tests/unit/Mvc/ModelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc;
+
+use Phalcon\Mvc\Model\Criteria;
+use Phalcon\Test\Models\AlbumORama\Albums;
+use Phalcon\Test\Module\UnitTest;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Model\ManagerTest
+ * Tests the Phalcon\Mvc\Model\Manager component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Mvc\Model
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class ModelTest extends UnitTest
+{
+    /**
+     * @var Manager
+     */
+    private $modelsManager;
+
+
+    protected function _before()
+    {
+        parent::_before();
+        /** @var \Phalcon\Mvc\Application $app */
+        $app = $this->tester->getApplication();
+        $this->modelsManager = $app->getDI()->getShared('modelsManager');
+    }
+    
+    public function testCamelCaseRelation()
+    {
+        $this->specify(
+            "CamelCase relation calls should be the same cache",
+            function () {
+                $this->modelsManager->registerNamespaceAlias('AlbumORama','Phalcon\Test\Models\AlbumORama');
+                $album = Albums::findFirst();
+                $album->artist->name = 'NotArtist';
+                expect($album->artist->name)->equals($album->Artist->name);
+            }
+        );
+    }
+}


### PR DESCRIPTION
Currently if you call a relation with CamelCase it will make a new fetch every and not pull the one from memory, this hapens even for alias in CamelCase.

i.e. $parts->robot != $parts->Robot

Refs #10800, #11726
