### PR TITLE
Added Phalcon\Assets\Manager::has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Added `Phalcon\Security\Random:base62` to provide the largest value that can safely be used in URLs without needing to take extra characters into consideration [#12105](https://github.com/phalcon/cphalcon/issues/12105)
 - Added `Phalcon\Assets\ResourceInterface`. So now `Phalcon\Assets\Inline` and `Phalcon\Assets\Resource` implements `ResourceInterface`
 - Added `Phalcon\Assets\Collection::has` to checks whether the resource is added to the collection or not
+- Added `Phalcon\Assets\Manager::has` to checks whether the Assets Manager has Collection
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)

--- a/phalcon/assets/manager.zep
+++ b/phalcon/assets/manager.zep
@@ -221,12 +221,12 @@ class Manager
 	}
 
 	/**
-	* Returns a collection by its id
-	*
-	*<code>
-	* $scripts = $assets->get("js");
-	*</code>
-	*/
+	 * Returns a collection by its id.
+	 *
+	 * <code>
+	 * $scripts = $assets->get("js");
+	 * </code>
+	 */
 	public function get(string! id) -> <Collection>
 	{
 		var collection;
@@ -236,6 +236,21 @@ class Manager
 		}
 
 		return collection;
+	}
+
+	/**
+	 * Checks whether the Assets Manager has Collection.
+	 *
+	 * <code>
+	 * if ($assets->has("jsHeader")) {
+	 *     // \Phalcon\Assets\Collection
+	 *     $collection = $assets->get("jsHeader");
+	 * }
+	 * </code>
+	 */
+	public function has(string! id) -> boolean
+	{
+		return isset this->_collections[id];
 	}
 
 	/**

--- a/tests/unit/Assets/ManagerTest.php
+++ b/tests/unit/Assets/ManagerTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Assets;
 
 use Phalcon\Tag;
 use Phalcon\Assets\Manager;
+use Phalcon\Assets\Exception;
 use Phalcon\Assets\Resource\Js;
 use Phalcon\Assets\Resource\Css;
 use Phalcon\Assets\Filters\None;
@@ -36,6 +37,70 @@ class ManagerTest extends UnitTest
     {
         // Setting the doctype to XHTML5 for other tests to run smoothly
         Tag::setDocType(Tag::XHTML5);
+    }
+
+    /**
+     * Test Manager::get
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-06-04
+     */
+    public function assetsManagerShouldThrowExceptionIfThereIsNoCollection()
+    {
+        $this->specify(
+            'The Assets Manager does not throw exception in case of absence of a collection',
+            function () {
+                $assets = new Manager();
+                $assets->get('some-non-existent-collection');
+            },
+            [
+                'throws' => [
+                    Exception::class,
+                    'The collection does not exist in the manager'
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Test Manager::has
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-06-04
+     */
+    public function assetsManagerShouldDetectAbsenceOfACollection()
+    {
+        $this->specify(
+            'The Assets Manager does not return valid status case of absence of a collection',
+            function () {
+                $assets = new Manager();
+                expect($assets->has('some-non-existent-collection'))->false();
+            }
+        );
+    }
+
+    /**
+     * Test Manager::has
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2017-06-04
+     */
+    public function assetsManagerShouldDetectCollection()
+    {
+        $this->specify(
+            'The Assets Manager does not return valid status case of presence of a collection',
+            function () {
+                $assets = new Manager();
+
+                $assets->addCss('/css/style1.css');
+                $assets->addCss('/css/style2.css');
+
+                expect($assets->has('css'))->true();
+            }
+        );
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR.

Small description of change:

Added `Phalcon\Assets\Manager::has` to checks whether the Assets Manager has Collection.

```php
use Phalcon\Assets\Manager;

$manager = new Manager();

// Throws Phalcon\Assets\Exception
$manager->get('jsHeader');

$manager->has('jsHeader'); // false

$manager->collection('jsHeader')->addJs('script1.js');

if ($manager->has('jsHeader')) {
    // Phalcon\Assets\Collection
    $collection = $manager->get('jsHeader');
}
```

Thanks
