### PR TITLE
Added smallint support in Phalcon\Db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Added afterBinding event to `Phalcon\Dispatcher` and `Phalcon\Mvc\Micro`, added `Phalcon\Mvc\Micro::afterBinding`
 - Added the ability to set custom Resultset class returned by find() [#12166](https://github.com/phalcon/cphalcon/issues/12166)
 - Added the ability to clear appended and prepended title elements (Phalcon\Tag::appendTitle, Phalcon\Tag::prependTitle). Now you can use array to add multiple titles. For more details check [#12238](https://github.com/phalcon/cphalcon/issues/12238).
+- Added SMALLINT support in `Phalcon\Db`
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (201X-XX-XX)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -96,14 +96,21 @@ class Mysql extends PdoAdapter
 				let definition["type"] = Column::TYPE_CHAR;
 			} elseif memstr(columnType, "bigint") {
 				/**
-				 * Smallint/Bigint/Integers/Int are int
+				 * Bigint are int
 				 */
 				let definition["type"] = Column::TYPE_BIGINTEGER,
 					definition["isNumeric"] = true,
 					definition["bindType"] = Column::BIND_PARAM_INT;
+			} elseif memstr(columnType, "smallint") {
+				/**
+				 * Smallint are int
+				 */
+				let definition["type"] = Column::TYPE_SMALLINTEGER,
+					definition["isNumeric"] = true,
+					definition["bindType"] = Column::BIND_PARAM_INT;
 			} elseif memstr(columnType, "int") {
 				/**
-				 * Smallint/Bigint/Integers/Int are int
+				 * Integers/Int are int
 				 */
 				let definition["type"] = Column::TYPE_INTEGER,
 					definition["isNumeric"] = true,

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -133,6 +133,13 @@ class Postgresql extends PdoAdapter
 				let definition["type"] = Column::TYPE_BIGINTEGER,
 					definition["isNumeric"] = true,
 					definition["bindType"] = Column::BIND_PARAM_INT;
+			} elseif memstr(columnType, "smallint") {
+				/**
+				 * Smallint
+				 */
+				let definition["type"] = Column::TYPE_SMALLINTEGER,
+					definition["isNumeric"] = true,
+					definition["bindType"] = Column::BIND_PARAM_INT;
 			} elseif memstr(columnType, "int") {
 				/**
 				 * Int

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -121,9 +121,16 @@ class Sqlite extends PdoAdapter
 				let definition["type"] = Column::TYPE_BIGINTEGER,
 					definition["isNumeric"] = true,
 					definition["bindType"] = Column::BIND_PARAM_INT;
+			} elseif memstr(columnType, "smallint") {
+				/**
+				 * Smallint are int
+				 */
+				let definition["type"] = Column::TYPE_SMALLINTEGER,
+					definition["isNumeric"] = true,
+					definition["bindType"] = Column::BIND_PARAM_INT;
 			} elseif memstr(columnType, "int") || memstr(columnType, "INT") {
 				/**
-				 * Smallint/Integers/Int are int
+				 * Integers/Int are int
 				 */
 				let definition["type"] = Column::TYPE_INTEGER,
 					definition["isNumeric"] = true,

--- a/phalcon/db/column.zep
+++ b/phalcon/db/column.zep
@@ -142,6 +142,11 @@ class Column implements ColumnInterface
 	const TYPE_TIMESTAMP = 17;
 
 	/**
+	 *  Small integer abstract type
+	 */
+	const TYPE_SMALLINTEGER = 18;
+
+	/**
 	 * Bind Type Null
 	 */
 	const BIND_PARAM_NULL = 0;
@@ -337,6 +342,7 @@ class Column implements ColumnInterface
 				case self::TYPE_DECIMAL:
 				case self::TYPE_DOUBLE:
 				case self::TYPE_BIGINTEGER:
+				case self::TYPE_SMALLINTEGER:
 					let this->_scale = scale;
 					break;
 
@@ -377,6 +383,7 @@ class Column implements ColumnInterface
 
 					case self::TYPE_INTEGER:
 					case self::TYPE_BIGINTEGER:
+					case self::TYPE_SMALLINTEGER:
 						let this->_autoIncrement = true;
 						break;
 
@@ -528,6 +535,7 @@ class Column implements ColumnInterface
 				case self::TYPE_DECIMAL:
 				case self::TYPE_DOUBLE:
 				case self::TYPE_BIGINTEGER:
+				case self::TYPE_SMALLINTEGER:
 					let definition["scale"] = scale;
 					break;
 			}

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -58,7 +58,10 @@ class Mysql extends Dialect
 				if empty columnSql {
 					let columnSql .= "INT";
 				}
-				let columnSql .= "(" . column->getSize() . ")";
+				let size = column->getSize();
+				if size {
+					let columnSql .= "(" . size . ")";
+				}
 				if column->isUnsigned() {
 					let columnSql .= " UNSIGNED";
 				}
@@ -159,9 +162,22 @@ class Mysql extends Dialect
 				if empty columnSql {
 					let columnSql .= "BIGINT";
 				}
-				let scale = column->getSize();
-				if scale {
-					let columnSql .= "(" . column->getSize() . ")";
+				let size = column->getSize();
+				if size {
+					let columnSql .= "(" . size . ")";
+				}
+				if column->isUnsigned() {
+					let columnSql .= " UNSIGNED";
+				}
+				break;
+
+			case Column::TYPE_SMALLINTEGER:
+				if empty columnSql {
+					let columnSql .= "SMALLINT";
+				}
+				let size = column->getSize();
+				if size {
+					let columnSql .= "(" . size . ")";
 				}
 				if column->isUnsigned() {
 					let columnSql .= " UNSIGNED";

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -127,6 +127,16 @@ class Postgresql extends Dialect
 				}
 				break;
 
+			case Column::TYPE_SMALLINTEGER:
+				if empty columnSql {
+					if column->isAutoIncrement() {
+						let columnSql .= "SMALLSERIAL";
+					} else {
+						let columnSql .= "SMALLINT";
+					}
+				}
+				break;
+
 			case Column::TYPE_JSON:
 				if empty columnSql {
 					let columnSql .= "JSON";
@@ -661,6 +671,7 @@ class Postgresql extends Dialect
 
 		if columnType === Column::TYPE_INTEGER ||
 			columnType === Column::TYPE_BIGINTEGER ||
+			columnType === Column::TYPE_SMALLINTEGER ||
 			columnType === Column::TYPE_DECIMAL ||
 			columnType === Column::TYPE_FLOAT ||
 			columnType === Column::TYPE_DOUBLE {

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -140,6 +140,15 @@ class Sqlite extends Dialect
 				}
 				break;
 
+			case Column::TYPE_SMALLINTEGER:
+				if empty columnSql {
+					let columnSql .= "SMALLINT";
+				}
+				if column->isUnsigned() {
+					let columnSql .= " UNSIGNED";
+				}
+				break;
+
 			case Column::TYPE_TINYBLOB:
 				if empty columnSql {
 					let columnSql .= "TINYBLOB";

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -570,6 +570,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 					switch attribute[1] {
 
 						case Column::TYPE_INTEGER:
+						case Column::TYPE_SMALLINTEGER:
 							let castValue = intval(value, 10);
 							break;
 
@@ -591,6 +592,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 					switch attribute[1] {
 
 						case Column::TYPE_INTEGER:
+						case Column::TYPE_SMALLINTEGER:
 						case Column::TYPE_DOUBLE:
 						case Column::TYPE_DECIMAL:
 						case Column::TYPE_FLOAT:
@@ -2527,6 +2529,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  											break;
 
  										case Column::TYPE_INTEGER:
+										case Column::TYPE_SMALLINTEGER:
  											let changed = (int) snapshotValue !== (int) value;
  											break;
 

--- a/tests/_support/Helper/Dialect/PostgresqlDialect.php
+++ b/tests/_support/Helper/Dialect/PostgresqlDialect.php
@@ -373,6 +373,8 @@ trait PostgresqlDialect
             ['column21', 'BIGSERIAL'],
             ['column22', 'BIGINT'],
             ['column23', 'SERIAL'],
+            ['column24', 'SMALLINT'],
+            ['column25', 'SMALLSERIAL'],
         ];
     }
 

--- a/tests/_support/Helper/DialectTrait.php
+++ b/tests/_support/Helper/DialectTrait.php
@@ -137,6 +137,14 @@ trait DialectTrait
                 'type'          => Column::TYPE_INTEGER,
                 'autoIncrement' => true,
             ]),
+            'column24' => new Column('column24', [
+                'type'          => Column::TYPE_SMALLINTEGER,
+                'autoIncrement' => false,
+            ]),
+            'column25' => new Column('column25', [
+                'type'          => Column::TYPE_SMALLINTEGER,
+                'autoIncrement' => true,
+            ]),
         ];
     }
 


### PR DESCRIPTION
This patch adds the capability to use the data type smallint, which is part of the SQL standard and is well supported by major DBMS. This data type uses 2 bytes instead of 4 bytes for type int, which will save memory if you don't need large numeric values.
