### PR TITLE
Added Phalcon\Mvc\Model\Criteria::createBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX) 
+# [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-XX-XX)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`
 - Added Factory Adapter loaders [#11001](https://github.com/phalcon/cphalcon/issues/11001)
 - Added ability to sanitize URL to `Phalcon\Filter`
@@ -16,6 +16,8 @@
 - Added parameters `skip_on_insert`, `skip_on_update` and `allow_empty_string` and fixed a bug for renamed integer columns in `Phalcon\Mvc\Model\MetaData\Strategy\Annotations::getMetaData`
 - Added way to disable setters in `Phalcon\Mvc\Model::assign` by using `Phalcon\Mvc\Model::setup` or ini option
 - Added ability to sanitize special characters to `Phalcon\Filter`
+- Added a new `Phalcon\Mvc\Model\Binder::findBoundModel` method. Params fetched from cache are being added to `internalCache`  class property in `Phalcon\Mvc\Model\Binder::getParamsFromCache`.
+- Added `Phalcon\Mvc\Model\Criteria::createBuilder` to create a query builder from criteria
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)
@@ -25,7 +27,6 @@
 - Fixed `Phalcon\Mvc\Micro:handle` to correctly handle `afterBinding` handlers
 - Fixed `Phalcon\Mvc\Model::hasChanged` to correctly use it with arrays [#12669](https://github.com/phalcon/cphalcon/issues/12669)
 - Fixed `Phalcon\Mvc\Model\Resultset::delete` to return result depending on success [#11133](https://github.com/phalcon/cphalcon/issues/11133)
-- Added a new `Phalcon\Mvc\Model\Binder::findBoundModel` method. Params fetched from cache are being added to `internalCache`  class property in `Phalcon\Mvc\Model\Binder::getParamsFromCache`.
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/model/criteria.zep
+++ b/phalcon/mvc/model/criteria.zep
@@ -19,6 +19,7 @@
 
 namespace Phalcon\Mvc\Model;
 
+use Phalcon\Di;
 use Phalcon\Db\Column;
 use Phalcon\DiInterface;
 use Phalcon\Mvc\Model\Exception;
@@ -662,7 +663,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 	}
 
 	/**
-	 * Builds a Phalcon\Mvc\Model\Criteria based on an input array like _POST
+	 * Builds a Phalcon\Mvc\Model\Criteria based on an input array like $_POST
 	 */
 	public static function fromInput(<DiInterface> dependencyInjector, string! modelName, array! data, string! operator = "AND") -> <Criteria>
 	{
@@ -721,6 +722,37 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
 
 		criteria->setModelName(modelName);
 		return criteria;
+	}
+
+	/**
+	 * Creates a query builder from criteria.
+	 *
+	 * <code>
+	 * $builder = Robots::query()
+	 *     ->where("type = :type:")
+	 *     ->bind(["type" => "mechanical"])
+	 *     ->createBuilder();
+	 * </code>
+	 */
+	public function createBuilder() -> <BuilderInterface>
+	{
+		var dependencyInjector, manager, builder;
+
+		let dependencyInjector = this->getDI();
+		if typeof dependencyInjector != "object" {
+			let dependencyInjector = Di::getDefault();
+			this->setDI(dependencyInjector);
+		}
+
+		let manager = <ManagerInterface> dependencyInjector->getShared("modelsManager");
+
+		/**
+		 * Builds a query with the passed parameters
+		 */
+		let builder = manager->createBuilder(this->_params);
+		builder->from(this->_model);
+
+		return builder;
 	}
 
 	/**

--- a/tests/integration/Mvc/Model/CriteriaCest.php
+++ b/tests/integration/Mvc/Model/CriteriaCest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phalcon\Test\Integration\Mvc\Model;
+
+use Phalcon\Di;
+use IntegrationTester;
+use Phalcon\Mvc\Model\Manager;
+use Phalcon\Test\Models\Robots;
+use Phalcon\Mvc\Model\Query\Builder;
+use Phalcon\Mvc\Model\MetaData\Memory;
+
+class CriteriaCest
+{
+    /**
+     * Executed before each test
+     *
+     * @param IntegrationTester $I
+     */
+    public function _before(IntegrationTester $I)
+    {
+        $I->haveServiceInDi('modelsManager', Manager::class, true);
+        $I->haveServiceInDi('modelsMetadata', Memory::class, true);
+
+        Di::setDefault($I->getApplication()->getDI());
+    }
+
+    /**
+     * Tests creating builder from criteria
+     *
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-05-21
+     *
+     * @param IntegrationTester $I
+     */
+    public function createBuilderFromCriteria(IntegrationTester $I)
+    {
+        $criteria = Robots::query()->where("type='mechanical'");
+        $I->assertInstanceOf(Builder::class, $criteria->createBuilder());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Added `Phalcon\Mvc\Model\Criteria::createBuilder` to create a query builder from criteria.

```php
/** @var \Phalcon\Mvc\Model\Criteria $criteria */
$criteria = Robots::query()
    ->where("type = :type:")
    ->bind(["type" => "mechanical"]);

/** @var \Phalcon\Mvc\Model\Query\Builder $builder */
$builder = $criteria->createBuilder();
```

Refs: #10504

Thanks
