### PR TITLE
Prepend Class Auto Loader

### DIFF
--- a/phalcon/loader.zep
+++ b/phalcon/loader.zep
@@ -1,4 +1,3 @@
-
 /*
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
@@ -65,6 +64,8 @@ class Loader implements EventsAwareInterface
 	protected _files = null;
 
 	protected _registered = false;
+
+	protected _prependLoader = false;
 
 	/**
 	 * Sets the events manager
@@ -217,6 +218,24 @@ class Loader implements EventsAwareInterface
 	}
 
 	/**
+	 * Enable Prepending of Autoload
+	 */
+	public function setPrepend(boolean prependLoader) -> <Loader>
+	{
+	    let this->_prependLoader = prependLoader;
+
+	    return this;
+	}
+
+    /**
+     * Retrieve Current Prepend Mode
+     */
+	public function canPrepend() -> boolean
+	{
+	    return this->_prependLoader;
+	}
+
+	/**
 	 * Register the autoload method
 	 */
 	public function register() -> <Loader>
@@ -234,7 +253,7 @@ class Loader implements EventsAwareInterface
 			/**
 			 * Registers directories & namespaces to PHP's autoload
 			 */
-			spl_autoload_register([this, "autoLoad"]);
+			spl_autoload_register([this, "autoLoad"], true, this->canPrepend());
 
 			let this->_registered = true;
 		}

--- a/tests/_data/vendor/Example/Test/AnotherTest.php
+++ b/tests/_data/vendor/Example/Test/AnotherTest.php
@@ -1,11 +1,4 @@
 <?php
-
-    /**
-     * Created by PhpStorm.
-     * User: fenikkusu
-     * Date: 8/5/16
-     * Time: 10:28 PM
-     */
     class AnotherTest {
 
     }

--- a/tests/_data/vendor/Example/Test/AnotherTest.php
+++ b/tests/_data/vendor/Example/Test/AnotherTest.php
@@ -1,0 +1,11 @@
+<?php
+
+    /**
+     * Created by PhpStorm.
+     * User: fenikkusu
+     * Date: 8/5/16
+     * Time: 10:28 PM
+     */
+    class AnotherTest {
+
+    }

--- a/tests/_data/vendor/Example/Test/YetAnotherTest.php
+++ b/tests/_data/vendor/Example/Test/YetAnotherTest.php
@@ -1,0 +1,11 @@
+<?php
+
+    /**
+     * Created by PhpStorm.
+     * User: fenikkusu
+     * Date: 8/5/16
+     * Time: 10:28 PM
+     */
+    class YetAnotherTest {
+
+    }

--- a/tests/_data/vendor/Example/Test/YetAnotherTest.php
+++ b/tests/_data/vendor/Example/Test/YetAnotherTest.php
@@ -1,11 +1,4 @@
 <?php
-
-    /**
-     * Created by PhpStorm.
-     * User: fenikkusu
-     * Date: 8/5/16
-     * Time: 10:28 PM
-     */
     class YetAnotherTest {
 
     }

--- a/tests/_proxies/Loader.php
+++ b/tests/_proxies/Loader.php
@@ -113,4 +113,14 @@ class Loader extends PhLoader
     {
         return parent::getCheckedPath();
     }
+
+    public function canPrepend()
+    {
+        return parent::canPrepend();
+    }
+
+    public function setPrepend($prependLoader)
+    {
+        return parent::setPrepend($prependLoader);
+    }
 }

--- a/tests/unit/LoaderTest.php
+++ b/tests/unit/LoaderTest.php
@@ -318,4 +318,78 @@ class LoaderTest extends UnitTest
             }
         );
     }
+
+    public function testPrepend() {
+        $this->specify(
+            'The loader is not pre-pending the loader',
+            function() {
+                $dataObject = (object) array(
+                    'wasCalled' => FALSE,
+                    'className' => ''
+                );
+
+                $autoRegister = function($className) use ($dataObject) {
+                    $dataObject->className = $className;
+                    $dataObject->wasCalled = TRUE;
+
+                    return new \Example\Adapter\Some();
+                };
+
+                spl_autoload_register($autoRegister);
+
+                $loader = new Loader();
+
+                $loader->setPrepend(TRUE)
+                       ->registerClasses(['AnotherTest' => PATH_DATA . 'vendor/Example/Test/AnotherTest.php'])
+                       ->register();
+
+                expect(class_exists('\AnotherTest', FALSE))->false();
+
+                expect(new \AnotherTest())->isInstanceOf('\AnotherTest');
+
+                expect($dataObject->wasCalled)->false();
+                expect($dataObject->className)->equals('');
+
+                $loader->unregister();
+
+                spl_autoload_unregister($autoRegister);
+            }
+        );
+
+        $this->specify(
+            'The loader is not appending the loader',
+            function() {
+                $dataObject = (object) array(
+                    'wasCalled' => FALSE,
+                    'className' => ''
+                );
+
+                $autoRegister = function($className) use ($dataObject) {
+                    $dataObject->className = $className;
+                    $dataObject->wasCalled = TRUE;
+
+                    return FALSE;
+                };
+
+                spl_autoload_register($autoRegister);
+
+                $loader = new Loader();
+
+                $loader->setPrepend(FALSE)
+                       ->registerClasses(['YetAnotherTest' => PATH_DATA . 'vendor/Example/Test/YetAnotherTest.php'])
+                       ->register();
+
+                expect(class_exists('\YetAnotherTest', FALSE))->false();
+
+                expect(new \YetAnotherTest())->isInstanceOf('\YetAnotherTest');
+
+                expect($dataObject->wasCalled)->true();
+                expect($dataObject->className)->equals('YetAnotherTest');
+
+                $loader->unregister();
+
+                spl_autoload_unregister($autoRegister);
+            }
+        );
+    }
 }


### PR DESCRIPTION
The auto loader class currently appends itself when calling spl_autoloader_register. This can cause the Phalcon loader to not be the primary loader when working with other registered autoloaders. The best example is Composer. Composer, by default, prepends its autoloader, making it the first to run.

The applied changes makes use of the same concept to prepend the Phalcon loader. This, in combination with the recent 'registerFiles' method allows Phalcon to always be the primary loader.

For backwards compatability, the loader defaults to appending still, but can be converted to prepending by calling setPrepend(TRUE)

$loader = new \Phalcon\Loader();
$loader->registerNamespaces(['SomeNamespace' => 'Some\Namespace'])
->setPrepend(TRUE)
->register();
