### PR TITLE
Imagick::getVersion()  to Imagick->getVersion() [ci skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)
+- Fixed `Imagick::getVersion()` error in some system
 
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-03-25)
 - Fixed undefined index warning on existing cached resultsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)
-- Fixed `Imagick::getVersion()` error in some system
+- Fixed `Imagick::getVersion()` error in some system [#12729](https://github.com/phalcon/cphalcon/pull/12729)
 
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-03-25)
 - Fixed undefined index warning on existing cached resultsets

--- a/phalcon/image/adapter/imagick.zep
+++ b/phalcon/image/adapter/imagick.zep
@@ -360,7 +360,7 @@ class Imagick extends Adapter
 
 		// Imagick >= 2.0.0
 		if likely method_exists(watermark, "getVersion") {
-			let version = \Imagick::getVersion();
+			let version = watermark->getVersion();
 
 			if version["versionNumber"] >= 0x700 {
 				let method = "setImageAlpha";


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
In some systems, the extend  Imagick  can't call method  Imagick::getVersion(), but can be call as Imagick->getVersion()

Thanks

