### PR TITLE
3.2.x Grouped Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added `Phalcon\Assets\ResourceInterface`. So now `Phalcon\Assets\Inline` and `Phalcon\Assets\Resource` implements `ResourceInterface`
 - Added `Phalcon\Assets\Collection::has` to checks whether the resource is added to the collection or not
 - Added `Phalcon\Cli\Dispatcher::getOption`, `Phalcon\Cli\Dispatcher::hasOption` and the options as parameter to cli handlers
+- Added `Phalcon\Config\Adapter\Grouped` to allow usage of multiple configuration files/adapters in a simple format [#12884](https://github.com/phalcon/cphalcon/pull/12884)
 - Fixed Dispatcher forwarding when handling exception [#11819](https://github.com/phalcon/cphalcon/issues/11819), [#12154](https://github.com/phalcon/cphalcon/issues/12154)
 - Fixed params view scope for PHP 7 [#12648](https://github.com/phalcon/cphalcon/issues/12648)
 - Fixed `Phalcon\Mvc\Micro::handle` to prevent attemps to send response twice [#12668](https://github.com/phalcon/cphalcon/pull/12668)

--- a/phalcon/config/adapter/grouped.zep
+++ b/phalcon/config/adapter/grouped.zep
@@ -1,0 +1,100 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Config\Adapter;
+
+use Phalcon\Config;
+use Phalcon\Factory\Exception;
+use Phalcon\Config\Factory;
+
+/**
+ * Phalcon\Config\Adapter\Grouped
+ *
+ * Reads multiple files (or arrays) and merges them all together.
+ *
+ *<code>
+ * $config = new \Phalcon\Config\Adapter\Grouped(
+ *    ["path/to/config.php", "path/to/config.dist.php"]
+ * );
+ *</code>
+ *
+ *<code>
+ * $config = new \Phalcon\Config\Adapter\Grouped(
+ *    ["path/to/config.json", "path/to/config.dist.json"],
+ *    "json"
+ * );
+ *</code>
+ *
+ *<code>
+ * $config = new \Phalcon\Config\Adapter\Grouped(
+ *    [
+ *        [
+ *            "filePath" => "path/to/config.php",
+ *            "adapter"  => "php""path/to/config.dist.php"
+ *        ],
+ *        [
+ *            "filePath" => "path/to/config.json",
+ *            "adapter"  => "json"
+ *        ],
+ *        [
+ *            "adapter"  => "array",
+ *            "config"   => [
+ *                "property" => "value"
+ *            ]
+ *        ],
+ * );
+ *</code>
+ */
+class Grouped extends Config
+{
+
+	/**
+	 * Phalcon\Config\Adapter\Grouped constructor
+	 */
+	public function __construct(array! arrayConfig, string! defaultAdapter = "php")
+	{
+		var configName, configInstance, adapterName, configArray;
+
+		parent::__construct([]);
+
+		for configName in arrayConfig {
+		    let configInstance = configName;
+
+		    //Set To Default Adapter If Passed As String
+		    if typeof configName === "string" {
+		        let configInstance = ["filePath" : configName, "adapter" : defaultAdapter];
+		    } elseif !isset(configInstance["adapter"]) {
+		        let configInstance["adapter"] = defaultAdapter;
+		    }
+
+            if configInstance["adapter"] === "array" {
+                if !isset(configInstance["config"]) {
+                    throw new Exception("Config Array Not Specified");
+                }
+
+                let configArray    = configInstance["config"];
+                let configInstance = new Config(configArray);
+            } else {
+                let configInstance = Factory::load(configInstance);
+            }
+
+            this->_merge(configInstance);
+		}
+	}
+}

--- a/phalcon/config/adapter/grouped.zep
+++ b/phalcon/config/adapter/grouped.zep
@@ -46,7 +46,7 @@ use Phalcon\Config\Factory;
  *    [
  *        [
  *            "filePath" => "path/to/config.php",
- *            "adapter"  => "php""path/to/config.dist.php"
+ *            "adapter"  => "php"
  *        ],
  *        [
  *            "filePath" => "path/to/config.json",
@@ -79,12 +79,12 @@ class Grouped extends Config
 		    //Set To Default Adapter If Passed As String
 		    if typeof configName === "string" {
 		        let configInstance = ["filePath" : configName, "adapter" : defaultAdapter];
-		    } elseif !isset(configInstance["adapter"]) {
+		    } elseif !isset configInstance["adapter"] {
 		        let configInstance["adapter"] = defaultAdapter;
 		    }
 
             if configInstance["adapter"] === "array" {
-                if !isset(configInstance["config"]) {
+                if !isset configInstance["config"] {
                     throw new Exception("Config Array Not Specified");
                 }
 

--- a/tests/unit/Config/Adapter/GroupTest.php
+++ b/tests/unit/Config/Adapter/GroupTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: fenikkusu
+ * Date: 6/6/17
+ * Time: 8:05 PM
+ */
+
+namespace Phalcon\Test\Unit\Config\Adapter;
+
+use Phalcon\Test\Unit\Config\Helper\ConfigBase;
+use Phalcon\Config\Adapter\Grouped;
+
+class GroupTest extends ConfigBase
+{
+    /**
+     * Tests Grouped config
+     *
+     * @author fenikkusu
+     * @since  2017-06-06
+     */
+    public function testGroupedConfig()
+    {
+        $this->specify(
+            "Comparison of configurations returned a not identical result",
+            function () {
+                $this->config["test"]["property2"] = "something-else";
+
+                $config = new Grouped(
+                    [
+                        PATH_DATA . 'config/config.php',
+                        [
+                            'filePath' => PATH_DATA . 'config/config.json',
+                            'adapter'  => 'json'
+                        ],
+                        [
+                            'adapter' => 'array',
+                            'config'  => [
+                                "test" => [
+                                    "property2" => "something-else"
+                                ]
+                            ]
+                        ]
+                    ]
+                );
+                $this->compareConfig($this->config, $config);
+            }
+        );
+    }
+
+    /**
+     * Testing For Exception
+     *
+     * @author fenikkusu
+     * @since  2017-06-06
+     */
+    public function testGroupedConfigThrowsException()
+    {
+        $this->specify(
+            "Exception not thrown when config array not set.",
+            function () {
+                $config = new Grouped(
+                    [
+                        [
+                            'adapter' => 'array'
+                        ]
+                    ]
+                );
+                $this->compareConfig($this->config, $config);
+            },
+            [
+                'throws' => 'Phalcon\Factory\Exception'
+            ]
+        );
+    }
+}

--- a/tests/unit/Config/Adapter/GroupedTest.php
+++ b/tests/unit/Config/Adapter/GroupedTest.php
@@ -1,17 +1,27 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: fenikkusu
- * Date: 6/6/17
- * Time: 8:05 PM
- */
-
 namespace Phalcon\Test\Unit\Config\Adapter;
 
 use Phalcon\Test\Unit\Config\Helper\ConfigBase;
 use Phalcon\Config\Adapter\Grouped;
 
-class GroupTest extends ConfigBase
+/**
+ * \Phalcon\Test\Unit\Config\Adapter\GroupedTest
+ * Tests the \Phalcon\Config\Adapter\Grouped component
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
+ * @package   Phalcon\Test\Unit\Config\Adapter
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file docs/LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class GroupedTest extends ConfigBase
 {
     /**
      * Tests Grouped config


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: NA

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Many systems use the concept of distribution config files where config.conf is added to the repo but config.dist.conf is ignored. These changes allow us to easily accomplish the same concept in Phalcon. Additionally, this leverages the existing Config Factory to allow us to combine either a specifc adapter or multiple different adapters.

```php
$configFiles = [
  [
    'adapter' => 'ini', //This specifically uses the ini adapter.
    'filePath' => '/usr/www/conf.ini'
  ],
  __DIR__ . '/etc/config.json' //This will use the default adapter.
];

if (file_exists([__DIR__ . '/etc/config.dist.json']) {
    $configFiles[] = __DIR__ . '/etc/config.dist.json'; //This will use the default adapter.
}

$configFiles[] = [
  'adapter' => 'array', //This will use the traditional \Phalcon\Config object.
  'config'   => [
    'debug' => true
  ]
];

//Initialize Config using the Json adapter as the default.
$config = new \Phalcon\Config\Adapter\Grouped($configFiles, 'json');
```

Thanks

