### PR TITLE
Fixed Phalcon\Validation\Message\Group::offsetUnset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Fixed `Phalcon\Mvc\Model` by adding missed `use` statement for `ResultsetInterface` [#12574](https://github.com/phalcon/cphalcon/pull/12574)
 - Fixed adding role after setting default action [#12573](https://github.com/phalcon/cphalcon/issues/12573)
 - Fixed except option in `Phalcon\Validation\Validator\Uniquenss` to allow using except fields other than unique fields
-- Cleaned `Phalcon\Translate\Adapter\Gettext::query` and removed ability to pass custom domain. The `Phalcon\Translate\Adapter\Gettext::query` must be compatible with `Phalcon\Translate\AdapterInterface::query` [#12598](https://github.com/phalcon/cphalcon/issues/12598), [#12606](https://github.com/phalcon/cphalcon/pull/12606)
+- Cleaned `Phalcon\Translate\Adapter\Gettext::query` and removed ability to pass custom domain [#12598](https://github.com/phalcon/cphalcon/issues/12598), [#12606](https://github.com/phalcon/cphalcon/pull/12606)
+- Fixed `Phalcon\Validation\Message\Group::offsetUnset` to correct unsetting a message by index [#12455](https://github.com/phalcon/cphalcon/issues/12455)
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (2016-12-24)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/validation/message/group.zep
+++ b/phalcon/validation/message/group.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2016 Phalcon Team (https://phalconphp.com)       |
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file docs/LICENSE.txt.                        |
@@ -109,15 +109,12 @@ class Group implements \Countable, \ArrayAccess, \Iterator
 	 *<code>
 	 * unset($message["database"]);
 	 *</code>
-	 *
-	 * @param string index
 	 */
 	public function offsetUnset(index)
 	{
 		if isset this->_messages[index] {
-			unset this->_messages[index];
+			array_splice(this->_messages, index, 1);
 		}
-		return false;
 	}
 
 	/**

--- a/tests/unit/Validation/Message/GroupTest.php
+++ b/tests/unit/Validation/Message/GroupTest.php
@@ -2,16 +2,17 @@
 
 namespace Phalcon\Test\Unit\Validation\Message;
 
+use Phalcon\Validation;
 use Phalcon\Validation\Message;
 use Phalcon\Test\Module\UnitTest;
-use Phalcon\Test\Proxy\Validation\Message\Group;
+use Phalcon\Validation\Message\Group;
 
 /**
  * \Phalcon\Test\Unit\Validation\Message\GroupTest
  * Tests the \Phalcon\Validation\Message\Group component
  *
- * @copyright (c) 2011-2016 Phalcon Team
- * @link      http://www.phalconphp.com
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://www.phalconphp.com
  * @author    Andres Gutierrez <andres@phalconphp.com>
  * @author    Serghei Iakovlev <serghei@phalconphp.com>
  * @package   Phalcon\Test\Unit\Validation\Message
@@ -29,10 +30,11 @@ class GroupTest extends UnitTest
     /**
      * Tests append messages
      *
+     * @test
      * @author Serghei Iakovlev <serghei@phalconphp.com>
      * @since  2016-06-12
      */
-    public function testValidationGroup()
+    public function validationGroup()
     {
         $this->specify(
             'The Message Group does not work with Messages as expected',
@@ -62,6 +64,104 @@ class GroupTest extends UnitTest
                     expect($messages[$position]->getField())->equals($message->getField());
                     expect($messages[$position]->getType())->equals($message->getType());
                 }
+            }
+        );
+    }
+
+    /**
+     * Tests unsetting a message by index
+     *
+     * @test
+     * @issue  12455
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-02-12
+     */
+    public function unsettingByIndex()
+    {
+        $this->specify(
+            'error',
+            function () {
+                $validation = new Validation();
+
+                $validation->appendMessage(new Message('error a', 'myField', 'MyValidator'));
+
+                expect($validation->getMessages())->count(1);
+                expect($validation->getMessages()[0])->equals(Message::__set_state([
+                    '_message' => 'error a',
+                    '_field'   => 'myField',
+                    '_type'    => 'MyValidator',
+                ]));
+
+                $validation->appendMessage(new Message('error b', 'myField', 'MyValidator'));
+
+                expect($validation->getMessages())->count(2);
+                expect($validation->getMessages()[1])->equals(Message::__set_state([
+                    '_message' => 'error b',
+                    '_field'   => 'myField',
+                    '_type'    => 'MyValidator',
+                ]));
+
+                $messages = $validation->getMessages();
+                unset($messages[count($messages) - 1]);
+
+                expect($validation->getMessages())->count(1);
+                expect($validation->getMessages()[0])->equals(Message::__set_state([
+                    '_message' => 'error a',
+                    '_field'   => 'myField',
+                    '_type'    => 'MyValidator',
+                ]));
+
+                $validation->appendMessage(new Message('error c', 'myField', 'MyValidator'));
+
+                expect($validation->getMessages())->count(2);
+                expect($validation->getMessages()[1])->equals(Message::__set_state([
+                    '_message' => 'error c',
+                    '_field'   => 'myField',
+                    '_type'    => 'MyValidator',
+                ]));
+
+                expect($validation->getMessages())->equals(Group::__set_state([
+                    '_position' => 0,
+                    '_messages' => [
+                        0 => Message::__set_state([
+                            '_message' => 'error a',
+                            '_field'   => 'myField',
+                            '_type'    => 'MyValidator',
+                        ]),
+                        1 => Message::__set_state([
+                            '_message' => 'error c',
+                            '_field'   => 'myField',
+                            '_type'    => 'MyValidator',
+                        ]),
+                    ]
+                ]));
+
+                $validation->appendMessage(new Message('error d', 'myField', 'MyValidator'));
+                $validation->appendMessage(new Message('error e', 'myField', 'MyValidator'));
+
+                $messages = $validation->getMessages();
+                $messages->offsetUnset(1);
+
+                expect($validation->getMessages())->equals(Group::__set_state([
+                    '_position' => 0,
+                    '_messages' => [
+                        0 => Message::__set_state([
+                            '_message' => 'error a',
+                            '_field'   => 'myField',
+                            '_type'    => 'MyValidator',
+                        ]),
+                        1 => Message::__set_state([
+                            '_message' => 'error d',
+                            '_field'   => 'myField',
+                            '_type'    => 'MyValidator',
+                        ]),
+                        2 => Message::__set_state([
+                            '_message' => 'error e',
+                            '_field'   => 'myField',
+                            '_type'    => 'MyValidator',
+                        ]),
+                    ]
+                ]));
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12455

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I wrote some tests for this PR.

Small description of change:
Fixed `Phalcon\Validation\Message\Group::offsetUnset` to correct unsetting a message by index

Thanks
