### PR TITLE
Fixed redis cache backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
-- Fixed implementation of Iterator interface in a Phalcon\Forms\Form that could cause a run-time warning
+- Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning
+- Fixed `Phalcon\Cache\Backend\Redis::get`, `Phalcon\Cache\Frontend\Data::afterRetrieve` to allow get empty strings from the Redis database [#12437](https://github.com/phalcon/cphalcon/issues/12437)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -162,7 +162,7 @@ class Redis extends Backend
 		let this->_lastKey = lastKey;
 		let cachedContent = redis->get(lastKey);
 
-		if !cachedContent {
+		if cachedContent === false {
 			return null;
 		}
 

--- a/phalcon/cache/frontend/data.zep
+++ b/phalcon/cache/frontend/data.zep
@@ -152,6 +152,11 @@ class Data implements FrontendInterface
 			return data;
 		}
 
+		// do not unserialize empty string, null, false, etc
+		if empty data {
+			return data;
+		}
+
 		return unserialize(data);
 	}
 }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -49,8 +49,6 @@ if (extension_loaded('xdebug')) {
     ini_set('xdebug.var_display_max_depth', 4);
 }
 
-
-
 $defaults = [
     // Beanstalk
     "TEST_BT_HOST"              => '127.0.0.1',

--- a/tests/shim.php
+++ b/tests/shim.php
@@ -51,3 +51,14 @@ if (!function_exists('xcache_get') && function_exists('apc_fetch')) {
     {
     }
 }
+
+if (!function_exists('env')) {
+    function env($key, $default = null)
+    {
+        if (defined($key)) {
+            return constant($key);
+        }
+
+        return getenv($key) ?: $default;
+    }
+}

--- a/tests/unit/Cache/Backend/RedisCest.php
+++ b/tests/unit/Cache/Backend/RedisCest.php
@@ -29,6 +29,8 @@ class RedisCest
 {
     public function _before(UnitTester $I)
     {
+        $I->wantToTest('Redis cache backend');
+
         if (!extension_loaded('redis')) {
             throw new \PHPUnit_Framework_SkippedTestError(
                 'Warning: redis extension is not loaded'
@@ -42,8 +44,8 @@ class RedisCest
 
         $key = '_PHCR' . 'increment';
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
         ]);
 
         $I->dontSeeInRedis($key);
@@ -65,8 +67,8 @@ class RedisCest
 
         $key = '_PHCR' . 'decrement';
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
         ]);
 
         $I->dontSeeInRedis($key);
@@ -90,8 +92,8 @@ class RedisCest
         $data = [uniqid(), gethostname(), microtime(), get_include_path(), time()];
 
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
         ]);
 
         $I->haveInRedis('string', $key, serialize($data));
@@ -107,6 +109,24 @@ class RedisCest
         $I->assertNull($cache->get($key));
     }
 
+    /**
+     * @issue 12437
+     * @param UnitTester $I
+     */
+    public function getEmpty(UnitTester $I)
+    {
+        $I->wantTo('Get empty value by using Redis as cache backend');
+
+        $key = '_PHCR' . 'data-empty-get';
+        $cache = new Redis(new Data(['lifetime' => 20]), [
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT'),
+        ]);
+
+        $I->haveInRedis('string', $key, '');
+        $I->assertSame('', $cache->get('data-empty-get'));
+    }
+
     public function save(UnitTester $I)
     {
         $I->wantTo('Save data by using Redis as cache backend');
@@ -115,8 +135,8 @@ class RedisCest
         $data = [uniqid(), gethostname(), microtime(), get_include_path(), time()];
 
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
         ]);
 
         $I->dontSeeInRedis($key);
@@ -140,8 +160,8 @@ class RedisCest
         );
 
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
         ]);
 
         $I->assertFalse($cache->delete('non-existent-keys'));
@@ -157,8 +177,8 @@ class RedisCest
         $I->wantTo('Flush cache by using Redis as cache backend');
 
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host'     => TEST_RS_HOST,
-            'port'     => TEST_RS_PORT,
+            'host'     => env('TEST_RS_HOST'),
+            'port'     => env('TEST_RS_PORT'),
             'statsKey' => '_PHCR'
         ]);
 
@@ -185,8 +205,8 @@ class RedisCest
         $I->wantTo('Get cache keys by using Redis as cache backend');
 
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host'     => TEST_RS_HOST,
-            'port'     => TEST_RS_PORT,
+            'host'     => env('TEST_RS_HOST'),
+            'port'     => env('TEST_RS_PORT'),
             'statsKey' => '_PHCR'
         ]);
 
@@ -209,8 +229,8 @@ class RedisCest
         $I->wantTo('Catch exception during the attempt getting cache keys by using Redis as cache backend without statsKey');
 
         $cache = new Redis(new Data(['lifetime' => 20]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT,
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT'),
         ]);
 
         $I->expectException(
@@ -227,8 +247,8 @@ class RedisCest
 
         $time = date('H:i:s');
         $cache = new Redis(new Output(['lifetime' => 2]), [
-            'host' => TEST_RS_HOST,
-            'port' => TEST_RS_PORT,
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT'),
         ]);
 
         ob_start();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12437

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed `Phalcon\Cache\Backend\Redis::get`, `Phalcon\Cache\Frontend\Data::afterRetrieve` to allow get empty strings from the Redis database.

Refs: https://github.com/phpredis/phpredis#get

Thanks

