### PR TITLE
Fixed Phalcon\Loader::autoLoad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added the value of the object intanceof Interface to `Phalcon\Acl\Adapter\Memory`
 - Fixed `Phalcon\Mvc\Model` to correctly add error when try to save empty string value to not null and not default column [#12688](https://github.com/phalcon/cphalcon/issues/12688)
 - Fixed `Phalcon\Validation\Validator\Uniqueness` collection persistent condition
+- Fixed `Phalcon\Loader::autoLoad` to prevent PHP warning [#12684](https://github.com/phalcon/cphalcon/pull/12684)
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (2017-02-20)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/loader.zep
+++ b/phalcon/loader.zep
@@ -337,11 +337,12 @@ class Loader implements EventsAwareInterface
 			 * Append the namespace separator to the prefix
 			 */
 			let fileName = substr(className, strlen(nsPrefix . ns));
-			let fileName = str_replace(ns, ds, fileName);
 
 			if !fileName {
 				continue;
 			}
+
+			let fileName = str_replace(ns, ds, fileName);
 
 			for directory in directories {
 				/**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12684

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Fixed `Phalcon\Loader::autoLoad` to prevent PHP warning

Thanks
