### PR TITLE
Fixed call functions to null variable in Phalcon\Forms\Form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
+- Fixed implementation of Iterator interface in a Phalcon\Forms\Form that could cause a run-time warning
+
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)
 - Fixed `Phalcon\Http\Response\Headers::send` to send correct status header [#12179](https://github.com/phalcon/cphalcon/issues/12179)

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -42,7 +42,7 @@ class Form extends Injectable implements \Countable, \Iterator
 
 	protected _data;
 
-	protected _elements;
+	protected _elements = [];
 
 	protected _elementsIndexed;
 
@@ -184,7 +184,7 @@ class Form extends Injectable implements \Countable, \Iterator
 		var filter, key, value, element, filters,
 			dependencyInjector, filteredValue, method;
 
-		if typeof this->_elements != "array" {
+		if empty this->_elements {
 			throw new Exception("There are no elements in the form");
 		}
 
@@ -259,7 +259,7 @@ class Form extends Injectable implements \Countable, \Iterator
 			validators, name, preparedValidators, filters,
 			validator, validation, elementMessages;
 
-		if typeof this->_elements != "array" {
+		if empty this->_elements {
 			return true;
 		}
 
@@ -441,7 +441,7 @@ class Form extends Injectable implements \Countable, \Iterator
 		 */
 		element->setForm(this);
 
-		if position == null || typeof this->_elements != "array" {
+		if position == null || empty this->_elements {
 			/**
 			 * Append the element by its name
 			 */

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -38,6 +38,9 @@ class FormTest extends UnitTest
             "Form::count does not return the correct number",
             function () {
                 $form = new Form();
+                
+                expect($form)->count(0);
+                expect($form->count())->equals(0);
 
                 $form->add(
                     new Text("name")
@@ -49,6 +52,40 @@ class FormTest extends UnitTest
 
                 expect($form)->count(2);
                 expect($form->count())->equals(2);
+            }
+        );
+    }
+    
+    public function testIterator()
+    {
+        $this->specify(
+            "Form incorrectly implements the Iterator interface",
+            function () {
+                $form = new Form();
+                $data = [];
+                
+                foreach ($form as $key => $value) {
+                    $data[$key] = $value->getName();
+                }
+                
+                expect($data)->equals([]);
+                
+                $form->add(
+                    new Text("name")
+                );
+
+                $form->add(
+                    new Text("telephone")
+                );
+                
+                foreach ($form as $key => $value) {
+                    $data[$key] = $value->getName();
+                }
+                
+                expect($data)->equals([
+                    0 => "name",
+                    1 => "telephone",
+                ]);
             }
         );
     }


### PR DESCRIPTION
By default _elements value isn't defined that can cause errors.
For example:
```
<?php

use Phalcon\Forms\Form;

class MyForm extends Form
{
    public function initialize()
    {
        
    }
}

$form = new MyForm();

foreach ($form as $element) {
    //...
}
```
There will be an error in the Phalcon\Forms\Form::rewind method: Warning: array_values() expects parameter 1 to be array, null given.
My patch will correct it.

