### PR TITLE
Fixed Redis auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fixed `Phalcon\Assets\Collection:add` to avoid duplication of resources [#10938](https://github.com/phalcon/cphalcon/issues/10938), [#2008](https://github.com/phalcon/cphalcon/issues/2008)
 - Fixed `Phalcon\Mvc\View\Engine\Volt::compile` to not throw exception in case of absence the file and `stat` option is true [#12849](https://github.com/phalcon/cphalcon/pull/12849)
 - Fixed `Phalcon\Mvc\Collection::getReservedAttributes` to workaround for PHP 7/7.1 bug with static null when extending class
+- Fixed `Phalcon\Cache\Backend\Redis::__construct` and `Phalcon\Cache\Backend\Redis::_connect` to correctly handle the Redis auth option [#12736](https://github.com/phalcon/cphalcon/issues/12736)
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -97,6 +97,10 @@ class Redis extends Backend
 			let options["statsKey"] = "";
 		}
 
+		if !isset options["auth"] {
+			let options["auth"] = "";
+		}
+
 		parent::__construct(frontend, options);
 	}
 
@@ -124,7 +128,7 @@ class Redis extends Backend
 			throw new Exception("Could not connect to the Redisd server ".host.":".port);
 		}
 
-		if fetch auth, options["auth"] {
+		if fetch auth, options["auth"] && !empty options["auth"] {
 			let success = redis->auth(auth);
 
 			if !success {


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12736

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed `Phalcon\Cache\Backend\Redis::__construct` and `Phalcon\Cache\Backend\Redis::_connect` to correctly handle the Redis auth option.

Thanks
