### PR TITLE
Added option to disable snapshot update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)
+- Added option to disable snapshot update on create/save using `Phalcon\Mvc\Model::setup(['updateSnapshotOnSave' => false])` or `phalcon.orm.update_snapshot_on_save = 0` in `php.ini`
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/config.json
+++ b/config.json
@@ -99,6 +99,10 @@
         "orm.ignore_unknown_columns": {
             "type": "bool",
             "default": false
+        },
+        "orm.update_snapshot_on_save": {
+            "type": "bool",
+            "default": true
         }
     },
     "destructors": {

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2419,7 +2419,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 			let this->{attributeField} = lastInsertedId;
 			let snapshot[attributeField] = lastInsertedId;
 
-			if manager->isKeepingSnapshots(this) {
+			if manager->isKeepingSnapshots(this) && globals_get("orm.update_snapshot_on_save") {
 			    let this->_snapshot = snapshot;
 			}
 
@@ -2654,7 +2654,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  			"bindTypes"  : uniqueTypes
  		], bindTypes);
 
- 		if success && manager->isKeepingSnapshots(this) {
+ 		if success && manager->isKeepingSnapshots(this) && globals_get("orm.update_snapshot_on_save") {
 			if typeof snapshot == "array" {
 				let this->_oldSnapshot = snapshot;
 				let this->_snapshot = array_merge(snapshot, newSnapshot);
@@ -4009,6 +4009,10 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		let snapshot = this->_snapshot;
 		let oldSnapshot = this->_oldSnapshot;
 
+		if !globals_get("orm.update_snapshot_on_save") {
+			throw new Exception("Update snapshot on save must be enabled for this method to work properly");
+		}
+
 		if typeof snapshot != "array" {
 			throw new Exception("The record doesn't have a valid data snapshot");
 		}
@@ -4651,7 +4655,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	{
 		var disableEvents, columnRenaming, notNullValidations,
 			exceptionOnFailedSave, phqlLiterals, virtualForeignKeys,
-			lateStateBinding, castOnHydrate, ignoreUnknownColumns;
+			lateStateBinding, castOnHydrate, ignoreUnknownColumns,
+			updateSnapshotOnSave;
 
 		/**
 		 * Enables/Disables globally the internal events
@@ -4714,6 +4719,10 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		 */
 		if fetch ignoreUnknownColumns, options["ignoreUnknownColumns"] {
 			globals_set("orm.ignore_unknown_columns", ignoreUnknownColumns);
+		}
+
+		if fetch updateSnapshotOnSave, options["updateSnapshotOnSave"] {
+			globals_set("orm.update_snapshot_on_save", updateSnapshotOnSave);
 		}
 	}
 

--- a/tests/_ci/install_zephir_parser.sh
+++ b/tests/_ci/install_zephir_parser.sh
@@ -35,7 +35,7 @@ TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-$(dirname $(dirname $CURRENT_DIR))}"
 PARSER_DIR=$HOME/zephir-parser-${ZEPHIR_PARSER_VERSION}
 
 # Use Travis cache
-if [ ! -f ${PARSER_DIR}/tests/ci/install-travis ]; then
+if [ ! -f ${PARSER_DIR}/unit-tests/ci/install-travis ]; then
     git clone --depth=1 -v https://github.com/phalcon/php-zephir-parser.git -b ${ZEPHIR_PARSER_VERSION} ${PARSER_DIR}
 fi
 

--- a/tests/unit/Mvc/Model/SnapshotTest.php
+++ b/tests/unit/Mvc/Model/SnapshotTest.php
@@ -3,6 +3,7 @@
 namespace Phalcon\Test\Unit\Mvc\Model;
 
 use Helper\ModelTrait;
+use Phalcon\Mvc\Model;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Test\Models\Snapshot\Robots;
 use Phalcon\Test\Models\Snapshot\Robotters;
@@ -399,6 +400,42 @@ class SnapshotTest extends UnitTest
                 expect($robots->getSnapshotData())->notEmpty();
                 expect($robots->hasChanged('name'))->false();
                 expect($robots->hasUpdated('name'))->true();
+            }
+        );
+    }
+
+    /**
+     * Tests get updated fields
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-03-28
+     */
+    public function testDisabledSnapshotUpdate()
+    {
+        $this->specify(
+            'Disabling snapshot update is not working',
+            function () {
+                $robots = Robots::findFirst();
+                Model::setup(
+                    [
+                        'updateSnapshotOnSave' => false,
+                    ]
+                );
+                $robots->name = 'changedName';
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->hasChanged('name'))->true();
+                $robots->save();
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->hasChanged('name'))->true();
+                Model::setup(
+                    [
+                        'updateSnapshotOnSave' => true,
+                    ]
+                );
+                $robots->name = 'otherName';
+                $robots->save();
+                expect($robots->getSnapshotData())->notEmpty();
+                expect($robots->hasChanged('name'))->false();
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: In phalcon 3.1.0 there were added a change considered as a bugfix that is changing snapshot to current model data after save, some might consider it as not wanted change or maybe have some code which operates on old behavior with bugged thing and want to keep old behavior. This PR is adding this.

Thanks

