### PR TITLE
PostgreSQL. Duplicate table: 7 ERROR: relation" PRIMARY "already exists"

### DIFF
--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -287,7 +287,7 @@ class Postgresql extends Dialect
 	 */
 	public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> string
 	{
-		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD CONSTRAINT \"PRIMARY\" PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
+		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD CONSTRAINT \"" . tableName . "_PRIMARY\" PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
 	}
 
 	/**
@@ -295,7 +295,7 @@ class Postgresql extends Dialect
 	 */
 	public function dropPrimaryKey(string! tableName, string! schemaName) -> string
 	{
-		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP CONSTRAINT \"PRIMARY\"";
+		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP CONSTRAINT \"" . tableName . "_PRIMARY\"";
 	}
 
 	/**

--- a/tests/_support/Helper/Dialect/PostgresqlDialect.php
+++ b/tests/_support/Helper/Dialect/PostgresqlDialect.php
@@ -193,8 +193,8 @@ trait PostgresqlDialect
             ['schema', 'index1',  'CREATE INDEX "index1" ON "schema"."table" ("column1")'],
             [null,     'index2',  'CREATE INDEX "index2" ON "table" ("column1", "column2")'],
             ['schema', 'index2',  'CREATE INDEX "index2" ON "schema"."table" ("column1", "column2")'],
-            [null,     'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
-            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
+            [null,     'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
+            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
             [null,     'index4',  'CREATE UNIQUE INDEX "index4" ON "table" ("column4")'],
             ['schema', 'index4',  'CREATE UNIQUE INDEX "index4" ON "schema"."table" ("column4")'],
         ];
@@ -395,16 +395,16 @@ trait PostgresqlDialect
     protected function getAddPrimaryKey()
     {
         return [
-            [null,     'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
-            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
+            [null,     'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
+            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
         ];
     }
 
     protected function getDropPrimaryKey()
     {
         return [
-            [null, 'ALTER TABLE "table" DROP CONSTRAINT "PRIMARY"'],
-            ['schema', 'ALTER TABLE "schema"."table" DROP CONSTRAINT "PRIMARY"'],
+            [null, 'ALTER TABLE "table" DROP CONSTRAINT "table_PRIMARY"'],
+            ['schema', 'ALTER TABLE "schema"."table" DROP CONSTRAINT "table_PRIMARY"'],
         ];
     }
 


### PR DESCRIPTION
CONSTRAINT must be unique

Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Postgresql in CONSTRAINT must specify a unique name for this CONSTRAINT, otherwise it leads to mistakes.
> "ERROR: SQLSTATE [42P07]: Duplicate table: 7 ERROR: relation" PRIMARY "already exists"

Thanks