### PR TITLE
Bugfix afterBinding handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed `Di::set`, `Di::setShared` to allow pass more than 10 arguments [#12299](https://github.com/phalcon/cphalcon/issues/12299)
 - Fixed `Phalcon\Mvc\Model\MetaData\Strategy\Annotations::getColumnMaps` where only renamed columns where returned if there was one
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `before` handlers [#10931](https://github.com/phalcon/cphalcon/pull/10931)
+- Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `afterBinding` handlers
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -786,18 +786,22 @@ class Micro extends Injectable implements \ArrayAccess
 						}
 
 						/**
-						 * Call the afterBinding handler, if it returns false exit
+						 * Call the afterBinding handler
 						 */
-						if call_user_func(afterBinding) === false {
-							return false;
-						}
+						let status = call_user_func(afterBinding);
 
 						/**
-						 * Reload the 'stopped' status
+						 * break the execution if the middleware was stopped
 						 */
 						if this->_stopped {
-							return status;
+						    break;
 						}
+					}
+					/**
+					* Reload the 'stopped' status
+					 */
+					if this->_stopped {
+						return status;
 					}
 				}
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/pull/10931#issuecomment-297516226

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fix `afterBindingHandlers`. `MiddlewareInterface` and `closure` will be handled the same way.