### PR TITLE
Code quality for php 7.1

### DIFF
--- a/unit-tests/DispatcherMvcEventsTest.php
+++ b/unit-tests/DispatcherMvcEventsTest.php
@@ -23,7 +23,7 @@ class DispatcherListener
 
 	protected $_test;
 
-	protected $_trace = '';
+	protected $_trace = [];
 
 	protected $_stop = '';
 


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: property had wrong type, in php 7.1 you can't use $this->property[] on non array accessible variable.

Thanks

