### PR TITLE
Cleaned Gettext::query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `Phalcon\Mvc\Model` by adding missed `use` statement for `ResultsetInterface` [#12574](https://github.com/phalcon/cphalcon/pull/12574)
 - Fixed adding role after setting default action [#12573](https://github.com/phalcon/cphalcon/issues/12573)
 - Fixed except option in `Phalcon\Validation\Validator\Uniquenss` to allow using except fields other than unique fields
+- Cleaned `Phalcon\Translate\Adapter\Gettext::query` and removed ability to pass custom domain. The `Phalcon\Translate\Adapter\Gettext::query` must be compatible with `Phalcon\Translate\AdapterInterface::query` [#12598](https://github.com/phalcon/cphalcon/issues/12598), [#12606](https://github.com/phalcon/cphalcon/pull/12606)
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (2016-12-24)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/translate/adapter.zep
+++ b/phalcon/translate/adapter.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |

--- a/phalcon/translate/adapter/gettext.zep
+++ b/phalcon/translate/adapter/gettext.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (http://www.phalconphp.com)       |
+ | Copyright (c) 2011-2017 Phalcon Team (https://www.phalconphp.com)      |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -77,28 +77,17 @@ class Gettext extends Adapter implements \ArrayAccess
 	}
 
 	/**
-	 * Returns the translation related to the given key
+	 * Returns the translation related to the given key.
 	 *
-	 * @param string  index
-	 * @param array   placeholders
-	 * @param string  domain
-	 * @return string
+	 * <code>
+	 * $translator->query("你好 %name%！", ["name" => "Phalcon"]);
+	 * </code>
 	 */
 	public function query(string! index, placeholders = null) -> string
 	{
-		var translation, domain;
+		var translation;
 
-		let domain = null;
-
-		if func_num_args() > 2 {
-			let domain = func_get_arg(2);
-		}
-
-		if !domain {
-			let translation = gettext(index);
-		} else {
-			let translation = dgettext(domain, index);
-		}
+		let translation = gettext(index);
 
 		return this->replacePlaceholders(translation, placeholders);
 	}

--- a/phalcon/translate/adapterinterface.zep
+++ b/phalcon/translate/adapterinterface.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |

--- a/tests/unit/Translate/Adapter/GettextCest.php
+++ b/tests/unit/Translate/Adapter/GettextCest.php
@@ -9,10 +9,10 @@ use Phalcon\Translate\Adapter\Gettext;
  * \Phalcon\Test\Unit\Translate\Adapter\GettextCest
  * Tests the \Phalcon\Translate\Adapter\Gettext component
  *
- * @copyright (c) 2011-2016 Phalcon Team
- * @link      http://www.phalconphp.com
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://www.phalconphp.com
  * @author    Serghei Iakovlev <serghei@phalconphp.com>
- * @package   Phalcon\Test\Unit\Translate\Adapter\
+ * @package   Phalcon\Test\Unit\Translate\Adapter
  *
  * The contents of this file are subject to the New BSD License that is
  * bundled with this package in the file docs/LICENSE.txt


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12598, #12606

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Cleaned `Phalcon\Translate\Adapter\Gettext::query` and removed ability to pass custom domain.

The `Phalcon\Translate\Adapter\Gettext::query` must be compatible with `Phalcon\Translate\AdapterInterface::query`.

Thanks
