### PR TITLE
Added totalCount config to Phalcon\Paginator\Adapter\QueryBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - Fixed wildcard inheritance in `Phalcon\Acl\Adapter\Memory` [#12004](https://github.com/phalcon/cphalcon/issues/12004)
 - Dropped support of Oracle [#12008](https://github.com/phalcon/cphalcon/issues/12008)
 - Improved `Phalcon\Mvc\Collection::findById`. Added check if a `id` in a valid format [#12010](https://github.com/phalcon/cphalcon/issues/12010)
+- Add totalCount config property to `Phalcon\Paginator\Adapter\QueryBuilder`
 
 # [2.0.13](https://github.com/phalcon/cphalcon/releases/tag/phalcon-v2.0.13) (2016-05-19)
 - Restored `Phalcon\Text::camelize` behavior [#11767](https://github.com/phalcon/cphalcon/issues/11767)

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -121,11 +121,6 @@ class QueryBuilder extends Adapter implements AdapterInterface
 		 */
 		let builder = clone originalBuilder;
 
-		/**
-		 * We make a copy of the original builder to count the total of records
-		 */
-		let totalBuilder = clone builder;
-
 		let limit = this->_limitRows;
 		let numberPage = (int) this->_page;
 
@@ -158,41 +153,57 @@ class QueryBuilder extends Adapter implements AdapterInterface
 		let items = query->execute();
 
 		/**
-		 * Change the queried columns by a COUNT(*)
-		 */
-		totalBuilder->columns("COUNT(*) [rowcount]");
+		* check if row count is defined in the config
+		*/
 
-		/**
-		 * Change 'COUNT()' parameters, when the query contains 'GROUP BY'
-		 */
-		var groups = totalBuilder->getGroupBy();
-		if !empty groups {
-			var groupColumn;
-			if typeof groups == "array" {
-				let groupColumn = implode(", ", groups);
-			} else {
-				let groupColumn = groups;
-			}
-			totalBuilder->groupBy(null)->columns(["COUNT(DISTINCT ".groupColumn.") AS rowcount"]);
-		}
+		if fetch rowcount, this->_config["totalCount"] {
 
-		/**
-		 * Remove the 'ORDER BY' clause, PostgreSQL requires this
-		 */
-		totalBuilder->orderBy(null);
+			let rowcount = intval(rowcount);
+		} else {
 
-		/**
-		 * Obtain the PHQL for the total query
-		 */
-		let totalQuery = totalBuilder->getQuery();
+			/**
+			* We make a copy of the original builder to count the total of records
+			*/
+			let totalBuilder = clone builder;
 
-		/**
-		 * Obtain the result of the total query
-		 */
-		let result = totalQuery->execute(),
-			row = result->getFirst(),
-			rowcount = row ? intval(row->rowcount) : 0,
-			totalPages = intval(ceil(rowcount / limit));
+			/**
+			* Change the queried columns by a COUNT(*)
+			*/
+			totalBuilder->columns("COUNT(*) [rowcount]");
+
+            /**
+            * Change 'COUNT()' parameters, when the query contains 'GROUP BY'
+            */
+            var groups = totalBuilder->getGroupBy();
+            if !empty groups {
+                var groupColumn;
+                if typeof groups == "array" {
+                    let groupColumn = implode(", ", groups);
+                } else {
+                    let groupColumn = groups;
+                }
+                totalBuilder->groupBy(null)->columns(["COUNT(DISTINCT ".groupColumn.") AS rowcount"]);
+            }
+
+            /**
+            * Remove the 'ORDER BY' clause, PostgreSQL requires this
+            */
+            totalBuilder->orderBy(null);
+
+            /**
+            * Obtain the PHQL for the total query
+            */
+            let totalQuery = totalBuilder->getQuery();
+
+            /**
+            * Obtain the row count from total query
+            */
+            let result = totalQuery->execute(),
+                row = result->getFirst(),
+                rowcount = row ? intval(row->rowcount) : 0;
+        }
+
+        let totalPages = intval(ceil(rowcount / limit));
 
 		if numberPage < totalPages {
 			let next = numberPage + 1;

--- a/tests/unit/Paginator/Adapter/QueryBuilderTest.php
+++ b/tests/unit/Paginator/Adapter/QueryBuilderTest.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Phalcon\Test\Unit\Paginator\Adapter;
+
+use Phalcon\Test\Module\UnitTest;
+use Phalcon\Test\Proxy\Paginator\Adapter\QueryBuilder;
+use Phalcon\Mvc\Model\Metadata\Memory;
+
+/**
+ * \Phalcon\Test\Unit\Paginator\Adapter\QueryBuilderTest
+ * Tests the \Phalcon\Paginator\Adapter\QueryBuilder component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Unit\Paginator\Adapter
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class QueryBuilderTest extends UnitTest
+{
+
+    /**
+     * @var Manager
+     */
+    private $modelsManager;
+
+    /**
+     * @var Manager
+     */
+    private $builder;
+
+    /**
+     * Executed before each test
+     *
+     * @param IntegrationTester $I
+     */
+    public function _before(IntegrationTester $I)
+    {
+        Di::setDefault($I->getApplication()->getDI());
+
+        $this->modelsManager = $I->getApplication()->getDI()->getShared('modelsManager');
+
+        $I->haveServiceInDi('modelsMetadata', function() {
+            return new Memory;
+        }, true);
+
+        $this->builder = $this->modelsManager->createBuilder()
+            ->columns('sel_id, sel_name')
+            ->from('Phalcon\Test\Models\Select')
+            ->orderBy('sel_name');
+    }
+
+    /**
+     * Tests QueryBuilder constructor
+     *
+     * @since  2016-27-07
+     */
+    public function testShouldCreatePaginator()
+    {
+        $this->specify(
+            "QueryBuilder does not create expected object for page 1",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 1
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(2);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(1);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+
+        $this->specify(
+            "QueryBuilder does not create expected object for page 2",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 2
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(3);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(2);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+
+        $this->specify(
+            "QueryBuilder does not create expected object for page 3",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 3
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(2);
+                expect($page->next)->equals(4);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(3);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+    }
+
+    /**
+     * Tests QueryBuilder::setCurrentPage
+     *
+     * @since  2016-27-07
+     */
+    public function testShouldSetCurrentPage()
+    {
+        $this->specify(
+            "NativeArray::setCurrentPage does not work correctly",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 3
+                    ]
+                );
+
+                $paginator->setCurrentPage(2);
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(3);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(2);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+    }
+
+    /**
+     * Tests QueryBuilder totalCount config
+     *
+     * @since  2016-27-07
+     */
+    public function testTotalCountConfig()
+    {
+        $this->specify(
+            "QueryBuilder totalCount config does not work correctly page 1",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 4,
+                        "page"  => 1,
+                        "totalCount" => 100
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(4);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(2);
+                expect($page->last)->equals(25);
+                expect($page->limit)->equals(4);
+
+                expect($page->current)->equals(1);
+                expect($page->total_pages)->equals(25);
+            }
+        );
+
+        $this->specify(
+            "QueryBuilder totalCount config does not work correctly page 2",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 4,
+                        "page"  => 2,
+                        "totalCount" => 100
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(4);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(3);
+                expect($page->last)->equals(25);
+                expect($page->limit)->equals(4);
+
+                expect($page->current)->equals(2);
+                expect($page->total_pages)->equals(25);
+            }
+        );
+    }
+}


### PR DESCRIPTION
I guess situations like this https://forum.phalconphp.com/discussion/12207/how-to-alter-count-logic-in-querybuilderpaginator in some high complex application,  are highly possible. 

With this patch developers can specify the exact number of total results ( by performing a query of their own before that )  without build-ed in counter being fired. 

Maybe another plus of this patch is sometimes people wants to count id, instead of *, with this patch they can do it the way they want without any dramatic changes to the framework itself.

//other ideas: 
It can be done by checking if the given value is_numeric, otherwise people can specify raw queries, or pass another builder, but i think it might end up being an overkill. 

example usage : 

```

paginator   = new \Phalcon\Paginator\Adapter\QueryBuilder(
   array(
         "builder"  => $builder,
          "limit" => 20,
          "page"  => $currentPage,
          "totalCount" => $counterQuery->execute()->total_rows
   )
);
```
