### PR TITLE
Fixed PHP 7 Catchable fatal error: session_regenerate_id(): Failed to create(read) session ID: user (path: ) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed `Phalcon\Cache\Frontend\Data::afterRetrieve`, `Phalcon\Cache\Frontend\Igbinary::afterRetrieve`, `Phalcon\Cache\Frontend\Msgpack::afterRetrieve` to unserialize only raw data [#12186](https://github.com/phalcon/cphalcon/issues/12186)
 - Fixed `Phalcon\Mvc\Model::cloneResultMapHydrate` to correct create array/objects from data by column map with types [#12191](https://github.com/phalcon/cphalcon/issues/12191)
 - Fixed `Phalcon\Validation\Validator\Confirmation::validate` to use `fieldWith` instead of `field` wehen looking up the value for labelWith.
-
+- Fixed PHP7 Catchable fatal error: session_regenerate_id(): Failed to create(read) session ID: user (path: )
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)
 - Fixed `Phalcon\Cache\Backend\Redis::flush` in order to flush cache correctly

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -158,7 +158,7 @@ class Libmemcached extends Adapter
 		for key, _ in _SESSION {
 			unset _SESSION[key];
 		}
-		return this->_libmemcached->delete(id);
+		return this->_libmemcached->exists(id) ? this->_libmemcached->delete(id) : true;
 	}
 
 	/**

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -129,9 +129,9 @@ class Libmemcached extends Adapter
 	/**
 	 * {@inheritdoc}
 	 */
-	public function read(string sessionId) -> var
+	public function read(string sessionId) -> string
 	{
-		return this->_libmemcached->get(sessionId, this->_lifetime);
+		return (string) this->_libmemcached->get(sessionId, this->_lifetime);
 	}
 
 	/**

--- a/phalcon/session/adapter/memcache.zep
+++ b/phalcon/session/adapter/memcache.zep
@@ -106,9 +106,9 @@ class Memcache extends Adapter
 	/**
 	 * {@inheritdoc}
 	 */
-	public function read(string sessionId) -> var
+	public function read(string sessionId) -> string
 	{
-		return this->_memcache->get(sessionId, this->_lifetime);
+		return (string) this->_memcache->get(sessionId, this->_lifetime);
 	}
 
 	/**

--- a/phalcon/session/adapter/memcache.zep
+++ b/phalcon/session/adapter/memcache.zep
@@ -132,7 +132,7 @@ class Memcache extends Adapter
 			let id = sessionId;
 		}
 
-		return this->_memcache->delete(id);
+		return this->_memcache->exists(id) ? this->_memcache->delete(id) : true;
 	}
 
 	/**

--- a/phalcon/session/adapter/redis.zep
+++ b/phalcon/session/adapter/redis.zep
@@ -140,7 +140,7 @@ class Redis extends Adapter
 			let id = sessionId;
 		}
 
-		return this->_redis->delete(id);
+		return this->_redis->exists(id) ? this->_redis->delete(id) : true;
 	}
 
 	/**

--- a/phalcon/session/adapter/redis.zep
+++ b/phalcon/session/adapter/redis.zep
@@ -114,9 +114,9 @@ class Redis extends Adapter
 	/**
 	 * {@inheritdoc}
 	 */
-	public function read(sessionId) -> var
+	public function read(sessionId) -> string
 	{
-		return this->_redis->get(sessionId, this->_lifetime);
+		return (string) this->_redis->get(sessionId, this->_lifetime);
 	}
 
 	/**


### PR DESCRIPTION
- read not returning always a string
- destroy wrongly returning false when session doesn't exist. 

**read**

If read returns anything else than a string it will fail with PHP Catchable fatal error: session_regenerate_id(): Failed to create(read) session ID: user. PHP 7 requires that reading always returns a string, regardless the existence of data.

**destroy**

When session_regenerate_id() is called right after session_start() php tries to destroy a session that doesn't exist yet. destroy() to wrongly return false when the session doesn't exist yet. PHP 7 will then fail with Warning: session_regenerate_id(): Session object destruction failed. ID: user (path: ) .

``` php
// with PHP 7.0.10 and Phalcon 3.0.1
use Phalcon\Session\Adapter\Redis as SessionAdapterRedis;

$session = new SessionAdapterRedis([
    'host'     => '127.0.0.1',
    'port'     => 6379,
]);

$session->start();

$oldId = $session->getId();

$session->regenerateId();

var_dump($oldId);
var_dump($session->getId());
```
