### PR TITLE
Need to check that response has not been already sent in phalcon/mvc/micro.zep

### DIFF
--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -887,8 +887,10 @@ class Micro extends Injectable implements \ArrayAccess
 		 */
 		if typeof returnedValue == "string" {
 			let response = <ResponseInterface> dependencyInjector->getShared("response");
-			response->setContent(returnedValue);
-			response->send();
+			if !response->isSent() {
+				response->setContent(returnedValue);
+				response->send();
+			}
 		}
 
 		/**
@@ -899,7 +901,9 @@ class Micro extends Injectable implements \ArrayAccess
 				/**
 				 * Automatically send the response
 				 */
-				returnedValue->send();
+				if !returnedValue->isSent() {
+					returnedValue->send();
+				}
 			}
 		}
 


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following :**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
It is not possible to return a string value from a mapped function for an HTTP Method, and then catch that returned value by using Micro::getReturnedValue() method inside handler on Micro::after($handler), its overriding my response.
Thanks

