### PR TITLE
Fix Confirmation validator replace pairs ':with' value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed `Phalcon\Cache\Backend\Memory::delete` to correct remove items from  `Phalcon\Cache\Backend\Memory::$_data`
 - Fixed `Phalcon\Cache\Frontend\Data::afterRetrieve`, `Phalcon\Cache\Frontend\Igbinary::afterRetrieve`, `Phalcon\Cache\Frontend\Msgpack::afterRetrieve` to unserialize only raw data [#12186](https://github.com/phalcon/cphalcon/issues/12186)
 - Fixed `Phalcon\Mvc\Model::cloneResultMapHydrate` to correct create array/objects from data by column map with types [#12191](https://github.com/phalcon/cphalcon/issues/12191)
+- Fixed `Phalcon\Validation\Validator\Confirmation::validate` to use `fieldWith` instead of `field` wehen looking up the value for labelWith.
 
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)

--- a/phalcon/validation/validator/confirmation.zep
+++ b/phalcon/validation/validator/confirmation.zep
@@ -43,7 +43,7 @@ use Phalcon\Validation\Validator;
  *         'email' => 'Email  doesn\'t match confirmation'
  *     ],
  *     'with' => [
- *         'password => 'confirmPassword',
+ *         'password' => 'confirmPassword',
  *         'email' => 'confirmEmail'
  *     ]
  * ]));
@@ -80,7 +80,7 @@ class Confirmation extends Validator
 
 			let labelWith = this->getOption("labelWith");
 			if typeof labelWith == "array" {
-				let labelWith = labelWith[field];
+				let labelWith = labelWith[fieldWith];
 			}
 			if empty labelWith {
 				let labelWith = validation->getLabel(fieldWith);


### PR DESCRIPTION
The wrong variable was being used as the key for looking up the 'labelWith' value. 
Also, there was a missing single-quote in the class example.
