### PR TITLE
Issue and PR templates improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
 > Questions should go to https://forum.phalconphp.com
+> Documentation issues should go to https://github.com/phalcon/docs/issues
 
 ### Expected and Actual Behavior
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,17 @@ Before you submit a Pull Request, please bear in mind that PRs must be made on a
 version branch (eg. `3.0.x`). `master` marks the latest stable release so PRs
 targeting `master` will be **rejected**.
 
-Please also make sure that the PR passes in Travis CI make the process more
-efficient.
+Please also check the following points are being met:
 
-Please also only use tabs for indentation.
+- [ ] Make sure that the PR passes in Travis CI to make the process more efficient.
+- [ ] Only use tabs for indentation.
+- [ ] if needed, rebase to the proper branch before submitting your pull request.
+      If it doesn't merge cleanly with master you may be asked to rebase your changes.
+- [ ] Don't put submodule updates in your pull request unless they are to landed commits.
+- [ ] Add tests relevant to the fixed bug or new feature. See our testing guide for
+      more information.
+- [ ] Phalcon 2 is written in Zephir, please do not submit commits that modify C generated
+      files directly or those whose functionality/fixes are implemented in the C
+      programming language
+- [ ] Remove any change to ext/kernel / *.zep.c / *.zep.h files before submitting the PR
+


### PR DESCRIPTION
This was surfaced by #12120 and is the correct version of #12145.

I've synchronized what's in the PR template with the contributing guide.

IMHO these files should be cherry-picked into `master`, as this is not related to the next Phalcon release and would help other developers to send better issues/PRs into the repository. Bear in mind that those changes don't get applied to the repository until they land into `master`.
