### PR TITLE
Fix snapshot setting when create/update operation made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `prepend` parameter to `Phalcon\Loader::register` to specify autoloader's loading order to top most
 - Fixed `Phalcon\Session\Bag::remove` to initialize the bag before removing a value [#12647](https://github.com/phalcon/cphalcon/pull/12647)
 - Fixed `Phalcon\Mvc\Model::getChangedFields` to correct detect changes from NULL to Zero [#12628](https://github.com/phalcon/cphalcon/issues/12628)
+- Fixed `Phalcon\Mvc\Model` to create/refresh snapshot after create/update/refresh operation [#11007](https://github.com/phalcon/cphalcon/issues/11007), [#11818](https://github.com/phalcon/cphalcon/issues/11818), [#11424](https://github.com/phalcon/cphalcon/issues/11424)
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (2017-02-20)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/tests/unit/Mvc/Model/SnapshotTest.php
+++ b/tests/unit/Mvc/Model/SnapshotTest.php
@@ -227,4 +227,76 @@ class SnapshotTest extends UnitTest
             }
         );
     }
+
+    /**
+     * When model is created/updated snapshot should be set/updated
+     *
+     * @issue  11007, 11818, 11424
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-03
+     */
+    public function testIssue11007()
+    {
+        $this->specify(
+            'Snapshot is not created/updated when create/update operation was made',
+            function () {
+                $this->setUpModelsManager();
+                $robots = new Robots(
+                    [
+                        'name'     => 'test',
+                        'type'     => 'mechanical',
+                        'year'     => 2017,
+                        'datetime' => (new \DateTime())->format('Y-m-d'),
+                        'text'     => 'asd',
+                    ]
+                );
+
+                expect($robots->create())->true();
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->getSnapshotData())->equals($robots->toArray());
+
+                $robots->name = "testabc";
+                expect($robots->hasChanged('name'))->true();
+                expect($robots->update())->true();
+                expect($robots->name)->equals("testabc");
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->getSnapshotData())->equals($robots->toArray());
+                expect($robots->hasChanged('name'))->false();
+            }
+        );
+    }
+
+    /**
+     * When model is refreshed snapshot should be updated
+     *
+     * @issue  11007, 11818, 11424
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-03
+     */
+    public function testIssue11007Refresh()
+    {
+        $this->specify(
+            'Snapshot is not updated when refresh operation was made',
+            function () {
+                $this->setUpModelsManager();
+                $robots = new Robots(
+                    [
+                        'name'     => 'test',
+                        'year'     => 2017,
+                        'datetime' => (new \DateTime())->format('Y-m-d'),
+                        'text'     => 'asd',
+                    ]
+                );
+
+                expect($robots->create())->true();
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->getSnapshotData())->equals($robots->toArray());
+
+                expect($robots->refresh())->isInstanceOf(Robots::class);
+                expect($robots->type)->equals('mechanical');
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->getSnapshotData())->equals($robots->toArray());
+            }
+        );
+    }
 }

--- a/unit-tests/ModelsDynamicOperationsTest.php
+++ b/unit-tests/ModelsDynamicOperationsTest.php
@@ -103,17 +103,17 @@ class ModelsDynamicOperationsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(count($tracer), 3);
 
 		$persona->nombres = 'Other Name '.mt_rand(0, 150000);
+        $this->assertEquals($persona->getChangedFields(), array('nombres'));
 		$this->assertTrue($persona->save());
 
 		$this->assertEquals('UPDATE `personas` SET `nombres` = ? WHERE `cedula` = ?', $tracer[3]);
-		$this->assertEquals($persona->getChangedFields(), array('nombres'));
 
 		$persona->nombres = 'Other Name '.mt_rand(0, 150000);
 		$persona->direccion = 'Address '.mt_rand(0, 150000);
+        $this->assertEquals($persona->getChangedFields(), array('nombres', 'direccion'));
 		$this->assertTrue($persona->save());
 
 		$this->assertEquals('UPDATE `personas` SET `nombres` = ?, `direccion` = ? WHERE `cedula` = ?', $tracer[4]);
-		$this->assertEquals($persona->getChangedFields(), array('nombres', 'direccion'));
 	}
 
 	protected function _executeTestsRenamed($di, &$tracer)
@@ -124,17 +124,17 @@ class ModelsDynamicOperationsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals(count($tracer), 3);
 
 		$personer->navnes = 'Other Name '.mt_rand(0, 150000);
+        $this->assertEquals($personer->getChangedFields(), array('navnes'));
 		$this->assertTrue($personer->save());
 
 		$this->assertEquals('UPDATE `personas` SET `nombres` = ? WHERE `cedula` = ?', $tracer[3]);
-		$this->assertEquals($personer->getChangedFields(), array('navnes'));
 
 		$personer->navnes = 'Other Name '.mt_rand(0, 150000);
 		$personer->adresse = 'Address '.mt_rand(0, 150000);
+        $this->assertEquals($personer->getChangedFields(), array('navnes', 'adresse'));
 		$this->assertTrue($personer->save());
 
 		$this->assertEquals('UPDATE `personas` SET `nombres` = ?, `direccion` = ? WHERE `cedula` = ?', $tracer[4]);
-		$this->assertEquals($personer->getChangedFields(), array('navnes', 'adresse'));
 	}
 
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/11007, https://github.com/phalcon/cphalcon/issues/11818, https://github.com/phalcon/cphalcon/issues/11424

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: This is adding setting snapshot to correct one when creating/updating model operation were succesfully made.

Thanks

