### PR TITLE
Added service provider interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `Phalcon\Mvc\Model::hasUpdated` and `Phalcon\Mvc\Model:getUpdatedFields`, way to check if fields were updated after create/save/update
 - Added support for having option in `Phalcon\Paginator\Adapter\QueryBuilder` [#12111](https://github.com/phalcon/cphalcon/issues/12111)
 - Added `Phalcon\Config::path` to get a value using a dot separated path [#12221](https://github.com/phalcon/cphalcon/issues/12221)
+- Added service provider interface to configure services by context [#12783](https://github.com/phalcon/cphalcon/pull/12783)
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,152 @@
+New BSD License
+
+Copyright (c) 2011-2017, Phalcon Framework Team
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Phalcon nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL PHALCON FRAMEWORK TEAM BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+                The Zend Engine License, Version 2.00
+Copyright (c) 1999-2006 Zend Technologies Ltd. All rights reserved.
+--------------------------------------------------------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, is permitted provided that the following conditions
+are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+
+  3. The names "Zend" and "Zend Engine" must not be used to endorse
+     or promote products derived from this software without prior
+     permission from Zend Technologies Ltd. For written permission,
+     please contact license@zend.com.
+
+  4. Zend Technologies Ltd. may publish revised and/or new versions
+     of the license from time to time. Each version will be given a
+     distinguishing version number.
+     Once covered code has been published under a particular version
+     of the license, you may always continue to use it under the
+     terms of that version. You may also choose to use such covered
+     code under the terms of any subsequent version of the license
+     published by Zend Technologies Ltd. No one other than Zend
+     Technologies Ltd. has the right to modify the terms applicable
+     to covered code created under this License.
+
+  5. Redistributions of any form whatsoever must retain the following
+     acknowledgment:
+     "This product includes the Zend Engine, freely available at
+     http://www.zend.com"
+
+  6. All advertising materials mentioning features or use of this
+     software must display the following acknowledgment:
+     "The Zend Engine is freely available at http://www.zend.com"
+
+THIS SOFTWARE IS PROVIDED BY ZEND TECHNOLOGIES LTD. ``AS IS'' AND
+ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL ZEND
+TECHNOLOGIES LTD.  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+--------------------------------------------------------------------
+
+--------------------------------------------------------------------
+                  The PHP License, version 3.01
+Copyright (c) 1999 - 2015 The PHP Group. All rights reserved.
+--------------------------------------------------------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, is permitted provided that the following conditions
+are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+  3. The name "PHP" must not be used to endorse or promote products
+     derived from this software without prior written permission. For
+     written permission, please contact group@php.net.
+
+  4. Products derived from this software may not be called "PHP", nor
+     may "PHP" appear in their name, without prior written permission
+     from group@php.net.  You may indicate that your software works in
+     conjunction with PHP by saying "Foo for PHP" instead of calling
+     it "PHP Foo" or "phpfoo"
+
+  5. The PHP Group may publish revised and/or new versions of the
+     license from time to time. Each version will be given a
+     distinguishing version number.
+     Once covered code has been published under a particular version
+     of the license, you may always continue to use it under the terms
+     of that version. You may also choose to use such covered code
+     under the terms of any subsequent version of the license
+     published by the PHP Group. No one other than the PHP Group has
+     the right to modify the terms applicable to covered code created
+     under this License.
+
+  6. Redistributions of any form whatsoever must retain the following
+     acknowledgment:
+     "This product includes PHP software, freely available from
+     <http://www.php.net/software/>".
+
+THIS SOFTWARE IS PROVIDED BY THE PHP DEVELOPMENT TEAM ``AS IS'' AND
+ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE PHP
+DEVELOPMENT TEAM OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------
+
+This software consists of voluntary contributions made by many
+individuals on behalf of the PHP Group.
+
+The PHP Group can be contacted via Email at group@php.net.
+
+For more information on the PHP Group and the PHP project,
+please see <http://www.php.net>.
+
+PHP includes the Zend Engine, freely available at
+<http://www.zend.com>.

--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -6,26 +6,23 @@
  | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
- | with this package in the file docs/LICENSE.txt.                        |
+ | with this package in the file LICENSE.txt.                             |
  |                                                                        |
  | If you did not receive a copy of the license and are unable to         |
  | obtain it through the world-wide-web, please send an email             |
  | to license@phalconphp.com so we can send you a copy immediately.       |
  +------------------------------------------------------------------------+
- | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
- |          Eduar Carvajal <eduar@phalconphp.com>                         |
- |          Nikolaos Dimopoulos <nikos@niden.net>                         |
- +------------------------------------------------------------------------+
  */
 
 namespace Phalcon;
 
-use Phalcon\DiInterface;
 use Phalcon\Di\Service;
-use Phalcon\Di\ServiceInterface;
+use Phalcon\DiInterface;
 use Phalcon\Di\Exception;
+use Phalcon\Di\ServiceInterface;
 use Phalcon\Events\ManagerInterface;
 use Phalcon\Di\InjectionAwareInterface;
+use Phalcon\Di\ServiceProviderInterface;
 
 /**
  * Phalcon\Di
@@ -404,6 +401,29 @@ class Di implements DiInterface
 		 * The method doesn't start with set/get throw an exception
 		 */
 		throw new Exception("Call to undefined method or service '" . method . "'");
+	}
+
+	/**
+	 * Registers a service provider.
+	 *
+	 * <code>
+	 * use Phalcon\DiInterface;
+	 * use Phalcon\Di\ServiceProviderInterface;
+	 *
+	 * class SomeServiceProvider implements ServiceProviderInterface
+	 * {
+	 *     public function register(DiInterface $di)
+	 *     {
+	 *         $di->setShared('service', function () {
+	 *             // ...
+	 *         });
+	 *     }
+	 * }
+	 * </code>
+	 */
+	public function register(<ServiceProviderInterface> provider) -> void
+	{
+		provider->register(this);
 	}
 
 	/**

--- a/phalcon/di/serviceproviderinterface.zep
+++ b/phalcon/di/serviceproviderinterface.zep
@@ -1,0 +1,50 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file LICENSE.txt.                             |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Di;
+
+use Phalcon\DiInterface;
+
+/**
+ * Phalcon\Di\ServiceProviderInterface
+ *
+ * Should be implemented by service providers, or such components,
+ * which register a service in the service container.
+ *
+ * <code>
+ * namespace Acme;
+ *
+ * use Phalcon\DiInterface;
+ * use Phalcon\Di\ServiceProviderInterface;
+ *
+ * class SomeServiceProvider implements ServiceProviderInterface
+ * {
+ *     public function register(DiInterface $di)
+ *     {
+ *         $di->setShared('service', function () {
+ *             // ...
+ *         });
+ *     }
+ * }
+ * </code>
+ */
+interface ServiceProviderInterface
+{
+	/**
+	 * Registers a service provider.
+	 */
+	public function register(<DiInterface> di) -> void;
+}

--- a/tests/_data/di/SomeServiceProvider.php
+++ b/tests/_data/di/SomeServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file LICENSE.txt.                             |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ */
+
+use Phalcon\DiInterface;
+use Phalcon\Di\ServiceProviderInterface;
+
+/**
+ * SomeServiceProvider
+ */
+class SomeServiceProvider implements ServiceProviderInterface
+{
+    public function register(DiInterface $di)
+    {
+        require_once __DIR__ . DIRECTORY_SEPARATOR . 'SomeComponent.php';
+
+        $di['foo'] = function () {
+            return 'bar';
+        };
+
+        $di['fooAction'] = function () {
+            return new \SomeComponent('phalcon');
+        };
+    }
+}

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -1,4 +1,18 @@
 <?php
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file LICENSE.txt.                             |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ */
 
 namespace Phalcon\Test\Unit;
 
@@ -9,21 +23,11 @@ use Phalcon\Http\Response;
 use Phalcon\Test\Module\UnitTest;
 
 /**
- * \Phalcon\Test\Unit\DiTest
+ * Phalcon\Test\Unit\DiTest
+ *
  * Tests the \Phalcon\Di component
  *
- * @copyright (c) 2011-2017 Phalcon Team
- * @link      https://phalconphp.com
- * @author    Andres Gutierrez <andres@phalconphp.com>
- * @author    Serghei Iakovlev <serghei@phalconphp.com>
  * @package   Phalcon\Test\Unit
- *
- * The contents of this file are subject to the New BSD License that is
- * bundled with this package in the file docs/LICENSE.txt
- *
- * If you did not receive a copy of the license and are unable to obtain it
- * through the world-wide-web, please send an email to license@phalconphp.com
- * so that we can send you a copy immediately.
  */
 class DiTest extends UnitTest
 {
@@ -40,6 +44,7 @@ class DiTest extends UnitTest
         parent::_before();
 
         require_once PATH_DATA . 'di/InjectableComponent.php';
+        require_once PATH_DATA . 'di/SomeServiceProvider.php';
         require_once PATH_DATA . 'di/SimpleComponent.php';
         require_once PATH_DATA . 'di/SomeComponent.php';
 
@@ -500,6 +505,26 @@ class DiTest extends UnitTest
                 $component = $this->phDi->get('complexProperties');
                 expect(is_object($component->getResponse()))->true();
                 expect($component->getResponse())->equals($response);
+            }
+        );
+    }
+
+    /**
+     * Register services using provider.
+     *
+     * @author Caio Almeida <caio.f.r.amd@gmail.com>
+     * @since  2017-04-11
+     */
+    public function testRegistersServiceProvider()
+    {
+        $this->specify(
+            'Registering services by using service provider does not work as expected',
+            function () {
+                $this->phDi->register(new \SomeServiceProvider());
+                expect($this->phDi['foo'])->equals('bar');
+
+                $service = $this->phDi->get('fooAction');
+                expect($service)->isInstanceOf('\SomeComponent');
             }
         );
     }


### PR DESCRIPTION
* Type: new feature
* Link to issue: #12543

```php
namespace Acme;

use Phalcon\DiInterface;
use Phalcon\Breadcrumbs;
use Phalcon\Di\ServiceProviderInterface;

class SomeServiceProvider implements ServiceProviderInterface
{
    public function register(DiInterface $di)
    {
        $di->setShared('breadcrumbs', function () {
            $breadcrumbs = new Breadcrumbs();
            $breadcrumbs->setEventsManager($di->get('eventsManager'));
            $breadcrumbs->setSeparator('');

           return $breadcrumbs;
        });
    }
}
```
