### PR TITLE
\Phalcon\Loader::register() class loader priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Added the ability to use `Phalcon\Validation` with `Phalcon\Mvc\Collection`, deprecated `Phalcon\Mvc\Collection::validationHasFailed`
 - Fixes internal cache saving in `Phalcon\Mvc\Model\Binder` when no cache backend is used
 - Added the ability to get original values from `Phalcon\Mvc\Model\Binder`, added `Phalcon\Mvc\Micro::getModelBinder`, `Phalcon\Dispatcher::getModelBinder`
+- Added `prepend` parameter to `Phalcon\Loader::register` to specify autoloader's loading order to top most
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (XXXX-XX-XX)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/loader.zep
+++ b/phalcon/loader.zep
@@ -223,7 +223,7 @@ class Loader implements EventsAwareInterface
 	/**
 	 * Register the autoload method
 	 */
-	public function register() -> <Loader>
+	public function register(boolean prepend = null) -> <Loader>
 	{
 		if this->_registered === false {
 			/**
@@ -234,7 +234,7 @@ class Loader implements EventsAwareInterface
 			/**
 			 * Registers directories & namespaces to PHP's autoload
 			 */
-			spl_autoload_register([this, "autoLoad"]);
+			spl_autoload_register([this, "autoLoad"], true, prepend);
 
 			let this->_registered = true;
 		}
@@ -323,7 +323,7 @@ class Loader implements EventsAwareInterface
 		 * Checking in namespaces
 		 */
 		let namespaces = this->_namespaces;
-		
+
 		for nsPrefix, directories in namespaces {
 
 			/**

--- a/tests/_proxies/Loader.php
+++ b/tests/_proxies/Loader.php
@@ -89,9 +89,9 @@ class Loader extends PhLoader
         return parent::getClasses();
     }
 
-    public function register()
+    public function register($prepend = null)
     {
-        return parent::register();
+        return parent::register($prepend);
     }
 
     public function unregister()


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/composer/composer/blob/master/src/Composer/Autoload/ClassLoader.php#L302

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Composer loader higher priority than Phalcon\Loader in any use case. This feature able to get ahead of composer loader.

Thanks

