### PR TITLE
Changed method addForeignKey for Postgresql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed visibility of `Phalcon\Mvc\Model\Query\Builder` methods: `_conditionNotIn`, `_conditionIn`, `_conditionNotBetween` and `_conditionBetween` to allow 3rd party libraries extend it
 - Fixed `Phalcon\Assets\Manager::output`, implemented missing resource type filtering for mixed resource collections [#2408](https://github.com/phalcon/cphalcon/issues/2408)
 - Fixed `Phalcon\Http\Response::getStatusCode` to return (int) HTTP code only, instead of full string [#12895](https://github.com/phalcon/cphalcon/issues/12895)
+- Fixed `Phalcon\Db\Dialect\Postgresql::addForeignKey` for proper creating the foreign key without a name
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -303,24 +303,27 @@ class Postgresql extends Dialect
 	 */
 	public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> string
 	{
-		var sql, onDelete, onUpdate;
+    		var sql, onDelete, onUpdate;
 
-		let sql = "ALTER TABLE " . this->prepareTable(tableName, schemaName)
-				. " ADD CONSTRAINT \"" . reference->getName() . "\" FOREIGN KEY (" . this->getColumnList(reference->getColumns()) . ")"
-				. " REFERENCES \"" . reference->getReferencedTable() . "\" (" . this->getColumnList(reference->getReferencedColumns()) . ")";
+    		let sql = "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD";
+    		if reference->getName() {
+    			let sql .= " CONSTRAINT \"" . reference->getName() . "\"";
+    		}
+    		let sql .= " FOREIGN KEY (" . this->getColumnList(reference->getColumns()) . ")"
+    				 . " REFERENCES \"" . reference->getReferencedTable() . "\" (" . this->getColumnList(reference->getReferencedColumns()) . ")";
 
-		let onDelete = reference->getOnDelete();
-		if !empty onDelete {
-			let sql .= " ON DELETE " . onDelete;
-		}
+    		let onDelete = reference->getOnDelete();
+    		if !empty onDelete {
+    			let sql .= " ON DELETE " . onDelete;
+    		}
 
-		let onUpdate = reference->getOnUpdate();
-		if !empty onUpdate {
-			let sql .= " ON UPDATE " . onUpdate;
-		}
+    		let onUpdate = reference->getOnUpdate();
+    		if !empty onUpdate {
+    			let sql .= " ON UPDATE " . onUpdate;
+    		}
 
-		return sql;
-	}
+    		return sql;
+    	}
 
 	/**
 	 * Generates SQL to delete a foreign key from a table

--- a/tests/_data/schemas/postgresql/phalcon_test.sql
+++ b/tests/_data/schemas/postgresql/phalcon_test.sql
@@ -316,6 +316,27 @@ CREATE SEQUENCE tipo_documento_id_seq
     NO MAXVALUE
     CACHE 1;
 
+-- Table: foreign_key_parent
+CREATE TABLE foreign_key_parent (
+    id SERIAL,
+    name character varying(70) NOT NULL,
+    refer_int integer NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (refer_int)
+);
+
+ALTER TABLE public.foreign_key_parent OWNER TO postgres;
+
+-- Table: foreign_key_child
+CREATE TABLE foreign_key_child (
+    id SERIAL,
+    name character varying(70) NOT NULL,
+    child_int integer NOT NULL,
+    PRIMARY KEY (id),
+    UNIQUE (child_int)
+);
+
+ALTER TABLE public.foreign_key_child OWNER TO postgres;
 
 ALTER TABLE public.tipo_documento_id_seq OWNER TO postgres;
 

--- a/tests/_support/Helper/Dialect/PostgresqlTrait.php
+++ b/tests/_support/Helper/Dialect/PostgresqlTrait.php
@@ -480,6 +480,68 @@ trait PostgresqlTrait
         ];
     }
 
+    protected function getReferenceAddForeignKey()
+    {
+        return [
+            'fk1' => new Reference('fk1', [
+                'referencedTable'   => 'foreign_key_parent',
+                'columns'           => ['child_int'],
+                'referencedColumns' => ['refer_int'],
+                'onDelete'          => 'CASCADE',
+                'onUpdate'          => 'RESTRICT',
+            ]),
+            'fk2' => new Reference('', [
+                'referencedTable'   => 'foreign_key_parent',
+                'columns'           => ['child_int'],
+                'referencedColumns' => ['refer_int']
+            ])
+        ];
+    }
+
+    protected function getForeignKey($foreignKeyName)
+    {
+        $sql = "SELECT COUNT(tc.constraint_name)
+                FROM information_schema.table_constraints tc
+                  INNER JOIN information_schema.key_column_usage kcu
+                    ON tc.constraint_catalog = kcu.constraint_catalog
+                       AND tc.constraint_schema = kcu.constraint_schema
+                       AND tc.constraint_name = kcu.constraint_name
+                  INNER JOIN information_schema.referential_constraints rc
+                    ON tc.constraint_catalog = rc.constraint_catalog
+                       AND tc.constraint_schema = rc.constraint_schema
+                       AND tc.constraint_name = rc.constraint_name
+                       AND  tc.constraint_type = 'FOREIGN KEY'
+                  INNER JOIN information_schema.constraint_column_usage ccu
+                    ON rc.unique_constraint_catalog = ccu.constraint_catalog
+                       AND rc.unique_constraint_schema = ccu.constraint_schema
+                       AND rc.unique_constraint_name = ccu.constraint_name
+                WHERE tc.constraint_name = '$foreignKeyName'
+                      AND rc.update_rule = 'RESTRICT'
+                      AND rc.delete_rule = 'CASCADE'";
+
+        return $sql;
+    }
+
+    protected function getReferenceDropForeignKey()
+    {
+        return [
+            'fk1' => new Reference('fk1', [
+                'referencedTable'   => 'foreign_key_parent',
+                'columns'           => ['child_int'],
+                'referencedColumns' => ['refer_int'],
+                'onDelete'          => 'CASCADE',
+                'onUpdate'          => 'RESTRICT',
+            ]),
+            'fk2' => new Reference('', [
+                'referencedTable'   => 'foreign_key_parent',
+                'columns'           => ['child_int'],
+                'referencedColumns' => ['refer_int'],
+                'onDelete'          => 'CASCADE',
+                'onUpdate'          => 'RESTRICT',
+            ])
+        ];
+    }
+
     protected function getCreateView()
     {
         return [

--- a/tests/unit/Db/Adapter/Pdo/PostgresqlTest.php
+++ b/tests/unit/Db/Adapter/Pdo/PostgresqlTest.php
@@ -6,6 +6,8 @@ use Phalcon\Db\Column;
 use Phalcon\Db\Reference;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Db\Adapter\Pdo\Postgresql;
+use Phalcon\Db\Dialect\Postgresql as DialectPostgresql;
+use Helper\Dialect\PostgresqlTrait;
 
 /**
  * \Phalcon\Test\Unit\Db\Adapter\Pdo\PostgresqlTest
@@ -27,6 +29,8 @@ use Phalcon\Db\Adapter\Pdo\Postgresql;
  */
 class PostgresqlTest extends UnitTest
 {
+    use PostgresqlTrait;
+
     /**
      * @var Postgresql
      */
@@ -63,6 +67,8 @@ class PostgresqlTest extends UnitTest
             function () {
                 $expected = [
                     'customers',
+                    'foreign_key_child',
+                    'foreign_key_parent',
                     'images',
                     'parts',
                     'personas',
@@ -190,6 +196,82 @@ class PostgresqlTest extends UnitTest
                 expect($this->connection->describeColumns('images', null))->equals($columns);
                 expect($this->connection->describeColumns('images', TEST_DB_POSTGRESQL_SCHEMA))->equals($columns);
             }
+        );
+    }
+
+    /**
+     * Tests Postgresql::addForeignKey
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-07-05
+     */
+    public function shouldAddForeignKey()
+    {
+        $this->specify(
+            "Foreign key hasn't created",
+            function ($reference, $expected) {
+                $dialect = new DialectPostgresql();
+                $references = $this->getReferenceAddForeignKey();
+                $sql = $dialect->addForeignKey('foreign_key_child', 'public', $references[$reference]);
+
+                expect($this->connection->execute($sql))->equals($expected);
+            },
+            [
+                'examples' => [
+                    ['fk1', true],
+                    ['fk2', true]
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Tests Postgresql::is created
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-07-05
+     */
+    public function shouldCheckAddedForeignKey()
+    {
+        $this->specify(
+            "Foreign key isn't created",
+            function ($sql, $expected) {
+                expect($this->connection->execute($sql))->equals($expected);
+            },
+            [
+                'examples' => [
+                    [$this->getForeignKey('fk1'), 1],
+                    [$this->getForeignKey('foreign_key_child_child_int_fkey'), 1]
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Tests Postgresql::dropAddForeignKey
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  2017-07-05
+     */
+    public function shouldDropForeignKey()
+    {
+        $this->specify(
+            "Foreign key can't be deleted",
+            function ($reference, $expected) {
+                $dialect = new DialectPostgresql();
+                $sql = $dialect->dropForeignKey('foreign_key_child', 'public', $reference);
+
+                expect($this->connection->execute($sql))->equals($expected);
+            },
+            [
+                'examples' => [
+                    ['fk1', true],
+                    ['foreign_key_child_child_int_fkey', true]
+                ]
+            ]
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Changed `addForeignKey` method  for Postgresql dialect

Thanks

