### PR TITLE
Use db service from the model when paginating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [3.2.2](https://github.com/phalcon/cphalcon/releases/tag/v3.2.2) (2017-XX-XX)
+- Fixed `Phalcon\Paginator\Adapter\QueryBuilder::getPaginate` to use the db connection service of the model
 
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-07-10)
 - Added `Phalcon\Db\Dialect\Mysql::getForeignKeyChecks` to generate a SQL to check the foreign key settings [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -125,7 +125,8 @@ class QueryBuilder extends Adapter
 	{
 		var originalBuilder, builder, totalBuilder, totalPages,
 			limit, numberPage, number, query, page, before, items, totalQuery,
-			result, row, rowcount, next, sql, columns, db, hasHaving, hasGroup;
+			result, row, rowcount, next, sql, columns, db, hasHaving, hasGroup,
+			model, modelClass, dbService;
 
 		let originalBuilder = this->_builder;
 		let columns = this->_columns;
@@ -224,7 +225,13 @@ class QueryBuilder extends Adapter
 		 */
 		if hasHaving {
 		    let sql = totalQuery->getSql();
-		    let db = totalBuilder->getDI()->get("db");
+			let modelClass = builder->_models;
+			if typeof modelClass == "array" {
+    			let modelClass = array_values(modelClass)[0];
+			}
+			let model = new {modelClass}();
+			let dbService = model->getReadConnectionService();
+			let db = totalBuilder->getDI()->get(dbService);
 		    let row = db->fetchOne("SELECT COUNT(*) as rowcount FROM (" .  sql["sql"] . ") as T1", Db::FETCH_ASSOC, sql["bind"]),
 		        rowcount = row ? intval(row["rowcount"]) : 0,
 		        totalPages = intval(ceil(rowcount / limit));


### PR DESCRIPTION
* Type: bug fix
* Link to issue: #12957

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Use the db service from the model when paginating instead of assuming `'db'` as the service name.
