### PR TITLE
Fixed Phalcon\Tag::resetInput for proper use without attempts to clear $_POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed `Phalcon\Db\Column::hasDefault` to return `false` for autoincrement columns [phalcon/phalcon-devtools#853](https://github.com/phalcon/phalcon-devtools/issues/853)
 - Fixed `Phalcon\Db\Dialect\Postgresql::createTable`, `Phalcon\Db\Dialect\Postgresql::addColumn`, `Phalcon\Db\Dialect\Postgresql::modifyColumn` to correct escape default values [#12267](https://github.com/phalcon/cphalcon/issues/12267), [phalcon/phalcon-devtools#859](https://github.com/phalcon/phalcon-devtools/issues/859)
 - Fixed `Phalcon\Forms\Form::bind` to clean form elements [#11978](https://github.com/phalcon/cphalcon/issues/11978), [#12165](https://github.com/phalcon/cphalcon/issues/12165), [#12099](https://github.com/phalcon/cphalcon/issues/12099), [#10044](https://github.com/phalcon/cphalcon/issues/10044)
+- Fixed `Phalcon\Tag::resetInput` for proper use without attempts to clear `$_POST` [#12099](https://github.com/phalcon/cphalcon/issues/12099)
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)
 - Fixed `Phalcon\Cache\Backend\Redis::flush` in order to flush cache correctly

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -432,7 +432,7 @@ abstract class Pdo extends Adapter
 	}
 
 	/**
-	 * Returns the number of affected rows by the lastest INSERT/UPDATE/DELETE executed in the database system
+	 * Returns the number of affected rows by the latest INSERT/UPDATE/DELETE executed in the database system
 	 *
 	 *<code>
 	 * $connection->execute(

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -301,7 +301,7 @@ class Tag
 	}
 
 	/**
-	 * Check if a helper has a default value set using Phalcon\Tag::setDefault or value from _POST
+	 * Check if a helper has a default value set using Phalcon\Tag::setDefault or value from $_POST
 	 *
 	 * @param string name
 	 * @return boolean
@@ -316,7 +316,7 @@ class Tag
 
 	/**
 	 * Every helper calls this function to check whether a component has a predefined
-	 * value using Phalcon\Tag::setDefault or value from _POST
+	 * value using Phalcon\Tag::setDefault or value from $_POST
 	 *
 	 * @param string name
 	 * @param array params
@@ -344,15 +344,16 @@ class Tag
 	}
 
 	/**
-	 * Resets the request and internal values to avoid those fields will have any default value
+	 * Resets the request and internal values to avoid those fields will have any default value.
+	 * @deprecated Will be removed in 4.0.0
 	 */
 	public static function resetInput() -> void
 	{
-		let self::_displayValues = [], {"_POST"} = [];
-		let self::_documentTitle = null;
-		let self::_documentAppendTitle = null;
-		let self::_documentPrependTitle = null;
-		let self::_documentTitleSeparator = null;
+		let self::_displayValues = [],
+			self::_documentTitle = null,
+			self::_documentAppendTitle = null,
+			self::_documentPrependTitle = null,
+			self::_documentTitleSeparator = null;
 	}
 
 	/**
@@ -394,12 +395,20 @@ class Tag
 	 *     ]
 	 * );
 	 *
+	 * echo Phalcon\Tag::linkTo(
+	 *     [
+	 *         "action" => "http://phalconphp.com/",
+	 *         "text"   => "Phalcon Home",
+	 *         "local"  => false,
+	 *         "target" => "_new"
+	 *     ]
+	 * );
+	 *
 	 *</code>
 	 *
 	 * @param array|string parameters
 	 * @param string text
 	 * @param boolean local
-	 * @return string
 	 */
 	public static function linkTo(parameters, text = null, local = true) -> string
 	{

--- a/tests/unit/Mvc/ModelTest.php
+++ b/tests/unit/Mvc/ModelTest.php
@@ -73,6 +73,10 @@ class ModelTest extends UnitTest
         $this->specify(
             'The Model::find with empty conditions + bind and limit return wrong result',
             function () {
+                if (!ini_get('opcache.enable_cli')) {
+                    $this->markTestSkipped("The " . __METHOD__ . " requires enabled opcache in CLI mode");
+                }
+
                 $album = Albums::find([
                     'conditions' => '',
                     'bind'       => [],
@@ -80,10 +84,7 @@ class ModelTest extends UnitTest
                 ]);
 
                 expect($album)->isInstanceOf(Simple::class);
-                expect(ini_get('opcache.enable_cli'))->equals(1);
-
                 expect($album->getFirst())->isInstanceOf(Albums::class);
-
                 expect($album->getFirst()->toArray())->equals([
                     'id' => 1,
                     'artists_id' => 1,

--- a/tests/unit/Tag/TagResetInputTest.php
+++ b/tests/unit/Tag/TagResetInputTest.php
@@ -25,20 +25,31 @@ use Phalcon\Test\Module\UnitTest;
 class TagResetInputTest extends UnitTest
 {
     /**
-     * Tests resetInput
+     * Tests Tag::resetInput
+     *
+     * Note: The Tag::resetInput should not clear $_POST data.
      *
      * @issue  11319
+     * @issue  12099
      * @author Serghei Iakovlev <serghei@phalconphp.com>
      * @since  2016-01-20
      */
     public function testResetInput()
     {
-        Tag::resetInput();
+        $this->specify(
+            'The resetInput does not work as expected',
+            function () {
+                $_POST = ['a' => '1', 'b' => '2'];
+                Tag::resetInput();
+                expect($_POST)->equals(['a' => '1', 'b' => '2']);
+            }
+        );
     }
 
     /**
      * Tests resetInput with setDefault
      *
+     * @issue  53
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
      * @since  2014-09-05
      */
@@ -48,11 +59,10 @@ class TagResetInputTest extends UnitTest
             "resetInput with setDefault returns invalid HTML Strict",
             function () {
 
-                Tag::setDoctype(Tag::XHTML10_STRICT);
+                Tag::setDocType(Tag::XHTML10_STRICT);
 
                 $options  = 'x_name';
-                $expected = '<input type="text" id="x_name" name="x_name" '
-                          . 'value="x_other" />';
+                $expected = '<input type="text" id="x_name" name="x_name" value="x_other" />';
                 Tag::setDefault('x_name', 'x_other');
                 $actual   = Tag::textField($options);
                 Tag::resetInput();
@@ -70,7 +80,7 @@ class TagResetInputTest extends UnitTest
             "resetInput with setDefault returns invalid HTML XHTML",
             function () {
 
-                Tag::setDoctype(Tag::HTML5);
+                Tag::setDocType(Tag::HTML5);
 
                 $options  = 'x_name';
                 $expected = '<input type="text" id="x_name" '
@@ -101,7 +111,7 @@ class TagResetInputTest extends UnitTest
             "resetInput with displayTo returns invalid HTML Strict",
             function () {
 
-                Tag::setDoctype(Tag::XHTML10_STRICT);
+                Tag::setDocType(Tag::XHTML10_STRICT);
 
                 $options  = 'x_name';
                 $expected = '<input type="text" id="x_name" name="x_name" '
@@ -123,7 +133,7 @@ class TagResetInputTest extends UnitTest
             "resetInput with displayTo returns invalid HTML XHTML",
             function () {
 
-                Tag::setDoctype(Tag::HTML5);
+                Tag::setDocType(Tag::HTML5);
 
                 $options  = 'x_name';
                 $expected = '<input type="text" id="x_name" name="x_name" '


### PR DESCRIPTION
Refs: #12099
