### PR TITLE
Take advantage of prefix in router for faster handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `before` handlers [#10931](https://github.com/phalcon/cphalcon/pull/10931)
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `afterBinding` handlers
 - Added way to disable setters in `Phalcon\Mvc\Model::assign` by using `Phalcon\Mvc\Model::setup` or ini option
+- Router now uses `Phalcon\Mvc\Router\Group::getPrefix` to optimize routes into groups for faster handling, added same possibility for `Phalcon\Mvc\Router::add` using `prefix` option in paths(using `Phalcon\Mvc\Router::usePrefix` you can actually select if it should affect pattern)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/router/group.zep
+++ b/phalcon/mvc/router/group.zep
@@ -169,6 +169,23 @@ class Group implements GroupInterface
 	 */
 	public function getRoutes() -> <RouteInterface[]>
 	{
+		var prefix, prefixGroup, route;
+		array routes = [];
+
+		for prefix, prefixGroup in this->_routes {
+			for route in prefixGroup {
+				let routes[] = route;
+			}
+		}
+
+		return routes;
+	}
+
+	/**
+	 * Returns routes as raw array with prefix groups
+	 */
+	public function getRawRoutes() -> array
+	{
 		return this->_routes;
 	}
 
@@ -281,7 +298,7 @@ class Group implements GroupInterface
 	 */
 	protected function _addRoute(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
 	{
-		var mergedPaths, route, defaultPaths, processedPaths;
+		var mergedPaths, route, defaultPaths, processedPaths, prefix;
 
 		/**
 		 * Check if the paths need to be merged with current paths
@@ -311,8 +328,19 @@ class Group implements GroupInterface
 		/**
 		 * Every route is internally stored as a Phalcon\Mvc\Router\Route
 		 */
-		let route = new Route(this->_prefix . pattern, mergedPaths, httpMethods),
-			this->_routes[] = route;
+		let route = new Route(this->_prefix . pattern, mergedPaths, httpMethods);
+
+		let prefix = this->_prefix;
+
+		if empty prefix {
+			if starts_with(pattern, "/") {
+				let prefix = "/";
+			} else {
+				let prefix = "";
+			}
+		}
+
+		let this->_routes[prefix][] = route;
 
 		route->setGroup(this);
 		return route;

--- a/tests/unit/Mvc/RouterTest.php
+++ b/tests/unit/Mvc/RouterTest.php
@@ -566,6 +566,45 @@ class RouterTest extends UnitTest
         );
     }
 
+    /**
+     * Tests routes with prefix
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-27
+     */
+    public function testPrefix()
+    {
+        $this->specify(
+            'Routes with prefix are not working correctly',
+            function () {
+                $router = $this->getRouter(false);
+                $router->add('/test/something', ['prefix' => '/test']);
+                expect($router->handle('/test/something'));
+                expect($router->wasMatched())->true();
+            }
+        );
+    }
+
+    /**
+     * Tests routes with prefix with prefix usage enabled
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-27
+     */
+    public function testPrefixWithUsingIt()
+    {
+        $this->specify(
+            'Routes with prefix are not working correctly',
+            function () {
+                $router = $this->getRouter(false);
+                $router->usePrefix(true);
+                $router->add('/something', ['prefix' => '/test']);
+                expect($router->handle('/test/something'));
+                expect($router->wasMatched())->true();
+            }
+        );
+    }
+
     protected function convertersProvider()
     {
         return [


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/12758

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Right now router always iterate through all routes even when for example using router groups prefix it couldn't have to. This PR adds such possibility to first check prefix if handledUri starts with it, if not then it continues to next prefix group.

Thanks

