### PR TITLE
Compound relation fix #10368

### DIFF
--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -1298,7 +1298,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 			 * Compound relation
 			 */
 			let referencedFields = relation->getReferencedFields();
-			for refPosition, field in relation->getReferencedFields() {
+			for refPosition, field in relation->getFields() {
 				let conditions[] = "[". referencedFields[refPosition] . "] = :APR" . refPosition . ":",
 					placeholders["APR" . refPosition] = record->readAttribute(field);
 			}


### PR DESCRIPTION
Fixes issue #10368
**Issue description:** Relations are not working properly when using multiple columns to join models by different field names.
**Example:**
`$this->hasOne(['user_id', 'client_id'], 'SomeModel', ['user_id_2', 'client_id']);`
