### PR TITLE
Ability to use an empty array for Criteria::inWhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed virtual foreign key check when having multiple keys [#12071](https://github.com/phalcon/cphalcon/issues/12071)
 - `Phalcon\Config\Adapter\Ini` constructor can now specify `parse_ini_file()` scanner mode [#12079](https://github.com/phalcon/cphalcon/pull/12079)
 - Fixed `Phalcon\Cache\Backend\Apc::save` due to which the `Apc::increment`/`Apc::decrement` could not be used properly [#12109](https://github.com/phalcon/cphalcon/issues/12109)
+- Fixed `Phalcon\Mvc\Model\Criteria::inWhere` so that now the second parameter can be an empty array [#10676](https://github.com/phalcon/cphalcon/issues/10676)
 
 # [3.0.0](https://github.com/phalcon/cphalcon/releases/tag/v3.0.0) (2016-07-29)
 - PHP 5.3 and 5.4 are now fully deprecated

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -33,15 +33,15 @@ use Phalcon\Mvc\Model\ResultsetInterface;
  * Phalcon\Mvc\Model::find() and Phalcon\Mvc\Model::findFirst()
  * using an object-oriented interface.
  *
- *<code>
- *$robots = Robots::query()
- *    ->where("type = :type:")
- *    ->andWhere("year < 2000")
- *    ->bind(array("type" => "mechanical"))
- *    ->limit(5, 10)
- *    ->orderBy("name")
- *    ->execute();
- *</code>
+ * <code>
+ * $robots = Robots::query()
+ *     ->where('type = :type:')
+ *     ->andWhere('year < 2000')
+ *     ->bind(['type' => 'mechanical'])
+ *     ->limit(5, 10)
+ *     ->orderBy('name')
+ *     ->execute();
+ * </code>
  */
 class Criteria implements CriteriaInterface, InjectionAwareInterface
 {
@@ -432,19 +432,22 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	/**
 	 * Appends an IN condition to the current conditions
 	 *
-	 *<code>
-	 *	$criteria->inWhere('id', [1, 2, 3]);
-	 *</code>
+	 * <code>
+	 *     $criteria->inWhere('id', [1, 2, 3]);
+	 * </code>
 	 */
 	public function inWhere(string! expr, array! values) -> <Criteria>
 	{
 		var hiddenParam, bindParams, bindKeys, value, key, queryKey;
 
+		if !count(values) {
+			this->andWhere(expr . " != " . expr);
+			return this;
+		}
+
 		let hiddenParam = this->_hiddenParamNumber;
 
-		let bindParams = [];
-		let bindKeys = [];
-
+		let bindParams = [], bindKeys = [];
 		for value in values {
 
 			/**

--- a/tests/unit/Mvc/Model/CriteriaTest.php
+++ b/tests/unit/Mvc/Model/CriteriaTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Phalcon\Test\Unit\Mvc\Model;
+
+use Phalcon\Di;
+use Phalcon\Test\Models\Users;
+use Phalcon\Mvc\Model\Manager;
+use Phalcon\Test\Module\UnitTest;
+use Phalcon\Mvc\Model\Metadata\Memory;
+use Phalcon\Mvc\Model\Resultset\Simple;
+
+/**
+ * \Phalcon\Test\Unit\Mvc\Model\CriteriaTest
+ * Tests the Phalcon\Mvc\Model\Criteria component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Unit\Mvc\Model
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class CriteriaTest extends UnitTest
+{
+    /**
+     * executed before each test
+     */
+    protected function _before()
+    {
+        parent::_before();
+
+        $di = $this->tester->getApplication()->getDI();
+
+        $di->set('modelsManager', function() {
+            return new Manager;
+        });
+
+        $di->set('modelsMetadata', function() {
+            return new Memory;
+        });
+
+        Di::setDefault($di);
+    }
+
+    /**
+     * Tests Criteria::inWhere with empty array.
+     *
+     * @issue  10676
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2016-08-11
+     */
+    public function testShouldExecuteInWhereQueryWithEmptyArray()
+    {
+        $this->specify(
+            'The Criteria::inWhere with empty array does not work as expected',
+            function() {
+                $criteria = Users::query()->inWhere(Users::class . '.id', []);
+
+                expect($criteria->getWhere())->equals(Users::class . '.id != ' . Users::class . '.id');
+                expect($criteria->execute())->isInstanceOf(Simple::class);
+            }
+        );
+    }
+}


### PR DESCRIPTION
Refs: #11947, #10676

Now the examples below works in a similar way:

``` php
Phalcon\Mvc\Model\Query\Builder::inWhere('id', []);
```

``` php
Phalcon\Mvc\Model\Criteria::inWhere('id', []);
```
