### PR TITLE
Fixed Request::getMethod to handle X-HTTP-Method-Override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `Phalcon\Security::checkToken` to prevent possible timing attack [#12418](https://github.com/phalcon/cphalcon/issues/12418)
 - Fixed `Phalcon\Mvc\Model\Resultset\Simple` to save snapshot when caching
 - Fixed `Phalcon\Http\Request::getHeaders` to handle auth headers correctly [#12480](https://github.com/phalcon/cphalcon/issues/12480)
+- Fixed `Phalcon\Http\Request::getMethod` to handle `X-HTTP-Method-Override` header correctly [#12478](https://github.com/phalcon/cphalcon/issues/12478)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -591,16 +591,16 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 */
 	public final function getMethod() -> string
 	{
-		var headers, overridedMethod, spoofedMethod, requestMethod;
+		var overridedMethod, spoofedMethod, requestMethod;
 		string returnMethod = "";
 
 		if fetch requestMethod, _SERVER["REQUEST_METHOD"] {
-			let returnMethod = requestMethod;
+			let returnMethod = strtoupper(requestMethod);
 		}
 
 		if "POST" === requestMethod {
-			let headers = this->getHeaders();
-			if fetch overridedMethod, headers["X-HTTP-METHOD-OVERRIDE"] {
+			let overridedMethod = this->getHeader("X-HTTP-METHOD-OVERRIDE");
+			if !empty overridedMethod {
 				let returnMethod = overridedMethod;
 			} elseif this->_httpMethodParameterOverride {
 				if fetch spoofedMethod, _REQUEST["_method"] {

--- a/tests/unit/Http/Request/AuthHeaderTest.php
+++ b/tests/unit/Http/Request/AuthHeaderTest.php
@@ -52,7 +52,7 @@ class AuthHeaderTest extends UnitTest
      * @test
      * @issue  12480
      * @author Serghei Iakovelv <serghei@phalconphp.com>
-     * @since  2016-01-31
+     * @since  2016-12-18
      */
     public function shouldCorrectHandleAuth()
     {

--- a/tests/unit/Http/RequestTest.php
+++ b/tests/unit/Http/RequestTest.php
@@ -755,6 +755,61 @@ class RequestTest extends HttpBase
         $this->assertFalse($request->isGet());
     }
 
+    /**
+     * Tests the ability to override the HTTP method
+     *
+     * @test
+     * @issue  12478
+     * @author Serghei Iakovelv <serghei@phalconphp.com>
+     * @since  2016-12-18
+     */
+    public function shouldOverrideHttpRequestMethod()
+    {
+        $this->specify(
+            'The request object gets http method incorrectly',
+            function ($header, $method, $expected) {
+                $_SERVER['REQUEST_METHOD'] = 'POST';
+                $request = $this->getRequestObject();
+
+                $_SERVER[$header] = $method;
+                expect($request->getMethod())->equals($expected);
+
+                $_SERVER[$header] = strtolower($method);
+                expect($request->getMethod())->equals($expected);
+
+                $_SERVER[strtolower($header)] = $method;
+                expect($request->getMethod())->equals($expected);
+            },
+            ['examples' => $this->overridedMethodProvider()]
+        );
+    }
+
+    protected function overridedMethodProvider()
+    {
+        return [
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PUT',     'PUT'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PAT',     'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'GET',     'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'GOT',     'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'HEAD',    'HEAD'   ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'HED',     'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'POST',    'POST'   ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PAST',    'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'DELETE',  'DELETE' ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'DILETE',  'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'OPTIONS', 'OPTIONS'],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'OPTION',  'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PATCH',   'PATCH'  ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PUTCH',   'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PURGE',   'PURGE'  ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'PURG',    'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'TRACE',   'TRACE'  ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'RACE',    'GET'    ],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'CONNECT', 'CONNECT'],
+            ['HTTP_X_HTTP_METHOD_OVERRIDE', 'CONECT',  'GET'    ],
+        ];
+    }
+
     public function testHttpRequestContentType()
     {
         $request = $this->getRequestObject();


### PR DESCRIPTION
* Type: bug fix
* Link to issue: #12478

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed `Phalcon\Http\Request::getMethod` to handle `X-HTTP-Method-Override` header correctly.