### PR TITLE
Support PATCH request in annotation router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fixed `Phalcon\Mvc\Collection::getReservedAttributes` to workaround for PHP 7/7.1 bug with static null when extending class [phalcon/incubator#762](https://github.com/phalcon/incubator/issues/762), [phalcon/incubator#760](https://github.com/phalcon/incubator/issues/760)
 - Fixed `Phalcon\Cache\Backend\Redis::__construct` and `Phalcon\Cache\Backend\Redis::_connect` to correctly handle the Redis auth option [#12736](https://github.com/phalcon/cphalcon/issues/12736)
 - Fixed `Phalcon\Mvc\Collection::getReservedAttributes`, added missing properties to reserved attributes [phalcon/incubator#762](https://github.com/phalcon/incubator/issues/762), [phalcon/incubator#760](https://github.com/phalcon/incubator/issues/760)
+- Fixed `Phalcon\Mvc\Router\Annotation::processActionAnnotation` to support PATCH request
 
 # [3.1.2](https://github.com/phalcon/cphalcon/releases/tag/v3.1.2) (2017-04-05)
 - Fixed PHP 7.1 issues [#12055](https://github.com/phalcon/cphalcon/issues/12055)

--- a/phalcon/mvc/router/annotations.zep
+++ b/phalcon/mvc/router/annotations.zep
@@ -253,6 +253,10 @@ class Annotations extends Router
 				let isRoute = true, methods = "PUT";
 				break;
 
+			case "Patch":
+				let isRoute = true, methods = "PATCH";
+				break;
+
 			case "Delete":
 				let isRoute = true, methods = "DELETE";
 				break;


### PR DESCRIPTION
Hello!

* Type: bug fix

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Sorry to my previous PR.
Phalcon's AnnotationRouter cannot parse PATCH request. This patch resolves this issue.

Thanks