### PR TITLE
Adding hasFunction/Auto Include PHP Functions Method To Volt Compiler

### DIFF
--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -2684,6 +2684,10 @@ class Compiler implements InjectionAwareInterface
 
 	    for functionName in configOptions {
 	        if !this->hasFunction(functionName) {
+	            if !call_user_func("function_exists", functionName) {
+	                throw new Exception(functionName . " does not exist");
+	            }
+
 	            this->addFunction(functionName, functionName);
 	        }
 	    }

--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -226,6 +226,14 @@ class Compiler implements InjectionAwareInterface
 		return this;
 	}
 
+    /**
+     * Checks to see if a function was previously defined.
+     */
+	public function hasFunction(string! name) -> boolean
+	{
+	    return isset this->_functions[name];
+	}
+
 	/**
 	 * Register the user registered functions
 	 */
@@ -2191,9 +2199,10 @@ class Compiler implements InjectionAwareInterface
 	{
 		var currentPath, intermediate, extended,
 			finalCompilation, blocks, extendedBlocks, name, block,
-			blockCompilation, localBlock, compilation, options, autoescape;
+			blockCompilation, localBlock, compilation, options, autoescape, includePhpFunctions;
 
 		let currentPath = this->_currentPath;
+        let includePhpFunctions = false;
 
 		/**
 		 * Check for compilation options
@@ -2210,7 +2219,22 @@ class Compiler implements InjectionAwareInterface
 				}
 				let this->_autoescape = autoescape;
 			}
+
+            /**
+             * Configures the compiler to register PHP Functions automatically.
+             */
+            if isset options["includePhpFunctions"] {
+                let includePhpFunctions = options["includePhpFunctions"];
+                if typeof includePhpFunctions != "boolean" {
+                    throw new Exception("'compileAlways' must be a bool value");
+                }
+            }
 		}
+
+        //Add PHP Internal Functions If Option Supplied
+        if includePhpFunctions {
+            this->addPhpFunctions();
+        }
 
 		let intermediate = phvolt_parse_view(viewCode, currentPath);
 
@@ -2644,5 +2668,22 @@ class Compiler implements InjectionAwareInterface
 		}
 
 		return path;
+	}
+
+    /**
+     * Registers all internal PHP Functions in the compiler where the function hasn't been defined.
+     */
+	final protected function addPhpFunctions() -> <Compiler>
+	{
+	    var defined, functionName;
+
+	    let defined = get_defined_functions();
+	    for functionName in defined["internal"] {
+	        if !this->hasFunction(functionName) {
+	            this->addFunction(functionName, functionName);
+	        }
+	    }
+
+	    return this;
 	}
 }

--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -2225,15 +2225,15 @@ class Compiler implements InjectionAwareInterface
              */
             if isset options["includePhpFunctions"] {
                 let includePhpFunctions = options["includePhpFunctions"];
-                if typeof includePhpFunctions != "boolean" {
-                    throw new Exception("'compileAlways' must be a bool value");
+                if typeof includePhpFunctions != "boolean" && typeof includePhpFunctions != "array" {
+                    throw new Exception("'includePhpFunctions' must be a bool or array value");
                 }
             }
 		}
 
         //Add PHP Internal Functions If Option Supplied
         if includePhpFunctions {
-            this->addPhpFunctions();
+            this->addPhpFunctions(includePhpFunctions);
         }
 
 		let intermediate = phvolt_parse_view(viewCode, currentPath);
@@ -2673,12 +2673,16 @@ class Compiler implements InjectionAwareInterface
     /**
      * Registers all internal PHP Functions in the compiler where the function hasn't been defined.
      */
-	final protected function addPhpFunctions() -> <Compiler>
+	final protected function addPhpFunctions(configOptions) -> <Compiler>
 	{
-	    var defined, functionName;
+	    var functionName;
 
-	    let defined = get_defined_functions();
-	    for functionName in defined["internal"] {
+	    if typeof configOptions == "bool" {
+            let configOptions = get_defined_functions();
+            let configOptions = configOptions["internal"];
+	    }
+
+	    for functionName in configOptions {
 	        if !this->hasFunction(functionName) {
 	            this->addFunction(functionName, functionName);
 	        }

--- a/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
+++ b/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
@@ -1299,6 +1299,26 @@ class CompilerTest extends UnitTest
         );
     }
 
+
+    public function testVoltPhpFunctionsThrowsException()
+    {
+        $this->specify(
+            'PHP Include Array Should Throw Exception',
+            function () {
+                $volt = new Compiler();
+
+                expect($volt->hasFunction('substr'))->false();
+
+                $volt->setOptions(['includePhpFunctions' => ['some_nonexistant_function']]);
+
+                $volt->compileString('{{ substr("hello world", 0, 6) }}');
+            },
+            [
+                'throws' => 'Phalcon\Mvc\View\Engine\Volt\Exception'
+            ]
+        );
+    }
+
     public function testVoltUsersFilters()
     {
         $this->specify(

--- a/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
+++ b/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
@@ -1280,6 +1280,25 @@ class CompilerTest extends UnitTest
         );
     }
 
+    public function testVoltPhpFunctionsArray()
+    {
+        $this->specify(
+            'PHP Include Array Of Functions Should Work',
+            function () {
+                $volt = new Compiler();
+
+                expect($volt->hasFunction('substr'))->false();
+
+                $volt->setOptions(['includePhpFunctions' => ['substr']]);
+
+                $compilation = $volt->compileString('{{ substr("hello world", 0, 6) }}');
+                expect($compilation)->equals("<?= substr('hello world', 0, 6) ?>");
+
+                expect($volt->hasFunction('substr'))->true();
+            }
+        );
+    }
+
     public function testVoltUsersFilters()
     {
         $this->specify(

--- a/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
+++ b/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
@@ -1264,19 +1264,19 @@ class CompilerTest extends UnitTest
     public function testVoltPhpFunctions()
     {
         $this->specify(
-        	'PHP Native Functions Should Work',
-	        function() {
-        		$volt = new Compiler();
+            'PHP Native Functions Should Work',
+            function () {
+                $volt = new Compiler();
 
-        		expect($volt->hasFunction('substr'))->false();
+                expect($volt->hasFunction('substr'))->false();
 
-        		$volt->setOptions(['includePhpFunctions' => true]);
+                $volt->setOptions(['includePhpFunctions' => true]);
 
-        		$compilation = $volt->compileString('{{ substr("hello world", 0, 6) }}');
-        		expect($compilation)->equals("<?= substr('hello world', 0, 6) ?>");
+                $compilation = $volt->compileString('{{ substr("hello world", 0, 6) }}');
+                expect($compilation)->equals("<?= substr('hello world', 0, 6) ?>");
 
-        		expect($volt->hasFunction('substr'))->true();
-	        }
+                expect($volt->hasFunction('substr'))->true();
+            }
         );
     }
 

--- a/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
+++ b/tests/unit/Mvc/View/Engine/Volt/CompilerTest.php
@@ -1261,6 +1261,25 @@ class CompilerTest extends UnitTest
         );
     }
 
+    public function testVoltPhpFunctions()
+    {
+        $this->specify(
+        	'PHP Native Functions Should Work',
+	        function() {
+        		$volt = new Compiler();
+
+        		expect($volt->hasFunction('substr'))->false();
+
+        		$volt->setOptions(['includePhpFunctions' => true]);
+
+        		$compilation = $volt->compileString('{{ substr("hello world", 0, 6) }}');
+        		expect($compilation)->equals("<?= substr('hello world', 0, 6) ?>");
+
+        		expect($volt->hasFunction('substr'))->true();
+	        }
+        );
+    }
+
     public function testVoltUsersFilters()
     {
         $this->specify(


### PR DESCRIPTION
Hello!

* Type:  new feature
* Link to issue: NA

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

In many of my projects, I find myself constantly adding PHP Internal Functions to the Volt Compiler Engine (IE: `substr`).

I found this very repetitive and frustrating to have to add to all of them. With this in mind, I've updated the compiler to have a new option of `includePhpFunctions`. When `_compileSource` is ran, it looks for this option and automatically registers all php internal functions within the compiler.

To maintain existing code bases, I've added a `hasFunction` method which I use in the function loop such that it only adds it if it wasn't previously added.

Thanks

