### PR TITLE
Install instructions for Gentoo with smoke-phalcon overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ CentOS/Fedora/RHEL
 sudo yum install php-devel pcre-devel gcc make
 ```
 
+Gentoo:
+
+Follow the instructions here https://github.com/smoke/phalcon-gentoo-overlay#get-started
+
 General Compilation
 -------------------
 


### PR DESCRIPTION
I have created an overlay and ebuilds in [smoke-phalcon overlay](https://github.com/smoke/phalcon-gentoo-overlay) for easy Phalcon installation on Gentoo.

This merge request updates the README.md file to point that option.
