### PR TITLE
Added way to disable setters in model assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed `Phalcon\Mvc\Model\MetaData\Strategy\Annotations::getColumnMaps` where only renamed columns where returned if there was one
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `before` handlers [#10931](https://github.com/phalcon/cphalcon/pull/10931)
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `afterBinding` handlers
+- Added way to disable setters in `Phalcon\Mvc\Model::assign` by using `Phalcon\Mvc\Model::setup` or ini option
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/config.json
+++ b/config.json
@@ -103,6 +103,10 @@
         "orm.update_snapshot_on_save": {
             "type": "bool",
             "default": true
+        },
+        "orm.disable_assign_setters": {
+            "type": "bool",
+            "default": false
         }
     },
     "destructors": {

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -445,6 +445,19 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 *         "year",
 	 *     ]
 	 * );
+	 *
+	 * // By default assign method will use setters if exist, you can disable it by using ini_set to directly use properties
+	 *
+	 * ini_set("phalcon.orm.disable_assign_setters", true);
+	 *
+	 * $robot->assign(
+	 *     $_POST,
+	 *     null,
+	 *     [
+	 *         "name",
+	 *         "year",
+	 *     ]
+	 * );
 	 * </code>
 	 *
 	 * @param array data
@@ -454,7 +467,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 */
 	public function assign(array! data, var dataColumnMap = null, var whiteList = null) -> <Model>
 	{
-		var key, keyMapped, value, attribute, attributeField, metaData, columnMap, dataMapped;
+		var key, keyMapped, value, attribute, attributeField, metaData, columnMap, dataMapped, disableAssignSetters;
+
+        let disableAssignSetters = globals_get("orm.disable_assign_setters");
 
 		// apply column map for data, if exist
 		if typeof dataColumnMap == "array" {
@@ -507,7 +522,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 				}
 
 				// Try to find a possible getter
-				if !this->_possibleSetter(attributeField, value) {
+				if disableAssignSetters || !this->_possibleSetter(attributeField, value) {
 					let this->{attributeField} = value;
 				}
 			}
@@ -3866,7 +3881,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	{
 		return this->_oldSnapshot;
 	}
-	
+
 	/**
 	 * Check if a specific attribute has changed
 	 * This only works if the model is keeping data snapshots
@@ -4664,7 +4679,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		var disableEvents, columnRenaming, notNullValidations,
 			exceptionOnFailedSave, phqlLiterals, virtualForeignKeys,
 			lateStateBinding, castOnHydrate, ignoreUnknownColumns,
-			updateSnapshotOnSave;
+			updateSnapshotOnSave, disableAssignSetters;
 
 		/**
 		 * Enables/Disables globally the internal events
@@ -4731,6 +4746,10 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
 		if fetch updateSnapshotOnSave, options["updateSnapshotOnSave"] {
 			globals_set("orm.update_snapshot_on_save", updateSnapshotOnSave);
+		}
+
+		if fetch disableAssignSetters, options["disableAssignSetters"] {
+		    globals_set("orm.disable_assign_setters", disableAssignSetters);
 		}
 	}
 

--- a/tests/_data/models/Robots.php
+++ b/tests/_data/models/Robots.php
@@ -27,6 +27,16 @@ use Phalcon\Mvc\Model\Resultset\Simple;
  */
 class Robots extends Model
 {
+    /**
+     * @var bool
+     */
+    public $wasSetterUsed = false;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
     public function initialize()
     {
         $this->keepSnapshots(true);
@@ -41,5 +51,13 @@ class Robots extends Model
                 'alias' => 'parts'
             ]
         );
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+        $this->wasSetterUsed = true;
+
+        return $this;
     }
 }

--- a/tests/unit/Mvc/ModelTest.php
+++ b/tests/unit/Mvc/ModelTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Mvc;
 
 use DateTime;
 use Helper\ModelTrait;
+use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\Message;
 use Phalcon\Test\Models\Users;
 use Phalcon\Cache\Backend\Apc;
@@ -666,6 +667,44 @@ class ModelTest extends UnitTest
                     [
                         'datetime' => (new DateTime())->format('Y-m-d'),
                         'text'     => 'text',
+                    ]
+                );
+            }
+        );
+    }
+
+    /**
+     * Tests disabling assign setters
+     *
+     * @issue  12645
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-23
+     */
+    public function testAssignSettersDisabled()
+    {
+        $this->specify(
+            'Disabling setters in assign is not working',
+            function () {
+                $robots = new Robots(
+                    [
+                        'name' => 'test',
+                    ]
+                );
+                expect($robots->wasSetterUsed)->true();
+                Model::setup(
+                    [
+                        'disableAssignSetters' => true,
+                    ]
+                );
+                $robots = new Robots(
+                    [
+                        'name' => 'test',
+                    ]
+                );
+                expect($robots->wasSetterUsed)->false();
+                Model::setup(
+                    [
+                        'disableAssignSetters' => false,
                     ]
                 );
             }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: currently `Phalcon\Mvc\Model::assign` is always using setters when it's not really necessary to always use it, just in most of apps setting properties could be enough but right now there is no way to do it. This is adding it by setting global/php ini option.

Thanks

