### PR TITLE
Different 404 pages for multi-module

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -78,3 +78,6 @@ No pledges yet.
 - Semen Pinigin
 - Daif Alotaibi ([@dalf](https://github.com/daif))
 - Baruch Spinoza
+
+# Core Team
+Andres, Serghei, Eduar, Nikolay, Nikolaos

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -48,6 +48,7 @@ No pledges yet.
 
 [Pledge](https://www.patreon.com/bePatron?u=4653615&rid=1185010)
 
+- Gregory Burns
 - Simon Schoenenberger
 - Jesse Forrest
 - Trent Ramseyer
@@ -65,6 +66,7 @@ No pledges yet.
 
 [Pledge](https://www.patreon.com/bePatron?u=4653615&rid=1221352)
 
+- Duke Homer Grippfield
 - Eduard Jiménez
 - Felix Ruzzoli
 - Philipp Sundermeyer


### PR DESCRIPTION
This problem is not new, but still relevant!

https://forum.phalconphp.com/discussion/397/intercepting-not-found-errors-in-multi-module-applications

Please correct this, because people can not assign different 404 pages for each individual module. As I understand it, the problem is that the modules load is terminated if an EXCEPTION_HANDLER_NOT_FOUND exception or EXCEPTION_ACTION_NOT_FOUND is thrown. Accordingly, the loading of the "dispatcher" dependency within the module is not performed and redirection to the necessary controller and action also.