### PR TITLE
ExclusionIn and InclusionIn validators not checking option "strict"

### DIFF
--- a/phalcon/validation/validator/exclusionin.zep
+++ b/phalcon/validation/validator/exclusionin.zep
@@ -64,11 +64,11 @@ class ExclusionIn extends Validator
 		
 		let strict = false;
 		if this->isSetOption("strict") {
+			let strict = this->getOption("strict");
+
 			if typeof strict != "boolean" {
 			    throw new Exception("Option 'strict' must be a boolean");
 			}
-
-			let strict = this->getOption("strict");
 		}
 
 		/**

--- a/phalcon/validation/validator/inclusionin.zep
+++ b/phalcon/validation/validator/inclusionin.zep
@@ -64,11 +64,11 @@ class InclusionIn extends Validator
 
 		let strict = false;
 		if this->isSetOption("strict") {
+			let strict = this->getOption("strict");
+
 			if typeof strict != "boolean" {
 			    throw new Exception("Option 'strict' must be a boolean");
 			}
-
-			let strict = this->getOption("strict");
 		}
 
 		/**


### PR DESCRIPTION
ExclusionIn and InclusionIn validators not checking option "strict" properly. Fixed

Original placement of check is redundant
