### PR TITLE
PHP warning fix for the autoLoad() function

### DIFF
--- a/phalcon/loader.zep
+++ b/phalcon/loader.zep
@@ -337,11 +337,12 @@ class Loader implements EventsAwareInterface
 			 * Append the namespace separator to the prefix
 			 */
 			let fileName = substr(className, strlen(nsPrefix . ns));
-			let fileName = str_replace(ns, ds, fileName);
 
 			if !fileName {
 				continue;
 			}
+			
+			let fileName = str_replace(ns, ds, fileName);
 
 			for directory in directories {
 				/**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

This small alteration should fix this situation: https://forum.phalconphp.com/discussion/10339/strange-warning-probably-from-zephirfaststrreplace-or-something-

If you have two classes:
* `My\Class\Foo\Bar`
and
* `My\Class\Foo`

When initializing `Foo()` the autoLoad will come to this line 
```zep
let fileName = substr(className, strlen(nsPrefix . ns));
```
at the moment where `className = "My\Class\Foo"` and `nsPrefix = "My\Class\Foo\Bar"`

At this point (could be a Zephir bug) `fileName` is something that will make 
```zep
let fileName = str_replace(ns, ds, fileName);
```
 throw the following warning (Invalid arguments supplied for `str_replace()`). Either `substr` is returning something other than an empy string or `str_replace` is not allowing an empy string either way testing if `fileName` has any value before 
```zep
let fileName = str_replace(ns, ds, fileName);
```
should mitigate this warning.

Thanks
