### PR TITLE
Renamed isSoapRequest to isSoap and isSecureRequest to isSecure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@
 - Fixed `Phalcon\Forms\Form::getValue`. Now Elements can have names that match with the internal Form getters [#10398](https://github.com/phalcon/cphalcon/issues/10398)
 - Add `setContentLength()` method to `Phalcon\Http\Response`
 - Fixed `Phalcon\Mvc\Model\Manager::_mergeFindParameters` - Merging conditions [#11987](https://github.com/phalcon/cphalcon/issues/11987)
+- Renamed `Phalcon\Http\Request::isSoapRequest` to `Phalcon\Http\Request::isSoap` and `Phalcon\Http\Request::isSecureRequest` to `Phalcon\Http\Request::isSecure`. Left the originals functions as aliases and marked them deprecated. 
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -308,7 +308,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 	/**
 	 * Checks whether request has been made using SOAP
 	 */
-	public function isSoapRequested() -> boolean
+	public function isSoap() -> boolean
 	{
 		var contentType;
 
@@ -324,11 +324,27 @@ class Request implements RequestInterface, InjectionAwareInterface
 	}
 
 	/**
+	 * Alias of isSoap(). It will be deprecated in future versions
+	 */
+	public function isSoapRequested() -> boolean
+	{
+		return this->isSoap();
+	}
+
+	/**
 	 * Checks whether request has been made using any secure layer
+	 */
+	public function isSecure() -> boolean
+	{
+		return this->getScheme() === "https";
+	}
+
+	/**
+	 * Alias of isSecure(). It will be deprecated in future versions
 	 */
 	public function isSecureRequest() -> boolean
 	{
-		return this->getScheme() === "https";
+		return this->isSecure();
 	}
 
 	/**

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -326,7 +326,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 	/**
 	 * Alias of isSoap(). It will be deprecated in future versions
 	 */
-	public function isSoapRequested() -> boolean
+	deprecated public function isSoapRequested() -> boolean
 	{
 		return this->isSoap();
 	}
@@ -342,7 +342,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 	/**
 	 * Alias of isSecure(). It will be deprecated in future versions
 	 */
-	public function isSecureRequest() -> boolean
+	deprecated public function isSecureRequest() -> boolean
 	{
 		return this->isSecure();
 	}


### PR DESCRIPTION
Keeping the interface/verbiage the same, renamed isSoapRequest to isSoap and isSecureRequest to isSecure. Left the existing functions as aliases (to be removed later on)
