### PR TITLE
Fix session_regenerate_id issue when using redis as the session handler

### DIFF
--- a/phalcon/session/adapter/redis.zep
+++ b/phalcon/session/adapter/redis.zep
@@ -118,7 +118,8 @@ class Redis extends Adapter
 	 */
 	public function read(sessionId) -> string
 	{
-		return (string) this->_redis->get(sessionId, this->_lifetime);
+	    let res = (string) this->_redis->get(sessionId, this->_lifetime);
+        return res == null ? "" : res;
 	}
 
 	/**

--- a/phalcon/session/adapter/redis.zep
+++ b/phalcon/session/adapter/redis.zep
@@ -119,7 +119,7 @@ class Redis extends Adapter
 	public function read(sessionId) -> string
 	{
 	    let res = (string) this->_redis->get(sessionId, this->_lifetime);
-        return res == null ? "" : res;
+	    return res == null ? "" : res;
 	}
 
 	/**


### PR DESCRIPTION
Fix session_regenerate_id issue when using redis as the session handler in php7. No session handler should return null for read method. it should return an empty string is the key is not found
