### PR TITLE
Collection behaviors now implement the interface properly

### DIFF
--- a/phalcon/mvc/collection/behavior.zep
+++ b/phalcon/mvc/collection/behavior.zep
@@ -26,7 +26,7 @@ use Phalcon\Mvc\CollectionInterface;
  *
  * This is an optional base class for ORM behaviors
  */
-abstract class Behavior
+abstract class Behavior implements BehaviorInterface
 {
 	protected _options;
 

--- a/phalcon/mvc/collection/behavior/softdelete.zep
+++ b/phalcon/mvc/collection/behavior/softdelete.zep
@@ -21,7 +21,6 @@ namespace Phalcon\Mvc\Collection\Behavior;
 
 use Phalcon\Mvc\CollectionInterface;
 use Phalcon\Mvc\Collection\Behavior;
-use Phalcon\Mvc\Collection\BehaviorInterface;
 use Phalcon\Mvc\Collection\Exception;
 
 /**
@@ -30,7 +29,7 @@ use Phalcon\Mvc\Collection\Exception;
  * Instead of permanently delete a record it marks the record as
  * deleted changing the value of a flag column
  */
-class SoftDelete extends Behavior implements BehaviorInterface
+class SoftDelete extends Behavior
 {
 
 	/**

--- a/phalcon/mvc/collection/behavior/timestampable.zep
+++ b/phalcon/mvc/collection/behavior/timestampable.zep
@@ -21,7 +21,6 @@ namespace Phalcon\Mvc\Collection\Behavior;
 
 use Phalcon\Mvc\CollectionInterface;
 use Phalcon\Mvc\Collection\Behavior;
-use Phalcon\Mvc\Collection\BehaviorInterface;
 use Phalcon\Mvc\Collection\Exception;
 
 /**
@@ -30,7 +29,7 @@ use Phalcon\Mvc\Collection\Exception;
  * Allows to automatically update a model’s attribute saving the
  * datetime when a record is created or updated
  */
-class Timestampable extends Behavior implements BehaviorInterface
+class Timestampable extends Behavior
 {
 
 	/**


### PR DESCRIPTION
* Type: code quality


**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

SoftDelete and Timestampable implemented the interface directly whilst the abstract Behavior class didn't. Now, the abstract class implements the interface and SoftDelete and Timestampable implicitly inherit it.