### PR TITLE
Update Phalcon\Mvc\Model return ResultsetInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)
 - Fixed `Phalcon\Forms\Element::label` to accept 0 as label instead of validating it as empty. [#12148](https://github.com/phalcon/cphalcon/issues/12148)
 - Added Aliases for ciphers in `Phalcon\Crypt`
+- Fixed `Phalcon\Mvc\Model` return type ResultsetInterface
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (2016-12-24)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -34,6 +34,7 @@ use Phalcon\Db\DialectInterface;
 use Phalcon\Mvc\Model\CriteriaInterface;
 use Phalcon\Mvc\Model\TransactionInterface;
 use Phalcon\Mvc\Model\Resultset;
+use Phalcon\Mvc\Model\ResultsetInterface;
 use Phalcon\Mvc\Model\Query;
 use Phalcon\Mvc\Model\Query\Builder;
 use Phalcon\Mvc\Model\Relation;


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

ResultsetInterface is not imported and causes problems when generating Stubs for IDE. It is generating `@return` type of `Phalcon\Mvc\ResultsetInterface` and not `Phalcon\Mvc\Model\ResultsetInterface`

I think it should be imported in order to easily find the correct class.

Let me know if I am missing something

Thanks

