### PR TITLE
Form validation some fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed `Phalcon\Http\Request::getHeaders` to handle auth headers correctly [#12480](https://github.com/phalcon/cphalcon/issues/12480)
 - Fixed `Phalcon\Http\Request::getMethod` to handle `X-HTTP-Method-Override` header correctly [#12478](https://github.com/phalcon/cphalcon/issues/12478)
 - Fixed `Phalcon\Mvc\Model\Criteria::limit` and `Phalcon\Mvc\Model\Query\Builder::limit` to work with `limit` and `offset` properly [#12419](https://github.com/phalcon/cphalcon/issues/12419)
+- Fixed `Phalcon\Forms\Form` to correct form validation and set messages for elements [#12465](https://github.com/phalcon/cphalcon/issues/12465), [#11500](https://github.com/phalcon/cphalcon/issues/11500), [#11135](https://github.com/phalcon/cphalcon/issues/11135), [#3167](https://github.com/phalcon/cphalcon/issues/3167)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed `Phalcon\Http\Request::getHeaders` to handle auth headers correctly [#12480](https://github.com/phalcon/cphalcon/issues/12480)
 - Fixed `Phalcon\Http\Request::getMethod` to handle `X-HTTP-Method-Override` header correctly [#12478](https://github.com/phalcon/cphalcon/issues/12478)
 - Fixed `Phalcon\Mvc\Model\Criteria::limit` and `Phalcon\Mvc\Model\Query\Builder::limit` to work with `limit` and `offset` properly [#12419](https://github.com/phalcon/cphalcon/issues/12419)
-- Fixed `Phalcon\Forms\Form` to correct form validation and set messages for elements [#12465](https://github.com/phalcon/cphalcon/issues/12465), [#11500](https://github.com/phalcon/cphalcon/issues/11500), [#11135](https://github.com/phalcon/cphalcon/issues/11135), [#3167](https://github.com/phalcon/cphalcon/issues/3167)
+- Fixed `Phalcon\Forms\Form` to correct form validation and set messages for elements [#12465](https://github.com/phalcon/cphalcon/issues/12465), [#11500](https://github.com/phalcon/cphalcon/issues/11500), [#11135](https://github.com/phalcon/cphalcon/issues/11135), [#3167](https://github.com/phalcon/cphalcon/issues/3167), [#12395](https://github.com/phalcon/cphalcon/issues/12395)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -20,6 +20,7 @@
 namespace Phalcon\Forms;
 
 use Phalcon\Validation;
+use Phalcon\ValidationInterface;
 use Phalcon\DiInterface;
 use Phalcon\FilterInterface;
 use Phalcon\Di\Injectable;
@@ -255,9 +256,9 @@ class Form extends Injectable implements \Countable, \Iterator
 	 */
 	public function isValid(var data = null, var entity = null) -> boolean
 	{
-		var notFailed, messages, element,
-			validators, name, preparedValidators, filters,
-			validator, validation, elementMessages;
+		var validationStatus, messages, element,
+			validators, name, filters,
+			validator, validation, elementMessage;
 
 		if empty this->_elements {
 			return true;
@@ -294,9 +295,9 @@ class Form extends Injectable implements \Countable, \Iterator
 
         let validation = this->getValidation();
 
-        if !(validation instanceof Validation) {
+        if !(validation instanceof ValidationInterface) {
             // Create an implicit validation
-            validation = new Validation();
+            let validation = new Validation();
         }
 
 		for element in this->_elements {
@@ -340,7 +341,7 @@ class Form extends Injectable implements \Countable, \Iterator
             for elementMessage in messages {
                 this->get(elementMessage->getField())->appendMessage(elementMessage);
             }
-            validationStatus = false;
+            let validationStatus = false;
         }
 
 		/**

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -295,7 +295,7 @@ class Form extends Injectable implements \Countable, \Iterator
 
         let validation = this->getValidation();
 
-        if !(validation instanceof ValidationInterface) {
+        if typeof validation != "object" || !(validation instanceof ValidationInterface) {
             // Create an implicit validation
             let validation = new Validation();
         }
@@ -336,11 +336,12 @@ class Form extends Injectable implements \Countable, \Iterator
         * Perform the validation
         */
         let messages = validation->validate(data, entity);
-        if count(messages) {
+        if messages->count() {
             // Add validation messages to relevant elements
-            for elementMessage in messages {
+            for elementMessage in iterator(messages) {
                 this->get(elementMessage->getField())->appendMessage(elementMessage);
             }
+            messages->rewind();
             let validationStatus = false;
         }
 
@@ -369,29 +370,14 @@ class Form extends Injectable implements \Countable, \Iterator
 	 */
 	public function getMessages(boolean byItemName = false) -> <Group>
 	{
-		var messages, group, elementMessages;
+		var messages;
 
 		let messages = this->_messages;
-		if byItemName {
-			if typeof messages != "array" {
-				return new Group();
-			}
-			return messages;
-		}
-
-        if messages instanceof Group {
+		if typeof messages == "object" && messages instanceof Group {
             return messages;
-        }
-
-		let group = new Group();
-
-		if typeof messages == "array" {
-			for elementMessages in messages {
-				group->appendMessages(elementMessages);
-			}
 		}
 
-		return group;
+		return new Group();
 	}
 
 	/**
@@ -399,17 +385,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 */
 	public function getMessagesFor(string! name) -> <Group>
 	{
-		var messages, elementMessages, group;
-
-		let messages = this->_messages;
-		if fetch elementMessages, messages[name] {
-			return elementMessages;
-		}
-
-		let group = new Group(),
-			this->_messages[name] = group;
-
-		return group;
+        return this->get(name)->getMessages();
 	}
 
 	/**
@@ -708,7 +684,11 @@ class Form extends Injectable implements \Countable, \Iterator
 	public function rewind() -> void
 	{
 		let this->_position = 0;
-		let this->_elementsIndexed = array_values(this->_elements);
+		if typeof this->_elements == "array" {
+		    let this->_elementsIndexed = array_values(this->_elements);
+		} else {
+		    let this->_elementsIndexed = [];
+		}
 	}
 
 	/**

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -385,7 +385,10 @@ class Form extends Injectable implements \Countable, \Iterator
 	 */
 	public function getMessagesFor(string! name) -> <Group>
 	{
-        return this->get(name)->getMessages();
+	    if this->has(name) {
+            return this->get(name)->getMessages();
+	    }
+	    return new Group();
 	}
 
 	/**

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -442,6 +442,7 @@ class FormTest extends UnitTest
                     ],
                 ])
             );
+            expect($form->get('telephone')->getMessages())->equals($form->getMessages());
             expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
         });
     }
@@ -482,6 +483,7 @@ class FormTest extends UnitTest
                     ],
                 ])
             );
+            expect($form->get('telephone')->getMessages())->equals($form->getMessages());
             expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
         });
     }
@@ -533,6 +535,7 @@ class FormTest extends UnitTest
                     ],
                 ])
             );
+            expect($form->get('telephone')->getMessages())->equals($form->getMessages());
             expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
         });
     }

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -13,6 +13,7 @@ use Phalcon\Validation\Message\Group;
 use Phalcon\Validation\Validator\PresenceOf;
 use Phalcon\Validation\Validator\Regex;
 use Phalcon\Validation\Validator\StringLength;
+use Phalcon\Validation;
 
 /**
  * \Phalcon\Test\Unit\Forms\FormTest
@@ -397,5 +398,142 @@ class FormTest extends UnitTest
                 expect($result)->equals($data);
             }
         );
+    }
+
+    /**
+     * Tests Element::hasMessages() Element::getMessages()
+     *
+     * @author Mohamad Rostami <rostami@outlook.com>
+     * @issue 11135, 3167
+     */
+    public function testElementMessages()
+    {
+        $this->specify('Element messages are empty if form validation fails', function () {
+            // First element
+            $telephone = new Text('telephone');
+
+            $telephone->addValidators([
+                new Regex([
+                    'pattern' => '/\+44 [0-9]+ [0-9]+/',
+                    'message' => 'The telephone has an invalid format'
+                ])
+            ]);
+
+            // Second element
+            $address = new Text('address');
+            $form = new Form();
+
+            $form->add($telephone);
+            $form->add($address);
+
+            expect($form->isValid(['telephone' => '12345', 'address' => 'hello']))->false();
+            expect($form->get('telephone')->hasMessages())->true();
+            expect($form->get('address')->hasMessages())->false();
+
+            expect($form->get('telephone')->getMessages())->equals(
+                Group::__set_state([
+                    '_messages' => [
+                        Message::__set_state([
+                            '_type'    => 'Regex',
+                            '_message' => 'The telephone has an invalid format',
+                            '_field'   => 'telephone',
+                            '_code'    => 0,
+                        ])
+                    ],
+                ])
+            );
+            expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
+        });
+    }
+
+    /**
+     * Tests Form::setValidation()
+     *
+     * @author Mohamad Rostami <rostami@outlook.com>
+     * @issue 12465
+     */
+    public function testCustomValidation()
+    {
+        $this->specify('Injecting custom validation to form doesn\'t validate correctly', function () {
+            // First element
+            $telephone = new Text('telephone');
+            $customValidation = new Validation();
+            $customValidation->add('telephone', new Regex([
+                'pattern' => '/\+44 [0-9]+ [0-9]+/',
+                'message' => 'The telephone has an invalid format'
+            ]));
+            $form = new Form();
+            $address = new Text('address');
+            $form->add($telephone);
+            $form->add($address);
+            $form->setValidation($customValidation);
+            expect($form->isValid(['telephone' => '12345', 'address' => 'hello']))->false();
+            expect($form->get('telephone')->hasMessages())->true();
+            expect($form->get('address')->hasMessages())->false();
+            expect($form->get('telephone')->getMessages())->equals(
+                Group::__set_state([
+                    '_messages' => [
+                        Message::__set_state([
+                            '_type' => 'Regex',
+                            '_message' => 'The telephone has an invalid format',
+                            '_field' => 'telephone',
+                            '_code' => 0,
+                        ])
+                    ],
+                ])
+            );
+            expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
+        });
+    }
+
+    /**
+     * Tests Form::isValid()
+     *
+     * @author Mohamad Rostami <rostami@outlook.com>
+     * @issue 11500
+     */
+    public function testMergeValidators()
+    {
+        $this->specify('Injecting custom validation to form doesn\'t merge validators on isValid', function () {
+            // First element
+            $telephone = new Text('telephone');
+            $telephone->addValidators([
+                new PresenceOf([
+                    'message' => 'The telephone is required'
+                ])
+            ]);
+            $customValidation = new Validation();
+            $customValidation->add('telephone', new Regex([
+                'pattern' => '/\+44 [0-9]+ [0-9]+/',
+                'message' => 'The telephone has an invalid format'
+            ]));
+            $form = new Form();
+            $address = new Text('address');
+            $form->add($telephone);
+            $form->add($address);
+            $form->setValidation($customValidation);
+            expect($form->isValid(['address' => 'hello']))->false();
+            expect($form->get('telephone')->hasMessages())->true();
+            expect($form->get('address')->hasMessages())->false();
+            expect($form->get('telephone')->getMessages())->equals(
+                Group::__set_state([
+                    '_messages' => [
+                        Message::__set_state([
+                            '_type' => 'Regex',
+                            '_message' => 'The telephone has an invalid format',
+                            '_field' => 'telephone',
+                            '_code' => 0,
+                        ]),
+                        Message::__set_state([
+                            '_type' => 'PresenceOf',
+                            '_message' => 'The telephone is required',
+                            '_field' => 'telephone',
+                            '_code' => 0,
+                        ])
+                    ],
+                ])
+            );
+            expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
+        });
     }
 }

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -444,6 +444,7 @@ class FormTest extends UnitTest
             );
             expect($form->get('telephone')->getMessages())->equals($form->getMessages());
             expect($form->get('address')->getMessages())->equals(Group::__set_state(['_messages' => []]));
+            expect($form->getMessagesFor('notelement'))->equals(Group::__set_state(['_messages' => []]));
         });
     }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issues (this will fix all of the below issues):
https://github.com/phalcon/cphalcon/issues/12465
https://github.com/phalcon/cphalcon/issues/11500
https://github.com/phalcon/cphalcon/issues/11135
https://github.com/phalcon/cphalcon/issues/3167

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
setValidation for form is not work correctly as I explained at #12465.
Elements messages doesn't set if custom validation fails.

Thanks
