### PR TITLE
[WIP] Model bindings: Abstracted out findFirst method. Set params from cache to internalCache class property.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
+# [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX) 
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`
 - Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001)
 - Added ability to sanitize URL to `Phalcon\Filter`
@@ -25,6 +25,7 @@
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `afterBinding` handlers
 - Fixed `Phalcon\Mvc\Model::hasChanged` to correctly use it with arrays [#12669](https://github.com/phalcon/cphalcon/issues/12669)
 - Fixed `Phalcon\Mvc\Model\Resultset::delete` to return result depending on success [#11133](https://github.com/phalcon/cphalcon/issues/11133)
+- Added a new `Phalcon\Mvc\Model\Binder::findBoundModel` method. Params fetched from cache are being added to `internalCache`  class property in `Phalcon\Mvc\Model\Binder::getParamsFromCache`.
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/model/binder.zep
+++ b/phalcon/mvc/model/binder.zep
@@ -15,6 +15,7 @@
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
  |          Eduar Carvajal <eduar@phalconphp.com>                         |
  |          Wojciech Ślawski <jurigag@gmail.com>                          |
+ |          Nathan Daly <justlikephp@gmail.com>                           |
  +------------------------------------------------------------------------+
  */
 
@@ -93,7 +94,7 @@ class Binder implements BinderInterface
 			if typeof paramsCache == "array" {
 				for paramKey, className in paramsCache {
 					let paramValue = params[paramKey];
-					let boundModel = {className}::findFirst(paramValue);
+					let boundModel = this->findBoundModel(paramValue, className);
 					let this->originalValues[paramKey] = paramValue;
 					let params[paramKey] = boundModel;
 					let this->boundModels[paramKey] = boundModel;
@@ -106,6 +107,14 @@ class Binder implements BinderInterface
 		}
 		throw new Exception("You must specify methodName for handler or pass Closure as handler");
 	}
+
+    /**
+    * Find the model by param value.
+    */
+    protected function findBoundModel(var paramValue, string className) -> object | boolean
+    {
+        return {className}::findFirst(paramValue);
+    }
 
 	/**
 	 * Get params classes from cache by key
@@ -121,7 +130,10 @@ class Binder implements BinderInterface
 		let cache = this->cache;
 
 		if cache != null && cache->exists(cacheKey) {
-			return cache->get(cacheKey);
+			let internalParams = cache->get(cacheKey);
+			let this->internalCache[cacheKey] = internalParams;
+
+			return internalParams;
 		}
 
 		return null;
@@ -172,18 +184,18 @@ class Binder implements BinderInterface
 				}
 				if typeof realClasses == "array" {
 					if fetch className, realClasses[paramKey] {
-						let boundModel = {className}::findFirst(paramValue);
+						let boundModel = this->findBoundModel(paramValue, className);
 					} else {
 						throw new Exception("You should provide model class name for ".paramKey." parameter");
 					}
 				} elseif typeof realClasses == "string" {
-					let boundModel = {realClasses}::findFirst(paramValue);
+					let boundModel = this->findBoundModel(paramValue, className);
 					let className = realClasses;
 				} else {
 					throw new Exception("getModelName should return array or string");
 				}
 			} elseif is_subclass_of(className, "Phalcon\\Mvc\\Model") {
-				let boundModel = {className}::findFirst(paramValue);
+				let boundModel = this->findBoundModel(paramValue, className);
 			}
 
 			if boundModel != null {

--- a/phalcon/mvc/model/binder.zep
+++ b/phalcon/mvc/model/binder.zep
@@ -188,9 +188,9 @@ class Binder implements BinderInterface
 					} else {
 						throw new Exception("You should provide model class name for ".paramKey." parameter");
 					}
-				} elseif typeof realClasses == "string" {
-					let boundModel = this->findBoundModel(paramValue, className);
+				} elseif typeof realClasses == "string" {					
 					let className = realClasses;
+					let boundModel = this->findBoundModel(paramValue, className);
 				} else {
 					throw new Exception("getModelName should return array or string");
 				}


### PR DESCRIPTION
Hello!

- [x] Type: bug fix | new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.

Small description of change:

Added a new `findBoundModel` method for extendability. Params fetched from cache are being added to internalCache class property in Phalcon\Mvc\Model\Binder:getParamsFromCache.

Thanks
Nathan Daly <justlikephp@gmail.com>