### PR TITLE
Fixes view params scope for php5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed `Phalcon\Mvc\Model` to correctly add error when try to save empty string value to not null and not default column [#12688](https://github.com/phalcon/cphalcon/issues/12688)
 - Fixed `Phalcon\Validation\Validator\Uniqueness` collection persistent condition
 - Fixed `Phalcon\Loader::autoLoad` to prevent PHP warning [#12684](https://github.com/phalcon/cphalcon/pull/12684)
+- Fixed params view scope for PHP5 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 
 # [3.0.4](https://github.com/phalcon/cphalcon/releases/tag/v3.0.4) (2017-02-20)
 - Fixed Isnull check is not correct when the model field defaults to an empty string. [#12507](https://github.com/phalcon/cphalcon/issues/12507)

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -846,7 +846,7 @@ class View extends Injectable implements ViewInterface
 		 * Create a virtual symbol table.
 		 * Variables are shared across symbol tables in PHP5
 		 */
-		if is_php_version("5") {
+		if PHP_MAJOR_VERSION == 5 {
 			create_symbol_table();
 		}
 

--- a/tests/unit/Mvc/ViewTest.php
+++ b/tests/unit/Mvc/ViewTest.php
@@ -994,6 +994,40 @@ class ViewTest extends UnitTest
         );
     }
 
+    /**
+     * Tests params view scope
+     *
+     * @issue  12648
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-17
+     */
+    public function testIssue12648()
+    {
+        if (PHP_MAJOR_VERSION != 5) {
+            $this->markTestSkipped("This issue is fixed only for php5");
+        }
+
+        $this->specify(
+            "View params are available in local scope",
+            function () {
+                $this->_clearCache();
+                $di = $this->_getDi();
+                $view = new View();
+                $view->setDI($di);
+                $view->setViewsDir(PATH_DATA . 'views' . DIRECTORY_SEPARATOR);
+                $view->setParamToView('a_cool_var', 'test');
+
+                $content = $view->setRenderLevel(View::LEVEL_ACTION_VIEW)->getRender('test3', 'another');
+                expect($content)->equals("<html>lol<p>test</p></html>\n");
+                try {
+                    echo $a_cool_var;
+                } catch (\PHPUnit_Framework_Exception $e) {
+                    expect($e->getMessage())->contains("Undefined variable: a_cool_var");
+                }
+            }
+        );
+    }
+
     private function _getDi($service = 'viewCache', $lifetime = 60)
     {
         $di = new Di();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12648

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: This is fixing issue that view params are available in local scope, **it's only fixing this issue for php5 because in php7 `create_symbol_table();` is not implemented**

Thanks

