### PR TITLE
Resource intanceof recourseInterface memory.zep

### DIFF
--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -319,7 +319,7 @@ class Memory extends Adapter
 	{
 		var resourceName, resourceObject;
 
-		if typeof resourceValue == "object" {
+		if typeof resourceValue == "object" && resourceValue instanceof ResourceInterface {
 			let resourceName   = resourceValue->getName();
 			let resourceObject = resourceValue;
 		 } else {


### PR DESCRIPTION
Hello!

Type: code quality
Link to issue: https://github.com/phalcon/cphalcon/blob/3.0.x/phalcon/acl/adapter/memory.zep#L322

In raising this pull request, I confirm the following (please check boxes):

- [x] I have read and understood the Contributing Guidelines?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Add in function addResource() , test to know if the value of the resource is instanceof recourseInterface.

Thanks

