### PR TITLE
Fixed Libmemcached::queryKeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fixed `Phalcon\Http\Request::getMethod` to handle `X-HTTP-Method-Override` header correctly [#12478](https://github.com/phalcon/cphalcon/issues/12478)
 - Fixed `Phalcon\Mvc\Model\Criteria::limit` and `Phalcon\Mvc\Model\Query\Builder::limit` to work with `limit` and `offset` properly [#12419](https://github.com/phalcon/cphalcon/issues/12419)
 - Fixed `Phalcon\Forms\Form` to correct form validation and set messages for elements [#12465](https://github.com/phalcon/cphalcon/issues/12465), [#11500](https://github.com/phalcon/cphalcon/issues/11500), [#11135](https://github.com/phalcon/cphalcon/issues/11135), [#3167](https://github.com/phalcon/cphalcon/issues/3167), [#12395](https://github.com/phalcon/cphalcon/issues/12395)
+- Fixed `Phalcon\Cache\Backend\Libmemcached::queryKeys` to correct query the existing cached keys [#11024](https://github.com/phalcon/cphalcon/issues/11024)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/cache/backend/libmemcached.zep
+++ b/phalcon/cache/backend/libmemcached.zep
@@ -46,13 +46,13 @@ use Phalcon\Cache\Exception;
  *     [
  *         "servers" => [
  *             [
- *                 "host"   => "localhost",
+ *                 "host"   => "127.0.0.1",
  *                 "port"   => 11211,
  *                 "weight" => 1,
  *             ],
  *         ],
  *         "client" => [
- *             \Memcached::OPT_HASH       => Memcached::HASH_MD5,
+ *             \Memcached::OPT_HASH       => \Memcached::HASH_MD5,
  *             \Memcached::OPT_PREFIX_KEY => "prefix.",
  *         ],
  *     ]
@@ -317,12 +317,18 @@ class Libmemcached extends Backend
 	/**
 	 * Query the existing cached keys
 	 *
+	 * <code>
+	 * $cache->save('users-ids', [1, 2, 3]);
+	 * $cache->save('projects-ids', [4, 5, 6]);
+	 *
+	 * var_dump($cache->queryKeys('users')); // [1, 2, 3]
+	 * </code>
+	 *
 	 * @param string prefix
-	 * @return array
 	 */
-	public function queryKeys(prefix = null)
+	public function queryKeys(prefix = null) -> array
 	{
-		var memcache, options, keys, specialKey, key;
+		var memcache, options, keys, specialKey, key, idx;
 
 		let memcache = this->_memcache;
 
@@ -345,11 +351,15 @@ class Libmemcached extends Backend
 		 * Get the key from memcached
 		 */
 		let keys = memcache->get(specialKey);
+		if typeof keys != "array" {
+			return [];
+		}
+
 		if typeof keys == "array" {
 			let keys = array_keys(keys);
-			for key in keys {
+			for idx, key in keys {
 				if prefix && !starts_with(key, prefix) {
-					unset keys[key];
+					unset keys[idx];
 				}
 			}
 		}

--- a/tests/unit/Cache/Backend/LibmemcachedCest.php
+++ b/tests/unit/Cache/Backend/LibmemcachedCest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Phalcon\Test\Unit\Cache\Backend;
+
+use UnitTester;
+use Phalcon\Cache\Frontend\Data;
+use Phalcon\Cache\Backend\Libmemcached;
+
+/**
+ * \Phalcon\Test\Unit\Cache\Backend\LibmemcachedCest
+ * Tests the \Phalcon\Cache\Backend\Libmemcached component
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      https://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Unit\Cache\Backend
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class LibmemcachedCest
+{
+    public function _before(UnitTester $I)
+    {
+        if (!extension_loaded('memcached')) {
+            throw new \PHPUnit_Framework_SkippedTestError(
+                'Warning: memcached extension is not loaded'
+            );
+        }
+    }
+
+    public function emptyQueryKeys(UnitTester $I)
+    {
+        $I->wantToTest('Getting empty keys list by using Libmemcached as cache backend');
+
+        $lifetime = 20;
+        $statsKey = '_PHCM';
+        $cache = $this->getCache($statsKey, $lifetime);
+
+        $I->assertEquals([], $cache->queryKeys());
+    }
+
+    public function queryKeys(UnitTester $I)
+    {
+        $I->wantToTest('Getting cache keys by using Libmemcached as cache backend');
+
+        $lifetime = 20;
+        $statsKey = '_PHCM';
+        $cache = $this->getCache($statsKey, $lifetime);
+
+        $I->haveInLibmemcached("{$statsKey}a", 1);
+        $I->haveInLibmemcached("{$statsKey}b", 2);
+        $I->haveInLibmemcached("{$statsKey}c", 3);
+
+        $I->haveInLibmemcached($statsKey, ['a' => $lifetime, 'b' => $lifetime, 'c' => $lifetime]);
+
+        $keys = $cache->queryKeys();
+        sort($keys);
+
+        $I->assertEquals(['a', 'b', 'c'], $keys);
+    }
+
+    /**
+     * @issue 11024
+     * @param UnitTester $I
+     */
+    public function prefixedQueryKeys(UnitTester $I)
+    {
+        $I->wantToTest('Getting prefixed cache keys by using Libmemcached as cache backend');
+
+        $lifetime = 20;
+        $statsKey = '_PHCM';
+        $cache = $this->getCache($statsKey, $lifetime);
+
+        $I->haveInLibmemcached("{$statsKey}prefix1-myKey", ['a', 'b']);
+        $I->haveInLibmemcached("{$statsKey}prefix2-myKey", ['x', 'z']);
+
+        $I->haveInLibmemcached($statsKey, ['prefix1-myKey' => $lifetime, 'prefix2-myKey' => $lifetime]);
+
+        $I->assertEquals([0 => 'prefix1-myKey'], $cache->queryKeys('prefix1'));
+        $I->assertEquals([1 => 'prefix2-myKey'], $cache->queryKeys('prefix2'));
+        $I->assertCount(2, $cache->queryKeys('prefix'));
+
+        $I->assertEquals([], $cache->queryKeys('prefix123'));
+    }
+
+    protected function getCache($statsKey = '_PHCM', $ttl = 0)
+    {
+        return new Libmemcached(
+            new Data(['lifetime' => $ttl]),
+            [
+                'servers' => [
+                    [
+                        'host'   => env('TEST_MC_HOST', '127.0.0.1'),
+                        'port'   => env('TEST_MC_PORT', 11211),
+                        'weight' => env('TEST_MC_WEIGHT', 1),
+                    ]
+                ],
+                'statsKey' => $statsKey,
+                'client' => [
+                    \Memcached::OPT_HASH => \Memcached::HASH_MD5,
+                ],
+            ]
+        );
+    }
+}


### PR DESCRIPTION

* Type: bug fix
* Link to issue: #11024

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Fixed `Phalcon\Cache\Backend\Libmemcached::queryKeys` to correct query the existing cached keys

