### PR TITLE
Fixed Model::getChangedFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added the ability to get original values from `Phalcon\Mvc\Model\Binder`, added `Phalcon\Mvc\Micro::getModelBinder`, `Phalcon\Dispatcher::getModelBinder`
 - Added `prepend` parameter to `Phalcon\Loader::register` to specify autoloader's loading order to top most
 - Fixed `Phalcon\Session\Bag::remove` to initialize the bag before removing a value [#12647](https://github.com/phalcon/cphalcon/pull/12647)
+- Fixed `Phalcon\Mvc\Model::getChangedFields` to correct detect changes from NULL to Zero [#12628](https://github.com/phalcon/cphalcon/issues/12628)
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (2017-02-20)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -13,7 +13,7 @@
  | to license@phalconphp.com so we can send you a copy immediately.       |
  +------------------------------------------------------------------------+
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
- |		  Eduar Carvajal <eduar@phalconphp.com>                   |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
  +------------------------------------------------------------------------+
  */
 
@@ -3838,7 +3838,17 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	}
 
 	/**
-	 * Returns a list of changed values
+	 * Returns a list of changed values.
+	 *
+	 * <code>
+	 * $robots = Robots::findFirst();
+	 * print_r($robots->getChangedFields()); // []
+	 *
+	 * $robots->deleted = 'Y';
+	 *
+	 * $robots->getChangedFields();
+	 * print_r($robots->getChangedFields()); // ["deleted"]
+	 * </code>
 	 */
 	public function getChangedFields() -> array
 	{
@@ -3882,7 +3892,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		let changed = [];
 
 		for name, _ in allAttributes {
-
 			/**
 			 * If some attribute is not present in the snapshot, we assume the record as changed
 			 */
@@ -3902,7 +3911,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 			/**
 			 * Check if the field has changed
 			 */
-			if value != snapshot[name] {
+			if value !== snapshot[name] {
 				let changed[] = name;
 				continue;
 			}

--- a/tests/unit/Mvc/Model/SnapshotTest.php
+++ b/tests/unit/Mvc/Model/SnapshotTest.php
@@ -198,4 +198,33 @@ class SnapshotTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Test snapshots for changes from NULL to Zero
+     *
+     * @test
+     * @issue  12628
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-02-26
+     */
+    public function shouldCorrectDetectChanges()
+    {
+        $this->specify(
+            "Snapshot does not work correctly with changed fields",
+            function () {
+                $this->setUpModelsManager();
+                $robots = Robots::findFirst();
+
+                expect($robots->getChangedFields())->isEmpty();
+                expect($robots->deleted)->null();
+                expect($robots->hasChanged('deleted'))->false();
+
+                $robots->deleted = 0;
+
+                expect($robots->getChangedFields())->notEmpty();
+                expect($robots->deleted)->notNull();
+                expect($robots->hasChanged('deleted'))->true();
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12628

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Fixed `Phalcon\Mvc\Model::getChangedFields` to correct detect changes from `NULL` to `0`

Thanks
