### PR TITLE
Need to check that response has not been already sent in phalcon/mvc/micro.zep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `prepend` parameter to `Phalcon\Loader::register` to specify autoloader's loading order to top most
 - Fixed `Phalcon\Session\Bag::remove` to initialize the bag before removing a value [#12647](https://github.com/phalcon/cphalcon/pull/12647)
 - Fixed `Phalcon\Mvc\Model::getChangedFields` to correct detect changes from NULL to Zero [#12628](https://github.com/phalcon/cphalcon/issues/12628)
+- Fixed when `Micro::getReturnedValue()` is `string` or `ResponseInterface`, if response is handled in `Micro::after($handle)` or `Micro::finish($handle)`, `Phalcon` attemps to send response again, and faces `Response Already Sent` error.
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (2017-02-20)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -985,8 +985,10 @@ class Micro extends Injectable implements \ArrayAccess
 		 */
 		if typeof returnedValue == "string" {
 			let response = <ResponseInterface> dependencyInjector->getShared("response");
-			response->setContent(returnedValue);
-			response->send();
+			if !response->isSent() {
+				response->setContent(returnedValue);
+				response->send();
+			}
 		}
 
 		/**
@@ -997,7 +999,9 @@ class Micro extends Injectable implements \ArrayAccess
 				/**
 				 * Automatically send the response
 				 */
-				returnedValue->send();
+				if !returnedValue->isSent() {
+					returnedValue->send();
+				}
 			}
 		}
 

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -459,7 +459,7 @@ class MicroTest extends UnitTest
                         return "success";
                     }
                 );
-                expect($app->handle('/api'))->equals("\"success\""); 
+                expect($app->handle('/api'))->equals("success"); 
             }
         );
     }

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -440,4 +440,28 @@ class MicroTest extends UnitTest
             }
         );
     }
+    
+    public function testMicroResponseAlreadySentError()
+    {
+        $this->specify(
+            "Micro::handle method doesn't work as expected",
+            function () {
+                $app = new Micro();
+                $app->after(
+                    function () use($app){
+                        $content = $app->getReturnedValue();
+                        $app->response->setJsonContent($content)->send();
+                    }
+                );
+                $app->map(
+                    "/api",
+                    function (){
+                       return "success";
+                    }
+                );
+                $app->handle("/api");
+            }
+        );
+    }
+    
 }

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -459,7 +459,6 @@ class MicroTest extends UnitTest
                         return "success";
                     }
                 );
-                $app->handle("/api");
                 expect($app->handle('/api'))->equals("\"success\""); 
             }
         );

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -460,6 +460,7 @@ class MicroTest extends UnitTest
                     }
                 );
                 $app->handle("/api");
+                expect($app->handle('/api'))->equals("\"success\""); 
             }
         );
     }

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -459,7 +459,7 @@ class MicroTest extends UnitTest
                         return "success";
                     }
                 );
-                expect($app->handle('/api'))->equals("success"); 
+                expect($app->handle('/api'))->equals("success");
             }
         );
     }

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -448,20 +448,19 @@ class MicroTest extends UnitTest
             function () {
                 $app = new Micro();
                 $app->after(
-                    function () use($app){
+                    function () use ($app) {
                         $content = $app->getReturnedValue();
                         $app->response->setJsonContent($content)->send();
                     }
                 );
                 $app->map(
                     "/api",
-                    function (){
-                       return "success";
+                    function () {
+                        return "success";
                     }
                 );
                 $app->handle("/api");
             }
         );
     }
-    
 }


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following :**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

It is not possible to return a string value from a mapped function for an HTTP Method, and then catch that returned value by using Micro::getReturnedValue() method inside handler on Micro::after($handler), its overriding my response.

Thanks

