### PR TITLE
Factory load for di

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`
-- Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001)
+- Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001) with option to load them as object or array(for passing it to `Phalcon\Di::set`)
 - Added ability to sanitize URL to `Phalcon\Filter`
 - Added missed `$type` argument to interface `Phalcon\Mvc\Model\Query\BuilderInterface::join()` to specify type join
 - Added `Phalcon\Mvc\Model::hasUpdated` and `Phalcon\Mvc\Model:getUpdatedFields`, way to check if fields were updated after create/save/update

--- a/phalcon/annotations/factory.zep
+++ b/phalcon/annotations/factory.zep
@@ -45,4 +45,12 @@ class Factory extends BaseFactory
 	{
 		return self::loadClass("Phalcon\\Annotations\\Adapter", config);
 	}
+
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Annotations\\Adapter", config);
+	}
 }

--- a/phalcon/cache/backend/factory.zep
+++ b/phalcon/cache/backend/factory.zep
@@ -50,9 +50,57 @@ class Factory extends BaseFactory
 		return self::loadClass("Phalcon\\Cache\\Backend", config);
 	}
 
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Cache\\Backend", config);
+	}
+
 	protected static function loadClass(string $namespace, var config)
 	{
-		var adapter, className, frontend;
+		var frontend, className, params;
+
+		let params = self::checkArguments($namespace, config);
+
+		let frontend = FrontendFactory::load(params["frontend"]);
+		let className = params["className"];
+
+		return new {className}(frontend, params["config"]);
+	}
+
+	protected static function loadAsArray(string $namespace, var config)
+	{
+		var params;
+
+		let params = self::checkArguments($namespace, config);
+
+		unset params["frontend"]["adapter"];
+
+		return [
+			"className" : params["className"],
+			"arguments" : [
+				[
+					"type" : "instance",
+					"className" : "Phalcon\\Cache\\Frontend\\".params["frontendAdapter"],
+					"arguments" : [
+						params["frontend"]
+					]
+				],
+				[
+					"type" : "parameter",
+					"value" : params["config"]
+				]
+			]
+		];
+	}
+
+	protected static function checkArguments(string $namespace, var config)
+	{
+		var adapter, frontend, frontendAdapter, params;
+
+		let params = [];
 
 		if typeof config == "object" && config instanceof Config {
 			let config = config->toArray();
@@ -69,14 +117,19 @@ class Factory extends BaseFactory
 		if fetch adapter, config["adapter"] {
 			unset config["adapter"];
 			unset config["frontend"];
-			if typeof frontend == "array" || frontend instanceof Config {
-				let frontend = FrontendFactory::load(frontend);
+
+			if !fetch frontendAdapter, frontend["adapter"] {
+				throw new Exception("You must provide 'adapter' option for frontend");
 			}
-			let className = $namespace."\\".camelize(adapter);
 
-			return new {className}(frontend, config);
+			let params["frontendAdapter"] = frontendAdapter;
+			let params["frontend"] = frontend;
+			let params["className"] = $namespace."\\".camelize(adapter);
+			let params["config"] = config;
+
+			return params;
+		} else {
+			throw new Exception("You must provide 'adapter' option in factory config parameter.");
 		}
-
-		throw new Exception("You must provide 'adapter' option in factory config parameter.");
 	}
 }

--- a/phalcon/cache/frontend/factory.zep
+++ b/phalcon/cache/frontend/factory.zep
@@ -47,29 +47,76 @@ class Factory extends BaseFactory
 		return self::loadClass("Phalcon\\Cache\\Frontend", config);
 	}
 
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Cache\\Frontend", config);
+	}
+
 	protected static function loadClass(string $namespace, var config)
 	{
-		var adapter, className;
+		var className, params;
 
-		if typeof config == "object" && config instanceof Config {
-			let config = config->toArray();
+		let params = self::checkArguments($namespace, config);
+
+		let className = params["className"];
+
+		if className == "Phalcon\\Cache\\Frontend\\None" {
+			return new {className}();
+		} else {
+			return new {className}(params["config"]);
 		}
+	}
 
-		if typeof config != "array" {
-			throw new Exception("Config must be array or Phalcon\\Config object");
+	protected static function loadAsArray(string $namespace, var config)
+	{
+		var className, params;
+
+		let params = self::checkArguments($namespace, config);
+
+		let className = params["className"];
+
+		if className == "Phalcon\\Cache\\Frontend\\None" {
+			return [
+				"className" : className
+			];
+		} else {
+			return [
+				"className" : className,
+				"arguments" : [
+					[
+						"type" : "parameter",
+						"value" : params["config"]
+					]
+				]
+			];
 		}
+	}
 
-		if fetch adapter, config["adapter"] {
-			unset config["adapter"];
-			let className = $namespace."\\".camelize(adapter);
+	protected static function checkArguments(string $namespace, var config)
+	{
+		var adapter, params;
 
-			if className == "Phalcon\\Cache\\Frontend\\None" {
-				return new {className}();
-			} else {
-				return new {className}(config);
-			}
-		}
+		let params = [];
 
-		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+        if typeof config == "object" && config instanceof Config {
+        	let config = config->toArray();
+        }
+
+        if typeof config != "array" {
+        	throw new Exception("Config must be array or Phalcon\\Config object");
+        }
+
+        if fetch adapter, config["adapter"] {
+        	unset config["adapter"];
+        	let params["className"] = $namespace."\\".camelize(adapter);
+        	let params["config"] = config;
+
+        	return params;
+        } else {
+        	throw new Exception("You must provide 'adapter' option in factory config parameter.");
+        }
 	}
 }

--- a/phalcon/db/adapter/pdo/factory.zep
+++ b/phalcon/db/adapter/pdo/factory.zep
@@ -49,4 +49,9 @@ class Factory extends BaseFactory
 	{
 		return self::loadClass("Phalcon\\Db\\Adapter\\Pdo", config);
 	}
+
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Db\\Adapter\\Pdo", config);
+	}
 }

--- a/phalcon/factory.zep
+++ b/phalcon/factory.zep
@@ -27,7 +27,36 @@ abstract class Factory implements FactoryInterface
 {
 	protected static function loadClass(string $namespace, var config)
 	{
-		var adapter, className;
+		var className, params;
+
+		let params = self::checkArguments($namespace, config);
+		let className = params["className"];
+
+		return new {className}(params["config"]);
+	}
+
+	protected static function loadAsArray(string $namespace, var config)
+	{
+		var params;
+
+		let params = self::checkArguments($namespace, config);
+
+		return [
+           	"className" : params["className"],
+           	"arguments" : [
+           		[
+           			"type" : "parameter",
+           			"value" : params["config"]
+           		]
+           	]
+        ];
+	}
+
+	protected static function checkArguments(string $namespace, var config)
+	{
+		var adapter, params;
+
+		let params = [];
 
 		if typeof config == "object" && config instanceof Config {
 			let config = config->toArray();
@@ -39,11 +68,13 @@ abstract class Factory implements FactoryInterface
 
 		if fetch adapter, config["adapter"] {
 			unset config["adapter"];
-			let className = $namespace."\\".adapter;
-
-			return new {className}(config);
+		} else {
+			throw new Exception("You must provide 'adapter' option in factory config parameter.");
 		}
 
-		throw new Exception("You must provide 'adapter' option in factory config parameter.");
+		let params["config"] = config;
+		let params["className"] = $namespace."\\".adapter;
+
+		return params;
 	}
 }

--- a/phalcon/factoryinterface.zep
+++ b/phalcon/factoryinterface.zep
@@ -26,4 +26,9 @@ interface FactoryInterface
 	 * @param \Phalcon\Config|array config
 	 */
 	public static function load(var config) -> object;
+
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array;
 }

--- a/phalcon/image/factory.zep
+++ b/phalcon/image/factory.zep
@@ -49,9 +49,89 @@ class Factory extends BaseFactory
 		return self::loadClass("Phalcon\\Image\\Adapter", config);
 	}
 
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Image\\Adapter", config);
+	}
+
 	protected static function loadClass(string $namespace, var config)
 	{
-		var adapter, className, file, height, width;
+		var width, height, className, params;
+
+		let params = self::checkArguments($namespace, config);
+
+		let width = 0;
+		let className = params["className"];
+
+		if fetch height, params["height"] {
+			fetch width, params["width"];
+			return new {className}(params["file"], width, height);
+		} elseif fetch width, params["width"] {
+			return new {className}(params["file"], width);
+		}
+
+		return new {className}(params["file"]);
+	}
+
+	protected static function loadAsArray(string $namespace, var config)
+	{
+		var height, width, params;
+
+		let params = self::checkArguments($namespace, config);
+
+		let width = 0;
+
+		if fetch height, params["height"] {
+			fetch width, params["width"];
+			return [
+				"className" : params["className"],
+				"arguments" : [
+					[
+						"type" : "parameter",
+						"value" : params["file"]
+					],
+					[
+						"type" : "parameter",
+						"value" : width
+					],
+					[
+						"type" : "parameter",
+						"value" : height
+					]
+				]
+			];
+		} elseif fetch width, params["width"] {
+			return [
+				"className" : params["className"],
+				"arguments" : [
+					[
+						"type" : "parameter",
+						"value" : params["file"]
+					],
+					[
+						"type" : "parameter",
+						"value" : width
+					]
+				]
+			];
+		}
+
+		return [
+			"className" : params["className"],
+			"arguments" : [
+				[
+					"type" : "parameter",
+					"value" : params["file"]
+				]
+			]
+		];
+	}
+
+	protected static function checkArguments(string $namespace, var config)
+	{
+		var adapter, file, height, width, params;
+
+		let params = [];
 
 		if typeof config == "object" && config instanceof Config {
 			let config = config->toArray();
@@ -66,19 +146,19 @@ class Factory extends BaseFactory
 		}
 
 		if fetch adapter, config["adapter"] {
-			let className = $namespace."\\".camelize(adapter);
+			let params["file"] = file;
+			let params["className"] = $namespace."\\".camelize(adapter);
 
 			if fetch width, config["width"] {
+				let params["width"] = width;
 				if fetch height, config["height"] {
-					return new {className}(file, width, height);
+					let params["height"] = height;
 				}
-
-				return new {className}(file, width);
 			}
 
-			return new {className}(file);
+			return params;
+		} else {
+			throw new Exception("You must provide 'adapter' option in factory config parameter.");
 		}
-
-		throw new Exception("You must provide 'adapter' option in factory config parameter.");
 	}
 }

--- a/phalcon/logger/factory.zep
+++ b/phalcon/logger/factory.zep
@@ -47,34 +47,86 @@ class Factory extends BaseFactory
 		return self::loadClass("Phalcon\\Logger\\Adapter", config);
 	}
 
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Logger\\Adapter", config);
+	}
+
 	protected static function loadClass(string $namespace, var config)
 	{
-		var adapter, className, name;
+		var className, params;
+
+		let params = self::checkArguments($namespace, config);
+		let className = params["className"];
+
+		if className != "Phalcon\\Logger\\Adapter\\Firephp" {
+			return new {className}(params["name"], params["config"]);
+		}
+
+		return new {className}();
+	}
+
+	protected static function loadAsArray(string $namespace, var config)
+	{
+		var className, params;
+
+		let params = self::checkArguments($namespace, config);
+
+		let className = params["className"];
+
+		if className != "Phalcon\\Logger\\Adapter\\Firephp" {
+			return [
+				"className" : className,
+				"arguments" : [
+					[
+						"type" : "parameter",
+						"value" : params["name"]
+					],
+					[
+						"type" : "parameter",
+						"value" : params["config"]
+					]
+				]
+			];
+		}
+
+		return [
+			"className" : "Phalcon\\Logger\\Adapter\\Firephp"
+		];
+	}
+
+	protected static function checkArguments(string $namespace, var config)
+	{
+		var adapter, className, name, params;
+
+		let params = [];
 
 		if typeof config == "object" && config instanceof Config {
-			let config = config->toArray();
-		}
+        	let config = config->toArray();
+        }
 
-		if typeof config != "array" {
-			throw new Exception("Config must be array or Phalcon\\Config object");
-		}
+        if typeof config != "array" {
+        	throw new Exception("Config must be array or Phalcon\\Config object");
+        }
 
-		if fetch adapter, config["adapter"] {
-			let className = $namespace."\\".camelize(adapter);
+        if fetch adapter, config["adapter"] {
+        	let className = $namespace."\\".camelize(adapter);
+        	let params["className"] = className;
 
-			if className != "Phalcon\\Logger\\Adapter\\Firephp" {
+        	if className != "Phalcon\\Logger\\Adapter\\Firephp" {
 				unset config["adapter"];
 				if !fetch name, config["name"] {
 					throw new Exception("You must provide 'name' option in factory config parameter.");
 				}
-				unset config["name"];
 
-				return new {className}(name, config);
+				let params["name"] = name;
+				unset config["name"];
+				let params["config"] = config;
 			}
 
-			return new {className}();
+			return params;
+		} else {
+			throw new Exception("You must provide 'adapter' option in factory config parameter.");
 		}
-
-		throw new Exception("You must provide 'adapter' option in factory config parameter.");
 	}
 }

--- a/phalcon/paginator/factory.zep
+++ b/phalcon/paginator/factory.zep
@@ -50,4 +50,12 @@ class Factory extends BaseFactory
 	{
 		return self::loadClass("Phalcon\\Paginator\\Adapter", config);
 	}
+
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Paginator\\Adapter", config);
+	}
 }

--- a/phalcon/session/factory.zep
+++ b/phalcon/session/factory.zep
@@ -50,4 +50,12 @@ class Factory extends BaseFactory
 	{
 		return self::loadClass("Phalcon\\Session\\Adapter", config);
 	}
+
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Session\\Adapter", config);
+	}
 }

--- a/phalcon/translate/factory.zep
+++ b/phalcon/translate/factory.zep
@@ -47,4 +47,12 @@ class Factory extends BaseFactory
 	{
 		return self::loadClass("Phalcon\\Translate\\Adapter", config);
 	}
+
+	/**
+	 * @param \Phalcon\Config|array config
+	 */
+	public static function loadForDi(var config) -> array
+	{
+		return self::loadAsArray("Phalcon\\Translate\\Adapter", config);
+	}
 }

--- a/tests/unit/Annotations/FactoryTest.php
+++ b/tests/unit/Annotations/FactoryTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Annotations;
 
 use Phalcon\Annotations\Adapter\Apc;
 use Phalcon\Annotations\Factory;
+use Phalcon\Di;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
 
 /**
@@ -59,6 +60,46 @@ class FactoryTest extends FactoryBase
                 /** @var Apc $annotations */
                 $options = $this->arrayConfig["annotations"];
                 $annotations = Factory::load($options);
+                expect($annotations)->isInstanceOf(Apc::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-08
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->annotations;
+                $di->set('annotations', Factory::loadForDi($options));
+                $annotations = $di->get('annotations');
+                expect($annotations)->isInstanceOf(Apc::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-08
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["annotations"];
+                $di->set('annotations', Factory::loadForDi($options));
+                $annotations = $di->get('annotations');
                 expect($annotations)->isInstanceOf(Apc::class);
             }
         );

--- a/tests/unit/Cache/Backend/FactoryTest.php
+++ b/tests/unit/Cache/Backend/FactoryTest.php
@@ -5,6 +5,7 @@ namespace Phalcon\Test\Unit\Cache\Backend;
 use Phalcon\Cache\Backend\Apc;
 use Phalcon\Cache\Backend\Factory;
 use Phalcon\Cache\Frontend\Data;
+use Phalcon\Di;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
 
 /**
@@ -62,6 +63,51 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["cache_backend"];
                 /** @var Apc $cache */
                 $cache = Factory::load($options);
+                expect($cache)->isInstanceOf(Apc::class);
+                expect(array_intersect_assoc($cache->getOptions(), $options))->equals($cache->getOptions());
+                expect($cache->getFrontend())->isInstanceOf(Data::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Instance doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->cache_backend;
+                $di->set("cache", Factory::loadForDi($options));
+                $cache = $di->get("cache");
+                expect($cache)->isInstanceOf(Apc::class);
+                expect(array_intersect_assoc($cache->getOptions(), $options->toArray()))->equals($cache->getOptions());
+                expect($cache->getFrontend())->isInstanceOf(Data::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["cache_backend"];
+                /** @var Apc $cache */
+                $di->set("cache", Factory::loadForDi($options));
+                $cache = $di->get("cache");
                 expect($cache)->isInstanceOf(Apc::class);
                 expect(array_intersect_assoc($cache->getOptions(), $options))->equals($cache->getOptions());
                 expect($cache->getFrontend())->isInstanceOf(Data::class);

--- a/tests/unit/Cache/Frontend/FactoryTest.php
+++ b/tests/unit/Cache/Frontend/FactoryTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Cache\Frontend;
 
 use Phalcon\Cache\Frontend\Data;
 use Phalcon\Cache\Frontend\Factory;
+use Phalcon\Di;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
 
 /**
@@ -60,6 +61,50 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["cache_frontend"];
                 /** @var Data $cache */
                 $cache = Factory::load($options);
+                expect($cache)->isInstanceOf(Data::class);
+                expect($cache->getLifetime())->equals($options["lifetime"]);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->cache_frontend;
+                /** @var Data $cache */
+                $di->set("cache", Factory::loadForDi($options));
+                $cache = $di->get("cache");
+                expect($cache)->isInstanceOf(Data::class);
+                expect($cache->getLifetime())->equals($options->lifetime);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["cache_frontend"];
+                $di->set("cache", Factory::loadForDi($options));
+                /** @var Data $cache */
+                $cache = $di->get("cache");
                 expect($cache)->isInstanceOf(Data::class);
                 expect($cache->getLifetime())->equals($options["lifetime"]);
             }

--- a/tests/unit/Config/FactoryTest.php
+++ b/tests/unit/Config/FactoryTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Config;
 
 use Phalcon\Config\Factory;
 use Phalcon\Config\Adapter\Ini;
+use Phalcon\Di;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
 
 /**
@@ -59,6 +60,46 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["config"];
                 /** @var Ini $ini */
                 $ini = Factory::load($options);
+                expect($ini)->isInstanceOf(Ini::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->config;
+                $di->set('ini', Factory::loadForDi($options));
+                $ini = $di->get('ini');
+                expect($ini)->isInstanceOf(Ini::class);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["config"];
+                $di->set('ini', Factory::loadForDi($options));
+                $ini = $di->get('ini');
                 expect($ini)->isInstanceOf(Ini::class);
             }
         );

--- a/tests/unit/Db/Adapter/Pdo/FactoryTest.php
+++ b/tests/unit/Db/Adapter/Pdo/FactoryTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Db\Adapter\Pdo;
 
 use Phalcon\Db\Adapter\Pdo\Factory;
 use Phalcon\Db\Adapter\Pdo\Mysql;
+use Phalcon\Di;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
 
 /**
@@ -62,6 +63,54 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["database"];
                 /** @var Mysql $database */
                 $database = Factory::load($options);
+                expect($database)->isInstanceOf(Mysql::class);
+                expect(array_intersect_assoc($database->getDescriptor(), $options))->equals(
+                    $database->getDescriptor()
+                );
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->database;
+                /** @var Mysql $database */
+                $di->set('db', Factory::loadForDi($options));
+                $database = $di->get('db');
+                expect($database)->isInstanceOf(Mysql::class);
+                expect(array_intersect_assoc($database->getDescriptor(), $options->toArray()))->equals(
+                    $database->getDescriptor()
+                );
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["database"];
+                /** @var Mysql $database */
+                $di->set('db', Factory::loadForDi($options));
+                $database = $di->get('db');
                 expect($database)->isInstanceOf(Mysql::class);
                 expect(array_intersect_assoc($database->getDescriptor(), $options))->equals(
                     $database->getDescriptor()

--- a/tests/unit/Image/FactoryTest.php
+++ b/tests/unit/Image/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Unit\Image;
 
+use Phalcon\Di;
 use Phalcon\Image\Factory;
 use Phalcon\Image\Adapter\Imagick;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
@@ -60,6 +61,50 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["image"];
                 /** @var Imagick $image */
                 $image = Factory::load($options);
+                expect($image)->isInstanceOf(Imagick::class);
+                expect($image->getRealpath())->equals(realpath($options["file"]));
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Di
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->image;
+                $di->set('image', Factory::loadForDi($options));
+                /** @var Imagick $image */
+                $image = $di->get('image');
+                expect($image)->isInstanceOf(Imagick::class);
+                expect($image->getRealpath())->equals(realpath($options->file));
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["image"];
+                /** @var Imagick $image */
+                $di->set('image', Factory::loadForDi($options));
+                $image = $di->get('image');
                 expect($image)->isInstanceOf(Imagick::class);
                 expect($image->getRealpath())->equals(realpath($options["file"]));
             }

--- a/tests/unit/Logger/FactoryTest.php
+++ b/tests/unit/Logger/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Unit\Logger;
 
+use Phalcon\Di;
 use Phalcon\Logger\Factory;
 use Phalcon\Logger\Adapter\File;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
@@ -60,6 +61,50 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["logger"];
                 /** @var File $logger */
                 $logger = Factory::load($options);
+                expect($logger)->isInstanceOf(File::class);
+                expect($logger->getPath())->equals($options["name"]);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->logger;
+                /** @var File $logger */
+                $di->set('logger', Factory::loadForDi($options));
+                $logger = $di->get('logger');
+                expect($logger)->isInstanceOf(File::class);
+                expect($logger->getPath())->equals($options->name);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["logger"];
+                /** @var File $logger */
+                $di->set('logger', Factory::loadForDi($options));
+                $logger = $di->get('logger');
                 expect($logger)->isInstanceOf(File::class);
                 expect($logger->getPath())->equals($options["name"]);
             }

--- a/tests/unit/Paginator/FactoryTest.php
+++ b/tests/unit/Paginator/FactoryTest.php
@@ -3,6 +3,7 @@
 namespace Phalcon\Test\Unit\Paginator;
 
 use Helper\ModelTrait;
+use Phalcon\Di;
 use Phalcon\Paginator\Factory;
 use Phalcon\Paginator\Adapter\QueryBuilder;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
@@ -72,6 +73,61 @@ class FactoryTest extends FactoryBase
                     ->orderBy("name");
                 /** @var QueryBuilder $paginator */
                 $paginator = Factory::load($options);
+                expect($paginator)->isInstanceOf(QueryBuilder::class);
+                expect($paginator->getLimit())->equals($options["limit"]);
+                expect($paginator->getCurrentPage())->equals($options["page"]);
+            }
+        );
+    }
+
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->paginator;
+                $options->builder = $this->setUpModelsManager()->createBuilder()
+                    ->columns("id,name")
+                    ->from("Robots")
+                    ->orderBy("name");
+                /** @var QueryBuilder $paginator */
+                $di->set('paginator', Factory::loadForDi($options));
+                $paginator = $di->get('paginator');
+                expect($paginator)->isInstanceOf(QueryBuilder::class);
+                expect($paginator->getLimit())->equals($options->limit);
+                expect($paginator->getCurrentPage())->equals($options->page);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["paginator"];
+                $options["builder"] = $this->setUpModelsManager()->createBuilder()
+                    ->columns("id,name")
+                    ->from("Robots")
+                    ->orderBy("name");
+                /** @var QueryBuilder $paginator */
+                $di->set('paginator', Factory::loadForDi($options));
+                $paginator = $di->get('paginator');
                 expect($paginator)->isInstanceOf(QueryBuilder::class);
                 expect($paginator->getLimit())->equals($options["limit"]);
                 expect($paginator->getCurrentPage())->equals($options["page"]);

--- a/tests/unit/Session/FactoryTest.php
+++ b/tests/unit/Session/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Unit\Session;
 
+use Phalcon\Di;
 use Phalcon\Session\Factory;
 use Phalcon\Session\Adapter\Memcache;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
@@ -41,7 +42,9 @@ class FactoryTest extends FactoryBase
                 /** @var Memcache $session */
                 $session = Factory::load($options);
                 expect($session)->isInstanceOf(Memcache::class);
-                expect(array_intersect_assoc($session->getOptions(), $options->toArray()))->equals($session->getOptions());
+                expect(array_intersect_assoc($session->getOptions(), $options->toArray()))->equals(
+                    $session->getOptions()
+                );
             }
         );
     }
@@ -62,6 +65,51 @@ class FactoryTest extends FactoryBase
                 $session = Factory::load($options);
                 expect($session)->isInstanceOf(Memcache::class);
                 expect(array_intersect_assoc($session->getOptions(), $options))->equals($session->getOptions());
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->session;
+                /** @var Memcache $session */
+                $di->set('session', Factory::loadForDi($options));
+                $session = $di->get('session');
+                expect($session)->isInstanceOf(Memcache::class);
+                expect(array_intersect_assoc($session->getOptions(), $options->toArray()))->equals(
+                    $session->getOptions()
+                );
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig['session'];
+                /** @var Memcache $session */
+                $di->set('session', Factory::loadForDi($options));
+                $session = $di->get('session');
+                expect($session)->isInstanceOf(Memcache::class);
             }
         );
     }

--- a/tests/unit/Translate/FactoryTest.php
+++ b/tests/unit/Translate/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Unit\Translate;
 
+use Phalcon\Di;
 use Phalcon\Translate\Factory;
 use Phalcon\Translate\Adapter\Gettext;
 use Phalcon\Test\Unit\Factory\Helper\FactoryBase;
@@ -71,6 +72,56 @@ class FactoryTest extends FactoryBase
                 $options = $this->arrayConfig["translate"];
                 /** @var Gettext $translate */
                 $translate = Factory::load($options);
+                expect($translate)->isInstanceOf(Gettext::class);
+                expect($translate->getCategory())->equals($options["category"]);
+                expect($translate->getLocale())->equals($options["locale"]);
+                expect($translate->getDefaultDomain())->equals($options["defaultDomain"]);
+                expect($translate->getDirectory())->equals($options["directory"]);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using Phalcon\Config
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiConfigFactory()
+    {
+        $this->specify(
+            "Factory for di using Phalcon\\Config doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->config->translate;
+                /** @var Gettext $translate */
+                $di->set('translate', Factory::loadForDi($options));
+                $translate = $di->get('translate');
+                expect($translate)->isInstanceOf(Gettext::class);
+                expect($translate->getCategory())->equals($options->category);
+                expect($translate->getLocale())->equals($options->locale);
+                expect($translate->getDefaultDomain())->equals($options->defaultDomain);
+                expect($translate->getDirectory())->equals($options->directory);
+            }
+        );
+    }
+
+    /**
+     * Test factory for di using array
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-04-07
+     */
+    public function testDiArrayFactory()
+    {
+        $this->specify(
+            "Factory for di using array doesn't work properly",
+            function () {
+                $di = new Di();
+                $options = $this->arrayConfig["translate"];
+                /** @var Gettext $translate */
+                $di->set('translate', Factory::loadForDi($options));
+                $translate = $di->get('translate');
                 expect($translate)->isInstanceOf(Gettext::class);
                 expect($translate->getCategory())->equals($options["category"]);
                 expect($translate->getLocale())->equals($options["locale"]);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: I already introduced factory loaders, this is other way to have output as array to pass it to `Phalcon\Di::set()` as second parameter. Is returns array for complex service registration, so for example instead of:

```php
$di->set('db', Factory::load($config->database));
```

Which will create adapter object here

You can use:

```php
$di->set('db', Factory::loadForDi($config->database));
```

Which will create adapter object on `$di->get('db')`

Thanks

