### PR TITLE
Added Di::loadFromYaml and Di::loadFromPhp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
-- `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct` will now trigger `E_DEPREACATED` on usage
+- Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`
 - Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001)
 - Added ability to sanitize URL to `Phalcon\Filter`
 - Added missed `$type` argument to interface `Phalcon\Mvc\Model\Query\BuilderInterface::join()` to specify type join
@@ -7,6 +7,7 @@
 - Added support for having option in `Phalcon\Paginator\Adapter\QueryBuilder` [#12111](https://github.com/phalcon/cphalcon/issues/12111)
 - Added `Phalcon\Config::path` to get a value using a dot separated path [#12221](https://github.com/phalcon/cphalcon/issues/12221)
 - Added service provider interface to configure services by context [#12783](https://github.com/phalcon/cphalcon/pull/12783)
+- Added the ability to load services from yaml (`Phalcon\Di::loadFromYaml`) and php array (`Phalcon\Di::loadFromPhp`) files, so we can keep the references cleanly separated from code [#12784](https://github.com/phalcon/cphalcon/pull/12784)
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 

--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -460,7 +460,7 @@ class Di implements DiInterface
 	 * $di->loadFromYaml(
 	 *     "path/services.yaml",
 	 *     [
-	 *         "!approot" => function($value) {
+	 *         "!approot" => function ($value) {
 	 *             return dirname(__DIR__) . $value;
 	 *         }
 	 *     ]
@@ -499,7 +499,7 @@ class Di implements DiInterface
 	 * Loads services from a php config file.
 	 *
 	 * <code>
-	 * $di->loadFromYaml("path/services.php");
+	 * $di->loadFromPhp("path/services.php");
 	 * </code>
 	 *
 	 * And the services can be specified in the file as:

--- a/tests/_data/di/services.php
+++ b/tests/_data/di/services.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+    'unit-test' => [
+        'className' => '\Phalcon\Test\Module\UnitTest',
+    ],
+    'config' => [
+        'className' => '\Phalcon\Config',
+        'shared' => true,
+    ],
+    'component' => [
+        'className' => '\SomeComponent',
+        'arguments' => [
+            [
+                'type' => 'service',
+                'name' => 'config',
+            ]
+        ],
+    ],
+];

--- a/tests/_data/di/services.yml
+++ b/tests/_data/di/services.yml
@@ -1,0 +1,12 @@
+unit-test:
+    className: \Phalcon\Test\Module\UnitTest
+
+config:
+    className: \Phalcon\Config
+    shared: true
+
+component:
+    className: \SomeComponent
+    arguments:
+        - type: service
+          name: config

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -528,4 +528,52 @@ class DiTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests loading services from yaml files.
+     *
+     * @author Gorka Guridi <gorka.guridi@gmail.com>
+     * @since  2017-04-12
+     */
+    public function testYamlLoader()
+    {
+        $this->specify(
+            '"Di does not load services from yaml files properly',
+            function () {
+                $this->phDi->loadFromYaml(PATH_DATA . 'di/services.yml');
+
+                expect($this->phDi->has('unit-test'))->true();
+                expect($this->phDi->getService('unit-test')->isShared())->false();
+                expect($this->phDi->has('config'))->true();
+                expect($this->phDi->getService('config')->isShared())->true();
+                expect($this->phDi->has('component'))->true();
+                expect($this->phDi->getService('component')->isShared())->false();
+                expect($this->phDi->get('component')->someProperty)->isInstanceOf('Phalcon\Config');
+            }
+        );
+    }
+
+    /**
+     * Tests loading services from php files.
+     *
+     * @author Gorka Guridi <gorka.guridi@gmail.com>
+     * @since  2017-04-12
+     */
+    public function testPhpLoader()
+    {
+        $this->specify(
+            'Di does not load services from php files properly',
+            function () {
+                $this->phDi->loadFromPhp(PATH_DATA . 'di/services.php');
+
+                expect($this->phDi->has('unit-test'))->true();
+                expect($this->phDi->getService('unit-test')->isShared())->false();
+                expect($this->phDi->has('config'))->true();
+                expect($this->phDi->getService('config')->isShared())->true();
+                expect($this->phDi->has('component'))->true();
+                expect($this->phDi->getService('component')->isShared())->false();
+                expect($this->phDi->get('component')->someProperty)->isInstanceOf('Phalcon\Config');
+            }
+        );
+    }
 }


### PR DESCRIPTION
* Type: new feature
* Link to issue: #12517

**Phalcon\Di::loadFromYaml**

Loads services from a yaml file.

```php
$di->loadFromYaml(
    "path/services.yaml",
    [
        "!approot" => function ($value) {
            return dirname(__DIR__) . $value;
        }
    ]
);
```

And the services can be specified in the file as:

```yml
myComponent:
    className: \Acme\Components\MyComponent
    shared: true

group:
    className: \Acme\Group
    arguments:
        - type: service
          name: myComponent

user:
   className: \Acme\User
```

**Phalcon\Di::loadFromPhp**

Loads services from a php config file.

```php
$di->loadFromPhp("path/services.php");
```

And the services can be specified in the file as:

```php
return [
     'myComponent' => [
         'className' => '\Acme\Components\MyComponent',
         'shared' => true,
     ],
     'group' => [
         'className' => '\Acme\Group',
         'arguments' => [
             [
                 'type' => 'service',
                 'service' => 'myComponent',
             ],
         ],
     ],
     'user' => [
         'className' => '\Acme\User',
     ],
];
```