### PR TITLE
Allow Config\Adapter\Ini constructor to specify parse_ini_file() mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-XX-XX)
 - Fixed `Phalcon\Cache\Backend\Redis::flush` in order to flush cache correctly
 - Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to correct using multi relation column [#12035](https://github.com/phalcon/cphalcon/issues/12035)
+- `Phalcon\Config\Adapter\Ini` constructor can now specify `parse_ini_file()` scanner mode [#12079](https://github.com/phalcon/cphalcon/pull/12079)
 
 # [3.0.0](https://github.com/phalcon/cphalcon/releases/tag/v3.0.0) (2016-07-29)
 - PHP 5.3 and 5.4 are now fully deprecated

--- a/phalcon/config/adapter/ini.zep
+++ b/phalcon/config/adapter/ini.zep
@@ -58,11 +58,16 @@ class Ini extends Config
 	/**
 	 * Phalcon\Config\Adapter\Ini constructor
 	 */
-	public function __construct(string! filePath)
+	public function __construct(string! filePath, mode = null)
 	{
 		var iniConfig;
 
-		let iniConfig = parse_ini_file(filePath, true, INI_SCANNER_RAW);
+		// Default to INI_SCANNER_RAW if not specified
+		if null === mode {
+			let mode = INI_SCANNER_RAW;
+		}
+
+		let iniConfig = parse_ini_file(filePath, true, mode);
 		if iniConfig === false {
 			throw new Exception("Configuration file " . basename(filePath) . " can't be loaded");
 		}

--- a/phalcon/config/adapter/ini.zep
+++ b/phalcon/config/adapter/ini.zep
@@ -51,6 +51,15 @@ use Phalcon\Config\Exception;
  * echo $config->phalcon->controllersDir;
  * echo $config->database->username;
  *</code>
+ *
+ * PHP constants may also be parsed in the ini file, so if you define a constant
+ * as an ini value before calling the constructor, the constant's value will be
+ * integrated into the results. To use it this way you must specify the optional
+ * second parameter as INI_SCANNER_NORMAL when calling the constructor:
+ *
+ * <code>
+ *  $config = new Phalcon\Config\Adapter\Ini("path/config-with-constants.ini", INI_SCANNER_NORMAL);
+ * </code>
  */
 class Ini extends Config
 {

--- a/tests/_data/config/config-with-constants.ini
+++ b/tests/_data/config/config-with-constants.ini
@@ -1,0 +1,8 @@
+; this is an INI file
+test = TEST_CONST
+path = TEST_CONST"/something/else"
+[section]
+test = TEST_CONST
+path = TEST_CONST"/another-thing/somewhere"
+parent.property = TEST_CONST
+parent.property2 = TEST_CONST"hello"

--- a/tests/unit/Config/Adapter/IniTest.php
+++ b/tests/unit/Config/Adapter/IniTest.php
@@ -25,6 +25,38 @@ use Phalcon\Config\Adapter\Ini;
 class IniTest extends ConfigBase
 {
     /**
+     * Tests constants in option values
+     * @author zytzagoo
+     * @since  2016-08-03
+     */
+    public function testConstants()
+    {
+        $this->specify(
+            "Constants in option values are not parsed properly",
+            function () {
+                define('TEST_CONST', 'foo');
+
+                $expected = [
+                    'test' => 'foo',
+                    'path' => 'foo/something/else',
+                    'section' => [
+                        'test' => 'foo',
+                        'path' => 'foo/another-thing/somewhere',
+                        'parent' => [
+                            'property' => 'foo',
+                            'property2' =>'foohello'
+                        ]
+                    ]
+                ];
+
+                $config = new Ini(PATH_DATA . 'config/config-with-constants.ini');
+
+                expect($config->toArray())->equals($expected);
+            }
+        );
+    }
+
+    /**
      * Tests toArray method
      *
      * @author kjdev

--- a/tests/unit/Config/Adapter/IniTest.php
+++ b/tests/unit/Config/Adapter/IniTest.php
@@ -32,7 +32,7 @@ class IniTest extends ConfigBase
     public function testConstants()
     {
         $this->specify(
-            "Constants in option values are not parsed properly",
+            "Constants in option values are not parsed properly with explicit INI_SCANNER_NORMAL mode",
             function () {
                 define('TEST_CONST', 'foo');
 
@@ -49,7 +49,7 @@ class IniTest extends ConfigBase
                     ]
                 ];
 
-                $config = new Ini(PATH_DATA . 'config/config-with-constants.ini');
+                $config = new Ini(PATH_DATA . 'config/config-with-constants.ini', INI_SCANNER_NORMAL);
 
                 expect($config->toArray())->equals($expected);
             }


### PR DESCRIPTION
This worked as expected on 2.0.13 (and earlier) and fails on 3.0.x currently
