### PR TITLE
 Parameter category has influence on method now

### DIFF
--- a/phalcon/translate/adapter/gettext.zep
+++ b/phalcon/translate/adapter/gettext.zep
@@ -209,10 +209,10 @@ class Gettext extends Adapter implements \ArrayAccess
 		let this->_locale   = call_user_func_array("setlocale", func_get_args());
 		let this->_category = category;
 
-		putenv("LC_ALL=" . this->_locale);
+		putenv(category . "=" . this->_locale);
 		putenv("LANG=" . this->_locale);
 		putenv("LANGUAGE=" . this->_locale);
-		setlocale(LC_ALL, this->_locale);
+		setlocale(category, this->_locale);
 
 		return this->_locale;
 	}


### PR DESCRIPTION
Hello!
I've found that passing parameter category to method setLocale() has no influence for that. Because there are string "LC_ALL".

* Type: bug fix
* Link to issue:

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: I changed string "LC_ALL" to parameter category.

Thanks

