### PR TITLE
Allow role and resource object in isAllowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fixed except option in `Phalcon\Validation\Validator\Uniquenss` to allow using except fields other than unique fields
 - Cleaned `Phalcon\Translate\Adapter\Gettext::query` and removed ability to pass custom domain [#12598](https://github.com/phalcon/cphalcon/issues/12598), [#12606](https://github.com/phalcon/cphalcon/pull/12606)
 - Fixed `Phalcon\Validation\Message\Group::offsetUnset` to correct unsetting a message by index [#12455](https://github.com/phalcon/cphalcon/issues/12455)
+- Fix using `Phalcon\Acl\Role` and `Phalcon\Acl\Resource` as parameters for `Phalcon\Acl\Adapter\Memory::isAllowed`
 
 # [3.0.3](https://github.com/phalcon/cphalcon/releases/tag/v3.0.3) (2016-12-24)
 - Fixed implementation of Iterator interface in a `Phalcon\Forms\Form` that could cause a run-time warning

--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -529,6 +529,9 @@ class Memory extends Adapter
 	 * //Do guests have access to any resource to edit?
 	 * $acl->isAllowed("guests", "*", "edit");
 	 * </code>
+	 *
+	 * @param  RoleInterface|RoleAware|string roleName
+	 * @param  ResourceInterface|ResourceAware|string resourceName
 	 */
 	public function isAllowed(var roleName, var resourceName, string access, array parameters = null) -> boolean
 	{
@@ -540,19 +543,26 @@ class Memory extends Adapter
 			reflectionParameter;
 
 		if typeof roleName == "object" {
-			if !(roleName instanceof RoleAware) {
-				throw new Exception("Object passed as roleName must implement RoleAware");
+			if roleName instanceof RoleAware {
+				let roleObject = roleName;
+				let roleName = roleObject->getRoleName();
+			} elseif roleName instanceof RoleInterface {
+				let roleName = roleName->getName();
+			} else {
+				throw new Exception("Object passed as roleName must implement Phalcon\\Acl\\RoleAware or Phalcon\\Acl\\RoleInterface");
 			}
-			let roleObject = roleName;
-			let roleName = roleObject->getRoleName();
 		}
 
 		if typeof resourceName == "object" {
-			if !(resourceName instanceof ResourceAware) {
-				throw new Exception("Object passed as resourceName must implement ResourceAware");
+			if resourceName instanceof ResourceAware {
+				let resourceObject = resourceName;
+				let resourceName = resourceObject->getResourceName();
+			} elseif resourceName instanceof ResourceInterface {
+				let resourceName = resourceName->getName();
+			} else {
+				throw new Exception("Object passed as resourceName must implement Phalcon\\Acl\\ResourceAware or Phalcon\\Acl\\ResourceInterface");
 			}
-			let resourceObject = resourceName;
-			let resourceName = resourceObject->getResourceName();
+
 		}
 
 		let this->_activeRole = roleName;

--- a/tests/unit/Acl/Adapter/MemoryTest.php
+++ b/tests/unit/Acl/Adapter/MemoryTest.php
@@ -740,4 +740,30 @@ class MemoryTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests role and resource objects as isAllowed parameters
+     *
+     * @author  Wojciech Slawski <jurigag@gmail.com>
+     * @since   2017-02-15
+     */
+    public function testRoleResourceObjects()
+    {
+        $this->specify(
+            "Role and Resource objects doesn't work with isAllowed method",
+            function () {
+                $acl = new Memory();
+                $acl->setDefaultAction(Acl::DENY);
+                $role = new Role('Guests');
+                $resource = new Resource('Post');
+                $acl->addRole($role);
+                $acl->addResource($resource, ['index', 'update', 'create']);
+
+                $acl->allow('Guests', 'Post', 'index');
+
+                expect($acl->isAllowed($role, $resource, 'index'))->true();
+                expect($acl->isAllowed($role, $resource, 'update'))->false();
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix | documentation


**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: allow `Phalcon\Acl\Role` and `Phalcon\Acl\Resource` objects in `Phalcon\Acl\Adapter\Memory::isAllowed` to be used, also add correct `@param` docs to this method.

Thanks

