### PR TITLE
Added two new filters for use in the Filter->sanitization() method.  …

### DIFF
--- a/phalcon/filter.zep
+++ b/phalcon/filter.zep
@@ -35,33 +35,38 @@ use Phalcon\Filter\Exception;
  *	$filter->sanitize("hello<<", "string"); // returns "hello"
  *	$filter->sanitize("!100a019", "int"); // returns "100019"
  *	$filter->sanitize("!100a019.01a", "float"); // returns "100019.01"
+ *	$filter->sanitize(1, "boolean"); // returns TRUE
  *</code>
  */
 class Filter implements FilterInterface
 {
-	const FILTER_EMAIL      = "email";
+	const FILTER_EMAIL        = "email";
 
-	const FILTER_ABSINT     = "absint";
+	const FILTER_ABSINT       = "absint";
 
-	const FILTER_INT        = "int";
+	const FILTER_INT          = "int";
 
-	const FILTER_INT_CAST   = "int!";
+	const FILTER_INT_CAST     = "int!";
 
-	const FILTER_STRING     = "string";
+	const FILTER_STRING       = "string";
 
-	const FILTER_FLOAT      = "float";
+	const FILTER_FLOAT        = "float";
 
-	const FILTER_FLOAT_CAST = "float!";
+	const FILTER_FLOAT_CAST   = "float!";
 
-	const FILTER_ALPHANUM   = "alphanum";
+	const FILTER_ALPHANUM     = "alphanum";
 
-	const FILTER_TRIM       = "trim";
+	const FILTER_TRIM         = "trim";
 
-	const FILTER_STRIPTAGS  = "striptags";
+	const FILTER_STRIPTAGS    = "striptags";
 
-	const FILTER_LOWER      = "lower";
+	const FILTER_LOWER        = "lower";
 
-	const FILTER_UPPER      = "upper";
+	const FILTER_UPPER        = "upper";
+	
+	const FILTER_BOOLEAN      = "boolean";
+	
+	const FILTER_BOOLEAN_CAST = "boolean!";
 
 	protected _filters;
 
@@ -103,6 +108,10 @@ class Filter implements FilterInterface
 					} else {
 						let value = this->_sanitize(value, filter);
 					}
+					/**
+					 * Account for any filters that may return a null value
+					 */
+					if (value === null) {break;}
 				}
 			}
 			return value;
@@ -209,6 +218,17 @@ class Filter implements FilterInterface
 				}
 				return strtoupper(value);
 
+			case Filter::FILTER_BOOLEAN:
+				/**
+				 * Must break, as it may return a null value
+				 */
+				return is_bool($value) ? $value : null;
+				break;
+				
+			case Filter::FILTER_BOOLEAN_CAST:
+
+				return boolval($value);
+			
 			default:
 				throw new Exception("Sanitize filter '" . filter . "' is not supported");
 		}

--- a/phalcon/filter.zep
+++ b/phalcon/filter.zep
@@ -111,13 +111,9 @@ class Filter implements FilterInterface
 					/**
 					 * Account for any filters that may return a null value
 					 */
-<<<<<<< HEAD
-					if (value === null) {break;}
-=======
 					if value === null {
 						break;
 					}
->>>>>>> f506ca6c0b6c502cfa3096a7d6a4256d8e38be56
 				}
 			}
 			return value;
@@ -228,20 +224,11 @@ class Filter implements FilterInterface
 				/**
 				 * Must break, as it may return a null value
 				 */
-<<<<<<< HEAD
-				return is_bool($value) ? $value : null;
-=======
 				return is_bool(value) ? value : null;
->>>>>>> f506ca6c0b6c502cfa3096a7d6a4256d8e38be56
 				break;
 				
 			case Filter::FILTER_BOOLEAN_CAST:
-
-<<<<<<< HEAD
-				return boolval($value);
-=======
 				return boolval(value);
->>>>>>> f506ca6c0b6c502cfa3096a7d6a4256d8e38be56
 			
 			default:
 				throw new Exception("Sanitize filter '" . filter . "' is not supported");

--- a/phalcon/filter.zep
+++ b/phalcon/filter.zep
@@ -224,12 +224,12 @@ class Filter implements FilterInterface
 				/**
 				 * Must break, as it may return a null value
 				 */
-				return is_bool($value) ? $value : null;
+				return is_bool(value) ? value : null;
 				break;
 				
 			case Filter::FILTER_BOOLEAN_CAST:
 
-				return boolval($value);
+				return boolval(value);
 			
 			default:
 				throw new Exception("Sanitize filter '" . filter . "' is not supported");

--- a/phalcon/filter.zep
+++ b/phalcon/filter.zep
@@ -111,7 +111,9 @@ class Filter implements FilterInterface
 					/**
 					 * Account for any filters that may return a null value
 					 */
-					if (value === null) {break;}
+					if value === null {
+						break;
+					}
 				}
 			}
 			return value;


### PR DESCRIPTION
Added two new filters for use in the Filter->_sanitization()_ method...

The first is FILTER_BOOLEAN, which returns the boolean value (true or false) if the value is an actual boolean (not 0, 1, 'true' as a string, etc) or it returns null if the value is not a true boolean.

The second is FILTER_BOOLEAN_CAST, which returns whatever the boolean would be of the casted value.  For example, 1 would return true and and empty string would return false.

**_NOTE:_** FILTER_BOOLEAN is a special case that required a break in the sanitization switch statement since it may return null.  This was accounted for in related loops.
