### PR TITLE
Fix appendTitle, prependTitle. Update unit test for append, prepend and setTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed `Phalcon\Validation\Validator\Confirmation::validate` to use `fieldWith` instead of `field` when looking up the value for labelWith.
 - Fixed `Phalcon\Cache\Backend\Redis::_connect` to use `select` redis internal function only when the `index` is greater than zero.
 - Fixed `Phalcon\Config\Adapter\Ini::_cast` to allow create extended config adapters [#12230](https://github.com/phalcon/cphalcon/issues/12230).
+- Fixed `Phalcon\Tag::appendTitle`, `Phalcon\Tag::prependTitle` to stack title prepending and appending [#12233](https://github.com/phalcon/cphalcon/issues/12233).
 
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1063,7 +1063,11 @@ class Tag
 	 */
 	public static function appendTitle(string title) -> void
 	{
-		let self::_documentAppendTitle = title;
+		if self::_documentAppendTitle !== null {
+			let self::_documentAppendTitle = self::_documentAppendTitle . self::_documentTitleSeparator . title ;
+		} else {
+			let self::_documentAppendTitle = title ;
+		}
 	}
 
 	/**
@@ -1071,7 +1075,11 @@ class Tag
 	 */
 	public static function prependTitle(string title) -> void
 	{
-		let self::_documentPrependTitle = title;
+		if self::_documentPrependTitle !== null {
+			let self::_documentPrependTitle = title . self::_documentTitleSeparator . self::_documentPrependTitle;
+		} else {
+			let self::_documentPrependTitle = title ;
+		}
 	}
 
 	/**

--- a/tests/unit/Tag/TagTitleTest.php
+++ b/tests/unit/Tag/TagTitleTest.php
@@ -63,6 +63,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle($value);
 
                 expect(Tag::getTitle())->equals("<title>{$value}</title>" . PHP_EOL);
+                
+                expect(Tag::getTitle(false))->equals("{$value}");
             }
         );
     }
@@ -84,11 +86,15 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Class');
 
                 expect(Tag::getTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
+                
+                Tag::resetInput();
 
                 Tag::setTitle('This is my title');
                 Tag::appendTitle(' - Welcome!');
 
                 expect(Tag::getTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
+                
+                Tag::resetInput();
 
                 Tag::setTitle('Title');
                 Tag::setTitleSeparator('|');
@@ -97,6 +103,13 @@ class TagTitleTest extends UnitTest
                 expect(Tag::getTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
 
                 Tag::resetInput();
+                
+                Tag::setTitle('Main');
+                Tag::setTitleSeparator(' - ');
+                Tag::appendTitle('Category');
+                Tag::appendTitle('Title');
+                
+                expect(Tag::getTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
             }
         );
     }
@@ -119,12 +132,23 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('PhalconPHP - ');
 
                 expect(Tag::getTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
-
+                
+                Tag::resetInput();
+                
                 Tag::setTitle('Title');
                 Tag::setTitleSeparator('|');
                 Tag::prependTitle('Class');
 
                 expect(Tag::getTitle())->equals('<title>Class|Title</title>' . PHP_EOL);
+                
+                Tag::resetInput();
+                
+                Tag::setTitle('Main');
+                Tag::setTitleSeparator(' - ');
+                Tag::prependTitle('Category');
+                Tag::prependTitle('Title');
+                
+                expect(Tag::getTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
             }
         );
     }


### PR DESCRIPTION
Update prependTitle and appendTitle to work correctly. 

Update tests for prependTitle and appendTitle functions.
For details: #12233

Update test for setTitle and getTitle: Make sure that getTitle(false) did not return tag element.
