### PR TITLE
Fixed Phalcon\Cache\Backend\Redis::exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning
 - Fixed `Phalcon\Cache\Backend\Redis::get`, `Phalcon\Cache\Frontend\Data::afterRetrieve` to allow get empty strings from the Redis database [#12437](https://github.com/phalcon/cphalcon/issues/12437)
-- Fixed `Phalcon\Cache\Backend\Redis::exists` to correct check if cache key exists for empty value in the Redis database [#12436](https://github.com/phalcon/cphalcon/pull/12436)
+- Fixed `Phalcon\Cache\Backend\Redis::exists` to correct check if cache key exists for empty value in the Redis database [#12434](https://github.com/phalcon/cphalcon/pull/12434)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning
 - Fixed `Phalcon\Cache\Backend\Redis::get`, `Phalcon\Cache\Frontend\Data::afterRetrieve` to allow get empty strings from the Redis database [#12437](https://github.com/phalcon/cphalcon/issues/12437)
+- Fixed `Phalcon\Cache\Backend\Redis::exists` to correct check if cache key exists for empty value in the Redis database [#12436](https://github.com/phalcon/cphalcon/pull/12436)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -178,7 +178,7 @@ class Redis extends Backend
 	 *
 	 * @param int|string keyName
 	 * @param string content
-	 * @param long lifetime
+	 * @param int lifetime
 	 * @param boolean stopBuffer
 	 */
 	public function save(keyName = null, content = null, lifetime = null, boolean stopBuffer = true) -> boolean
@@ -351,8 +351,7 @@ class Redis extends Backend
 	 * Checks if cache exists and it isn't expired
 	 *
 	 * @param string keyName
-	 * @param   long lifetime
-	 * @return boolean
+	 * @param int lifetime
 	 */
 	public function exists(keyName = null, lifetime = null) -> boolean
 	{
@@ -372,10 +371,7 @@ class Redis extends Backend
 				let redis = this->_redis;
 			}
 
-			if !redis->get(lastKey) {
-				return false;
-			}
-			return true;
+			return redis->exists(lastKey);
 		}
 
 		return false;
@@ -385,7 +381,7 @@ class Redis extends Backend
 	 * Increment of given $keyName by $value
 	 *
 	 * @param string keyName
-	 * @param long value
+	 * @param int value
 	 */
 	public function increment(keyName = null, value = null) -> int
 	{
@@ -417,7 +413,7 @@ class Redis extends Backend
 	 * Decrement of $keyName by given $value
 	 *
 	 * @param string keyName
-	 * @param long value
+	 * @param int value
 	 */
 	public function decrement(keyName = null, value = null) -> int
 	{
@@ -466,7 +462,7 @@ class Redis extends Backend
 		}
 
 		if specialKey == "" {
-			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCM')!");
+			throw new Exception("Cached keys need to be enabled to use this function (options['statsKey'] == '_PHCR')!");
 		}
 
 		let keys = redis->sMembers(specialKey);

--- a/tests/unit/Cache/Backend/RedisCest.php
+++ b/tests/unit/Cache/Backend/RedisCest.php
@@ -84,6 +84,46 @@ class RedisCest
         $I->seeInRedis($key, 87);
     }
 
+    public function exists(UnitTester $I)
+    {
+        $I->wantTo('Check if cache exists in cache by using Redis as cache backend');
+
+        $key = '_PHCR' . 'data-exists';
+
+        $data = [uniqid(), gethostname(), microtime(), get_include_path(), time()];
+
+        $cache = new Redis(new Data(['lifetime' => 20]), [
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
+        ]);
+
+        $I->haveInRedis('string', $key, serialize($data));
+
+        $I->assertTrue($cache->exists('data-exists'));
+        $I->assertFalse($cache->exists('non-existent-key'));
+    }
+
+    /**
+     * @issue 12434
+     * @param UnitTester $I
+     */
+    public function existsEmpty(UnitTester $I)
+    {
+        $I->wantTo('Check if cache exists for empty value in cache by using Redis as cache backend');
+
+        $key = '_PHCR' . 'data-empty-exists';
+
+        $cache = new Redis(new Data(['lifetime' => 20]), [
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
+        ]);
+
+        $I->haveInRedis('string', $key, '');
+
+        $I->assertTrue($cache->exists('data-empty-exists'));
+        $I->assertFalse($cache->exists('non-existent-key'));
+    }
+
     public function get(UnitTester $I)
     {
         $I->wantTo('Get data by using Redis as cache backend');


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12434

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed `Phalcon\Cache\Backend\Redis::exists` to correct check if cache key exists for empty value in the Redis database

Thanks


