### PR TITLE
[NFR] Micro: Response handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the ability to clear appended and prepended title elements (Phalcon\Tag::appendTitle, Phalcon\Tag::prependTitle). Now you can use array to add multiple titles. For more details check [#12238](https://github.com/phalcon/cphalcon/issues/12238).
 - Added the ability to specify what empty means in the 'allowEmpty' option of the validators. Now it accepts as well an array specifying what's empty, for example ['', false]
 - Added the ability to use `Phalcon\Validation` with `Phalcon\Mvc\Collection`, deprecated `Phalcon\Mvc\Collection::validationHasFailed`
+- Added response handler to `Phalcon\Mvc\Micro`, `Phalcon\Mvc\Micro::setResponseHandler`, to allow use of a custom response handler.
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -440,4 +440,33 @@ class MicroTest extends UnitTest
             }
         );
     }
+
+    public function testMicroResponseHandler()
+    {
+        $this->specify(
+            "Micro::response event handler don't work as expected",
+            function () {
+                $trace = [];
+
+                $app = new Micro();
+
+                $app->setResponseHandler(
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
+
+                $app->map(
+                    "/blog",
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
+
+                $app->handle("/blog");
+
+                expect($trace)->count(2);
+            }
+        );
+    }
 }


### PR DESCRIPTION
* Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

## Small description of change:

**What:**
Adds the possibility to create a response handler, that will handle the
response instead of the default hard coded micro handler.

**Why:**
Before the reponse format had to be coded into every route.
Now is it possible to create a custom rosponse handler, that will format
the data in custom created function.

**Changes to phalcon/mvc/micro.zep**
* Added **protected** class variable **_responseHandler**
_The custom response handler_

* Added **public** function **response** 
_Appends a response handler_

* Change to **public** function  **handle** 
_Check if a response handler has been appended._
_If **yes**, run the response handler._
_If **no**, run the same code as before this PR._

## Unit test
Adds a response handler, and check if it has been called.

## How to use
```php
$app->setResponseHandler(function () use ($app) {

    // Gets the client response, that has been returned from executed route
    $return = $app->getReturnedValue();

    // Put controller return array item data
    $return = array('data' => $return);

    // Set reponse Content-Type to json
    header('Content-Type: application/json');

    // Print json response string
    echo json_encode($return);
});
```
