### PR TITLE
Fixed _doLowUpdate warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-XX-XX)
 - Fixed undefined index warning on existing cached resultsets
+- Fixed `Phalcon\Mvc\Model::_dowLowUpdate` warning first argument is not an array [#12742](https://github.com/phalcon/cphalcon/issues/12742)
 
 # [3.1.0](https://github.com/phalcon/cphalcon/releases/tag/v3.1.0) (2017-03-22)
 - Added `Phalcon\Validation\Validator\Callback`, `Phalcon\Validation::getData`

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2650,8 +2650,12 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  		], bindTypes);
 
  		if success && manager->isKeepingSnapshots(this) {
-            let this->_snapshot = array_merge(this->_snapshot, newSnapshot);
- 		}
+			if typeof this->_snapshot == "array" {
+				let this->_snapshot = array_merge(this->_snapshot, newSnapshot);
+			} else {
+				let this->_snapshot = newSnapshot;
+			}
+		}
 
  		return success;
  	}

--- a/tests/unit/Mvc/Model/SnapshotTest.php
+++ b/tests/unit/Mvc/Model/SnapshotTest.php
@@ -299,4 +299,21 @@ class SnapshotTest extends UnitTest
             }
         );
     }
+
+    /**
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-23
+     */
+    public function testNewInstanceUpdate()
+    {
+        $this->specify(
+            'When updating model from new instance there is some problem',
+            function () {
+                $this->setUpModelsManager();
+                $robots = Robots::findFirst();
+                $robots = new Robots($robots->toArray());
+                expect($robots->save())->true();
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12742

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: when test case like in created tests there is warning happening about wrong type passed to array_merge in _doLowUpdate

Thanks

