### PR TITLE
Added DI services loading from php/yaml file for readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added afterBinding event to `Phalcon\Dispatcher` and `Phalcon\Mvc\Micro`, added `Phalcon\Mvc\Micro::afterBinding`
 - Added the ability to set custom Resultset class returned by find() [#12166](https://github.com/phalcon/cphalcon/issues/12166)
 - Added the ability to clear appended and prepended title elements (Phalcon\Tag::appendTitle, Phalcon\Tag::prependTitle). Now you can use array to add multiple titles. For more details check [#12238](https://github.com/phalcon/cphalcon/issues/12238).
+- Added the ability to load services from yaml (Phalcon\Di::loadFromYaml) and php (Phalcon\Di::loadFromPhp) files, so we can keep the references cleanly separated from code.
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -399,7 +399,7 @@ abstract class Element implements ElementInterface
 		 * Use the default label or leave the same name as label
 		 */
 		let label = this->_label;
-		if label {
+		if label || is_numeric(label) {
 			let code .= ">" . label . "</label>";
 		} else {
 			let code .= ">" . name . "</label>";

--- a/tests/_data/di/services.php
+++ b/tests/_data/di/services.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'unit-test' => [
+        'className' => '\Phalcon\Test\Module\UnitTest',
+    ],
+    'config' => [
+        'className' => '\Phalcon\Config',
+        'shared' => true,
+    ],
+    'component' => [
+        'className' => '\SomeComponent',
+        'arguments' => [
+            [
+                'type' => 'service',
+                'name' => 'config',
+            ]
+        ],
+    ],
+];

--- a/tests/_data/di/services.yml
+++ b/tests/_data/di/services.yml
@@ -1,0 +1,12 @@
+unit-test:
+  className: \Phalcon\Test\Module\UnitTest
+
+config:
+  className: \Phalcon\Config
+  shared: true  
+  
+component:
+  className: \SomeComponent
+  arguments:
+  - type: service
+    name: config

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -503,4 +503,52 @@ class DiTest extends UnitTest
             }
         );
     }
+    
+    /**
+     * Tests loading services from yaml files.
+     *
+     * @author Gorka Guridi <gorka.guridi@gmail.com>
+     * @since  2016-12-29
+     */
+    public function testYamlLoader()
+    {
+        $this->specify(
+            "Di does not load services from yaml files properly",
+            function () {
+                $this->phDi->loadFromYaml(PATH_DATA . 'di/services.yml');
+                
+                expect($this->phDi->has('unit-test'))->true();
+                expect($this->phDi->getService('unit-test')->isShared())->false();
+                expect($this->phDi->has('config'))->true();
+                expect($this->phDi->getService('config')->isShared())->true();
+                expect($this->phDi->has('component'))->true();
+                expect($this->phDi->getService('component')->isShared())->false();
+                expect($this->phDi->get('component')->someProperty)->isInstanceOf('Phalcon\Config');
+            }
+        );
+    }
+    
+    /**
+     * Tests loading services from php files.
+     *
+     * @author Gorka Guridi <gorka.guridi@gmail.com>
+     * @since  2016-12-29
+     */
+    public function testPhpLoader()
+    {
+        $this->specify(
+            "Di does not load services from php files properly",
+            function () {
+                $this->phDi->loadFromPhp(PATH_DATA . 'di/services.php');
+                
+                expect($this->phDi->has('unit-test'))->true();
+                expect($this->phDi->getService('unit-test')->isShared())->false();
+                expect($this->phDi->has('config'))->true();
+                expect($this->phDi->getService('config')->isShared())->true();
+                expect($this->phDi->has('component'))->true();
+                expect($this->phDi->getService('component')->isShared())->false();
+                expect($this->phDi->get('component')->someProperty)->isInstanceOf('Phalcon\Config');
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Dependency injection is the container of any instance declaration in the system. Theoretically any instance should be obtained through dependency injection, which means that in a normal website/application we can end up with lots of classes set in the di as a services. The current system to add services into the dependency injection object require the di itself, setting them one by one.

This pull request is to enable the load of the services from yaml or php files. This is not a big feature and won't solve any real problem, but I just though it would make things more readable as we can have one file with the declaration of the dependencies without having to call di methods, parameters, etc.

This just improves readability, nothing else.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phalcon/cphalcon/12517)
<!-- Reviewable:end -->
