### PR TITLE
3.2.x Method `path` added to `Phalcon\Config`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: 7.1
     - php: nightly
   include:
     - php: 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
 - `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct` will now trigger `E_DEPREACATED` on usage
+- Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct` will now trigger `E_DEPREACATED` on usage
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
+- Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)
 
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-03-25)
 - Fixed undefined index warning on existing cached resultsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
+- `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct` will now trigger `E_DEPREACATED` on usage
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
+
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-XX-XX)
 
 # [3.1.0](https://github.com/phalcon/cphalcon/releases/tag/v3.1.0) (2017-03-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct` will now trigger `E_DEPREACATED` on usage
 - Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001)
 - Added ability to sanitize URL to `Phalcon\Filter`
+- Method `path` added to `Phalcon\Config` to get a value using a dot separated path [#12221](https://github.com/phalcon/cphalcon/issues/12221)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
+
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-03-25)
 - Fixed undefined index warning on existing cached resultsets
 - Fixed `Phalcon\Mvc\Model::_dowLowUpdate` warning first argument is not an array [#12742](https://github.com/phalcon/cphalcon/issues/12742)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
+
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-XX-XX)
 
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-03-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
+- Added ability to sanitize URL to `Phalcon\Filter`
 
 # [3.1.1](https://github.com/phalcon/cphalcon/releases/tag/v3.1.1) (2017-XX-XX)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Phalcon Framework
 =================
 
 [![Build Status](https://travis-ci.org/phalcon/cphalcon.svg?branch=master)](https://travis-ci.org/phalcon/cphalcon)
-[![Windows Build](https://ci.appveyor.com/api/projects/status/github/phalcon/cphalcon?branch=master&svg=true)](https://ci.appveyor.com/project/phalcon/cphalcon/branch/master)
+[![Windows Build](https://ci.appveyor.com/api/projects/status/github/sergeyklay/cphalcon?branch=master&svg=true)](https://ci.appveyor.com/project/phalcon/cphalcon/branch/master)
 [![Support Us](https://img.shields.io/badge/support-patreon-red.svg)](https://www.patreon.com/bePatron?u=4653615)
 [![Phalcon Backers](https://img.shields.io/badge/phalcon-backers-99ddc0.svg)](https://github.com/phalcon/cphalcon/blob/master/BACKERS.md)
 

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "name": "phalcon",
     "description": "Web framework delivered as a C-extension for PHP",
     "author": "Phalcon Team and contributors",
-    "version": "3.1.1",
+    "version": "3.2.0a",
     "verbose": false,
     "optimizer-dirs": [
         "optimizers"

--- a/ext/php_phalcon.h
+++ b/ext/php_phalcon.h
@@ -11,7 +11,7 @@
 #include "kernel/globals.h"
 
 #define PHP_PHALCON_NAME        "phalcon"
-#define PHP_PHALCON_VERSION     "3.1.1"
+#define PHP_PHALCON_VERSION     "3.2.0a"
 #define PHP_PHALCON_EXTNAME     "phalcon"
 #define PHP_PHALCON_AUTHOR      "Phalcon Team and contributors"
 #define PHP_PHALCON_ZEPVERSION  "0.9.6a-dev-3a72ba9bb5"

--- a/phalcon/annotations/factory.zep
+++ b/phalcon/annotations/factory.zep
@@ -1,0 +1,48 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Annotations;
+
+use Phalcon\Factory as BaseFactory;
+
+/**
+ * Loads Annotations Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Annotations\Factory;
+ *
+ * $options = [
+ *     "prefix"   => "annotations",
+ *     "lifetime" => "3600",
+ *     "adapter"  => "apc",
+ * ];
+ * $annotations = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Annotations\\Adapter", config);
+	}
+}

--- a/phalcon/cache/backend/factory.zep
+++ b/phalcon/cache/backend/factory.zep
@@ -1,0 +1,82 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Cache\Backend;
+
+use Phalcon\Factory as BaseFactory;
+use Phalcon\Factory\Exception;
+use Phalcon\Cache\BackendInterface;
+use Phalcon\Cache\Frontend\Factory as FrontendFactory;
+use Phalcon\Config;
+
+/**
+ * Loads Backend Cache Adapter class using 'adapter' option, if frontend will be provided as array it will call Frontend Cache Factory
+ *
+ *<code>
+ * use Phalcon\Cache\Backend\Factory;
+ * use Phalcon\Cache\Frontend\Data;
+ *
+ * $options = [
+ *     "prefix"   => "app-data",
+ *     "frontend" => new Data(),
+ *     "adapter"  => "apc",
+ * ];
+ * $backendCache = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <BackendInterface>
+	{
+		return self::loadClass("Phalcon\\Cache\\Backend", config);
+	}
+
+	protected static function loadClass(string $namespace, var config)
+	{
+		var adapter, className, frontend;
+
+		if typeof config == "object" && config instanceof Config {
+			let config = config->toArray();
+		}
+
+		if typeof config != "array" {
+			throw new Exception("Config must be array or Phalcon\\Config object");
+		}
+
+		if !fetch frontend, config["frontend"] {
+			throw new Exception("You must provide 'frontend' option in factory config parameter.");
+		}
+
+		if fetch adapter, config["adapter"] {
+			unset config["adapter"];
+			unset config["frontend"];
+			if typeof frontend == "array" || frontend instanceof Config {
+				let frontend = FrontendFactory::load(frontend);
+			}
+			let className = $namespace."\\".camelize(adapter);
+
+			return new {className}(frontend, config);
+		}
+
+		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+	}
+}

--- a/phalcon/cache/frontend/factory.zep
+++ b/phalcon/cache/frontend/factory.zep
@@ -1,0 +1,75 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Cache\Frontend;
+
+use Phalcon\Cache\FrontendInterface;
+use Phalcon\Factory\Exception;
+use Phalcon\Factory as BaseFactory;
+use Phalcon\Config;
+
+/**
+ * Loads Frontend Cache Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Cache\Frontend\Factory;
+ *
+ * $options = [
+ *     "lifetime" => 172800,
+ *     "adapter"  => "data",
+ * ];
+ * $frontendCache = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <FrontendInterface>
+	{
+		return self::loadClass("Phalcon\\Cache\\Frontend", config);
+	}
+
+	protected static function loadClass(string $namespace, var config)
+	{
+		var adapter, className;
+
+		if typeof config == "object" && config instanceof Config {
+			let config = config->toArray();
+		}
+
+		if typeof config != "array" {
+			throw new Exception("Config must be array or Phalcon\\Config object");
+		}
+
+		if fetch adapter, config["adapter"] {
+			unset config["adapter"];
+			let className = $namespace."\\".camelize(adapter);
+
+			if className == "Phalcon\\Cache\\Frontend\\None" {
+				return new {className}();
+			} else {
+				return new {className}(config);
+			}
+		}
+
+		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+	}
+}

--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -50,6 +50,8 @@ use Phalcon\Config\Exception;
 class Config implements \ArrayAccess, \Countable
 {
 
+	protected static _delimiter = ".";
+
 	/**
 	 * Phalcon\Config constructor
 	 */
@@ -77,6 +79,60 @@ class Config implements \ArrayAccess, \Countable
 
 		return isset this->{index};
 	}
+
+    /**
+     * Sets the default path delimiter
+     */
+    public function setPathDelimiter(string! delimiter) -> <Config>
+    {
+        let self::_delimiter = delimiter;
+        return this;
+    }
+
+    /**
+     * Returns a value from current config using a dot separated path.
+     *
+     *<code>
+     * echo $config->get("unknown.path", "default", ".");
+     *</code>
+     */
+    public function path(var path, var defaultValue = null, var delimiter = null) -> var
+    {
+        var key, keys, stack;
+
+        let path = strval(path);
+
+        if isset this->{path} {
+            return this->{path};
+        }
+
+        if empty delimiter {
+            let delimiter = self::_delimiter;
+        }
+
+        let keys = explode(delimiter, path),
+            stack = this;
+
+        while !empty keys {
+            let key = array_shift(keys);
+
+            if !isset stack->{key} {
+                break;
+            }
+
+            if empty keys {
+                return stack->{key};
+            }
+
+            let stack = stack->{key};
+
+            if empty stack {
+                break;
+            }
+        }
+
+        return defaultValue;
+    }
 
 	/**
 	 * Gets an attribute from the configuration, if the attribute isn't defined returns null

--- a/phalcon/config/factory.zep
+++ b/phalcon/config/factory.zep
@@ -1,0 +1,87 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Config;
+
+use Phalcon\Factory as BaseFactory;
+use Phalcon\Factory\Exception;
+use Phalcon\Config;
+
+/**
+ * Loads Config Adapter class using 'adapter' option, if no extension is provided it will be added to filePath
+ *
+ *<code>
+ * use Phalcon\Config\Factory;
+ *
+ * $options = [
+ *     "filePath" => "path/config",
+ *     "adapter"  => "php",
+ * ];
+ * $config = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <Config>
+	{
+		return self::loadClass("Phalcon\\Config\\Adapter", config);
+	}
+
+	protected static function loadClass(string $namespace, var config)
+	{
+		var adapter, className, mode, callbacks, filePath;
+
+		if typeof config == "object" && config instanceof Config {
+			let config = config->toArray();
+		}
+
+		if typeof config != "array" {
+			throw new Exception("Config must be array or Phalcon\\Config object");
+		}
+
+		if !fetch filePath, config["filePath"] {
+			throw new Exception("You must provide 'filePath' option in factory config parameter.");
+		}
+
+		if fetch adapter, config["adapter"] {
+			let className = $namespace."\\".camelize(adapter);
+			if !strpos(filePath, ".") {
+				let filePath = filePath.".".lcfirst(adapter);
+			}
+
+			if className == "Phalcon\\Config\\Adapter\\Ini" {
+				if fetch mode, config["mode"] {
+					return new {className}(filePath, mode);
+				}
+			} elseif className == "Phalcon\\Config\\Adapter\\Yaml" {
+				if fetch callbacks, config["callbacks"] {
+					return new {className}(filePath, callbacks);
+				}
+			}
+
+			return new {className}(filePath);
+		}
+
+		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+	}
+}

--- a/phalcon/db/adapter/pdo/factory.zep
+++ b/phalcon/db/adapter/pdo/factory.zep
@@ -1,0 +1,52 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Db\Adapter\Pdo;
+
+use Phalcon\Factory as BaseFactory;
+use Phalcon\Db\AdapterInterface;
+
+/**
+ * Loads PDO Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Db\Adapter\Pdo\Factory;
+ *
+ * $options = [
+ *     "host"     => "localhost",
+ *     "dbname"   => "blog",
+ *     "port"     => 3306,
+ *     "username" => "sigma",
+ *     "password" => "secret",
+ *     "adapter"  => "mysql",
+ * ];
+ * $db = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Db\\Adapter\\Pdo", config);
+	}
+}

--- a/phalcon/debug.zep
+++ b/phalcon/debug.zep
@@ -269,9 +269,11 @@ class Debug
 
 	/**
 	 * Returns the major framework's version
+	 *
 	 * @deprecated Will be removed in 4.0.0
+	 * @see Phalcon\Version::getPart()
 	 */
-	public function getMajorVersion() -> string
+	deprecated public function getMajorVersion() -> string
 	{
 		var parts;
 

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -338,7 +338,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	 * @deprecated 3.1.0 Use setModelBinder method
 	 * @see Phalcon\Dispatcher::setModelBinder()
 	 */
-	public function setModelBinding(boolean value, var cache = null) -> <Dispatcher>
+	deprecated public function setModelBinding(boolean value, var cache = null) -> <Dispatcher>
 	{
 		var dependencyInjector;
 

--- a/phalcon/factory.zep
+++ b/phalcon/factory.zep
@@ -1,0 +1,49 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon;
+
+use Phalcon\Factory\Exception;
+use Phalcon\Config;
+
+abstract class Factory implements FactoryInterface
+{
+	protected static function loadClass(string $namespace, var config)
+	{
+		var adapter, className;
+
+		if typeof config == "object" && config instanceof Config {
+			let config = config->toArray();
+		}
+
+		if typeof config != "array" {
+			throw new Exception("Config must be array or Phalcon\\Config object");
+		}
+
+		if fetch adapter, config["adapter"] {
+			unset config["adapter"];
+			let className = $namespace."\\".adapter;
+
+			return new {className}(config);
+		}
+
+		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+	}
+}

--- a/phalcon/factory/exception.zep
+++ b/phalcon/factory/exception.zep
@@ -1,0 +1,30 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com                           |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Factory;
+
+/**
+ * Phalcon\Factory\Exception
+ *
+ * Exceptions thrown in Phalcon\Factory will use this class
+ */
+class Exception extends \Phalcon\Exception
+{
+}

--- a/phalcon/factoryinterface.zep
+++ b/phalcon/factoryinterface.zep
@@ -1,0 +1,29 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon;
+
+interface FactoryInterface
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> object;
+}

--- a/phalcon/filter.zep
+++ b/phalcon/filter.zep
@@ -64,6 +64,8 @@ class Filter implements FilterInterface
 
 	const FILTER_UPPER      = "upper";
 
+	const FILTER_URL        = "url";
+
 	protected _filters;
 
 	/**
@@ -209,6 +211,10 @@ class Filter implements FilterInterface
 					return mb_strtoupper(value);
 				}
 				return strtoupper(value);
+
+			case Filter::FILTER_URL:
+
+				return filter_var(value, FILTER_SANITIZE_URL);
 
 			default:
 				throw new Exception("Sanitize filter '" . filter . "' is not supported");

--- a/phalcon/image/factory.zep
+++ b/phalcon/image/factory.zep
@@ -1,0 +1,84 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Image;
+
+use Phalcon\Factory as BaseFactory;
+use Phalcon\Factory\Exception;
+use Phalcon\Config;
+
+/**
+ * Loads Image Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Image\Factory;
+ *
+ * $options = [
+ *     "width"   => 200,
+ *     "height"  => 200,
+ *     "file"    => "upload/test.jpg",
+ *     "adapter" => "imagick",
+ * ];
+ * $image = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Image\\Adapter", config);
+	}
+
+	protected static function loadClass(string $namespace, var config)
+	{
+		var adapter, className, file, height, width;
+
+		if typeof config == "object" && config instanceof Config {
+			let config = config->toArray();
+		}
+
+		if typeof config != "array" {
+			throw new Exception("Config must be array or Phalcon\\Config object");
+		}
+
+		if !fetch file, config["file"] {
+			throw new Exception("You must provide 'file' option in factory config parameter.");
+		}
+
+		if fetch adapter, config["adapter"] {
+			let className = $namespace."\\".camelize(adapter);
+
+			if fetch width, config["width"] {
+				if fetch height, config["height"] {
+					return new {className}(file, width, height);
+				}
+
+				return new {className}(file, width);
+			}
+
+			return new {className}(file);
+		}
+
+		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+	}
+}

--- a/phalcon/logger/factory.zep
+++ b/phalcon/logger/factory.zep
@@ -1,0 +1,80 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Logger;
+
+use Phalcon\Factory as BaseFactory;
+use Phalcon\Factory\Exception;
+use Phalcon\Config;
+
+/**
+ * Loads Logger Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Logger\Factory;
+ *
+ * $options = [
+ *     "name"    => "log.txt",
+ *     "adapter" => "file",
+ * ];
+ * $logger = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Logger\\Adapter", config);
+	}
+
+	protected static function loadClass(string $namespace, var config)
+	{
+		var adapter, className, name;
+
+		if typeof config == "object" && config instanceof Config {
+			let config = config->toArray();
+		}
+
+		if typeof config != "array" {
+			throw new Exception("Config must be array or Phalcon\\Config object");
+		}
+
+		if fetch adapter, config["adapter"] {
+			let className = $namespace."\\".camelize(adapter);
+
+			if className != "Phalcon\\Logger\\Adapter\\Firephp" {
+				unset config["adapter"];
+				if !fetch name, config["name"] {
+					throw new Exception("You must provide 'name' option in factory config parameter.");
+				}
+				unset config["name"];
+
+				return new {className}(name, config);
+			}
+
+			return new {className}();
+		}
+
+		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+	}
+}

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -267,7 +267,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	 * @deprecated 1.0.0
 	 * @see \Phalcon\Mvc\Model\Criteria::andWhere()
 	 */
-	public function addWhere(string! conditions, var bindParams = null, var bindTypes = null) -> <Criteria>
+	deprecated public function addWhere(string! conditions, var bindParams = null, var bindTypes = null) -> <Criteria>
 	{
 		return this->andWhere(conditions, bindParams, bindTypes);
 	}

--- a/phalcon/mvc/model/validator.zep
+++ b/phalcon/mvc/model/validator.zep
@@ -42,7 +42,7 @@ abstract class Validator implements ValidatorInterface
 	/**
 	 * Phalcon\Mvc\Model\Validator constructor
 	 */
-	public function __construct(array! options)
+	deprecated public function __construct(array! options)
 	{
 		let this->_options = options;
 	}

--- a/phalcon/paginator/factory.zep
+++ b/phalcon/paginator/factory.zep
@@ -1,0 +1,53 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Paginator;
+
+use Phalcon\Factory as BaseFactory;
+
+/**
+ * Loads Paginator Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Paginator\Factory;
+ * $builder = $this->modelsManager->createBuilder()
+ *                 ->columns("id, name")
+ *                 ->from("Robots")
+ *                 ->orderBy("name");
+ *
+ * $options = [
+ *     "builder" => $builder,
+ *     "limit"   => 20,
+ *     "page"    => 1,
+ *     "adapter" => "queryBuilder",
+ * ];
+ * $paginator = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Paginator\\Adapter", config);
+	}
+}

--- a/phalcon/queue/beanstalk.zep
+++ b/phalcon/queue/beanstalk.zep
@@ -562,7 +562,7 @@ class Beanstalk
 	/**
 	 * Writes data to the socket. Performs a connection if none is available
 	 */
-	protected function write(string data) -> boolean|int
+	public function write(string data) -> boolean|int
 	{
 		var connection, packet;
 

--- a/phalcon/session/factory.zep
+++ b/phalcon/session/factory.zep
@@ -1,0 +1,53 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Session;
+
+use Phalcon\Factory as BaseFactory;
+
+
+/**
+ * Loads Session Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Session\Factory;
+ *
+ * $options = [
+ *     "uniqueId"   => "my-private-app",
+ *     "host"       => "127.0.0.1",
+ *     "port"       => 11211,
+ *     "persistent" => true,
+ *     "lifetime"   => 3600,
+ *     "prefix"     => "my_",
+ *     "adapter"    => "memcache",
+ * ];
+ * $session = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Session\\Adapter", config);
+	}
+}

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -341,7 +341,7 @@ class Tag
 	 * Resets the request and internal values to avoid those fields will have any default value.
 	 * @deprecated Will be removed in 4.0.0
 	 */
-	public static function resetInput() -> void
+	deprecated public static function resetInput() -> void
 	{
 		let self::_displayValues = [],
 			self::_documentTitle = null,

--- a/phalcon/translate/factory.zep
+++ b/phalcon/translate/factory.zep
@@ -1,0 +1,50 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Translate;
+
+use Phalcon\Factory as BaseFactory;
+
+/**
+ * Loads Translate Adapter class using 'adapter' option
+ *
+ *<code>
+ * use Phalcon\Translate\Factory;
+ *
+ * $options = [
+ *     "locale"        => "de_DE.UTF-8",
+ *     "defaultDomain" => "translations",
+ *     "directory"     => "/path/to/application/locales",
+ *     "category"      => LC_MESSAGES,
+ *     "adapter"       => "gettext",
+ * ];
+ * $translate = Factory::load($options);
+ *</code>
+ */
+class Factory extends BaseFactory
+{
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function load(var config) -> <AdapterInterface>
+	{
+		return self::loadClass("Phalcon\\Translate\\Adapter", config);
+	}
+}

--- a/phalcon/version.zep
+++ b/phalcon/version.zep
@@ -95,7 +95,7 @@ class Version
 	 */
 	protected static function _getVersion() -> array
 	{
-		return [3, 1, 1, 4, 0];
+		return [3, 2, 0, 1, 1];
 	}
 
 	/**

--- a/tests/_data/config/factory.ini
+++ b/tests/_data/config/factory.ini
@@ -1,0 +1,56 @@
+[annotations]
+prefix = annotations
+lieftime = 3600
+adapter = apc
+
+[cache_backend]
+prefix = app-data
+frontend.adapter = data
+frontend.lifetime = 172800
+adapter = apc
+
+[cache_frontend]
+lifetime = 172800
+adapter = data
+
+[config]
+filePath = PATH_DATA"config/config"
+adapter = ini
+
+[database]
+host = TEST_DB_MYSQL_HOST
+username = TEST_DB_MYSQL_USER
+password = TEST_DB_MYSQL_PASSWD
+dbname = TEST_DB_MYSQL_NAME
+port = TEST_DB_MYSQL_PORT
+charset = TEST_DB_MYSQL_CHARSET
+adapter = mysql
+
+[image]
+file = PATH_DATA"assets/phalconphp.jpg"
+adapter = imagick
+
+[logger]
+name = PATH_OUTPUT"tests/logs/factory.log"
+adapter = file
+
+[paginator]
+limit = 20
+page = 1
+adapter = queryBuilder
+
+[session]
+uniqueId = my-private-app
+host = 127.0.0.1
+port = 11211
+persistent = true
+lifetime = 3600
+prefix = my_
+adapter = memcache
+
+[translate]
+locale = en_US.utf8
+defaultDomain = messages
+directory = PATH_DATA"translation/gettext"
+category = LC_MESSAGES
+adapter = gettext

--- a/tests/unit/Annotations/FactoryTest.php
+++ b/tests/unit/Annotations/FactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Phalcon\Test\Unit\Annotations;
+
+use Phalcon\Annotations\Adapter\Apc;
+use Phalcon\Annotations\Factory;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Annotations\FactoryTest
+ * Tests for \Phalcon\Annotations\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                /** @var Apc $annotations */
+                $options = $this->config->annotations;
+                $annotations = Factory::load($options);
+                expect($annotations)->isInstanceOf(Apc::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                /** @var Apc $annotations */
+                $options = $this->arrayConfig["annotations"];
+                $annotations = Factory::load($options);
+                expect($annotations)->isInstanceOf(Apc::class);
+            }
+        );
+    }
+}

--- a/tests/unit/Cache/Backend/FactoryTest.php
+++ b/tests/unit/Cache/Backend/FactoryTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Phalcon\Test\Unit\Cache\Backend;
+
+use Phalcon\Cache\Backend\Apc;
+use Phalcon\Cache\Backend\Factory;
+use Phalcon\Cache\Frontend\Data;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Cache\Backend\FactoryTest
+ * Tests for \Phalcon\Cache\Backend\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->cache_backend;
+                /** @var Apc $cache */
+                $cache = Factory::load($options);
+                expect($cache)->isInstanceOf(Apc::class);
+                expect(array_intersect_assoc($cache->getOptions(), $options->toArray()))->equals($cache->getOptions());
+                expect($cache->getFrontend())->isInstanceOf(Data::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["cache_backend"];
+                /** @var Apc $cache */
+                $cache = Factory::load($options);
+                expect($cache)->isInstanceOf(Apc::class);
+                expect(array_intersect_assoc($cache->getOptions(), $options))->equals($cache->getOptions());
+                expect($cache->getFrontend())->isInstanceOf(Data::class);
+            }
+        );
+    }
+}

--- a/tests/unit/Cache/Frontend/FactoryTest.php
+++ b/tests/unit/Cache/Frontend/FactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Phalcon\Test\Unit\Cache\Frontend;
+
+use Phalcon\Cache\Frontend\Data;
+use Phalcon\Cache\Frontend\Factory;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Cache\Frontend\FactoryTest
+ * Tests for \Phalcon\Cache\Frontend\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->cache_frontend;
+                /** @var Data $cache */
+                $cache = Factory::load($options);
+                expect($cache)->isInstanceOf(Data::class);
+                expect($cache->getLifetime())->equals($options->lifetime);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["cache_frontend"];
+                /** @var Data $cache */
+                $cache = Factory::load($options);
+                expect($cache)->isInstanceOf(Data::class);
+                expect($cache->getLifetime())->equals($options["lifetime"]);
+            }
+        );
+    }
+}

--- a/tests/unit/Config/FactoryTest.php
+++ b/tests/unit/Config/FactoryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Phalcon\Test\Unit\Config;
+
+use Phalcon\Config\Factory;
+use Phalcon\Config\Adapter\Ini;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Config\FactoryTest
+ * Tests for \Phalcon\Config\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->config;
+                /** @var Ini $ini */
+                $ini = Factory::load($options);
+                expect($ini)->isInstanceOf(Ini::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["config"];
+                /** @var Ini $ini */
+                $ini = Factory::load($options);
+                expect($ini)->isInstanceOf(Ini::class);
+            }
+        );
+    }
+}

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -25,6 +25,30 @@ use Phalcon\Test\Unit\Config\Helper\ConfigBase;
 class ConfigTest extends ConfigBase
 {
     /**
+     * Tests path method
+     *
+     * @author michanismus
+     * @since  2017-03-29
+     */
+    public function testConfigPath()
+    {
+        $this->specify(
+            "Config path does not return expected value",
+            function () {
+                $config = new Config($this->config);
+                expect($config->path('test.parent.property2'))->equals('yeah');
+                expect($config->path('test.parent.property3', 'No'))->equals('No');
+                expect($config->path('test.parent'))->isInstanceOf('Phalcon\Config');
+                expect($config->path('unknown.path'))->equals(null);
+                $config->setPathDelimiter('/');
+                expect($config->path('test.parent.property2', false))->equals(false);
+                expect($config->path('test/parent/property2'))->equals('yeah');
+                expect($config->path('test/parent'))->isInstanceOf('Phalcon\Config');
+            }
+        );
+    }
+
+    /**
      * Tests toArray method
      *
      * @author Serghei Iakovlev <serghei@phalconphp.com>

--- a/tests/unit/Db/Adapter/Pdo/FactoryTest.php
+++ b/tests/unit/Db/Adapter/Pdo/FactoryTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Phalcon\Test\Unit\Db\Adapter\Pdo;
+
+use Phalcon\Db\Adapter\Pdo\Factory;
+use Phalcon\Db\Adapter\Pdo\Mysql;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Db\Adapter\Pdo\FactoryTest
+ * Tests for \Phalcon\Db\Adapter\Pdo\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->database;
+                /** @var Mysql $database */
+                $database = Factory::load($options);
+                expect($database)->isInstanceOf(Mysql::class);
+                expect(array_intersect_assoc($database->getDescriptor(), $options->toArray()))->equals(
+                    $database->getDescriptor()
+                );
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["database"];
+                /** @var Mysql $database */
+                $database = Factory::load($options);
+                expect($database)->isInstanceOf(Mysql::class);
+                expect(array_intersect_assoc($database->getDescriptor(), $options))->equals(
+                    $database->getDescriptor()
+                );
+            }
+        );
+    }
+}

--- a/tests/unit/Factory/Helper/FactoryBase.php
+++ b/tests/unit/Factory/Helper/FactoryBase.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Phalcon\Test\Unit\Factory\Helper;
+
+use Phalcon\Config\Adapter\Ini;
+use Phalcon\Test\Module\UnitTest;
+
+/**
+ * Class FactoryBase
+ * @package Phalcon\Test\unit\Factory\Helper
+ */
+abstract class FactoryBase extends UnitTest
+{
+    /**
+     * @var Ini
+     */
+    protected $config;
+    /**
+     * @var array
+     */
+    protected $arrayConfig;
+
+    public function _before()
+    {
+        parent::_before();
+
+        $this->config = new Ini(PATH_DATA."config/factory.ini", INI_SCANNER_NORMAL);
+        $this->arrayConfig = $this->config->toArray();
+    }
+}

--- a/tests/unit/Filter/FilterUrlTest.php
+++ b/tests/unit/Filter/FilterUrlTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phalcon\Test\Unit\Filter;
+
+/**
+ * \Phalcon\Test\Unit\Filter\FilterUrlTest
+ * Tests the \Phalcon\Filter component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @author    Zamrony P. Juhara <zamronypj@yahoo.com>
+ * @package   Phalcon\Test\Unit\Filter
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FilterUrlTest extends Helper\FilterBase
+{
+    /**
+     * Tests Url
+     *
+     * @author Zamrony P. Juhara <zamronypj@yahoo.com>
+     * @since  2017-03-23
+     */
+    public function testSanitizeUrl()
+    {
+        $this->specify(
+            "sanitizing url does not return the correct url",
+            function () {
+                $expected = 'http://juhara.com';
+                $value    = 'http://juhara��.co�m';
+                $this->sanitizer('url', $expected, $value);
+            }
+        );
+    }
+}

--- a/tests/unit/Image/FactoryTest.php
+++ b/tests/unit/Image/FactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Phalcon\Test\Unit\Image;
+
+use Phalcon\Image\Factory;
+use Phalcon\Image\Adapter\Imagick;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Image\FactoryTest
+ * Tests for \Phalcon\Image\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->image;
+                /** @var Imagick $image */
+                $image = Factory::load($options);
+                expect($image)->isInstanceOf(Imagick::class);
+                expect($image->getRealpath())->equals(realpath($options->file));
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["image"];
+                /** @var Imagick $image */
+                $image = Factory::load($options);
+                expect($image)->isInstanceOf(Imagick::class);
+                expect($image->getRealpath())->equals(realpath($options["file"]));
+            }
+        );
+    }
+}

--- a/tests/unit/Logger/FactoryTest.php
+++ b/tests/unit/Logger/FactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Phalcon\Test\Unit\Logger;
+
+use Phalcon\Logger\Factory;
+use Phalcon\Logger\Adapter\File;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Logger\FactoryTest
+ * Tests for \Phalcon\Logger\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->logger;
+                /** @var File $logger */
+                $logger = Factory::load($options);
+                expect($logger)->isInstanceOf(File::class);
+                expect($logger->getPath())->equals($options->name);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["logger"];
+                /** @var File $logger */
+                $logger = Factory::load($options);
+                expect($logger)->isInstanceOf(File::class);
+                expect($logger->getPath())->equals($options["name"]);
+            }
+        );
+    }
+}

--- a/tests/unit/Paginator/FactoryTest.php
+++ b/tests/unit/Paginator/FactoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Phalcon\Test\Unit\Paginator;
+
+use Helper\ModelTrait;
+use Phalcon\Paginator\Factory;
+use Phalcon\Paginator\Adapter\QueryBuilder;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Paginator\FactoryTest
+ * Tests for \Phalcon\Paginator\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    use ModelTrait;
+
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->paginator;
+                $options->builder = $this->setUpModelsManager()->createBuilder()
+                    ->columns("id,name")
+                    ->from("Robots")
+                    ->orderBy("name");
+                /** @var QueryBuilder $paginator */
+                $paginator = Factory::load($options);
+                expect($paginator)->isInstanceOf(QueryBuilder::class);
+                expect($paginator->getLimit())->equals($options->limit);
+                expect($paginator->getCurrentPage())->equals($options->page);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["paginator"];
+                $options["builder"] = $this->setUpModelsManager()->createBuilder()
+                    ->columns("id,name")
+                    ->from("Robots")
+                    ->orderBy("name");
+                /** @var QueryBuilder $paginator */
+                $paginator = Factory::load($options);
+                expect($paginator)->isInstanceOf(QueryBuilder::class);
+                expect($paginator->getLimit())->equals($options["limit"]);
+                expect($paginator->getCurrentPage())->equals($options["page"]);
+            }
+        );
+    }
+}

--- a/tests/unit/Session/FactoryTest.php
+++ b/tests/unit/Session/FactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Phalcon\Test\Unit\Session;
+
+use Phalcon\Session\Factory;
+use Phalcon\Session\Adapter\Memcache;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Session\FactoryTest
+ * Tests for \Phalcon\Session\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->session;
+                /** @var Memcache $session */
+                $session = Factory::load($options);
+                expect($session)->isInstanceOf(Memcache::class);
+                expect(array_intersect_assoc($session->getOptions(), $options->toArray()))->equals($session->getOptions());
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig['session'];
+                /** @var Memcache $session */
+                $session = Factory::load($options);
+                expect($session)->isInstanceOf(Memcache::class);
+                expect(array_intersect_assoc($session->getOptions(), $options))->equals($session->getOptions());
+            }
+        );
+    }
+}

--- a/tests/unit/Translate/FactoryTest.php
+++ b/tests/unit/Translate/FactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Phalcon\Test\Unit\Translate;
+
+use Phalcon\Translate\Factory;
+use Phalcon\Translate\Adapter\Gettext;
+use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
+
+/**
+ * \Phalcon\Test\Unit\Translate\FactoryTest
+ * Tests for \Phalcon\Translate\Factory component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      https://phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @author    Wojciech Ślawski <jurigag@gmail.com>
+ * @package   Phalcon\Test\Unit\Annotations
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class FactoryTest extends FactoryBase
+{
+    /**
+     * Test factory using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testConfigFactory()
+    {
+        $this->specify(
+            "Factory using Phalcon\\Config doesn't work properly",
+            function () {
+                $options = $this->config->translate;
+                /** @var Gettext $translate */
+                $translate = Factory::load($options);
+                expect($translate)->isInstanceOf(Gettext::class);
+                expect($translate->getCategory())->equals($options->category);
+                expect($translate->getLocale())->equals($options->locale);
+                expect($translate->getDefaultDomain())->equals($options->defaultDomain);
+                expect($translate->getDirectory())->equals($options->directory);
+            }
+        );
+    }
+
+    /**
+     * Test factory using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-02
+     */
+    public function testArrayFactory()
+    {
+        $this->specify(
+            "Factory using array doesn't work properly",
+            function () {
+                $options = $this->arrayConfig["translate"];
+                /** @var Gettext $translate */
+                $translate = Factory::load($options);
+                expect($translate)->isInstanceOf(Gettext::class);
+                expect($translate->getCategory())->equals($options["category"]);
+                expect($translate->getLocale())->equals($options["locale"]);
+                expect($translate->getDefaultDomain())->equals($options["defaultDomain"]);
+                expect($translate->getDirectory())->equals($options["directory"]);
+            }
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/12221

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

I added a `path` method to `Phalcon\Config` to fetch values by using a dot separated path.

```php

$config = new \Phalcon\Config(
   [
        'phalcon' => [
            'baseuri' => '/phalcon/'
        ],
        'models' => [
            'metadata' => 'memory'
        ],
        'database' => [
            'adapter'  => 'mysql',
            'host'     => 'localhost',
            'username' => 'user',
            'password' => 'passwd',
            'name'     => 'demo'
        ],
        'test' => [
            'parent' => [
                'property' => 1,
                'property2' => 'yeah'
            ],
        ],
   ]
);

$config->path('test.parent.property2'); // yeah
$config->path('test/parent/property3', 'no', '/'); // no
```