### PR TITLE
[3.0.x] Fix query keys method with prefix in file cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed `Phalcon\Cache\Backend\Apc::flush` to remove only it's own keys by prefix [#12153](https://github.com/phalcon/cphalcon/issues/12153)
 - Fixed `Phalcon\Acl\Adapter\Memory::isAllowed` to call closures when using wildcard [#12333](https://github.com/phalcon/cphalcon/issues/12333)
 - Fixed `Phalcon\Validation\Validator\File` array to string conversion in `minResolution` and `maxResolution` [#12349](https://github.com/phalcon/cphalcon/issues/12349)
+- Fixed `Phalcon\Cache\Backend\File::queryKeys()` to compare the filename against parsed prefix
 
 # [3.0.1](https://github.com/phalcon/cphalcon/releases/tag/v3.0.1) (2016-08-24)
 - Fixed `Phalcon\Cache\Backend\Redis::flush` in order to flush cache correctly

--- a/phalcon/cache/backend/file.zep
+++ b/phalcon/cache/backend/file.zep
@@ -268,6 +268,7 @@ class File extends Backend implements BackendInterface
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
+		string prefixedKey =  this->_prefix . this->getKey(prefix);
 		/**
 		 * We use a directory iterator to traverse the cache dir directory
 		 */
@@ -276,7 +277,7 @@ class File extends Backend implements BackendInterface
 			if likely item->isDir() === false {
 				let key = item->getFileName();
 				if prefix !== null {
-					if starts_with(key, prefix) {
+					if starts_with(key, prefixedKey) {
 						let keys[] = key;
 					}
 				} else {


### PR DESCRIPTION
The passed prefix should not be compared to the filename directly, it should be parsed into filename, just like it did in save/get/delete