### PR TITLE
allowEmpty can be populated with the list of what we consider 'empty'. The validation only will stop if the empty validation returns true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added afterBinding event to `Phalcon\Dispatcher` and `Phalcon\Mvc\Micro`, added `Phalcon\Mvc\Micro::afterBinding`
 - Added the ability to set custom Resultset class returned by find() [#12166](https://github.com/phalcon/cphalcon/issues/12166)
 - Added the ability to clear appended and prepended title elements (Phalcon\Tag::appendTitle, Phalcon\Tag::prependTitle). Now you can use array to add multiple titles. For more details check [#12238](https://github.com/phalcon/cphalcon/issues/12238).
+- Added the ability to specify what empty means in the 'allowEmpty' option of the validators. Now it accepts as well an array specifying what's empty, for example ['', false]
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -579,23 +579,31 @@ class Validation extends Injectable implements ValidationInterface
 	 */
 	protected function preChecking(var field, <ValidatorInterface> validator) -> boolean
 	{
-		var singleField;
+		var singleField, allowEmpty, emptyValue, value, result;
 		if typeof field == "array" {
 			for singleField in field {
-				if validator->getOption("allowEmpty", false) {
-					if method_exists(validator, "isAllowEmpty") {
-						return validator->isAllowEmpty(this, singleField);
-					}
-					return empty this->getValue(singleField);
+				let result = this->preChecking(singleField, validator);
+				if result {
+					return result;
 				}
 			}
 		}
 		else {
-			if validator->getOption("allowEmpty", false) {
+			let allowEmpty = validator->getOption("allowEmpty", false);
+			if allowEmpty {
 				if method_exists(validator, "isAllowEmpty") {
 					return validator->isAllowEmpty(this, field);
 				}
-				return empty this->getValue(field);
+				let value = this->getValue(field);
+				if typeof allowEmpty == "array" {
+					for emptyValue in allowEmpty {
+						if emptyValue === value {
+							return true;
+						}
+					}
+					return false;						
+				}
+				return empty value;
 			}
 		}
 

--- a/tests/unit/ValidationTest.php
+++ b/tests/unit/ValidationTest.php
@@ -229,4 +229,66 @@ class ValidationTest extends UnitTest
             }
         );
     }
+    
+    /**
+     * Tests that empty values behaviour.
+     *
+     * @author Gorka Guridi <gorka.guridi@gmail.com>
+     * @since  2016-12-30
+     */
+    public function testEmptyValues()
+    {
+        $this->specify(
+            "Validation of empty values doesn't work as expected",
+            function () {
+                $validation = new Validation();
+
+                $validation->setDI(new FactoryDefault());
+
+                $validation
+                    ->add('name', new Validation\Validator\Alpha(array(
+                        'message' => 'The name is not valid',
+                    )))
+                    ->add('name', new Validation\Validator\PresenceOf(array(
+                        'message' => 'The name is required',
+                    )))
+                    ->add('url', new Validation\Validator\Url(array(
+                        'message' => 'The url is not valid.',
+                        'allowEmpty' => true,
+                    )))
+                    ->add('email', new Validation\Validator\Email(array(
+                        'message' => 'The email is not valid.',
+                        'allowEmpty' => [null, false],
+                    )));
+
+                $messages = $validation->validate([
+                    'name' => '',
+                    'url' => null,
+                    'email' => '',
+                ]);
+                expect($messages)->count(2);
+                
+                $messages = $validation->validate([
+                    'name' => 'MyName',
+                    'url' => '',
+                    'email' => '',
+                ]);
+                expect($messages)->count(1);
+                
+                $messages = $validation->validate([
+                    'name' => 'MyName',
+                    'url' => false,
+                    'email' => null,
+                ]);
+                expect($messages)->count(0);
+                
+                $messages = $validation->validate([
+                    'name' => 'MyName',
+                    'url' => 0,
+                    'email' => 0,
+                ]);
+                expect($messages)->count(1);
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/12106

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Added the possibility to specify in allowEmpty option what we consider 'empty'. Fixed the behaviour so only in case it returns true we move to the next validation. Added recursivity in the preChecking method so we don't duplicate code. Updated changelog.

- allowEmtpy = true (this means that everything that evaluates to empty is ok)
- allowEmpty = ['', null] (this means that empty only means empty string and null, false and 0 won't evaluate as empty).

I've added a pull request with this change. The benefits are:
- Backwards compatible.
- Flexible, we can specify 'unknown', 'empty' or -1 as empty values in case we are using a shitty api.

An improvement also added in the pull request is that only if the allowEmpty validation is true the validation will stop there, in case of false it will continue with the next validators.

Thanks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phalcon/cphalcon/12519)
<!-- Reviewable:end -->
