### PR TITLE
Phalcon\Session\Bag: add of initialization for remove()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [3.1.0](https://github.com/phalcon/cphalcon/releases/tag/v3.1.0) (2016-XX-XX)
+# [3.1.0](https://github.com/phalcon/cphalcon/releases/tag/v3.1.0) (2017-XX-XX)
 - Added `Phalcon\Validation\Validator\Callback`, `Phalcon\Validation::getData`
 - Added the ability to truncate database tables
 - Added `Phalcon\Mvc\Model\Binder`, class used for binding models to parameters in dispatcher, micro, added `Phalcon\Dispatcher::getBoundModels` and `Phalcon\Mvc\Micro::getBoundModels` to getting bound models, added `Phalcon\Mvc\Micro\Collection\LazyLoader::callMethod`
@@ -10,6 +10,7 @@
 - Fixes internal cache saving in `Phalcon\Mvc\Model\Binder` when no cache backend is used
 - Added the ability to get original values from `Phalcon\Mvc\Model\Binder`, added `Phalcon\Mvc\Micro::getModelBinder`, `Phalcon\Dispatcher::getModelBinder`
 - Added `prepend` parameter to `Phalcon\Loader::register` to specify autoloader's loading order to top most
+- Fixed `Phalcon\Session\Bag::remove` to initialize the bag before removing a value [#12647](https://github.com/phalcon/cphalcon/pull/12647)
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (2017-02-20)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/session/bag.zep
+++ b/phalcon/session/bag.zep
@@ -231,6 +231,10 @@ class Bag implements InjectionAwareInterface, BagInterface, \IteratorAggregate, 
 	 */
 	public function remove(string! property) -> boolean
 	{
+		if this->_initialized === false {
+			this->initialize();
+		}
+
 		var data;
 
 		let data = this->_data;

--- a/tests/unit/Session/BagTest.php
+++ b/tests/unit/Session/BagTest.php
@@ -31,8 +31,26 @@ class BagTest extends UnitTest
      */
     protected function _before()
     {
+        parent::_before();
+
         FactoryDefault::reset();
         new FactoryDefault;
+
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+    }
+
+    /**
+     * executed after each test
+     */
+    protected function _after()
+    {
+        parent::_after();
+
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_destroy();
+        }
     }
 
     /**
@@ -46,8 +64,6 @@ class BagTest extends UnitTest
         $this->specify(
             "Session bag incorrectly handling writing and reading",
             function () {
-                @session_start();
-
                 // Using getters and setters
                 $bag = new Bag('test1');
                 $bag->set('a', ['b' => 'c']);
@@ -59,8 +75,6 @@ class BagTest extends UnitTest
                 $bag->{'a'} = ['b' => 'c'];
                 expect($bag->{'a'})->equals(['b' => 'c']);
                 expect($_SESSION['test2']['a'])->same(['b' => 'c']);
-
-                @session_destroy();
             }
         );
     }
@@ -76,13 +90,11 @@ class BagTest extends UnitTest
         $this->specify(
             "Setting an empty array to Session Bag do not return the same",
             function () {
-                @session_start();
                 $bag    = new Bag('container');
                 $value  = [];
                 $bag->a = $value;
 
                 expect($bag->a)->same($value);
-                @session_destroy();
             }
         );
     }
@@ -100,8 +112,6 @@ class BagTest extends UnitTest
         $this->specify(
             "Delete a value in a non initialized bag has failed",
             function () {
-                @session_start();
-
                 $reflectionClass = new ReflectionClass(Bag::class);
                 $_data = $reflectionClass->getProperty('_data');
                 $_data->setAccessible(true);
@@ -129,8 +139,6 @@ class BagTest extends UnitTest
                 expect($bag->remove('apples'))->true();
                 expect($bag->get('apples'))->null();
                 expect($_initialized->getValue($bag))->true();
-
-                @session_destroy();
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12647

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Initialization steps in remove() have been added.

Thanks

