### PR TITLE
Form Elements no longer implement ElementInterface twice.

### DIFF
--- a/phalcon/forms/element/check.zep
+++ b/phalcon/forms/element/check.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Check
  *
  * Component INPUT[type=check] for forms
  */
-class Check extends Element implements ElementInterface
+class Check extends Element
 {
 
 	/**

--- a/phalcon/forms/element/date.zep
+++ b/phalcon/forms/element/date.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Date
  *
  * Component INPUT[type=date] for forms
  */
-class Date extends Element implements ElementInterface
+class Date extends Element
 {
 
 	/**

--- a/phalcon/forms/element/email.zep
+++ b/phalcon/forms/element/email.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Email
  *
  * Component INPUT[type=email] for forms
  */
-class Email extends Element implements ElementInterface
+class Email extends Element
 {
 
 	/**

--- a/phalcon/forms/element/file.zep
+++ b/phalcon/forms/element/file.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\File
  *
  * Component INPUT[type=file] for forms
  */
-class File extends Element implements ElementInterface
+class File extends Element
 {
 
 	/**

--- a/phalcon/forms/element/hidden.zep
+++ b/phalcon/forms/element/hidden.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Hidden
  *
  * Component INPUT[type=hidden] for forms
  */
-class Hidden extends Element implements ElementInterface
+class Hidden extends Element
 {
 
 	/**

--- a/phalcon/forms/element/numeric.zep
+++ b/phalcon/forms/element/numeric.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Numeric
  *
  * Component INPUT[type=number] for forms
  */
-class Numeric extends Element implements ElementInterface
+class Numeric extends Element
 {
 
 	/**

--- a/phalcon/forms/element/password.zep
+++ b/phalcon/forms/element/password.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Password
  *
  * Component INPUT[type=password] for forms
  */
-class Password extends Element implements ElementInterface
+class Password extends Element
 {
 
 	/**

--- a/phalcon/forms/element/radio.zep
+++ b/phalcon/forms/element/radio.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Radio
  *
  * Component INPUT[type=radio] for forms
  */
-class Radio extends Element implements ElementInterface
+class Radio extends Element
 {
 
 	/**

--- a/phalcon/forms/element/select.zep
+++ b/phalcon/forms/element/select.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag\Select;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Select
  *
  * Component SELECT (choice) for forms
  */
-class Select extends Element implements ElementInterface
+class Select extends Element
 {
 
 	protected _optionsValues;

--- a/phalcon/forms/element/submit.zep
+++ b/phalcon/forms/element/submit.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Submit
  *
  * Component INPUT[type=submit] for forms
  */
-class Submit extends Element implements ElementInterface
+class Submit extends Element
 {
 
 	/**

--- a/phalcon/forms/element/text.zep
+++ b/phalcon/forms/element/text.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\Text
  *
  * Component INPUT[type=text] for forms
  */
-class Text extends Element implements ElementInterface
+class Text extends Element
 {
 
 	/**

--- a/phalcon/forms/element/textarea.zep
+++ b/phalcon/forms/element/textarea.zep
@@ -21,14 +21,13 @@ namespace Phalcon\Forms\Element;
 
 use Phalcon\Tag;
 use Phalcon\Forms\Element;
-use Phalcon\Forms\ElementInterface;
 
 /**
  * Phalcon\Forms\Element\TextArea
  *
  * Component TEXTAREA for forms
  */
-class TextArea extends Element implements ElementInterface
+class TextArea extends Element
 {
 
 	/**


### PR DESCRIPTION
[Phalcon\Forms\Element already implements ElementInterface](https://github.com/phalcon/cphalcon/blob/3.0.x/phalcon/forms/element.zep#L34)
