### PR TITLE
Add @deprecated to Dispatcher::setModelBinding()

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -334,6 +334,9 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	 *     return $dispatcher;
 	 * });
 	 * </code>
+	 *
+	 * @deprecated 3.1.0 Use setModelBinder method
+	 * @see Phalcon\Dispatcher::setModelBinder()
 	 */
 	public function setModelBinding(boolean value, var cache = null) -> <Dispatcher>
 	{


### PR DESCRIPTION
Hello!

* Type: code quality

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: add `@deprecated` to deprecated method.

Thanks

