### PR TITLE
handles "options" arg on Collection aggregate

### DIFF
--- a/phalcon/mvc/collection.zep
+++ b/phalcon/mvc/collection.zep
@@ -1323,7 +1323,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 	/**
 	 * Perform an aggregation using the Mongo aggregation framework
 	 */
-	public static function aggregate(array parameters = null) -> array
+	public static function aggregate(array parameters = null, array options = null) -> array
 	{
 		var className, model, connection, source;
 
@@ -1338,7 +1338,7 @@ abstract class Collection implements EntityInterface, CollectionInterface, Injec
 			throw new Exception("Method getSource() returns empty string");
 		}
 
-		return connection->selectCollection(source)->aggregate(parameters);
+		return connection->selectCollection(source)->aggregate(parameters, options);
 	}
 
 	/**


### PR DESCRIPTION
As seen on http://php.net/manual/fr/mongocollection.aggregate.php there is a second argument available for MongoCollection::aggregate.
It accepts for instance a _maxTimeMS_ argument which can be very useful to increase for the aggregation process.
