### PR TITLE
Update cookie.zep

### DIFF
--- a/phalcon/http/cookie.zep
+++ b/phalcon/http/cookie.zep
@@ -49,7 +49,7 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 
 	protected _expire;
 
-	protected _path = "/";
+	protected _path;
 
 	protected _domain;
 
@@ -68,7 +68,7 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	 * @param string domain
 	 * @param boolean httpOnly
 	 */
-	public function __construct(string! name, var value = null, expire = 0, path = "/", secure = null, domain = null, httpOnly = null)
+	public function __construct(string! name, var value = null, expire = 0, path = null, secure = null, domain = null, httpOnly = null)
 	{
 		let this->_name = name;
 


### PR DESCRIPTION
If set to '/', the cookie will be available within the entire domain, but if i need, that cookie will only be available current directory?

see official API Description 

``` php
bool setcookie ( string $name [, string $value = "" [, int $expire = 0 [, string $path = "" [, string $domain = "" [, bool $secure = false [, bool $httponly = false ]]]]]] )
```
