### PR TITLE
Fixes Binder internal cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added the ability to clear appended and prepended title elements (Phalcon\Tag::appendTitle, Phalcon\Tag::prependTitle). Now you can use array to add multiple titles. For more details check [#12238](https://github.com/phalcon/cphalcon/issues/12238).
 - Added the ability to specify what empty means in the 'allowEmpty' option of the validators. Now it accepts as well an array specifying what's empty, for example ['', false]
 - Added the ability to use `Phalcon\Validation` with `Phalcon\Mvc\Collection`, deprecated `Phalcon\Mvc\Collection::validationHasFailed`
+- Fixes internal cache saving in `Phalcon\Mvc\Model\Binder` when no cache backend is used
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/mvc/model/binder.zep
+++ b/phalcon/mvc/model/binder.zep
@@ -179,9 +179,7 @@ class Binder implements BinderInterface
 			if boundModel != null {
 				let params[paramKey] = boundModel;
 				let this->boundModels[paramKey] = boundModel;
-				if cache != null {
-					let paramsCache[paramKey] = className;
-				}
+				let paramsCache[paramKey] = className;
 			}
 		}
 

--- a/tests/integration/Mvc/Model/BinderCest.php
+++ b/tests/integration/Mvc/Model/BinderCest.php
@@ -790,6 +790,33 @@ class BinderCest
     }
 
     /**
+     * Tests dispatcher and single model without cache
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-01-24
+     *
+     * @param IntegrationTester $I
+     */
+    public function testDispatcherSingleBindingNoCache(IntegrationTester $I)
+    {
+        $dispatcher = $this->createDispatcher(false);
+        $modelBinder = new Binder();
+        $dispatcher->setModelBinder($modelBinder);
+        $this->assertDispatcher($dispatcher, $I);
+
+        for ($i = 0; $i <= 1; $i++) {
+            $returnedValue = $this->returnDispatcherValueForAction(
+                $dispatcher,
+                'test10',
+                'view',
+                ['people' => $this->people->cedula]
+            );
+            $I->assertInstanceOf('Phalcon\Test\Models\People', $returnedValue);
+            $I->assertEquals($this->people->cedula, $returnedValue->cedula);
+        }
+    }
+
+    /**
      * @param bool $useModelBinder
      * @return Dispatcher
      */


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: info about classes for which where binding where done was created only when cache for binder was enabled which was causing internal cache not working properly. This is fixing this problem by removing not needed condition.

Thanks

