### PR TITLE
Add service provider interface to configure services by context

### DIFF
--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -26,6 +26,7 @@ use Phalcon\Di\ServiceInterface;
 use Phalcon\Di\Exception;
 use Phalcon\Events\ManagerInterface;
 use Phalcon\Di\InjectionAwareInterface;
+use Phalcon\Di\ServiceProviderInterface;
 
 /**
  * Phalcon\Di
@@ -404,6 +405,16 @@ class Di implements DiInterface
 		 * The method doesn't start with set/get throw an exception
 		 */
 		throw new Exception("Call to undefined method or service '" . method . "'");
+	}
+
+	/**
+	 * Registers a service provider
+	 * @param  ServiceProviderInterface
+	 * @return void
+	 */
+	public function register(<ServiceProviderInterface> provider)
+	{
+		provider->register(this);
 	}
 
 	/**

--- a/phalcon/di/serviceproviderinterface.zep
+++ b/phalcon/di/serviceproviderinterface.zep
@@ -1,0 +1,30 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+*/
+
+namespace Phalcon\Di;
+
+use Phalcon\DiInterface;
+
+interface ServiceProviderInterface
+{
+    /**
+     * @param  Phalcon\Di
+     * @return void
+     */
+    public function register(<DiInterface> di);
+}

--- a/tests/_data/di/SomeServiceProvider.php
+++ b/tests/_data/di/SomeServiceProvider.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * SomeServiceProvider class
+ *
+ * @copyright (c) 2011-2016 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+use Phalcon\Di\ServiceProviderInterface;
+use Phalcon\DiInterface;
+
+class SomeServiceProvider implements ServiceProviderInterface
+{
+    public function register(DiInterface $di)
+    {
+        require_once PATH_DATA . 'di/SomeComponent.php';
+
+        $di['foo'] = function () {
+            return 'bar';
+        };
+
+        $di['fooAction'] = function () {
+            return new SomeComponent();
+        };
+    }
+}

--- a/tests/_data/di/SomeServiceProvider.php
+++ b/tests/_data/di/SomeServiceProvider.php
@@ -29,7 +29,7 @@ class SomeServiceProvider implements ServiceProviderInterface
         };
 
         $di['fooAction'] = function () {
-            return new \SomeComponent();
+            return new \SomeComponent('phalcon');
         };
     }
 }

--- a/tests/_data/di/SomeServiceProvider.php
+++ b/tests/_data/di/SomeServiceProvider.php
@@ -29,7 +29,7 @@ class SomeServiceProvider implements ServiceProviderInterface
         };
 
         $di['fooAction'] = function () {
-            return new SomeComponent();
+            return new \SomeComponent();
         };
     }
 }

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -515,10 +515,9 @@ class DiTest extends UnitTest
     public function testRegistersServiceProvider()
     {
         $this->phDi->register(new \SomeServiceProvider());
+        expect($this->phDi['foo'])->equals('bar');
 
-        $this->assertEquals('bar', $this->phDi['foo']);
         $service = $this->phDi->get('fooAction');
-
-        $this->assertInstanceOf('SomeComponent', $service);
+        expect($service)->isInstanceOf('\SomeComponent');
     }
 }

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -40,6 +40,7 @@ class DiTest extends UnitTest
         parent::_before();
 
         require_once PATH_DATA . 'di/InjectableComponent.php';
+        require_once PATH_DATA . 'di/SomeServiceProvider.php';
         require_once PATH_DATA . 'di/SimpleComponent.php';
         require_once PATH_DATA . 'di/SomeComponent.php';
 
@@ -502,5 +503,21 @@ class DiTest extends UnitTest
                 expect($component->getResponse())->equals($response);
             }
         );
+    }
+
+    /**
+     * Register services using provider.
+     *
+     * @author Caio Almeida <caio.f.r.amd@gmail.com>
+     * @since  2016-12-28
+     */
+    public function testRegistersServiceProvider()
+    {
+        $this->phDi->register(new SomeServiceProvider());
+
+        $this->assertEquals('bar', $this->phDi['foo']);
+        $service = $this->phDi->get('fooAction');
+
+        $this->assertInstanceOf('SomeComponent', $service);
     }
 }

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -510,10 +510,11 @@ class DiTest extends UnitTest
      *
      * @author Caio Almeida <caio.f.r.amd@gmail.com>
      * @since  2016-12-28
+     * @group jamal
      */
     public function testRegistersServiceProvider()
     {
-        $this->phDi->register(new SomeServiceProvider());
+        $this->phDi->register(new \SomeServiceProvider());
 
         $this->assertEquals('bar', $this->phDi['foo']);
         $service = $this->phDi->get('fooAction');


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

With this interface it is possible to separate services by context, improving the organization of applications have many dependencies in Container:

e.g:

```php
use Phalcon\Di\ServiceProviderInterface;
use Phalcon\DiInterface;

class SomeComponent
{
}

class SomeServiceProvider implements ServiceProviderInterface
{
    public function register(DiInterface $di)
    {
        $di['foo'] = function () {
            return 'bar';
        };

        $di['fooAction'] = function () {
            return new SomeComponent();
        };
    }
}

$di = new \Phalcon\Di\FactoryDefault();
$di->register(new SomeServiceProvider());

$di->get('fooAction');
```
Thanks
