### PR TITLE
Added dispatcher::beforeForward event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
 - Added parameters `skip_on_insert`, `skip_on_update` and `allow_empty_string` and fixed a bug for renamed integer columns in `Phalcon\Mvc\Model\MetaData\Strategy\Annotations::getMetaData`
 - Added way to disable setters in `Phalcon\Mvc\Model::assign` by using `Phalcon\Mvc\Model::setup` or ini option
 - Added ability to sanitize special characters to `Phalcon\Filter`
-- Added a new `Phalcon\Mvc\Model\Binder::findBoundModel` method. Params fetched from cache are being added to `internalCache`  class property in `Phalcon\Mvc\Model\Binder::getParamsFromCache`.
+- Added a new `Phalcon\Mvc\Model\Binder::findBoundModel` method. Params fetched from cache are being added to `internalCache`  class property in `Phalcon\Mvc\Model\Binder::getParamsFromCache`
 - Added `Phalcon\Mvc\Model\Criteria::createBuilder` to create a query builder from criteria
+- Added `dispatcher::beforeForward` event to allow forwarding request to the separated module [#121](https://github.com/phalcon/cphalcon/issues/121), [#12417](https://github.com/phalcon/cphalcon/issues/12417)
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -699,17 +699,16 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	}
 
 	/**
-	 * Forwards the execution flow to another controller/action
-	 * Dispatchers are unique per module. Forwarding between modules is not allowed
+	 * Forwards the execution flow to another controller/action.
 	 *
-	 *<code>
+	 * <code>
 	 * $this->dispatcher->forward(
 	 *     [
 	 *         "controller" => "posts",
 	 *         "action"     => "index",
 	 *     ]
 	 * );
-	 *</code>
+	 * </code>
 	 *
 	 * @param array forward
 	 */

--- a/phalcon/mvc/dispatcher.zep
+++ b/phalcon/mvc/dispatcher.zep
@@ -164,6 +164,75 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
 	}
 
 	/**
+	 * Forwards the execution flow to another controller/action.
+	 *
+	 * <code>
+	 * // Registering modules
+	 * $application->registerModules(
+	 *     [
+	 *         "frontend" => [
+	 *             "className" => "App\Frontend\Bootstrap",
+	 *             "path"      => __DIR__ . "/app/Modules/Frontend/Bootstrap.php",
+	 *             "metadata"  => [
+	 *                 // Enable forwarding to other modules
+	 *                 "controllersNamespace" => "App\Frontend\Controllers",
+	 *                 // ...
+	 *             ],
+	 *         ],
+	 *         "backend" => [
+	 *             "className" => "App\Backend\Bootstrap",
+	 *             "path"      => __DIR__ . "/app/Modules/Backend/Bootstrap.php",
+	 *             "metadata"  => [
+	 *                 // Enable forwarding to other modules
+	 *                 "controllersNamespace" => "App\Backend\Controllers",
+	 *                 // ...
+	 *             ],
+	 *         ],
+	 *     ]
+	 * );
+	 *
+	 * // Setting beforeForward listener
+	 * $di->getShared("eventsManager")->attach("dispatch:beforeForward", function($event, $dispatcher, array $forward) {
+	 *     if (!empty($forward["module"])) {
+	 *         $modulesRegistry = $this->get("modules");
+	 *
+	 *         // Check module in \Phalcon\Registry
+	 *         if (!$modulesRegistry->offsetExists($forward["module"])) {
+	 *             throw new \Phalcon\Mvc\Dispatcher\Exception("Module {$forward['module']} does not exist.");
+	 *         }
+	 *
+	 *         // ...
+	 *
+	 *         $dispatcher->setModuleName($forward["module"]);
+	 *         $dispatcher->setNamespaceName($forward["metadata"]["controllersNamespace"]);
+	 *     }
+	 * });
+	 *
+	 * // Forward
+	 * $this->dispatcher->forward(
+	 *     [
+	 *         "module"     => "backend",
+	 *         "controller" => "posts",
+	 *         "action"     => "index",
+	 *     ]
+	 * );
+	 * </code>
+	 *
+	 * @param array forward
+	 */
+	public function forward(var forward)
+	{
+		var eventsManager;
+
+		let eventsManager = <ManagerInterface> this->_eventsManager;
+		if typeof eventsManager == "object" {
+			eventsManager->fire("dispatch:beforeForward", this, forward);
+		}
+
+		parent::forward(forward);
+	}
+
+	/**
 	 * Possible controller class name that will be located to dispatch the request
 	 */
 	public function getControllerClass() -> string

--- a/phalcon/mvc/dispatcher.zep
+++ b/phalcon/mvc/dispatcher.zep
@@ -167,46 +167,43 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
 	 * Forwards the execution flow to another controller/action.
 	 *
 	 * <code>
+	 * use Phalcon\Events\Event;
+	 * use Phalcon\Mvc\Dispatcher;
+	 * use App\Backend\Bootstrap as Backend;
+	 * use App\Frontend\Bootstrap as Frontend;
+	 *
 	 * // Registering modules
-	 * $application->registerModules(
-	 *     [
-	 *         "frontend" => [
-	 *             "className" => "App\Frontend\Bootstrap",
-	 *             "path"      => __DIR__ . "/app/Modules/Frontend/Bootstrap.php",
-	 *             "metadata"  => [
-	 *                 // Enable forwarding to other modules
-	 *                 "controllersNamespace" => "App\Frontend\Controllers",
-	 *                 // ...
-	 *             ],
+	 * $modules = [
+	 *     "frontend" => [
+	 *         "className" => Frontend::class,
+	 *         "path"      => __DIR__ . "/app/Modules/Frontend/Bootstrap.php",
+	 *         "metadata"  => [
+	 *             "controllersNamespace" => "App\Frontend\Controllers",
 	 *         ],
-	 *         "backend" => [
-	 *             "className" => "App\Backend\Bootstrap",
-	 *             "path"      => __DIR__ . "/app/Modules/Backend/Bootstrap.php",
-	 *             "metadata"  => [
-	 *                 // Enable forwarding to other modules
-	 *                 "controllersNamespace" => "App\Backend\Controllers",
-	 *                 // ...
-	 *             ],
+	 *     ],
+	 *     "backend" => [
+	 *         "className" => Backend::class,
+	 *         "path"      => __DIR__ . "/app/Modules/Backend/Bootstrap.php",
+	 *         "metadata"  => [
+	 *             "controllersNamespace" => "App\Backend\Controllers",
 	 *         ],
-	 *     ]
-	 * );
+	 *     ],
+	 * ];
+	 *
+	 * $application->registerModules($modules);
 	 *
 	 * // Setting beforeForward listener
-	 * $di->getShared("eventsManager")->attach("dispatch:beforeForward", function($event, $dispatcher, array $forward) {
-	 *     if (!empty($forward["module"])) {
-	 *         $modulesRegistry = $this->get("modules");
+	 * $eventsManager  = $di->getShared("eventsManager");
 	 *
-	 *         // Check module in \Phalcon\Registry
-	 *         if (!$modulesRegistry->offsetExists($forward["module"])) {
-	 *             throw new \Phalcon\Mvc\Dispatcher\Exception("Module {$forward['module']} does not exist.");
-	 *         }
-	 *
-	 *         // ...
+	 * $eventsManager->attach(
+	 *     "dispatch:beforeForward",
+	 *     function(Event $event, Dispatcher $dispatcher, array $forward) use ($modules) {
+	 *         $metadata = $modules[$forward["module"]]["metadata"];
 	 *
 	 *         $dispatcher->setModuleName($forward["module"]);
-	 *         $dispatcher->setNamespaceName($forward["metadata"]["controllersNamespace"]);
+	 *         $dispatcher->setNamespaceName($metadata["controllersNamespace"]);
 	 *     }
-	 * });
+	 * );
 	 *
 	 * // Forward
 	 * $this->dispatcher->forward(


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #121, #12417, #1658, #2496

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Added `dispatcher::beforeForward` event to allow forwarding request to the separated module.

```php
use Phalcon\Events\Event;
use Phalcon\Mvc\Dispatcher;
use App\Backend\Bootstrap as Backend;
use App\Frontend\Bootstrap as Frontend;

// Registering modules
$modules = [
    'frontend' => [
        'className' => Frontend::class,
        'path'      => __DIR__ . '/app/Modules/Frontend/Bootstrap.php',
        'metadata'  => [
            'controllersNamespace' => 'App\Frontend\Controllers',
        ],
    ],
    'backend' => [
        'className' => Backend::class,
        'path'      => __DIR__ . '/app/Modules/Backend/Bootstrap.php',
        'metadata'  => [
            'controllersNamespace' => 'App\Backend\Controllers',
        ],
    ],
];

$application->registerModules($modules);

// Setting beforeForward listener
$eventsManager = $di->getShared('eventsManager');

$eventsManager->attach(
    'dispatch:beforeForward',
    function(Event $event, Dispatcher $dispatcher, array $forward) use ($modules) {
        $metadata = $modules[$forward['module']]['metadata'];

        $dispatcher->setModuleName($forward['module']);
        $dispatcher->setNamespaceName($metadata['controllersNamespace']);
    }
);

// Forward
$this->dispatcher->forward(
    [
        'module'     => 'backend',
        'controller' => 'posts',
        'action'     => 'index',
    ]
);
```

Thanks

