### PR TITLE
Added the ability to truncate DB tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.1.0](https://github.com/phalcon/cphalcon/releases/tag/v3.1.0) (2016-XX-XX)``
 - Added `Phalcon\Validation\Validator\Callback`, `Phalcon\Validation::getData`
+- Added the ability to truncate database tables
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-XX-XX)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -500,6 +500,24 @@ class Mysql extends Dialect
 	}
 
 	/**
+	 * Generates SQL to truncate a table
+	 */
+	public function truncateTable(string! tableName, string! schemaName) -> string
+	{
+		var sql, table;
+
+		if schemaName {
+			let table = "`" . schemaName . "`.`" . tableName . "`";
+		} else {
+			let table = "`" . tableName . "`";
+		}
+
+		let sql = "TRUNCATE TABLE " . table;
+
+		return sql;
+	}
+
+	/**
 	 * Generates SQL to drop a table
 	 */
 	public function dropTable(string! tableName, string schemaName = null, boolean! ifExists = true) -> string

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -468,6 +468,24 @@ class Postgresql extends Dialect
 	}
 
 	/**
+	 * Generates SQL to truncate a table
+	 */
+	public function truncateTable(string! tableName, string! schemaName) -> string
+	{
+		var sql, table;
+
+		if schemaName {
+			let table = schemaName . "." . tableName;
+		} else {
+			let table = tableName;
+		}
+
+		let sql = "TRUNCATE TABLE " . table;
+
+		return sql;
+	}
+
+	/**
 	 * Generates SQL to drop a table
 	 */
 	public function dropTable(string! tableName, string schemaName = null, boolean! ifExists = true) -> string

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -423,6 +423,24 @@ class Sqlite extends Dialect
 	}
 
 	/**
+	 * Generates SQL to truncate a table
+	 */
+	public function truncateTable(string! tableName, string! schemaName) -> string
+	{
+		var sql, table;
+
+		if schemaName {
+			let table = schemaName . "\".\"" . tableName;
+		} else {
+			let table = tableName;
+		}
+
+		let sql = "DELETE FROM \"" . table . "\"";
+
+		return sql;
+	}
+
+	/**
 	 * Generates SQL to drop a table
 	 */
 	public function dropTable(string! tableName, string schemaName = null, boolean! ifExists = true) -> string

--- a/unit-tests/DbDialectTest.php
+++ b/unit-tests/DbDialectTest.php
@@ -654,6 +654,10 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 		// issue 11359
 		$this->assertEquals($dialect->describeColumns('table', 'database.name.with.dots'), 'DESCRIBE `database.name.with.dots`.`table`');
 		$this->assertEquals($dialect->describeColumns('table', '`database.name.with.dots`'), 'DESCRIBE `database.name.with.dots`.`table`');
+
+		//Truncate tables
+		$this->assertEquals($dialect->truncateTable('table', null), 'TRUNCATE TABLE `table`');
+		$this->assertEquals($dialect->truncateTable('table', 'schema'), 'TRUNCATE TABLE `schema`.`table`');
 	}
 
 	public function testSQLiteDialect()
@@ -919,6 +923,10 @@ class DbDialectTest extends PHPUnit_Framework_TestCase
 
 		// issue 11359
 		$this->assertEquals($dialect->describeColumns('table', 'database.name.with.dots'), "PRAGMA table_info('table')");
+
+		//Truncate tables
+		$this->assertEquals($dialect->truncateTable('table', null), 'DELETE FROM "table"');
+		$this->assertEquals($dialect->truncateTable('table', 'schema'), 'DELETE FROM "schema"."table"');
 	}
 
 	public function testViews()


### PR DESCRIPTION
I've purposely left `truncateTable()` out of DialectInterface to maintain BC.
