### PR TITLE
Fixed Phalcon\Debug::getVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `Phalcon\Cache\Backend\Redis::_connect` to use `select` redis internal function only when the `index` is greater than zero.
 - Fixed `Phalcon\Config\Adapter\Ini::_cast` to allow create extended config adapters [#12230](https://github.com/phalcon/cphalcon/issues/12230).
 - Fixed `Phalcon\Tag::appendTitle`, `Phalcon\Tag::prependTitle` to stack title prepending and appending [#12233](https://github.com/phalcon/cphalcon/issues/12233).
+- Fixed `Phalcon\Debug::getVersion` to provide valid link to the latest Phalcon major version [#12215](https://github.com/phalcon/cphalcon/issues/12215)
 
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)

--- a/phalcon/debug.zep
+++ b/phalcon/debug.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -280,6 +280,7 @@ class Debug
 
 	/**
 	 * Returns the major framework's version
+	 * @deprecated Will be removed in 4.0.0
 	 */
 	public function getMajorVersion() -> string
 	{
@@ -294,9 +295,16 @@ class Debug
 	 */
 	public function getVersion() -> string
 	{
-		return "<div class=\"version\">Phalcon Framework <a target=\"_new\" href=\"//docs.phalconphp.com/en/" .
-			this->getMajorVersion() . "/\">" .
-			\Phalcon\Version::get() . "</a></div>";
+		var link;
+
+		let link = [
+			"action": "https://docs.phalconphp.com/en/" . Version::getPart(Version::VERSION_MAJOR) . ".0.0/",
+			"text"  : Version::get(),
+			"local" : false,
+			"target": "_new"
+		];
+
+		return "<div class='version'>Phalcon Framework " . Tag::linkTo(link) . "</div>";
 	}
 
 	/**

--- a/tests/unit/DebugTest.php
+++ b/tests/unit/DebugTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Phalcon\Test\Unit;
+
+use Phalcon\Debug;
+use Phalcon\Version;
+use Phalcon\Test\Module\UnitTest;
+
+/**
+ * \Phalcon\Test\Unit\DebugTest
+ * Tests the \Phalcon\Debug component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      https://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Unit
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class DebugTest extends UnitTest
+{
+    /**
+     * Tests the Debug::getVersion
+     *
+     * @issue  12215
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2016-09-25
+     */
+    public function testShouldGetVersion()
+    {
+        $this->specify(
+            "The getVersion doesn't work as expected",
+            function () {
+                $debug = new Debug;
+
+                $target = '"_new"';
+                $uri = '"https://docs.phalconphp.com/en/' . Version::getPart(Version::VERSION_MAJOR) . '.0.0/"';
+                $version = Version::get();
+
+                expect($debug->getVersion())->equals(
+                    "<div class='version'>Phalcon Framework <a href={$uri} target={$target}>{$version}</a></div>"
+                );
+            }
+        );
+    }
+}


### PR DESCRIPTION
Refs: #12215, https://github.com/phalcon/docs/issues/879

@SidRoberts 
Could you please check current documentation uri to solve this issue. 
