### PR TITLE
Cache\Backend\Redis::exists method bugfix

### DIFF
--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -372,7 +372,7 @@ class Redis extends Backend
 				let redis = this->_redis;
 			}
 
-			if !redis->get(lastKey) {
+			if redis->get(lastKey) === false {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12434

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: When you put a key with empty value in redis cache backend, the exists method returns false for that key.

Thanks


When there is a key with value of empty string (""), exists method MUST return true, it didn't.