### PR TITLE
Phalcon\Session\Bag: add of initialization for remove()

### DIFF
--- a/phalcon/session/bag.zep
+++ b/phalcon/session/bag.zep
@@ -231,6 +231,10 @@ class Bag implements InjectionAwareInterface, BagInterface, \IteratorAggregate, 
 	 */
 	public function remove(string! property) -> boolean
 	{
+		if this->_initialized === false {
+			this->initialize();
+		}
+
 		var data;
 
 		let data = this->_data;


### PR DESCRIPTION
* Type: bug fix
* Issue: when `Phalcon\Session\Bag` is restored by the session handler, the `remove` method results not initialized and `remove()` won't work properly.

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] ~I wrote some tests for this PR.~ There was no unit test coverage at all for `bag.zep`, see below 

Small description of change:  Initialization steps in `remove()` have been added.

Steps to reproduce:

       <?php
       
        // debug with reflection
        $reflectionClass = new \ReflectionClass(get_class($this->bag));
        $_data = $reflectionClass->getProperty('_data');
        $_data->setAccessible(true);
        $_initialized = $reflectionClass->getProperty('_initialized');
        $_initialized->setAccessible(true);

        // create a Bag with one value
        $bag = new \Phalcon\Session\Bag('fruit');
        $bag->set('apples', 10);
        var_dump($bag->get('apples')); // int(10)
        var_dump($_data->getValue($bag)); // array(1) { ["apples"]=> int(10) }
        var_dump($_initialized->getValue($bag)); // bool(true)

        // save and cleanup
        $serializedBag = serialize($bag);
        unset($bag);

        // emulate restore in the same way it would be done
        // any PHP session handler, e.g.: `session.save_handler => redis => redis`
        $bag = unserialize($serializedBag);
        $_data->setValue($bag, NULL);
        $_initialized->setValue($bag, false);

        // remove attempt fails because `_data` is NULL
        var_dump($bag->remove('apples')); // bool(false) // EXPECTED: bool(true)
        var_dump($bag->get('apples')); // int(10) // EXPECTED: NULL

        // get performs _initialize under the hood, so now it works
        var_dump($bag->remove('apples')); // bool(true)
        var_dump($bag->get('apples')); // NULL

this calls initialize also on `Bag::remove`.

I don't know how cover this with Codeconception functional tests.

Thanks

