### PR TITLE
Clean new PR for 12409 add transaction in model::find()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the ability to clear appended and prepended title elements (Phalcon\Tag::appendTitle, Phalcon\Tag::prependTitle). Now you can use array to add multiple titles. For more details check [#12238](https://github.com/phalcon/cphalcon/issues/12238).
 - Added the ability to specify what empty means in the 'allowEmpty' option of the validators. Now it accepts as well an array specifying what's empty, for example ['', false]
 - Added the ability to use `Phalcon\Validation` with `Phalcon\Mvc\Collection`, deprecated `Phalcon\Mvc\Collection::validationHasFailed`
+- Added the ability to set custom transaction to the query object as well as using a custom transaction calling Model::find(), Criteria::execute() [#12409](https://github.com/phalcon/cphalcon/pull/12409)
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -25,6 +25,7 @@ use Phalcon\Mvc\Model\Exception;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Mvc\Model\CriteriaInterface;
 use Phalcon\Mvc\Model\ResultsetInterface;
+use Phalcon\Mvc\Model\TransactionInterface;
 
 /**
  * Phalcon\Mvc\Model\Criteria
@@ -134,8 +135,8 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	 */
 	 public function distinct(var distinct) -> <Criteria>
 	 {
-	 	let this->_params["distinct"] = distinct;
-	 	return this;
+		let this->_params["distinct"] = distinct;
+		return this;
 	 }
 
 	/**
@@ -725,8 +726,19 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 
 	/**
 	 * Executes a find using the parameters built with the criteria
+	 *
+	 * <code>
+	 * // without encapsulating transaction
+	 * $criteria = Robot::query()->inWhere(Robot::class . '.id = :id', ['id' => 1]);
+	 * $resultSet = $criteria->execute();
+	 *
+	 * // with encapsulating transaction
+	 * $tm = new TransactionManager();
+	 * $transaction = $tm->get(true);
+	 * $resultSet = $criteria->execute($transaction);
+	 * </code>
 	 */
-	public function execute() -> <ResultsetInterface>
+	public function execute(<TransactionInterface> transaction = null) -> <ResultsetInterface>
 	{
 		var model;
 
@@ -735,6 +747,6 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 			throw new Exception("Model name must be string");
 		}
 
-		return {model}::find(this->getParams());
+		return {model}::find(this->getParams(), transaction);
 	}
 }

--- a/phalcon/mvc/model/criteriainterface.zep
+++ b/phalcon/mvc/model/criteriainterface.zep
@@ -20,6 +20,7 @@
 namespace Phalcon\Mvc\Model;
 
 use Phalcon\DiInterface;
+use Phalcon\Mvc\Model\TransactionInterface;
 
 /**
  * Phalcon\Mvc\Model\CriteriaInterface
@@ -192,6 +193,6 @@ interface CriteriaInterface
 	/**
 	 * Executes a find using the parameters built with the criteria
 	 */
-	public function execute() -> <ResultsetInterface>;
+	public function execute(<TransactionInterface> transaction = null) -> <ResultsetInterface>;
 
 }

--- a/tests/unit/Mvc/Model/CriteriaTest.php
+++ b/tests/unit/Mvc/Model/CriteriaTest.php
@@ -8,6 +8,8 @@ use Phalcon\Mvc\Model\Manager;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Mvc\Model\Metadata\Memory;
 use Phalcon\Mvc\Model\Resultset\Simple;
+use Phalcon\Test\Proxy\Mvc\Model\Transaction\Manager as TransactionManager;
+
 
 /**
  * \Phalcon\Test\Unit\Mvc\Model\CriteriaTest
@@ -90,6 +92,28 @@ class CriteriaTest extends UnitTest
                 expect($query->getLimit())->equals($expected);
             },
             ['examples' => $this->limitOffsetProvider()]
+        );
+    }
+
+    /**
+     * Tests Criteria::execute with a transaction passed
+     *
+     * @test
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function criteriaExecuteWithTransaction() {
+        $this->specify(
+            'The Criteria::execute with a transaction passed as parameter does not work as expected',
+            function() {
+                $criteria = Users::query()->inWhere(Users::class . '.id', []);
+                $tm = new TransactionManager();
+                $transaction = $tm->get(true);
+
+                expect($criteria->getWhere())->equals(Users::class . '.id != ' . Users::class . '.id');
+                expect($criteria->execute($transaction))->isInstanceOf(Simple::class);
+            }
         );
     }
 

--- a/tests/unit/Mvc/Model/QueryTest.php
+++ b/tests/unit/Mvc/Model/QueryTest.php
@@ -4,7 +4,12 @@ namespace Phalcon\Test\Unit\Mvc\Model;
 
 use Phalcon\DiInterface;
 use Phalcon\Mvc\Model\Query;
+use Phalcon\Mvc\Model\Transaction;
+use Phalcon\Mvc\Model\Manager;
+use Phalcon\Mvc\Model\Metadata\Memory;
+use Phalcon\Mvc\Model\Transaction\Manager as TransactionManager;
 use Phalcon\Test\Module\UnitTest;
+use Phalcon\Test\Models\Users;
 use Phalcon\Test\Models\Deles;
 use Phalcon\Test\Models\Parts;
 use Phalcon\Test\Models\Personers;
@@ -25,6 +30,7 @@ use Phalcon\Test\Models\Some\Products as SomeProducts;
  * @link      http://www.phalconphp.com
  * @author    Andres Gutierrez <andres@phalconphp.com>
  * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author Jakob Oberhummer <cphalcon@chilimatic.com>
  * @package   Phalcon\Test\Unit\Mvc\Model
  *
  * The contents of this file are subject to the New BSD License that is
@@ -48,6 +54,18 @@ class QueryTest extends UnitTest
         /** @var \Phalcon\Mvc\Application $app */
         $app = $this->tester->getApplication();
         $this->di = $app->getDI();
+
+        $this->di->set('modelsManager', function() {
+            return new Manager;
+        });
+
+        $this->di->set('modelsMetadata', function() {
+            return new Memory;
+        });
+
+        $this->di->set('transactionManager', function() {
+            return new TransactionManager;
+        });
     }
 
     public function testSelectParsing()
@@ -8127,5 +8145,473 @@ class QueryTest extends UnitTest
                 expect($query->parse())->equals($expected);
             }
         );
+    }
+
+    /**
+     * Tests Query::__construct behaviour
+     *
+     * @test
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testQueryConstructorWithPHQLString() {
+        $this->specify(
+            'The Query::__construct sets _phql string in the object',
+            function() {
+                $query = 'SELECT 1';
+                $q = new Query($query);
+                $testValue = $this->getInaccessibleObjectProperty($q, '_phql');
+                expect($testValue)->equals($query);
+            }
+        );
+    }
+
+
+
+    /**
+     * Tests Query::__construct behaviour
+     *
+     * @test
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function queryConstructorWithoutPHQL() {
+        $this->specify(
+            'The Query::__construct sets _phql in the object',
+            function() {
+                $q = new Query();
+                $testValue = $this->getInaccessibleObjectProperty($q, '_phql');
+                expect($testValue)->equals(null);
+            }
+        );
+    }
+
+
+    /**
+     * Tests Query::__construct behaviour
+     *
+     * @test
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function queryConstructorSetsDI() {
+        $this->specify(
+            'The Query::__construct sets DI in the object',
+            function() {
+                $q = new Query(null, $this->di);
+                expect($this->di)->equals($q->getDI());
+            }
+        );
+    }
+
+    /**
+     * Tests Query::__construct behaviour
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testConstructorSetsImplicitJoins() {
+        $this->specify(
+            'The Query::__construct sets DI in the object',
+            function() {
+                $options = [
+                    'enable_implicit_joins' => true
+                ];
+                $q = new Query(null, $this->di, $options);
+                $enableImplicitJoins = $this->getInaccessibleObjectProperty($q, '_enableImplicitJoins');
+                expect(true)->equals($enableImplicitJoins);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::setBindParams default behaviour
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testSetBindParams() {
+        $this->specify(
+            'The Query::setBindParams sets bind params',
+            function() {
+                $bindParams = [
+                    'myField' => 1,
+                    'myOtherField' => 'test'
+                ];
+
+                $q = new Query(null, $this->di);
+                $q->setBindParams($bindParams);
+
+                expect($bindParams)->equals($q->getBindParams());
+            }
+        );
+    }
+
+    /**
+     * Tests Query::setBindParams default behaviour
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testSetBindParamsMerge() {
+        $this->specify(
+            'The Query::setBindParams union merge',
+            function() {
+                $bindParams = [
+                    'myField' => 1,
+                    'myOtherField' => 'test'
+                ];
+
+                $mergeParams = [
+                    'myField' => 12,
+                    'myThirdField' => 14
+                ];
+
+                $result = [
+                    'myField' => 1,
+                    'myOtherField' => 'test',
+                    'myThirdField' => 14
+                ];
+
+                $q = new Query(null, $this->di);
+                $q->setBindParams($bindParams);
+                $q->setBindParams($mergeParams, true);
+
+                expect($result)->equals($q->getBindParams());
+            }
+        );
+    }
+
+    /**
+     * Tests Query::setType
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testSetType() {
+        $this->specify(
+            'The Query::setType ',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setType(1);
+
+                expect(1)->equals($q->getType());
+            }
+        );
+    }
+
+
+    /**
+     * Tests Query::set unique row
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testSetUniqueRow() {
+        $this->specify(
+            'The Query::setUniqueRow',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+
+                expect(true)->equals($q->getUniqueRow());
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getTransactionConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetTransactionConnectionWithNoModelTransaction() {
+        $this->specify(
+            'The Query::getTransaction should return the connection of the query transaction',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $transaction = $transactionManager->getOrCreateTransaction();
+                $q->setTransaction($transaction);
+                $model = new Users();
+
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getTransactionConnection', [$model]);
+
+                expect($transaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getTransactionConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetTransactionConnectionWithModelTransaction() {
+        $this->specify(
+            'The Query::getTransactionConnection should return the transaction of the query object',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $transaction = $transactionManager->getOrCreateTransaction();
+                $q->setTransaction($transaction);
+                $model = new Users();
+                $modelTransaction = new Transaction($this->di);
+                $model->setTransaction($modelTransaction);
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getTransactionConnection', [$model]);
+                expect($transaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getTransactionConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetTransactionConnectionWithModelTransactionButNoQueryTransaction() {
+        $this->specify(
+            'The Query::getTransactionConnection should return the connection of the model transaction',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $model = new Users();
+                $modelTransaction = $transactionManager->getOrCreateTransaction();
+                $model->setTransaction($modelTransaction);
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getTransactionConnection', [$model]);
+                expect($modelTransaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+
+    /**
+     * Tests Query::getReadConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetReadConnectionWithModelTransactionButNoQueryTransaction() {
+        $this->specify(
+            'The Query::getReadConnection should return the connection of the model transaction',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $model = new Users();
+                $modelTransaction = $transactionManager->getOrCreateTransaction();
+                $model->setTransaction($modelTransaction);
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getReadConnection', [$model, [], [], []]);
+                expect($modelTransaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getReadConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetReadConnectionWithModelTransactionAndQueryTransaction() {
+        $this->specify(
+            'The Query::getReadConnection should return connection of the transaction of the query object',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $transaction = $transactionManager->getOrCreateTransaction();
+                $q->setTransaction($transaction);
+                $model = new Users();
+                $modelTransaction = new Transaction($this->di);
+                $model->setTransaction($modelTransaction);
+
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getReadConnection', [$model, [], [], []]);
+                expect($transaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getReadConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetReadConnectionWithNoModelTransactionButQueryTransaction() {
+        $this->specify(
+            'The Query::getReadConnection should return the connection of the query transaction',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $transaction = $transactionManager->getOrCreateTransaction();
+                $q->setTransaction($transaction);
+                $model = new Users();
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getReadConnection', [$model, [], [], []]);
+                expect($transaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+
+    /**
+     * Tests Query::getReadConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetWriteConnectionWithModelTransactionButNoQueryTransaction() {
+        $this->specify(
+            'The Query::getWriteConnection should return the connection of the model transaction',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $model = new Users();
+                $modelTransaction = $transactionManager->getOrCreateTransaction();
+                $model->setTransaction($modelTransaction);
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getWriteConnection', [$model, [], [], []]);
+                expect($modelTransaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getWriteConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetWriteConnectionWithModelTransactionAndQueryTransaction() {
+        $this->specify(
+            'The Query::getWriteConnection should return connection of the transaction of the query object',
+            function() {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $transaction = $transactionManager->getOrCreateTransaction();
+                $q->setTransaction($transaction);
+                $model = new Users();
+                $modelTransaction = new Transaction($this->di);
+                $model->setTransaction($modelTransaction);
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getWriteConnection', [$model, [], [], []]);
+                expect($transaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+    /**
+     * Tests Query::getWriteConnection
+     *
+     * @issue 12409
+     * @author Jakob Oberhummer <cphalcon@chilimatic.com>
+     * @since 2016-11-28
+     */
+    public function testGetWriteConnectionWithNoModelTransactionButQueryTransaction()
+    {
+        $this->specify(
+            'The Query::getReadConnection should return the connection of the query transaction',
+            function () {
+                $q = new Query(null, $this->di);
+                $q->setUniqueRow(true);
+                /**
+                 * @var TransactionManager $transactionManager
+                 */
+                $transactionManager = $this->di->get('transactionManager');
+                $transaction = $transactionManager->getOrCreateTransaction();
+                $q->setTransaction($transaction);
+                $model = new Users();
+                $result = $this->getInaccessibleObjectMethodReturn($q, 'getWriteConnection', [$model, [], [], []]);
+                expect($transaction->getConnection())->equals($result);
+            }
+        );
+    }
+
+
+    /**
+     * helper method DRY -> any object should be reflectable
+     *
+     * @param mixed $object
+     * @param string $propertyName
+     * @return mixed
+     */
+    protected function getInaccessibleObjectProperty($object, $propertyName)
+    {
+        if (!$object || !$propertyName) {
+            throw new \InvalidArgumentException('Object or property has to be passed');
+        }
+
+        $reflectionClass = new \ReflectionClass($object);
+        $reflectionProperty = $reflectionClass->getProperty($propertyName);
+        $reflectionProperty->setAccessible(true);
+        return $reflectionProperty->getValue($object);
+    }
+
+    /**
+     * @param $object
+     * @param string $methodName
+     * @param array $paramSet
+     * @return mixed
+     */
+    protected function getInaccessibleObjectMethodReturn($object, $methodName, array $paramSet = [])
+    {
+        if (!$object || !$methodName) {
+            throw new \InvalidArgumentException('Object or property has to be passed');
+        }
+
+        $reflectionClass = new \ReflectionClass($object);
+        $reflectionMethod = $reflectionClass->getMethod($methodName);
+        $reflectionMethod->setAccessible(true);
+
+        return $reflectionMethod->invokeArgs($object, $paramSet);
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: [#12409](https://github.com/phalcon/cphalcon/pull/12409)

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I wrote some tests for this PR.

**Adds transaction to model::find() so you can query inserted data before comiting**

***Main usecases***
 * complex insert processes (you may need to check the state inside of the transaction or add a model to a transaction)
 * unitesting -> start a transaction at the beginning and rollback at the end so you don't polute your test database

***Minor change*** 
 * DRY for selectWrite and selectRead transaction inside of query.zep
 * Adds general unitests for query.zep
