### PR TITLE
Update `_connect` function in redis.zep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Fixed `Phalcon\Cache\Backend\Memory::delete` to correct remove items from  `Phalcon\Cache\Backend\Memory::$_data`
 - Fixed `Phalcon\Cache\Frontend\Data::afterRetrieve`, `Phalcon\Cache\Frontend\Igbinary::afterRetrieve`, `Phalcon\Cache\Frontend\Msgpack::afterRetrieve` to unserialize only raw data [#12186](https://github.com/phalcon/cphalcon/issues/12186)
 - Fixed `Phalcon\Mvc\Model::cloneResultMapHydrate` to correct create array/objects from data by column map with types [#12191](https://github.com/phalcon/cphalcon/issues/12191)
-- Fixed `Phalcon\Validation\Validator\Confirmation::validate` to use `fieldWith` instead of `field` wehen looking up the value for labelWith.
+- Fixed `Phalcon\Validation\Validator\Confirmation::validate` to use `fieldWith` instead of `field` when looking up the value for labelWith.
+- Fixed `Phalcon\Cache\Backend\Redis::_connect` to use `select` redis internal function only when the `index` is greater than zero.
 
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -128,7 +128,7 @@ class Redis extends Backend implements BackendInterface
 			}
 		}
 
-		if fetch index, options["index"] {
+		if fetch index, options["index"] && index > 0 {
 			let success = redis->select(index);
 
 			if !success {


### PR DESCRIPTION
Use `select` internal function only when the index is greater than zero. Because, new connections always use DB 0 and the index is zero-based. It is important when use twemproxy, some people have a troubles with it. twemproxy (https://github.com/twitter/twemproxy) doesn't implement select function. I found simple solution. What do you say, comrades?
