### PR TITLE
Implement convert option to Uniqueness validator (#12005)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - Fixed wildcard inheritance in `Phalcon\Acl\Adapter\Memory` [#12004](https://github.com/phalcon/cphalcon/issues/12004)
 - Dropped support of Oracle [#12008](https://github.com/phalcon/cphalcon/issues/12008)
 - Improved `Phalcon\Mvc\Collection::findById`. Added check if a `id` in a valid format [#12010](https://github.com/phalcon/cphalcon/issues/12010)
+- Added `convert` option to `Phalcon\Validation\Validator\Uniqueness` to convert values to do the database lookup [#12005](https://github.com/phalcon/cphalcon/issues/12005)
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/tests/unit/Validation/Validator/UniquenessTest.php
+++ b/tests/unit/Validation/Validator/UniquenessTest.php
@@ -70,6 +70,27 @@ class UniquenessTest extends UnitTest
     }
 
     /**
+     * Tests uniqueness validator with single fields and a converted value
+     *
+     * @author Bas Stottelaar <basstottelaar@gmail.com>
+     * @since  2016-07-25
+     */
+    public function testSingleFieldConvert()
+    {
+        $this->specify('Test uniqueness with single field and a converted value.', function () {
+            $validation = new Validation();
+            $validation->add('type', new Uniqueness([
+                'convert' => function (array $values) {
+                    $values['type'] = 'hydraulic'; // mechanical -> hydraulic
+                    return $values;
+                }
+            ]));
+            $messages = $validation->validate(null, $this->robot);
+            expect($messages->count())->equals(0);
+        });
+    }
+
+    /**
      * Tests uniqueness validator with single field and a null value
      *
      * @author Bas Stottelaar <basstottelaar@gmail.com>
@@ -103,6 +124,27 @@ class UniquenessTest extends UnitTest
             $messages = $validation->validate(null, $this->robot);
             expect($messages->count())->equals(1);
             $messages = $validation->validate(null, $this->anotherRobot);
+            expect($messages->count())->equals(0);
+        });
+    }
+
+    /**
+     * Tests uniqueness validator with multiple fields and a converted value
+     *
+     * @author Bas Stottelaar <basstottelaar@gmail.com>
+     * @since  2016-07-25
+     */
+    public function testMultipleFieldsConvert()
+    {
+        $this->specify('Test uniqueness with combination of fields and a converted value.', function () {
+            $validation = new Validation();
+            $validation->add(['name', 'type'], new Uniqueness([
+                'convert' => function (array $values) {
+                    $values['type'] = 'hydraulic'; // mechanical -> hydraulic
+                    return $values;
+                }
+            ]));
+            $messages = $validation->validate(null, $this->robot);
             expect($messages->count())->equals(0);
         });
     }
@@ -210,6 +252,31 @@ class UniquenessTest extends UnitTest
             expect($messages->count())->equals(0);
             $messages = $validation->validate(null, $this->anotherRobot);
             expect($messages->count())->equals(0);
+        });
+    }
+
+    /**
+     * Tests value conversion for returning an array.
+     *
+     * @author Bas Stottelaar <basstottelaar@gmail.com>
+     * @since  2016-07-25
+     */
+    public function testConvertArrayReturnsArray()
+    {
+        $this->specify('Test value conversion to return an array.', function () {
+            $validation = new Validation();
+            $validation->add('type', new Uniqueness([
+                'convert' => function (array $values) {
+                    ($values);
+                    return null;
+                }
+            ]));
+            try {
+                $validation->validate(null, $this->robot);
+                verify_that(false);
+            } catch (\Exception $e) {
+                verify_that(true);
+            }
         });
     }
 


### PR DESCRIPTION
This PR proposes a fix for #12005, for Phalcon 3.0.x.

I have only implemented this for the Uniqueness validator, because that is the only one that does a database lookup, which may need values to be converted to do the lookup..
