### PR TITLE
Fixes #12779

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-XX-XX)
+- Fixed inconsistent behaviour of `Phalcon\Config::merge` across minor version of PHP7 [#12779](https://github.com/phalcon/cphalcon/issues/12779)
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -302,7 +302,7 @@ class Config implements \ArrayAccess, \Countable
 	 */
 	protected final function _merge(<Config> config, var instance = null) -> <Config>
 	{
-		var key, value, number, localObject;
+		var key, value, number, localObject, property;
 
 		if typeof instance !== "object" {
 			let instance = this;
@@ -312,7 +312,8 @@ class Config implements \ArrayAccess, \Countable
 
 		for key, value in get_object_vars(config) {
 
-			if fetch localObject, instance->{key} {
+			let property = strval(key);
+			if fetch localObject, instance->{property} {
 				if typeof localObject === "object" && typeof value === "object" {
 					if localObject instanceof Config && value instanceof Config {
 						this->_merge(value, localObject);

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -309,4 +309,45 @@ class ConfigTest extends ConfigBase
             }
         );
     }
+
+    /**
+     * Tests issue 12779
+     *
+     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @since  2017-06-19
+     */
+    public function testIssue12779()
+    {
+        $config = new Config(
+            [
+                'a' => [
+                    [
+                        1,
+                    ],
+                ],
+            ]
+        );
+
+        $config->merge(
+            new Config(
+                [
+                    'a' => [
+                        [
+                            2,
+                        ],
+                    ],
+                ]
+            )
+        );
+        expect($config->toArray())->equals(
+            [
+                'a' => [
+                    [
+                        1,
+                        2,
+                    ],
+                ],
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12779

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: get_object_vars was returning key as string or int depending on minor php version. In zephir there is difference if we use `object->{1}` or `object->{"1"}`(in php not). So we need to cast key to string.

Thanks

