### PR TITLE
Model tables can now have prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@
 - Added the ability to load services from yaml (`Phalcon\Di::loadFromYaml`) and php array (`Phalcon\Di::loadFromPhp`) files, so we can keep the references cleanly separated from code [#12784](https://github.com/phalcon/cphalcon/pull/12784)
 - Added `Phalcon\Cache\Backend\Apcu` to introduce pure support of APCu [#12098](https://github.com/phalcon/cphalcon/issues/12098), [#11934](https://github.com/phalcon/cphalcon/issues/11934)
 - Added `Phalcon\Annotations\Adapter\Apcu` to introduce pure support of APCu [#12098](https://github.com/phalcon/cphalcon/issues/12098)
+- Added option to disable snapshot update on create/save using `Phalcon\Mvc\Model::setup(['updateSnapshotOnSave' => false])` or `phalcon.orm.update_snapshot_on_save = 0` in `php.ini`
+- Added `Phalcon\Mvc\Model\Manager::setModelPrefix` and `Phalcon\Mvc\Model\Manager::getModelPrefix` to introduce tables prefixes [#10328](https://github.com/phalcon/cphalcon/issues/10328)
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)
-- Added option to disable snapshot update on create/save using `Phalcon\Mvc\Model::setup(['updateSnapshotOnSave' => false])` or `phalcon.orm.update_snapshot_on_save = 0` in `php.ini`
+- Fixed `Di::set`, `Di::setShared` to allow pass more than 10 arguments [#12299](https://github.com/phalcon/cphalcon/issues/12299)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -122,6 +122,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	protected _initialized;
 
+	protected _prefix = "";
+
 	protected _sources;
 
 	protected _schemas;
@@ -313,6 +315,50 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	}
 
 	/**
+	 * Sets the prefix for all model sources.
+	 *
+	 * <code>
+	 * use Phalcon\Mvc\Model\Manager;
+	 *
+	 * $di->set("modelsManager", function () {
+	 *     $modelsManager = new Manager();
+	 *     $modelsManager->setModelPrefix("wp_");
+	 *
+	 *     return $modelsManager;
+	 * });
+	 *
+	 * $robots = new Robots();
+	 * echo $robots->getSource(); // wp_robots
+	 * </code>
+	 */
+	public function setModelPrefix(string! prefix) -> void
+	{
+		let this->_prefix = prefix;
+	}
+
+	/**
+	 * Returns the prefix for all model sources.
+	 *
+	 * <code>
+	 * use Phalcon\Mvc\Model\Manager;
+	 *
+	 * $di->set("modelsManager", function () {
+	 *     $modelsManager = new Manager();
+	 *     $modelsManager->setModelPrefix("wp_");
+	 *
+	 *     return $modelsManager;
+	 * });
+	 *
+	 * $robots = new Robots();
+	 * echo $robots->getSource(); // wp_robots
+	 * </code>
+	 */
+	public function getModelPrefix() -> string
+	{
+		return this->_prefix;
+	}
+
+	/**
 	 * Sets the mapped source for a model
 	 */
 	public function setModelSource(<ModelInterface> model, string! source) -> void
@@ -358,7 +404,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 			let this->_sources[entityName] = uncamelize(get_class_ns(model));
 		}
 
-		return this->_sources[entityName];
+		return this->_prefix . this->_sources[entityName];
 	}
 
 	/**

--- a/tests/unit/Mvc/Model/ManagerTest.php
+++ b/tests/unit/Mvc/Model/ManagerTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Mvc\Model;
 
 use Phalcon\Di;
 use Phalcon\Mvc\Model\Manager;
+use Phalcon\Test\Models\Robots;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Test\Models\Customers;
 use Phalcon\Mvc\Model\MetaData\Memory;
@@ -46,6 +47,51 @@ class ManagerTest extends UnitTest
         Di::setDefault($di);
 
         return $manager;
+    }
+
+
+    /**
+     * Tests empty prefix for model
+     *
+     * @issue  10328
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2017-04-15
+     */
+    public function testShoudReturSourceWithoutPrefix()
+    {
+        $this->specify(
+            'Models manager does not return valid mapped source for a model',
+            function () {
+                $robots = new Robots();
+
+                expect($robots->getModelsManager()->getModelSource($robots))->equals('robots');
+                expect($robots->getSource())->equals('robots');
+            }
+        );
+    }
+
+    /**
+     * Tests non-empty prefix for model
+     *
+     * @issue  10328
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2017-04-15
+     */
+    public function testShoudReturSourceWithPrefix()
+    {
+        $this->specify(
+            'Models manager does not return valid mapped source for a model',
+            function () {
+                $manager = new Manager();
+                $manager->setModelPrefix('wp_');
+
+                $robots = new Robots(null, null, $manager);
+
+
+                expect($robots->getModelsManager()->getModelSource($robots))->equals('wp_robots');
+                expect($robots->getSource())->equals('wp_robots');
+            }
+        );
     }
 
     public function testAliasedNamespacesRelations()


### PR DESCRIPTION
* Type: new feature
* Link to issue: #10328, #10329, #2719

```php
use Phalcon\Mvc\Model\Manager;

$di->set("modelsManager", function () {
    $modelsManager = new Manager();
    $modelsManager->setModelPrefix("wp_");

    return $modelsManager;
});

$robots = new Robots();
echo $robots->getSource(); // wp_robots
```

**NOTE:** After that to override a model's source developers can only use:

```php
public function initialize()
{
    $this->setSource('new_source');
}
```