### PR TITLE
Added a number (0) to be a label in a form field. Null, empty string …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)
+- Fixed `Phalcon\Forms\Element::label` to accept 0 as label instead of validating it as empty. [#12148](https://github.com/phalcon/cphalcon/issues/12148)
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (2016-12-24)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -399,7 +399,7 @@ abstract class Element implements ElementInterface
 		 * Use the default label or leave the same name as label
 		 */
 		let label = this->_label;
-		if label {
+		if label || is_numeric(label) {
 			let code .= ">" . label . "</label>";
 		} else {
 			let code .= ">" . name . "</label>";

--- a/tests/unit/Forms/Element/TextTest.php
+++ b/tests/unit/Forms/Element/TextTest.php
@@ -167,6 +167,9 @@ class TextTest extends UnitTest
                 expect($element->getAttribute('class'))->equals('big-input');
                 expect($element->getAttribute('placeholder', 'the name'))->equals('Type the name');
                 expect($element->getAttribute('lang', 'en'))->equals('en');
+                
+                $element->setLabel(0);
+                expect($element->label())->equals('<label for="name">0</label>');
             }
         );
     }


### PR DESCRIPTION
…or empty array will keep invalidating a label and using the value instead.

Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12148

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Can't associate a 0 with the element label. Tried to use empty label as condition because zephir documentation says that ‘Empty’ means the expression is null, is an empty string or an empty array. But that's not true and '0'also validates as false. So the only way to add '0' as a label is by explicitly check if it's numeric as condition.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phalcon/cphalcon/12515)
<!-- Reviewable:end -->
