### PR TITLE
[WIP][dont merge] Fix build with image magick 7

### DIFF
--- a/phalcon/image/adapter/imagick.zep
+++ b/phalcon/image/adapter/imagick.zep
@@ -359,7 +359,7 @@ class Imagick extends Adapter implements AdapterInterface
 			watermark = new \Imagick();
 
 		watermark->readImageBlob(image->render());
-		watermark->setImageOpacity(opacity);
+		watermark->evaluateImage(\Imagick::EVALUATE_MULTIPLY, opacity, \Imagick::CHANNEL_ALPHA);
 
 		this->_image->setIteratorIndex(0);
 


### PR DESCRIPTION
If you are using latest image magic 7 build fails because  `setImageOpacity` doesnt exists

build fails with 

```

Zephir\CompilerException: Class 'Imagick' does not implement method: 'setImageOpacity' in /home/izopi4a/cphalcon/phalcon/image/adapter/imagick.zep on line 362

          watermark->setImageOpacity(opacity);
        -------------------------------------^

```

https://github.com/mkoppanen/imagick/blob/bd9548c426391878905b2a6bc36accc4c79f7ef7/php_imagick_defs.h#L428

i used this to replace it

http://stackoverflow.com/questions/3538851/php-imagick-setimageopacity-destroys-transparency-and-does-nothing
