### PR TITLE
Fixes Phalcon\Http\Response getStatusCode() to return code only (int)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-XX-XX)
 - Fixed inconsistent behaviour of `Phalcon\Config::merge` across minor version of PHP7 [#12779](https://github.com/phalcon/cphalcon/issues/12779)
 - Fixed visibility of `Phalcon\Mvc\Model\Query\Builder::{_conditionNotIn,_conditionIn,_conditionNotBetween,_conditionBetween}` to allow 3rd party libraries extend it
+- Fixed `Phalcon\Http\Response` method `getStatusCode()` to return (int) HTTP code only, instead of full string [#12895]
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-XX-XX)
 - Fixed inconsistent behaviour of `Phalcon\Config::merge` across minor version of PHP7 [#12779](https://github.com/phalcon/cphalcon/issues/12779)
 - Fixed visibility of `Phalcon\Mvc\Model\Query\Builder::{_conditionNotIn,_conditionIn,_conditionNotBetween,_conditionBetween}` to allow 3rd party libraries extend it
-- Fixed `Phalcon\Http\Response` method `getStatusCode()` to return (int) HTTP code only, instead of full string [#12895]
+- Fixed `Phalcon\Http\Response::getStatusCode` to return (int) HTTP code only, instead of full string [#12895](https://github.com/phalcon/cphalcon/issues/12895)
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -228,14 +228,14 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 * Returns the status code
 	 *
 	 *<code>
-	 * print_r(
-	 *     $response->getStatusCode()
-	 * );
+	 * echo $response->getStatusCode();
 	 *</code>
 	 */
-	public function getStatusCode() -> array
+	public function getStatusCode() -> int | null
 	{
-		return this->getHeaders()->get("Status");
+		var statusCode;
+		let statusCode = substr(this->getHeaders()->get("Status"), 0, 3);
+		return statusCode ? (int) statusCode : null;
 	}
 
 	/**


### PR DESCRIPTION

* Type: bug fix | new feature ?
* Link to issue: #12895 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR. (not unit tests but my own code tests)

Small description of change:

Changes wrong behavior of Phalcon\Http\Response getStatusCode() method to return status code only as int instead of full string (see #12895)

Thanks
