### PR TITLE
Added ability to get original values from model binder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added the ability to specify what empty means in the 'allowEmpty' option of the validators. Now it accepts as well an array specifying what's empty, for example ['', false]
 - Added the ability to use `Phalcon\Validation` with `Phalcon\Mvc\Collection`, deprecated `Phalcon\Mvc\Collection::validationHasFailed`
 - Fixes internal cache saving in `Phalcon\Mvc\Model\Binder` when no cache backend is used
+- Added the ability to get original values from `Phalcon\Mvc\Model\Binder`, added `Phalcon\Mvc\Micro::getModelBinder`, `Phalcon\Dispatcher::getModelBinder`
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -387,6 +387,14 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	}
 
 	/**
+	 * Gets model binder
+	 */
+	public function getModelBinder() -> <BinderInterface>|null
+	{
+		return this->_modelBinder;
+	}
+
+	/**
 	 * Dispatches a handle action taking into account the routing parameters
 	 *
 	 * @return object

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -1152,6 +1152,14 @@ class Micro extends Injectable implements \ArrayAccess
 	}
 
 	/**
+	 * Gets model binder
+	 */
+	public function getModelBinder() -> <BinderInterface>|null
+	{
+		return this->_modelBinder;
+	}
+
+	/**
 	 * Sets model binder
 	 *
 	 * <code>

--- a/phalcon/mvc/model/binder.zep
+++ b/phalcon/mvc/model/binder.zep
@@ -49,6 +49,11 @@ class Binder implements BinderInterface
 	protected internalCache = [];
 
 	/**
+	 * Array for original values
+	 */
+	protected originalValues = [] { get };
+
+	/**
 	 * Phalcon\Mvc\Model\Binder constructor
 	 */
 	public function __construct(<BackendInterface> cache = null)
@@ -79,14 +84,17 @@ class Binder implements BinderInterface
 	 */
 	public function bindToHandler(object handler, array params, string cacheKey, var methodName = null) -> array
 	{
-		var paramKey, className, boundModel, paramsCache;
+		var paramKey, className, boundModel, paramsCache, paramValue;
 
+		let this->originalValues = [];
 		if handler instanceof \Closure || methodName != null {
 			let this->boundModels = [];
 			let paramsCache = this->getParamsFromCache(cacheKey);
 			if typeof paramsCache == "array" {
 				for paramKey, className in paramsCache {
-					let boundModel = {className}::findFirst(params[paramKey]);
+					let paramValue = params[paramKey];
+					let boundModel = {className}::findFirst(paramValue);
+					let this->originalValues[paramKey] = paramValue;
 					let params[paramKey] = boundModel;
 					let this->boundModels[paramKey] = boundModel;
 				}
@@ -125,7 +133,7 @@ class Binder implements BinderInterface
 	protected function getParamsFromReflection(object handler, array params, string cacheKey, var methodName) -> array
 	{
 		var methodParams, reflection, paramKey, methodParam, paramsCache, className, realClasses = null,
-			boundModel, cache, handlerClass, reflectionClass, paramsKeys;
+			boundModel, cache, handlerClass, reflectionClass, paramsKeys, paramValue;
 		let paramsCache = [];
 		if methodName != null {
 			let reflection = new \ReflectionMethod(handler, methodName);
@@ -149,6 +157,8 @@ class Binder implements BinderInterface
 				let paramKey = paramsKeys[paramKey];
 			}
 			let boundModel = null;
+			let paramValue = params[paramKey];
+
 			if className == "Phalcon\\Mvc\\Model" {
 				if realClasses == null {
 					if handler instanceof BindModelInterface {
@@ -162,21 +172,22 @@ class Binder implements BinderInterface
 				}
 				if typeof realClasses == "array" {
 					if fetch className, realClasses[paramKey] {
-						let boundModel = {className}::findFirst(params[paramKey]);
+						let boundModel = {className}::findFirst(paramValue);
 					} else {
 						throw new Exception("You should provide model class name for ".paramKey." parameter");
 					}
 				} elseif typeof realClasses == "string" {
-					let boundModel = {realClasses}::findFirst(params[paramKey]);
+					let boundModel = {realClasses}::findFirst(paramValue);
 					let className = realClasses;
 				} else {
 					throw new Exception("getModelName should return array or string");
 				}
 			} elseif is_subclass_of(className, "Phalcon\\Mvc\\Model") {
-				let boundModel = {className}::findFirst(params[paramKey]);
+				let boundModel = {className}::findFirst(paramValue);
 			}
 
 			if boundModel != null {
+				let this->originalValues[paramKey] = paramValue;
 				let params[paramKey] = boundModel;
 				let this->boundModels[paramKey] = boundModel;
 				let paramsCache[paramKey] = className;

--- a/phalcon/mvc/model/binderinterface.zep
+++ b/phalcon/mvc/model/binderinterface.zep
@@ -42,7 +42,7 @@ interface BinderInterface
 	/**
 	 * Sets cache instance
 	 */
-	public function setCache(<BackendInterface> cache) -> <Binding>;
+	public function setCache(<BackendInterface> cache) -> <BinderInterface>;
 
 	/**
 	 * Bind models into params in proper handler

--- a/tests/integration/Mvc/Model/BinderCest.php
+++ b/tests/integration/Mvc/Model/BinderCest.php
@@ -790,6 +790,31 @@ class BinderCest
     }
 
     /**
+     * Tests dispatcher and single model original values
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-01-19
+     *
+     * @param IntegrationTester $I
+     */
+    public function testDispatcherSingleBindingOriginalValues(IntegrationTester $I)
+    {
+        $dispatcher = $this->createDispatcher();
+        $params = ['people' => $this->people->cedula];
+        $this->assertDispatcher($dispatcher, $I);
+
+        $returnedValue = $this->returnDispatcherValueForAction(
+            $dispatcher,
+            'test10',
+            'view',
+            $params
+        );
+        $I->assertInstanceOf('Phalcon\Test\Models\People', $returnedValue);
+        $I->assertEquals($this->people->cedula, $returnedValue->cedula);
+        $I->assertEquals($params, $dispatcher->getModelBinder()->getOriginalValues());
+    }
+
+    /**
      * Tests dispatcher and single model without cache
      *
      * @author Wojciech Ślawski <jurigag@gmail.com>


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: with introducing `Phalcon\Mvc\Model\Binder` which will change values in dispatcher loop parameters sometimes you would like to have ability to get original values for example caching related stuff. This PR is adding way to return original values before changing them to models.

Thanks

