### PR TITLE
Add filter to manager so CSS and JS resources are not mixed when outputing by type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-XX-XX)
 - Fixed inconsistent behaviour of `Phalcon\Config::merge` across minor version of PHP7 [#12779](https://github.com/phalcon/cphalcon/issues/12779)
 - Fixed visibility of `Phalcon\Mvc\Model\Query\Builder::{_conditionNotIn,_conditionIn,_conditionNotBetween,_conditionBetween}` to allow 3rd party libraries extend it
+- Fixed `Phalcon\Assets\Manager::output`, implemented missing resource type filtering for mixed resource collections [#2408](https://github.com/phalcon/cphalcon/issues/2408)
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/phalcon/assets/manager.zep
+++ b/phalcon/assets/manager.zep
@@ -287,6 +287,18 @@ class Manager
 		return collection;
 	}
 
+	public function collectionResourcesByType(array resources, string type) -> array
+	{
+		var $filtered = [], $resource;
+		for $resource in resources {
+			if $resource->getType() == type {
+				let $filtered[] = $resource;
+			}
+		}
+
+		return $filtered;
+	}
+
 	/**
 	 * Traverses a collection calling the callback to generate its HTML
 	 *
@@ -310,7 +322,7 @@ class Manager
 		/**
 		 * Get the resources as an array
 		 */
-		let resources = collection->getResources();
+		let resources = this->collectionResourcesByType(collection->getResources(), type);
 
 		/**
 		 * Get filters in the collection

--- a/tests/unit/Assets/ManagerTest.php
+++ b/tests/unit/Assets/ManagerTest.php
@@ -133,6 +133,44 @@ class ManagerTest extends UnitTest
     }
 
     /**
+     * Tests addCss and addJs
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     * @since  2017-06-20
+     */
+    public function testAssetsManagerAddingCssAndJs()
+    {
+        $this->specify(
+            "The combination of addCss and addJs on assets manager does add resources correctly",
+            function () {
+                $assets = new Manager();
+
+                $assets->addCss('/css/style1.css');
+                $assets->addCss('/css/style2.css');
+                $assets->addJs('/js/script1.js');
+                $assets->addJs('/js/script2.js');
+
+                $collectionCss = $assets->get('css');
+                $collectionJs = $assets->get('js');
+
+                $CSSnumber = 0;
+                foreach ($collectionCss as $resource) {
+                    expect('css')->equals($resource->getType());
+                    $CSSnumber++;
+                }
+                expect($CSSnumber)->equals(2);
+
+                $JSnumber = 0;
+                foreach ($collectionJs as $resource) {
+                    expect('js')->equals($resource->getType());
+                    $JSnumber++;
+                }
+                expect($JSnumber)->equals(2);
+            }
+        );
+    }
+
+    /**
      * Tests addJs
      *
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
@@ -373,6 +411,48 @@ class ManagerTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests collection with mixed resources
+     *
+     * @author Paul Scarrone <paul@savvysoftworks.com>
+     * @since  2017-06-20
+     */
+    public function testAssetsManagerOutputJsWithMixedResourceCollection()
+    {
+        $this->specify(
+            "The outputJs using a mixed resource collection returns only JS resources",
+            function () {
+                $assets = new Manager();
+
+                $assets->collection('header')
+                    ->setPrefix('http:://cdn.example.com/')
+                    ->setLocal(false)
+                    ->addJs('js/script1.js')
+                    ->addJs('js/script2.js')
+                    ->addCss('css/styles1.css')
+                    ->addCss('css/styles2.css');
+                $assets->useImplicitOutput(false);
+
+                $actualJS = $assets->outputJs('header');
+                $expectedJS = sprintf(
+                    "%s\n%s\n",
+                    '<script type="text/javascript" src="http:://cdn.example.com/js/script1.js"></script>',
+                    '<script type="text/javascript" src="http:://cdn.example.com/js/script2.js"></script>'
+                );
+                expect($actualJS)->equals($expectedJS);
+
+                $actualCSS = $assets->outputCss('header');
+                $expectedCSS = sprintf(
+                    "%s\n%s\n",
+                    '<link rel="stylesheet" type="text/css" href="http:://cdn.example.com/css/styles1.css" />',
+                    '<link rel="stylesheet" type="text/css" href="http:://cdn.example.com/css/styles2.css" />'
+                );
+                expect($actualCSS)->equals($expectedCSS);
+            }
+        );
+    }
+
 
     /**
      * Tests setting local target


### PR DESCRIPTION

Hello!

* Type: bug fix
* Link to issue: phalcon/cphalcon#2408

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

This PR adds a filter method which returns a new copy of the collection resources array that only includes the supplied type. So that a collection an contain a mix of JS and CSS resources so that:
- [x] `outputJs` will only return js resources from that collection
- [x] `outputCss` will only return css resources from that collection

Thanks
Paul Scarrone(ninjapanzer)<paul@savvysoftworks.com>
