### PR TITLE
beforeException on Application getModule

### DIFF
--- a/phalcon/application.zep
+++ b/phalcon/application.zep
@@ -120,11 +120,28 @@ abstract class Application extends Injectable implements EventsAwareInterface
 		var module;
 
 		if !fetch module, this->_modules[name] {
-			throw new Exception("Module '" . name . "' isn't registered in the application container");
+			exception = new Exception("Module '" . name . "' isn't registered in the application container");
+  			this->_handleException(exception);
 		}
 
 		return module;
 	}
+	
+	/**
+  	 * Handles a user exception
+  	 */
+  	protected function _handleException(<\Exception> exception)
+  	{
+  		var eventsManager;
+  		let eventsManager = <ManagerInterface> this->_eventsManager;
+  		if typeof eventsManager == "object" {
+  			if eventsManager->fire("application:beforeException", this, exception) === false {
+ 				return false;
+  			} else {
+  				throw exception;
+  			}
+  		}
+  	}
 
 	/**
 	 * Sets the module name to be used if the router doesn't return a valid module

--- a/phalcon/application.zep
+++ b/phalcon/application.zep
@@ -122,7 +122,7 @@ abstract class Application extends Injectable implements EventsAwareInterface
 
 		if !fetch module, this->_modules[name] {
 			let exception = new Exception("Module '" . name . "' isn't registered in the application container");
-  			this->_handleException(exception)			
+  			this->_handleException(exception);
 		}
 
 		return module;

--- a/phalcon/application.zep
+++ b/phalcon/application.zep
@@ -122,13 +122,8 @@ abstract class Application extends Injectable implements EventsAwareInterface
 
 		if !fetch module, this->_modules[name] {
 			let exception = new Exception("Module '" . name . "' isn't registered in the application container");
-  			if this->_handleException(exception) === false {
-				return false;
-			}
-
-			throw exception;
+  			this->_handleException(exception)			
 		}
-		
 
 		return module;
 	}
@@ -144,6 +139,8 @@ abstract class Application extends Injectable implements EventsAwareInterface
 			if eventsManager->fire("dispatch:beforeException", this, exception) === false {
 				return false;
 			}
+			
+			throw exception;
 		}
 	}
 

--- a/phalcon/application.zep
+++ b/phalcon/application.zep
@@ -118,30 +118,34 @@ abstract class Application extends Injectable implements EventsAwareInterface
 	public function getModule(string! name) -> array | object
 	{
 		var module;
+		var exception;
 
 		if !fetch module, this->_modules[name] {
-			exception = new Exception("Module '" . name . "' isn't registered in the application container");
-  			this->_handleException(exception);
+			let exception = new Exception("Module '" . name . "' isn't registered in the application container");
+  			if this->_handleException(exception) === false {
+				return false;
+			}
+
+			throw exception;
 		}
+		
 
 		return module;
 	}
 	
 	/**
-  	 * Handles a user exception
-  	 */
-  	protected function _handleException(<\Exception> exception)
-  	{
-  		var eventsManager;
-  		let eventsManager = <ManagerInterface> this->_eventsManager;
-  		if typeof eventsManager == "object" {
-  			if eventsManager->fire("application:beforeException", this, exception) === false {
- 				return false;
-  			} else {
-  				throw exception;
-  			}
-  		}
-  	}
+	 * Handles a user exception
+	 */
+	protected function _handleException(<\Exception> exception)
+	{
+		var eventsManager;
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		if typeof eventsManager == "object" {
+			if eventsManager->fire("dispatch:beforeException", this, exception) === false {
+				return false;
+			}
+		}
+	}
 
 	/**
 	 * Sets the module name to be used if the router doesn't return a valid module


### PR DESCRIPTION
For multi-module applications it is possible to attach a beforeException event to the Application.
The default behaviour is the same (throw exception) if not event listener is set.

Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks
