### PR TITLE
Phalcon\Crypt safe base64 padding

### DIFF
--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -372,7 +372,7 @@ class Crypt implements CryptInterface
 	public function encryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{
 		if safe == true {
-			return rtrim(strtr(base64_encode(this->encrypt(text, key)), "+/", "-_"), '=');
+			return rtrim(strtr(base64_encode(this->encrypt(text, key)), "+/", "-_"), "=");
 		}
 		return base64_encode(this->encrypt(text, key));
 	}
@@ -383,7 +383,7 @@ class Crypt implements CryptInterface
 	public function decryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{
 		if safe == true {
-			return this->decrypt(base64_decode(strtr(text, "-_", "+/") . substr('===', (strlen(text) + 3) % 4)), key);
+			return this->decrypt(base64_decode(strtr(text, "-_", "+/") . substr("===", (strlen(text) + 3) % 4)), key);
 		}
 		return this->decrypt(base64_decode(text), key);
 	}

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -372,7 +372,7 @@ class Crypt implements CryptInterface
 	public function encryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{
 		if safe == true {
-			return strtr(base64_encode(this->encrypt(text, key)), "+/", "-_");
+			return rtrim(strtr(base64_encode(this->encrypt(text, key)), "+/", "-_"), '=');
 		}
 		return base64_encode(this->encrypt(text, key));
 	}
@@ -383,7 +383,7 @@ class Crypt implements CryptInterface
 	public function decryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{
 		if safe == true {
-			return this->decrypt(base64_decode(strtr(text, "-_", "+/")), key);
+			return this->decrypt(base64_decode(strtr(text, "-_", "+/") . substr('===', (strlen(text) + 3) % 4)), key);
 		}
 		return this->decrypt(base64_decode(text), key);
 	}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/joaquimserafim/base64-url/blob/master/index.js

Small description of change:

Added autopadding feature for following methods

- `Phalcon\Crypt::encryptBase64`
- `Phalcon\Crypt::decryptBase64`

Equal character is unsafe for url and base64 use for padding this character. base64 able to automatically padded by character length. I inspired this feature from above link.

Thanks,
Tuğrul Topuz

