### PR TITLE
Added totalCount config to Phalcon\Paginator\Adapter\QueryBuilder

### DIFF
--- a/tests/_proxies/Paginator/Adapter/QueryBuilder.php
+++ b/tests/_proxies/Paginator/Adapter/QueryBuilder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phalcon\Test\Proxy\Paginator\Adapter;
+
+use Phalcon\Paginator\Adapter\QueryBuilder as PhQueryBuilder;
+
+/**
+ * \Phalcon\Test\Proxy\Paginator\Adapter\QueryBuilder
+ * Beanstalk proxy class for \Phalcon\Paginator\Adapter\QueryBuilder
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Proxy\Paginator\Adapter
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class QueryBuilder extends PhQueryBuilder
+{
+    public function __construct($config)
+    {
+        parent::__construct($config);
+    }
+
+    public function getPaginate()
+    {
+        return parent::getPaginate();
+    }
+}

--- a/tests/unit/Paginator/Adapter/QueryBuilderTest.php
+++ b/tests/unit/Paginator/Adapter/QueryBuilderTest.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Phalcon\Test\Unit\Paginator\Adapter;
+
+use Phalcon\Test\Module\UnitTest;
+use Phalcon\Test\Proxy\Paginator\Adapter\QueryBuilder;
+use Phalcon\Mvc\Model\Metadata\Memory;
+
+/**
+ * \Phalcon\Test\Unit\Paginator\Adapter\QueryBuilderTest
+ * Tests the \Phalcon\Paginator\Adapter\QueryBuilder component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Unit\Paginator\Adapter
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class QueryBuilderTest extends UnitTest
+{
+
+    /**
+     * @var Manager
+     */
+    private $modelsManager;
+
+    /**
+     * @var Manager
+     */
+    private $builder;
+
+    /**
+     * Executed before each test
+     *
+     * @param IntegrationTester $I
+     */
+    public function _before()
+    {
+        parent::_before();
+        /** @var \Phalcon\Mvc\Application $app */
+        $app = $this->tester->getApplication();
+        $this->modelsManager = $app->getDI()->getShared('modelsManager');
+
+        $this->builder = $this->modelsManager->createBuilder()
+            ->columns('sel_id, sel_name')
+            ->from('Phalcon\Test\Models\Select')
+            ->orderBy('sel_name');
+    }
+
+    /**
+     * Tests QueryBuilder constructor
+     *
+     * @since  2016-27-07
+     */
+    public function testShouldCreatePaginator()
+    {
+        $this->specify(
+            "Paginator QueryBuilder does not create expected object for page 1",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 1
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(2);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(1);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+
+        $this->specify(
+            "Paginator QueryBuilder does not create expected object for page 2",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 2
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(3);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(2);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+
+        $this->specify(
+            "Paginator QueryBuilder does not create expected object for page 3",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 3
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(2);
+                expect($page->next)->equals(4);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(3);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+    }
+
+    /**
+     * Tests QueryBuilder::setCurrentPage
+     *
+     * @since  2016-27-07
+     */
+    public function testShouldSetCurrentPage()
+    {
+        $this->specify(
+            "Paginator QueryBuilder::setCurrentPage does not work correctly",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 2,
+                        "page"  => 3
+                    ]
+                );
+
+                $paginator->setCurrentPage(2);
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(2);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(3);
+                expect($page->last)->equals(4);
+                expect($page->limit)->equals(2);
+
+                expect($page->current)->equals(2);
+                expect($page->total_pages)->equals(4);
+            }
+        );
+    }
+
+    /**
+     * Tests QueryBuilder totalCount config
+     *
+     * @since  2016-27-07
+     */
+    public function testTotalCountConfig()
+    {
+        $this->specify(
+            "Paginator QueryBuilder totalCount config does not work correctly page 1",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 4,
+                        "page"  => 1,
+                        "totalCount" => 100
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(4);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(2);
+                expect($page->last)->equals(25);
+                expect($page->limit)->equals(4);
+
+                expect($page->current)->equals(1);
+                expect($page->total_pages)->equals(25);
+            }
+        );
+
+        $this->specify(
+            "Paginator QueryBuilder totalCount config does not work correctly page 2",
+            function () {
+                $paginator = new QueryBuilder(
+                    [
+                        "builder"  => $this->builder,
+                        "limit" => 4,
+                        "page"  => 2,
+                        "totalCount" => 100
+                    ]
+                );
+
+                $page = $paginator->getPaginate();
+
+                expect($page)->isInstanceOf('stdClass');
+                expect($page->items)->count(4);
+
+                expect($page->before)->equals(1);
+                expect($page->next)->equals(3);
+                expect($page->last)->equals(25);
+                expect($page->limit)->equals(4);
+
+                expect($page->current)->equals(2);
+                expect($page->total_pages)->equals(25);
+            }
+        );
+    }
+}


### PR DESCRIPTION
I guess situations like this https://forum.phalconphp.com/discussion/12207/how-to-alter-count-logic-in-querybuilderpaginator in some high complex application,  are highly possible. 

With this patch developers can specify the exact number of total results ( by performing a query of their own before that )  without build-ed in counter being fired. 

Maybe another plus of this patch is sometimes people wants to count id, instead of *, with this patch they can do it the way they want without any dramatic changes to the framework itself.

//other ideas: 
It can be done by checking if the given value is_numeric, otherwise people can specify raw queries, or pass another builder, but i think it might end up being an overkill. 

example usage : 

``` php
use Phalcon\Paginator\Adapter\QueryBuilder;

$paginator = new QueryBuilder(
    [
        'builder'    => $builder,
        'limit'      => 20,
        'page'       => $currentPage,
        'totalCount' => $counterQuery->execute()->total_rows
   ]
);
```
