### PR TITLE
Volt Compiler: Remove exception when stat option is true, and when fi…

### DIFF
--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -2569,7 +2569,10 @@ class Compiler implements InjectionAwareInterface
 				 * Stat is off but the compiled file doesn't exist
 				 */
 				if !file_exists(realCompiledPath) {
-					throw new Exception("Compiled template file " . realCompiledPath . " does not exist");
+				    /**
+                     * The file doesn't exist so we compile the php version for the first time
+                     */
+				    let compilation = this->compileFile(templatePath, realCompiledPath, extendsMode);
 				}
 
 			}


### PR DESCRIPTION
Hello!

- [x] Type: code quality

For production environnements, to improve a lot the volt performance, it's really interresting to work with `stat` option = true on Volt compiler. But the problem is that there is not an easy way to warmup Volt cache. Also, if you clear the cache folder, then you'll have many exceptions. I propose to remove this exception and  compile the file.

Thanks

