### PR TITLE
Install file refactoring, custom phpize & php-config paths

### DIFF
--- a/build/install
+++ b/build/install
@@ -13,15 +13,47 @@
 #
 #  Authors: Andres Gutierrez <andres@phalconphp.com>
 #            Eduar Carvajal <eduar@phalconphp.com>
+#
+#  Available params:
+#  --arch
+#  --phpize
+#  --php-config
+#
+#  Example:
+#  ./install --phpize /usr/bin/phpize5.6 --php-config /usr/bin/php-config5.6
 
 # Check best compilation flags for GCC
 export CC="gcc"
 export CFLAGS="-march=native -mtune=native -O2 -fomit-frame-pointer"
 export CPPFLAGS="-DPHALCON_RELEASE"
 
-#PHP_CONFIG=`php-config --version`
+# Set defaults
+ARCH=
+PHPIZE_BIN=phpize
+PHPCONFIG_BIN=php-config
 
-PHP_FULL_VERSION=`php-config --version`
+# Translate long options to short
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--arch") set -- "$@" "-a" ;;
+    "--phpize") set -- "$@" "-i" ;;
+    "--php-config") set -- "$@" "-c" ;;
+    *) set -- "$@" "$arg"
+  esac
+done
+
+# Options switcher
+while getopts a:i:c: opts; do
+   case ${opts} in
+      a) ARCH=${OPTARG} ;;
+      i) PHPIZE_BIN=${OPTARG} ;;
+      c) PHPCONFIG_BIN=${OPTARG} ;;
+   esac
+done
+
+PHP_FULL_VERSION=`${PHPCONFIG_BIN} --version`
+
 if [ $? != 0 ]; then
 	echo "php-config is not installed"
 	exit 1
@@ -64,7 +96,7 @@ fi
 rm -f t.t t.c t
 
 # Check processor architecture
-if [ -z $1 ]; then
+if [ -z ${ARCH} ]; then
 	DIR="32bits"
 	gcc gccarch.c -o gccarch
 	if [ -f gccarch ]; then
@@ -74,7 +106,7 @@ if [ -z $1 ]; then
 		fi
 	fi
 else
-	DIR=$1
+	DIR=${ARCH}
 fi
 
 # Move to specified architecture
@@ -83,8 +115,12 @@ cd "$PHP_VERSION/$DIR"
 # Clean current compilation
 if [ -f Makefile ]; then
 	make clean
-	phpize --clean
+	${PHPIZE_BIN} --clean
 fi
 
 # Perform the compilation
-phpize && ./configure --enable-phalcon && make && make install && echo -e "\nThanks for compiling Phalcon!\nBuild succeed: Please restart your web server to complete the installation"
+${PHPIZE_BIN} && \
+./configure --with-php-config=${PHPCONFIG_BIN} --enable-phalcon && \
+make && \
+make install && \
+echo -e "\nThanks for compiling Phalcon!\nBuild succeed: Please restart your web server to complete the installation"

--- a/build/install
+++ b/build/install
@@ -12,7 +12,7 @@
 #  to license@phalconphp.com so we can send you a copy immediately.
 #
 #  Authors: Andres Gutierrez <andres@phalconphp.com>
-#            Eduar Carvajal <eduar@phalconphp.com>
+#           Eduar Carvajal <eduar@phalconphp.com>
 #
 #  Available params:
 #  --arch
@@ -29,8 +29,8 @@ export CPPFLAGS="-DPHALCON_RELEASE"
 
 # Set defaults
 ARCH=
-PHPIZE_BIN=phpize
-PHPCONFIG_BIN=php-config
+PHPIZE_BIN=`which phpize`
+PHPCONFIG_BIN=`which php-config`
 
 # Translate long options to short
 for arg in "$@"; do


### PR DESCRIPTION
Hello. 

I've made small refactoring for `install` file. Previously it supported only `$PATH`'s binaries for `phpize` and `php-config`, but now users are able to set custom paths for them. It is very useful if you have more than one PHP instance and you want to compile Phalcon for each of them.

For example I've three different PHP versions in my Ubuntu and default one is 7.1. To compile Phalcon for 5.6 instance:

`./install --phpize /usr/bin/phpize5.6 --php-config /usr/bin/php-config5.6`

To save backward compatibility I also added an `--arch` param (for 32bits & 64bits dirs).
