### PR TITLE
Fix undefined index warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-XX-XX)
+- Fixed undefined index warning on existing cached resultsets
 
 # [3.1.0](https://github.com/phalcon/cphalcon/releases/tag/v3.1.0) (2017-03-22)
 - Added `Phalcon\Validation\Validator\Callback`, `Phalcon\Validation::getData`

--- a/phalcon/mvc/model/resultset/simple.zep
+++ b/phalcon/mvc/model/resultset/simple.zep
@@ -245,7 +245,7 @@ class Simple extends Resultset
 	 */
 	public function unserialize(string! data) -> void
 	{
-		var resultset;
+		var resultset, keepSnapshots;
 
 		let resultset = unserialize(data);
 		if typeof resultset != "array" {
@@ -257,7 +257,10 @@ class Simple extends Resultset
 			this->_count = count(resultset["rows"]),
 			this->_cache = resultset["cache"],
 			this->_columnMap = resultset["columnMap"],
-			this->_hydrateMode = resultset["hydrateMode"],
-			this->_keepSnapshots = resultset["keepSnapshots"];
+			this->_hydrateMode = resultset["hydrateMode"];
+
+		if fetch keepSnapshots, resultset["keepSnapshots"] {
+		    let this->_keepSnapshots = keepSnapshots;
+		}
 	}
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:https://forum.phalconphp.com/discussion/15799/undefined-index-keepsnapshots-after-phalcon-upgrade-to-310

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR. Not testable really on travis

Small description of change: if someone had old resultsets existing in cache then on unserialize he would have warning about not existing index, this is fixing this.

Thanks

