### PR TITLE
Added retainer for current session token in order to not break checkToken functionality if getToken is called before.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)
+- Added a retainer for the current token to be used during the checkings, so when `Phalcon\Security::getToken` is called the token used for checkings don't change. [#12392](https://github.com/phalcon/cphalcon/issues/12392)
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (2016-12-24)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/security.zep
+++ b/phalcon/security.zep
@@ -60,6 +60,8 @@ class Security implements InjectionAwareInterface
 
 	protected _tokenKey;
 
+	protected _requestToken;
+
 	protected _random;
 
 	protected _defaultHash;
@@ -343,6 +345,7 @@ class Security implements InjectionAwareInterface
 		var dependencyInjector, session;
 
 		if null === this->_token {
+			let this->_requestToken = this->getSessionToken();
 			let this->_token = this->_random->base64Safe(this->_numberBytes);
 
 			let dependencyInjector = <DiInterface> this->_dependencyInjector;
@@ -390,7 +393,7 @@ class Security implements InjectionAwareInterface
 			/**
 			 * We always check if the value is correct in post
 			 */
-			let userToken = request->getPost(tokenKey);
+			let userToken = (string) request->getPost(tokenKey);
 		} else {
 			let userToken = tokenValue;
 		}
@@ -398,7 +401,7 @@ class Security implements InjectionAwareInterface
 		/**
 		 * The value is the same?
 		 */
-		let knownToken = session->get(this->_tokenValueSessionID);
+		let knownToken = this->getRequestToken();
 		let equals = hash_equals(knownToken, userToken);
 
 		/**
@@ -409,6 +412,17 @@ class Security implements InjectionAwareInterface
 		}
 
 		return equals;
+	}
+
+	/**
+	 * Returns the value of the CSRF token for the current request.
+	 */
+	public function getRequestToken() -> string
+	{
+		if empty this->_requestToken {
+			return this->getSessionToken();                    
+		}
+		return this->_requestToken;
 	}
 
 	/**
@@ -449,6 +463,7 @@ class Security implements InjectionAwareInterface
 
 		let this->_token = null;
 		let this->_tokenKey = null;
+		let this->_requestToken = null;
 
 		return this;
 	}


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/12392

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Security::checkToken functionality doesn't use the regenerated session but uses the one that was set at the beginning if it existed. This will prevent that if we call getToken and the session token is regenerated, the checkToken method will fail because the session token has changed.

I've also cast to string the userToken coming from the request::getPost method as it could be null and I was receiving an E_WARNING when passing it to hash_equals.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phalcon/cphalcon/12518)
<!-- Reviewable:end -->
