### PR TITLE
Fix query keys method with prefix in file cache

### DIFF
--- a/phalcon/cache/backend/file.zep
+++ b/phalcon/cache/backend/file.zep
@@ -268,6 +268,7 @@ class File extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
+		let prefixedKey =  this->_prefix . this->getKey(prefix);
 		/**
 		 * We use a directory iterator to traverse the cache dir directory
 		 */
@@ -276,7 +277,7 @@ class File extends Backend implements BackendInterface
 			if likely item->isDir() === false {
 				let key = item->getFileName();
 				if prefix !== null {
-					if starts_with(key, prefix) {
+					if starts_with(key, prefixedKey) {
 						let keys[] = key;
 					}
 				} else {


### PR DESCRIPTION
The passed prefix should not be compared to the filename directly, it should be parsed into filename, just like it did in save/get/delete