### PR TITLE
Fixed Phalcon\Assets\Collection:add to avoid duplication of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added `dispatcher::beforeForward` event to allow forwarding request to the separated module [#121](https://github.com/phalcon/cphalcon/issues/121), [#12417](https://github.com/phalcon/cphalcon/issues/12417)
 - Added `Phalcon\Security\Random:base62` to provide the largest value that can safely be used in URLs without needing to take extra characters into consideration [#12105](https://github.com/phalcon/cphalcon/issues/12105)
 - Added `Phalcon\Assets\ResourceInterface`. So now `Phalcon\Assets\Inline` and `Phalcon\Assets\Resource` implements `ResourceInterface`
+- Added `Phalcon\Assets\Collection::has` to checks whether the resource is added to the collection or not
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)
@@ -31,6 +32,7 @@
 - Fixed `Phalcon\Mvc\Model::hasChanged` to correctly use it with arrays [#12669](https://github.com/phalcon/cphalcon/issues/12669)
 - Fixed `Phalcon\Mvc\Model\Resultset::delete` to return result depending on success [#11133](https://github.com/phalcon/cphalcon/issues/11133)
 - Fixed `Phalcon\Session\Adapter::destroy` to  correctly clear the `$_SESSION` superglobal [#12326](https://github.com/phalcon/cphalcon/pull/12326), [#12835](https://github.com/phalcon/cphalcon/pull/12835)
+- Fixed `Phalcon\Assets\Collection:add` to avoid duplication of resources [#10938](https://github.com/phalcon/cphalcon/issues/10938)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/assets/collection.zep
+++ b/phalcon/assets/collection.zep
@@ -59,12 +59,23 @@ class Collection implements \Countable, \Iterator
 
 	protected _sourcePath { get };
 
+	protected _includedResources;
+
+	/**
+	 * Phalcon\Assets\Collection constructor
+	 */
+	public function __construct()
+	{
+		let this->_includedResources = [];
+	}
+
 	/**
 	 * Adds a resource to the collection
 	 */
 	public function add(<$Resource> $resource) -> <Collection>
 	{
-		let this->_resources[] = $resource;
+		this->addResource($resource);
+
 		return this;
 	}
 
@@ -73,8 +84,32 @@ class Collection implements \Countable, \Iterator
 	 */
 	public function addInline(<$Inline> code) -> <Collection>
 	{
-		let this->_codes[] = code;
+		this->addResource(code);
+
 		return this;
+	}
+
+	/**
+	 * Checks this the resource is added to the collection.
+	 *
+	 * <code>
+	 * use Phalcon\Assets\Resource;
+	 * use Phalcon\Assets\Collection;
+	 *
+	 * $collection = new Collection();
+	 *
+	 * $resource = new Resource("js", "js/jquery.js");
+	 * $resource->has($resource); // true
+	 * </code>
+	 */
+	public function has(<ResourceInterface> $resource) -> boolean
+	{
+		var key, resources;
+
+		let key = $resource->getResourceKey(),
+			resources = this->_includedResources;
+
+		return in_array(key, resources);
 	}
 
 	/**
@@ -96,7 +131,7 @@ class Collection implements \Countable, \Iterator
 			let collectionAttributes = this->_attributes;
 		}
 
-		let this->_resources[] = new ResourceCss(path, collectionLocal, filter, collectionAttributes);
+		this->add(new ResourceCss(path, collectionLocal, filter, collectionAttributes));
 
 		return this;
 	}
@@ -143,7 +178,7 @@ class Collection implements \Countable, \Iterator
 			let collectionAttributes = this->_attributes;
 		}
 
-		let this->_resources[] = new ResourceJs(path, collectionLocal, filter, collectionAttributes);
+		this->add(new ResourceJs(path, collectionLocal, filter, collectionAttributes));
 
 		return this;
 	}
@@ -328,5 +363,25 @@ class Collection implements \Countable, \Iterator
 	{
 		let this->_filters[] = filter;
 		return this;
+	}
+
+	/**
+	 * Adds a resource or inline-code to the collection
+	 */
+	protected final function addResource(<ResourceInterface> $resource) -> boolean
+	{
+		if !this->has($resource) {
+			if $resource instanceof $Resource {
+				let this->_resources[] = $resource;
+			} else {
+				let this->_codes[] = $resource;
+			}
+
+			let this->_includedResources[] = $resource->getResourceKey();
+
+			return true;
+		}
+
+		return false;
 	}
 }

--- a/tests/unit/Assets/CollectionTest.php
+++ b/tests/unit/Assets/CollectionTest.php
@@ -51,4 +51,54 @@ class CollectionTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests Collection::has
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-06-02
+     */
+    public function hasReource()
+    {
+        $this->specify(
+            "Unable to find resource in collection",
+            function () {
+                $collection = new Collection();
+
+                $resource1 = new Resource('js', 'js/jquery.js');
+                $resource2 = new Resource('js', 'js/jquery-ui.js');
+
+                $collection->add($resource1);
+
+                expect($collection->has($resource1))->true();
+                expect($collection->has($resource2))->false();
+            }
+        );
+    }
+
+    /**
+     * Tests Collection::has
+     *
+     * @test
+     * @issue  10938
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-06-02
+     */
+    public function doNotAddTheSameRecources()
+    {
+        $this->specify(
+            "The assets collection incorrectly stores resources",
+            function () {
+                $collection = new Collection();
+
+                for ($i = 0; $i < 10; $i++) {
+                    $collection->add(new Resource('css', 'css/style.css'));
+                    $collection->add(new Resource('js', 'js/script.js'));
+                }
+
+                expect($collection->getResources())->count(2);
+            }
+        );
+    }
 }

--- a/tests/unit/Assets/ManagerTest.php
+++ b/tests/unit/Assets/ManagerTest.php
@@ -492,4 +492,41 @@ class ManagerTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests avoid duplication of resources when adding a
+     * new one with existing name
+     *
+     * @test
+     * @issue  10938
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-06-02
+     */
+    public function doNotAddTheSameRecources()
+    {
+        $this->specify(
+            "The assets collection incorrectly stores resources",
+            function () {
+                $assets = new Manager();
+
+                for ($i = 0; $i < 10; $i++) {
+                    $assets
+                        ->addCss('css/style.css')
+                        ->addJs('script.js');
+                }
+
+                expect($assets->getCss())->count(1);
+                expect($assets->getJs())->count(1);
+
+                for ($i = 0; $i < 2; $i++) {
+                    $assets
+                        ->addCss('style_' . $i . '.css')
+                        ->addJs('script_' . $i . '.js');
+                }
+
+                expect($assets->getCss())->count(3);
+                expect($assets->getJs())->count(3);
+            }
+        );
+    }
 }

--- a/tests/unit/Assets/ResourceTest.php
+++ b/tests/unit/Assets/ResourceTest.php
@@ -45,7 +45,7 @@ class ResourceTest extends UnitTest
     }
 
     /**
-     * Tests getType
+     * Tests getResourceKey
      *
      * @test
      * @author Serghei Iakovlev <serghei@phalconphp.com>


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature
* Link to issue: #10938

Small description of change:

- Added `Phalcon\Assets\Collection::has` to checks whether the resource is added to the collection or not
- Fixed `Phalcon\Assets\Collection:add` to avoid duplication of resources [#10938](https://github.com/phalcon/cphalcon/issues/10938)
