### PR TITLE
[4.0.0] CLI parameters now work like MVC parameters

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,3 +7,4 @@
 - Changed `Phalcon\Db\Dialect\Postgresql::describeReferences` to generate correct SQL for postgresql adapter, added constraints on update and on delete
 - Added `Phalcon\Db\Adapter\Pdo\Postgresql::describeReferences` method for postgresql adapter
 - Change catch Exception to Throwable [#12288](https://github.com/phalcon/cphalcon/issues/12288)
+- CLI parameters now work like MVC parameters [#12375](https://github.com/phalcon/cphalcon/pull/12375)

--- a/phalcon/cli/dispatcher.zep
+++ b/phalcon/cli/dispatcher.zep
@@ -191,16 +191,4 @@ class Dispatcher extends CliDispatcher implements DispatcherInterface
 	{
 		return isset this->_options[option];
 	}
-
-	/**
-	 * Calls the action method.
-	 */
-	public function callActionMethod(handler, string actionMethod, array! params = []) -> var
-	{
-		var options;
-
-		let options = this->_options;
-		
-		return call_user_func_array([handler, actionMethod], [params, options]);
-	}
 }

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -651,7 +651,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 			try {
 				// We update the latest value produced by the latest handler
-				let this->_returnedValue = this->callActionMethod(handler, actionMethod, params);
+				let this->_returnedValue = call_user_func_array([handler, actionMethod], params);
 			} catch \Throwable, e {
 				if this->{"_handleException"}(e) === false {
 					if this->_finished === false {
@@ -794,11 +794,6 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		}
 
 		return handlerClass;
-	}
-
-	public function callActionMethod(handler, string actionMethod, array! params = [])
-	{
-		return call_user_func_array([handler, actionMethod], params);
 	}
 
 	/**

--- a/tests/_data/tasks/MainTask.php
+++ b/tests/_data/tasks/MainTask.php
@@ -12,11 +12,8 @@ class MainTask extends \Phalcon\CLI\Task
         return $this->di['registry']->data;
     }
 
-    public function helloAction($params = array())
+    public function helloAction($world = "", $symbol = "!")
     {
-        $world  = isset($params[0]) ? $params[0] : "";
-        $symbol = isset($params[1]) ? $params[1] : "!";
-
         return "Hello " . $world . $symbol;
     }
 }

--- a/tests/_data/tasks/ParamsTask.php
+++ b/tests/_data/tasks/ParamsTask.php
@@ -2,16 +2,16 @@
 
 class ParamsTask extends \Phalcon\CLI\Task
 {
-    public function paramsAction($params)
+    public function paramsAction()
     {
-        return ($params === $this->dispatcher->getParams())
-                ? '$params is the same as $this->dispatcher->getParams()'
-                : '$params is not the same as $this->dispatcher->getParams()';
+        return (func_get_args() === $this->dispatcher->getParams())
+                ? 'Action params are the same as $this->dispatcher->getParams()'
+                : 'Action params are not the same as $this->dispatcher->getParams()';
     }
 
-    public function paramAction($params)
+    public function paramAction($param)
     {
-        return ($params[0] === $this->dispatcher->getParam(0))
+        return ($param === $this->dispatcher->getParam(0))
                 ? '$param[0] is the same as $this->dispatcher->getParam(0)'
                 : '$param[0] is not the same as $this->dispatcher->getParam(0)';
     }

--- a/tests/unit/Cli/DispatcherTest.php
+++ b/tests/unit/Cli/DispatcherTest.php
@@ -113,7 +113,7 @@ class DispatcherTest extends UnitTest
                 $dispatcher->setActionName('params');
                 $dispatcher->setParams(array('This', 'Is', 'An', 'Example'));
                 $dispatcher->dispatch();
-                expect($dispatcher->getReturnedValue())->equals('$params is the same as $this->dispatcher->getParams()');
+                expect($dispatcher->getReturnedValue())->equals('Action params are the same as $this->dispatcher->getParams()');
 
                 // Test $this->dispatcher->getParam()
                 $dispatcher->setTaskName('params');
@@ -121,29 +121,6 @@ class DispatcherTest extends UnitTest
                 $dispatcher->setParams(array('This', 'Is', 'An', 'Example'));
                 $dispatcher->dispatch();
                 expect($dispatcher->getReturnedValue())->equals('$param[0] is the same as $this->dispatcher->getParam(0)');
-            }
-        );
-    }
-
-    public function testCallActionMethod()
-    {
-        $this->specify(
-            "CLI Dispatcher's callActionMethod doesn't work as expected",
-            function () {
-                $di = new CliFactoryDefault();
-
-                $dispatcher = new Dispatcher();
-
-                $di->setShared("dispatcher", $dispatcher);
-
-                $dispatcher->setDI($di);
-
-                $mainTask = new \MainTask();
-                $mainTask->setDI($di);
-
-                expect($dispatcher->callActionMethod($mainTask, 'mainAction', []))->equals('mainAction');
-                expect($dispatcher->callActionMethod($mainTask, 'helloAction', ['World']))->equals('Hello World!');
-                expect($dispatcher->callActionMethod($mainTask, 'helloAction', ['World', '.']))->equals('Hello World.');
             }
         );
     }

--- a/tests/unit/Cli/TaskTest.php
+++ b/tests/unit/Cli/TaskTest.php
@@ -45,7 +45,7 @@ class TaskTest extends UnitTest
 
                 expect($task->requestRegistryAction())->equals("data");
                 expect($task->helloAction())->equals("Hello !");
-                expect($task->helloAction(["World"]))->equals("Hello World!");
+                expect($task->helloAction("World"))->equals("Hello World!");
 
                 $task2 = new \EchoTask();
                 $task2->setDI($di);

--- a/tests/unit/Mvc/DispatcherTest.php
+++ b/tests/unit/Mvc/DispatcherTest.php
@@ -586,33 +586,6 @@ class DispatcherTest extends UnitTest
         );
     }
 
-    public function testCallActionMethod()
-    {
-        $this->specify(
-            "Action method isn't called properly",
-            function () {
-                $di = new FactoryDefault();
-
-                $dispatcher = new Dispatcher();
-
-                $di->setShared("dispatcher", $dispatcher);
-
-                $dispatcher->setDI($di);
-
-                $mainTask = new \Test2Controller();
-                $mainTask->setDI($di);
-
-                $actionMethod = $dispatcher->callActionMethod(
-                    $mainTask,
-                    "anotherTwoAction",
-                    [1, 2]
-                );
-
-                expect($actionMethod)->equals(3);
-            }
-        );
-    }
-
     public function testLastController()
     {
         $this->specify(


### PR DESCRIPTION
Taking this as an example:

``` bash
php cli.php greeting morning Sid Roberts
```

Before:

``` php
class GreetingTask extends \Phalcon\Cli\Task
{
    public function morningAction($params)
    {
        echo "Good morning " . $params[0] . " " . $params[1];
    }
}
```

Now:

``` php
class GreetingTask extends \Phalcon\Cli\Task
{
    public function morningAction($firstName, $lastName)
    {
        echo "Good morning " . $firstName . " " . $lastName;
    }
}
```

This, of course, makes `Dispatcher::callActionMethod()` redundant.
