### PR TITLE
Fixed Cache\Backend\Redis::save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed `Phalcon\Forms\Form` to correct form validation and set messages for elements [#12465](https://github.com/phalcon/cphalcon/issues/12465), [#11500](https://github.com/phalcon/cphalcon/issues/11500), [#11135](https://github.com/phalcon/cphalcon/issues/11135), [#3167](https://github.com/phalcon/cphalcon/issues/3167), [#12395](https://github.com/phalcon/cphalcon/issues/12395)
 - Fixed `Phalcon\Cache\Backend\Libmemcached::queryKeys` to correct query the existing cached keys [#11024](https://github.com/phalcon/cphalcon/issues/11024)
 - Fixed building extension for ImageMagick 7 [mkoppanen/imagick#180](https://github.com/mkoppanen/imagick/issues/180)
+- Fixed `Phalcon\Cache\Backend\Redis::save` to allow save data termlessly [#12327](https://github.com/phalcon/cphalcon/issues/12327)
 
 # [3.0.2](https://github.com/phalcon/cphalcon/releases/tag/v3.0.2) (2016-11-26)
 - Fixed saving snapshot data while caching model [#12170](https://github.com/phalcon/cphalcon/issues/12170), [#12000](https://github.com/phalcon/cphalcon/issues/12000)

--- a/phalcon/cache/backend/memory.zep
+++ b/phalcon/cache/backend/memory.zep
@@ -160,7 +160,7 @@ class Memory extends Backend implements \Serializable
 	 */
 	public function queryKeys(string prefix = null) -> array
 	{
-		var data, index, keys, key, idx;
+		var data, keys, key, idx;
 
 		let data = this->_data;
 		if typeof data != "array" {

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -176,6 +176,13 @@ class Redis extends Backend
 	/**
 	 * Stores cached content into the file backend and stops the frontend
 	 *
+	 * <code>
+	 * $cache->save("my-key", $data);
+	 *
+	 * // Save data termlessly
+	 * $cache->save("my-key", $data, -1);
+	 * </code>
+	 *
 	 * @param int|string keyName
 	 * @param string content
 	 * @param int lifetime
@@ -243,7 +250,10 @@ class Redis extends Backend
 			throw new Exception("Failed storing the data in redis");
 		}
 
-		redis->settimeout(lastKey, tt1);
+		// Don't set expiration for negative ttl or zero
+		if tt1 >= 1 {
+			redis->settimeout(lastKey, tt1);
+		}
 
 		let options = this->_options;
 

--- a/tests/unit/Cache/Backend/RedisCest.php
+++ b/tests/unit/Cache/Backend/RedisCest.php
@@ -192,6 +192,39 @@ class RedisCest
         $I->seeInRedis($key, serialize($data));
     }
 
+    /**
+     * @issue 12327
+     * @param UnitTester $I
+     */
+    public function saveNonExpiring(UnitTester $I)
+    {
+        $I->wantTo('Save data termlessly by using Redis as cache backend');
+
+        $key  = '_PHCR' . 'data-save-2';
+        $data = 1000;
+
+        $cache = new Redis(new Data(['lifetime' => 200]), [
+            'host' => env('TEST_RS_HOST'),
+            'port' => env('TEST_RS_PORT')
+        ]);
+
+        $I->dontSeeInRedis($key);
+
+        $cache->save('data-save-2', $data, -1);
+
+        sleep(2);
+        $I->seeInRedis($key);
+
+        $cache->save('data-save-2', $data, 0);
+
+        sleep(2);
+        $I->seeInRedis($key);
+
+        $cache->save('data-save-2', $data, 1);
+
+        sleep(2);
+        $I->dontSeeInRedis($key);
+    }
 
     public function delete(UnitTester $I)
     {


### PR DESCRIPTION
* Type: bug fix
* Link to issue: #12327

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Fixed `Phalcon\Cache\Backend\Redis::save` to allow save data termlessly:

```php
// Set expiration to 10 second
$cache->save("my-key", $data, 10);

// Save data termlessly
$cache->save("my-key", $data, -1);

// Save data termlessly
$cache->save("my-key", $data, -1789789789);

// Save data termlessly
$cache->save("my-key", $data, 0);
```

