### PR TITLE
Remove php 7.1 from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.1
     - php: nightly
   include:
     - php: 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct` will now trigger `E_DEPREACATED` on usage
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
+- Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)
 
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-03-25)
 - Fixed undefined index warning on existing cached resultsets

--- a/phalcon/queue/beanstalk.zep
+++ b/phalcon/queue/beanstalk.zep
@@ -562,7 +562,7 @@ class Beanstalk
 	/**
 	 * Writes data to the socket. Performs a connection if none is available
 	 */
-	protected function write(string data) -> boolean|int
+	public function write(string data) -> boolean|int
 	{
 		var connection, packet;
 


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: removes php 7.1 from allowed failure

Thanks

