### PR TITLE
Added describeReferences method in postgresql DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Fixed `Phalcon\Cache\Backend\Apcu::flush` to use APCu instead APC [#12934](https://github.com/phalcon/cphalcon/issues/12934)
 - Fixed `Phalcon\Db\Adapter\Pdo\Mysql::addForeignKey` for proper creating the foreign key with a desired key name [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)
 - Fixed `Phalcon\Db\Dialect\Mysql::addForeignKey` to generate correct SQL [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)
+- Fixed `Phalcon\Db\Dialect\Postgresql::describeReferences` to generate correct SQL
+- Added `Phalcon\Db\Adapter\Pdo\Postgresql::describeReferences` for proper creating `Reference` object [#438](https://github.com/phalcon/phalcon-devtools/issues/438)
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [3.2.2](https://github.com/phalcon/cphalcon/releases/tag/v3.2.2) (2017-XX-XX)
+- Added delimiters to escape reserverd words in `Phalcon\Paginator\Adapter\QueryBuilder` method `getPaginate` [#12950](https://github.com/phalcon/cphalcon/issues/12950)
 
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-07-10)
 - Added `Phalcon\Db\Dialect\Mysql::getForeignKeyChecks` to generate a SQL to check the foreign key settings [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Fixed `Phalcon\Cache\Backend\Apcu::flush` to use APCu instead APC [#12934](https://github.com/phalcon/cphalcon/issues/12934)
 - Fixed `Phalcon\Db\Adapter\Pdo\Mysql::addForeignKey` for proper creating the foreign key with a desired key name [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)
 - Fixed `Phalcon\Db\Dialect\Mysql::addForeignKey` to generate correct SQL [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)
+- Fixed `Phalcon\Db\Dialect\Postgresql::describeReferences` to generate correct SQL
+- Added `Phalcon\Db\Adapter\Pdo\Postgresql::describeReferences` for proper creating `Reference` object [#438](https://github.com/phalcon/phalcon-devtools/issues/438)
 
 # [3.2.0](https://github.com/phalcon/cphalcon/releases/tag/v3.2.0) (2017-06-19)
 - Phalcon will now trigger `E_DEPREACATED` by using `Phalcon\Mvc\Model\Criteria::addWhere`, `Phalcon\Debug::getMajorVersion`, `Phalcon\Dispatcher::setModelBinding`, `Phalcon\Tag::resetInput`, `Phalcon\Mvc\Model\Validator::__construct`

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": ">=5.5"
     },
     "require-dev": {
+        "doctrine/instantiator": "^1.0",
         "phpdocumentor/reflection-docblock": "^2.0",
         "phpunit/phpunit": "^4.8",
         "mustache/mustache": "^2.11",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "php": ">=5.5"
     },
     "require-dev": {
-        "doctrine/instantiator": "^1.0",
+        "doctrine/instantiator": "1.0.5",
         "phpdocumentor/reflection-docblock": "^2.0",
         "phpunit/phpunit": "^4.8",
         "mustache/mustache": "^2.11",

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -24,6 +24,9 @@ use Phalcon\Db\Column;
 use Phalcon\Db\RawValue;
 use Phalcon\Db\Adapter\Pdo as PdoAdapter;
 use Phalcon\Db\Exception;
+use Phalcon\Db;
+use Phalcon\Db\Reference;
+use Phalcon\Db\ReferenceInterface;
 
 /**
  * Phalcon\Db\Adapter\Pdo\Postgresql
@@ -105,7 +108,7 @@ class Postgresql extends PdoAdapter
 		 * We're using FETCH_NUM to fetch the columns
 		 * 0:name, 1:type, 2:size, 3:numericsize, 4: numericscale, 5: null, 6: key, 7: extra, 8: position, 9 default
 		 */
-		for field in this->fetchAll(this->_dialect->describeColumns(table, schema), \Phalcon\Db::FETCH_NUM) {
+		for field in this->fetchAll(this->_dialect->describeColumns(table, schema), Db::FETCH_NUM) {
 
 			/**
 			 * By default the bind types is two
@@ -394,5 +397,71 @@ class Postgresql extends PdoAdapter
 	public function supportSequences() -> boolean
 	{
 		return true;
+	}
+
+	/**
+	 * Lists table references
+	 *
+	 *<code>
+	 * print_r(
+	 *     $connection->describeReferences("robots_parts")
+	 * );
+	 *</code>
+	 */
+	public function describeReferences(string! table, string! schema = null) -> <ReferenceInterface[]>
+	{
+		var references, reference,
+			arrayReference, constraintName, referenceObjects, name,
+			referencedSchema, referencedTable, columns, referencedColumns,
+			referenceUpdate, referenceDelete;
+
+		let references = [];
+
+		for reference in this->fetchAll(this->_dialect->describeReferences(table, schema), Db::FETCH_NUM) {
+
+			let constraintName = reference[2];
+			if !isset references[constraintName] {
+				let referencedSchema  = reference[3];
+				let referencedTable   = reference[4];
+				let referenceUpdate   = reference[6];
+				let referenceDelete   = reference[7];
+				let columns           = [];
+				let referencedColumns = [];
+
+			} else {
+				let referencedSchema  = references[constraintName]["referencedSchema"];
+				let referencedTable   = references[constraintName]["referencedTable"];
+				let columns           = references[constraintName]["columns"];
+				let referencedColumns = references[constraintName]["referencedColumns"];
+				let referenceUpdate   = references[constraintName]["onUpdate"];
+				let referenceDelete   = references[constraintName]["onDelete"];
+			}
+
+			let columns[] = reference[1],
+				referencedColumns[] = reference[5];
+
+			let references[constraintName] = [
+				"referencedSchema"  : referencedSchema,
+				"referencedTable"   : referencedTable,
+				"columns"           : columns,
+				"referencedColumns" : referencedColumns,
+				"onUpdate"          : referenceUpdate,
+				"onDelete"          : referenceDelete
+			];
+		}
+
+		let referenceObjects = [];
+		for name, arrayReference in references {
+			let referenceObjects[name] = new Reference(name, [
+				"referencedSchema"  : arrayReference["referencedSchema"],
+				"referencedTable"   : arrayReference["referencedTable"],
+				"columns"           : arrayReference["columns"],
+				"referencedColumns" : arrayReference["referencedColumns"],
+				"onUpdate"          : arrayReference["onUpdate"],
+				"onDelete"          : arrayReference["onDelete"]
+			]);
+		}
+
+		return referenceObjects;
 	}
 }

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -24,6 +24,9 @@ use Phalcon\Db\Column;
 use Phalcon\Db\RawValue;
 use Phalcon\Db\Adapter\Pdo as PdoAdapter;
 use Phalcon\Db\Exception;
+use Phalcon\Db;
+use Phalcon\Db\Reference;
+use Phalcon\Db\ReferenceInterface;
 
 /**
  * Phalcon\Db\Adapter\Pdo\Postgresql
@@ -105,7 +108,7 @@ class Postgresql extends PdoAdapter
 		 * We're using FETCH_NUM to fetch the columns
 		 * 0:name, 1:type, 2:size, 3:numericsize, 4: numericscale, 5: null, 6: key, 7: extra, 8: position, 9 default
 		 */
-		for field in this->fetchAll(this->_dialect->describeColumns(table, schema), \Phalcon\Db::FETCH_NUM) {
+		for field in this->fetchAll(this->_dialect->describeColumns(table, schema), Db::FETCH_NUM) {
 
 			/**
 			 * By default the bind types is two
@@ -397,5 +400,71 @@ class Postgresql extends PdoAdapter
 	public function supportSequences() -> boolean
 	{
 		return true;
+	}
+
+	/**
+	 * Lists table references
+	 *
+	 *<code>
+	 * print_r(
+	 *     $connection->describeReferences("robots_parts")
+	 * );
+	 *</code>
+	 */
+	public function describeReferences(string! table, string! schema = null) -> <ReferenceInterface[]>
+	{
+		var references, reference,
+			arrayReference, constraintName, referenceObjects, name,
+			referencedSchema, referencedTable, columns, referencedColumns,
+			referenceUpdate, referenceDelete;
+
+		let references = [];
+
+		for reference in this->fetchAll(this->_dialect->describeReferences(table, schema), Db::FETCH_NUM) {
+
+			let constraintName = reference[2];
+			if !isset references[constraintName] {
+				let referencedSchema  = reference[3];
+				let referencedTable   = reference[4];
+				let referenceUpdate   = reference[6];
+				let referenceDelete   = reference[7];
+				let columns           = [];
+				let referencedColumns = [];
+
+			} else {
+				let referencedSchema  = references[constraintName]["referencedSchema"];
+				let referencedTable   = references[constraintName]["referencedTable"];
+				let columns           = references[constraintName]["columns"];
+				let referencedColumns = references[constraintName]["referencedColumns"];
+				let referenceUpdate   = references[constraintName]["onUpdate"];
+				let referenceDelete   = references[constraintName]["onDelete"];
+			}
+
+			let columns[] = reference[1],
+				referencedColumns[] = reference[5];
+
+			let references[constraintName] = [
+				"referencedSchema"  : referencedSchema,
+				"referencedTable"   : referencedTable,
+				"columns"           : columns,
+				"referencedColumns" : referencedColumns,
+				"onUpdate"          : referenceUpdate,
+				"onDelete"          : referenceDelete
+			];
+		}
+
+		let referenceObjects = [];
+		for name, arrayReference in references {
+			let referenceObjects[name] = new Reference(name, [
+				"referencedSchema"  : arrayReference["referencedSchema"],
+				"referencedTable"   : arrayReference["referencedTable"],
+				"columns"           : arrayReference["columns"],
+				"referencedColumns" : arrayReference["referencedColumns"],
+				"onUpdate"          : arrayReference["onUpdate"],
+				"onDelete"          : arrayReference["onDelete"]
+			]);
+		}
+
+		return referenceObjects;
 	}
 }

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -627,7 +627,28 @@ class Postgresql extends Dialect
 	 */
 	public function describeReferences(string! table, string schema = null) -> string
 	{
-		var sql = "SELECT DISTINCT tc.table_name as TABLE_NAME, kcu.column_name as COLUMN_NAME, tc.constraint_name as CONSTRAINT_NAME, tc.table_catalog as REFERENCED_TABLE_SCHEMA, ccu.table_name AS REFERENCED_TABLE_NAME, ccu.column_name AS REFERENCED_COLUMN_NAME FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name WHERE constraint_type = 'FOREIGN KEY' AND ";
+		var sql = "
+			SELECT DISTINCT
+					tc.table_name as TABLE_NAME,
+					kcu.column_name as COLUMN_NAME,
+					tc.constraint_name as CONSTRAINT_NAME,
+					tc.table_catalog as REFERENCED_TABLE_SCHEMA,
+					ccu.table_name AS REFERENCED_TABLE_NAME,
+					ccu.column_name AS REFERENCED_COLUMN_NAME,
+					rc.update_rule AS UPDATE_RULE,
+					rc.delete_rule AS DELETE_RULE
+				FROM information_schema.table_constraints AS tc
+				JOIN information_schema.key_column_usage AS kcu
+					ON tc.constraint_name = kcu.constraint_name
+				JOIN information_schema.constraint_column_usage AS ccu
+					ON ccu.constraint_name = tc.constraint_name
+				JOIN information_schema.referential_constraints rc
+					ON tc.constraint_catalog = rc.constraint_catalog
+					AND tc.constraint_schema = rc.constraint_schema
+					AND tc.constraint_name = rc.constraint_name
+					AND tc.constraint_type = 'FOREIGN KEY'
+				WHERE constraint_type = 'FOREIGN KEY'
+					AND ";
 
 		if schema {
 			let sql .= "tc.table_schema = '" . schema . "' AND tc.table_name='" . table . "'";

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -202,7 +202,7 @@ class QueryBuilder extends Adapter
 			}
 
 			if !hasHaving {
-			    totalBuilder->groupBy(null)->columns(["COUNT(DISTINCT ".groupColumn.") AS rowcount"]);
+			    totalBuilder->groupBy(null)->columns(["COUNT(DISTINCT ".groupColumn.") AS [rowcount]"]);
 			} else {
 			    totalBuilder->columns(["DISTINCT ".groupColumn]);
 			}
@@ -225,7 +225,7 @@ class QueryBuilder extends Adapter
 		if hasHaving {
 		    let sql = totalQuery->getSql();
 		    let db = totalBuilder->getDI()->get("db");
-		    let row = db->fetchOne("SELECT COUNT(*) as rowcount FROM (" .  sql["sql"] . ") as T1", Db::FETCH_ASSOC, sql["bind"]),
+		    let row = db->fetchOne("SELECT COUNT(*) as \"rowcount\" FROM (" .  sql["sql"] . ") as T1", Db::FETCH_ASSOC, sql["bind"]),
 		        rowcount = row ? intval(row["rowcount"]) : 0,
 		        totalPages = intval(ceil(rowcount / limit));
 		} else {

--- a/phalcon/security.zep
+++ b/phalcon/security.zep
@@ -512,7 +512,7 @@ class Security implements InjectionAwareInterface
 	 */
 	public function getSslVersionNumber() -> int
 	{
-		var matches;
+		var matches = null;
 
 		preg_match("#^(?:Libre|Open)SSL ([\d]+)\.([\d]+)(\.([\d]+))?$#", OPENSSL_VERSION_TEXT, matches);
 

--- a/phalcon/security.zep
+++ b/phalcon/security.zep
@@ -488,6 +488,8 @@ class Security implements InjectionAwareInterface
 
 	/**
 	 * Testing for LibreSSL
+	 *
+	 * @deprecated Will be removed in 4.0.0
 	 */
 	public function hasLibreSsl() -> boolean
 	{
@@ -499,9 +501,12 @@ class Security implements InjectionAwareInterface
 	}
 
 	/**
-	 * Getting OpenSSL or LibreSSL version
+	 * Getting OpenSSL or LibreSSL version.
 	 *
 	 * Parse OPENSSL_VERSION_TEXT because OPENSSL_VERSION_NUMBER is no use for LibreSSL.
+	 * This constant show not the current system openssl library version but version PHP was compiled with.
+	 *
+	 * @deprecated Will be removed in 4.0.0
 	 * @link https://bugs.php.net/bug.php?id=71143
 	 *
 	 * <code>
@@ -512,19 +517,25 @@ class Security implements InjectionAwareInterface
 	 */
 	public function getSslVersionNumber() -> int
 	{
-		var matches = null;
+		var major, minor, patch, matches = null;
 
-		preg_match("#^(?:Libre|Open)SSL ([\d]+)\.([\d]+)(\.([\d]+))?$#", OPENSSL_VERSION_TEXT, matches);
+		if !defined("OPENSSL_VERSION_TEXT") {
+			return 0;
+		}
+
+		preg_match("#(?:Libre|Open)SSL ([\d]+)\.([\d]+)(?:\.([\d]+))?#", OPENSSL_VERSION_TEXT, matches);
 
 		if !isset matches[2] {
 			return 0;
 		}
 
-		var patch = 0;
+		let major = (int) matches[1],
+			minor = (int) matches[2];
+
 		if isset matches[3] {
-			let patch = intval(matches[3]);
+			let patch = (int) matches[3];
 		}
 
-		return (10000 * intval(matches[2])) + (100 * intval(matches[2])) + patch;
+		return 10000 * major + 100 * minor + patch;
 	}
 }

--- a/phalcon/validation/validator/file.zep
+++ b/phalcon/validation/validator/file.zep
@@ -155,7 +155,7 @@ class File extends Validator
 
 			let byteUnits = ["B": 0, "K": 10, "M": 20, "G": 30, "T": 40, "KB": 10, "MB": 20, "GB": 30, "TB": 40],
 				maxSize = this->getOption("maxSize"),
-				matches = NULL,
+				matches = null,
 				unit = "B";
 
 			if typeof maxSize == "array" {

--- a/tests/_ci/install_zephir.sh
+++ b/tests/_ci/install_zephir.sh
@@ -31,3 +31,6 @@ cp ./bin/zephir-cmd ${HOME}/bin/zephir
 rm ./bin/zephir-cmd
 
 cd ${TRAVIS_BUILD_DIR}
+
+
+zephir version

--- a/tests/_data/models/Robos.php
+++ b/tests/_data/models/Robos.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Phalcon\Test\Models;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * Robos
+ *
+ * "Robôs" is robots in portuguese
+ * 
+ * @author David Napierata
+ *
+ * @package Phalcon\Test\Models
+ */
+class Robos extends Model
+{
+    public function getSource()
+    {
+        return 'robots';
+    }
+
+    public function initialize()
+    {
+        $this->setConnectionService('dbTwo');
+    }
+}

--- a/tests/_data/schemas/postgresql/phalcon_test.sql
+++ b/tests/_data/schemas/postgresql/phalcon_test.sql
@@ -340,6 +340,7 @@ ALTER TABLE public.foreign_key_child OWNER TO postgres;
 
 ALTER TABLE public.tipo_documento_id_seq OWNER TO postgres;
 
+ALTER TABLE foreign_key_child ADD CONSTRAINT test_describeReferences FOREIGN KEY (child_int) REFERENCES foreign_key_parent (refer_int) ON UPDATE CASCADE ON DELETE RESTRICT;
 --
 -- Name: tipo_documento_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
 --

--- a/tests/_fixtures/metadata/test_describereference.php
+++ b/tests/_fixtures/metadata/test_describereference.php
@@ -1,0 +1,29 @@
+<?php
+
+use Phalcon\Db\Reference;
+
+/**
+ * Fixture for Reference method
+ *
+ * @copyright (c) 2011-2017 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+ * @package   Helper\Dialect\PostgresqlTrait
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+
+return
+    new Reference('test_describereferences', [
+        'referencedTable'   => 'foreign_key_parent',
+        'referencedSchema' => 'phalcon_test',
+        'columns'           => ['child_int'],
+        'referencedColumns' => ['refer_int'],
+        'onUpdate'          => 'CASCADE',
+        'onDelete'          => 'RESTRICT',
+    ]);

--- a/tests/_fixtures/postgresql/example6.sql
+++ b/tests/_fixtures/postgresql/example6.sql
@@ -1,0 +1,18 @@
+SELECT COUNT(tc.constraint_name)
+    FROM information_schema.table_constraints tc
+      INNER JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_catalog = kcu.constraint_catalog
+           AND tc.constraint_schema = kcu.constraint_schema
+           AND tc.constraint_name = kcu.constraint_name
+      INNER JOIN information_schema.referential_constraints rc
+        ON tc.constraint_catalog = rc.constraint_catalog
+           AND tc.constraint_schema = rc.constraint_schema
+           AND tc.constraint_name = rc.constraint_name
+           AND  tc.constraint_type = 'FOREIGN KEY'
+      INNER JOIN information_schema.constraint_column_usage ccu
+        ON rc.unique_constraint_catalog = ccu.constraint_catalog
+           AND rc.unique_constraint_schema = ccu.constraint_schema
+           AND rc.unique_constraint_name = ccu.constraint_name
+    WHERE tc.constraint_name = '$foreignKeyName'
+          AND rc.update_rule = 'RESTRICT'
+          AND rc.delete_rule = 'CASCADE'

--- a/tests/_fixtures/postgresql/example7.sql
+++ b/tests/_fixtures/postgresql/example7.sql
@@ -1,0 +1,22 @@
+
+			SELECT DISTINCT
+					tc.table_name as TABLE_NAME,
+					kcu.column_name as COLUMN_NAME,
+					tc.constraint_name as CONSTRAINT_NAME,
+					tc.table_catalog as REFERENCED_TABLE_SCHEMA,
+					ccu.table_name AS REFERENCED_TABLE_NAME,
+					ccu.column_name AS REFERENCED_COLUMN_NAME,
+					rc.update_rule AS UPDATE_RULE,
+					rc.delete_rule AS DELETE_RULE
+				FROM information_schema.table_constraints AS tc
+				JOIN information_schema.key_column_usage AS kcu
+					ON tc.constraint_name = kcu.constraint_name
+				JOIN information_schema.constraint_column_usage AS ccu
+					ON ccu.constraint_name = tc.constraint_name
+				JOIN information_schema.referential_constraints rc
+					ON tc.constraint_catalog = rc.constraint_catalog
+					AND tc.constraint_schema = rc.constraint_schema
+					AND tc.constraint_name = rc.constraint_name
+					AND tc.constraint_type = 'FOREIGN KEY'
+				WHERE constraint_type = 'FOREIGN KEY'
+					AND tc.table_schema = 'public' AND tc.table_name='table'

--- a/tests/_fixtures/postgresql/example8.sql
+++ b/tests/_fixtures/postgresql/example8.sql
@@ -1,0 +1,22 @@
+
+			SELECT DISTINCT
+					tc.table_name as TABLE_NAME,
+					kcu.column_name as COLUMN_NAME,
+					tc.constraint_name as CONSTRAINT_NAME,
+					tc.table_catalog as REFERENCED_TABLE_SCHEMA,
+					ccu.table_name AS REFERENCED_TABLE_NAME,
+					ccu.column_name AS REFERENCED_COLUMN_NAME,
+					rc.update_rule AS UPDATE_RULE,
+					rc.delete_rule AS DELETE_RULE
+				FROM information_schema.table_constraints AS tc
+				JOIN information_schema.key_column_usage AS kcu
+					ON tc.constraint_name = kcu.constraint_name
+				JOIN information_schema.constraint_column_usage AS ccu
+					ON ccu.constraint_name = tc.constraint_name
+				JOIN information_schema.referential_constraints rc
+					ON tc.constraint_catalog = rc.constraint_catalog
+					AND tc.constraint_schema = rc.constraint_schema
+					AND tc.constraint_name = rc.constraint_name
+					AND tc.constraint_type = 'FOREIGN KEY'
+				WHERE constraint_type = 'FOREIGN KEY'
+					AND tc.table_schema = 'schema' AND tc.table_name='table'

--- a/tests/_support/Helper/Dialect/PostgresqlTrait.php
+++ b/tests/_support/Helper/Dialect/PostgresqlTrait.php
@@ -500,24 +500,7 @@ trait PostgresqlTrait
 
     protected function getForeignKey($foreignKeyName)
     {
-        $sql = "SELECT COUNT(tc.constraint_name)
-                FROM information_schema.table_constraints tc
-                  INNER JOIN information_schema.key_column_usage kcu
-                    ON tc.constraint_catalog = kcu.constraint_catalog
-                       AND tc.constraint_schema = kcu.constraint_schema
-                       AND tc.constraint_name = kcu.constraint_name
-                  INNER JOIN information_schema.referential_constraints rc
-                    ON tc.constraint_catalog = rc.constraint_catalog
-                       AND tc.constraint_schema = rc.constraint_schema
-                       AND tc.constraint_name = rc.constraint_name
-                       AND  tc.constraint_type = 'FOREIGN KEY'
-                  INNER JOIN information_schema.constraint_column_usage ccu
-                    ON rc.unique_constraint_catalog = ccu.constraint_catalog
-                       AND rc.unique_constraint_schema = ccu.constraint_schema
-                       AND rc.unique_constraint_name = ccu.constraint_name
-                WHERE tc.constraint_name = '$foreignKeyName'
-                      AND rc.update_rule = 'RESTRICT'
-                      AND rc.delete_rule = 'CASCADE'";
+        $sql = rtrim(file_get_contents(PATH_FIXTURES . 'postgresql/example6.sql'));
 
         return $sql;
     }
@@ -605,11 +588,11 @@ trait PostgresqlTrait
         return [
             [
                 null,
-                "SELECT DISTINCT tc.table_name as TABLE_NAME, kcu.column_name as COLUMN_NAME, tc.constraint_name as CONSTRAINT_NAME, tc.table_catalog as REFERENCED_TABLE_SCHEMA, ccu.table_name AS REFERENCED_TABLE_NAME, ccu.column_name AS REFERENCED_COLUMN_NAME FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = 'public' AND tc.table_name='table'"
+                rtrim(file_get_contents(PATH_FIXTURES . 'postgresql/example7.sql'))
             ],
             [
                 'schema',
-                "SELECT DISTINCT tc.table_name as TABLE_NAME, kcu.column_name as COLUMN_NAME, tc.constraint_name as CONSTRAINT_NAME, tc.table_catalog as REFERENCED_TABLE_SCHEMA, ccu.table_name AS REFERENCED_TABLE_NAME, ccu.column_name AS REFERENCED_COLUMN_NAME FROM information_schema.table_constraints AS tc JOIN information_schema.key_column_usage AS kcu ON tc.constraint_name = kcu.constraint_name JOIN information_schema.constraint_column_usage AS ccu ON ccu.constraint_name = tc.constraint_name WHERE constraint_type = 'FOREIGN KEY' AND tc.table_schema = 'schema' AND tc.table_name='table'"
+                rtrim(file_get_contents(PATH_FIXTURES . 'postgresql/example8.sql'))
             ]
         ];
     }
@@ -746,6 +729,15 @@ trait PostgresqlTrait
                 ],
                 rtrim(file_get_contents(PATH_FIXTURES . 'postgresql/example5.sql')),
             ],
+        ];
+    }
+
+    protected function getReferenceObject()
+    {
+        return [
+            [
+                ['test_describereferences' => require PATH_FIXTURES . 'metadata/test_describereference.php']
+            ]
         ];
     }
 }

--- a/tests/unit/Db/Adapter/Pdo/PostgresqlTest.php
+++ b/tests/unit/Db/Adapter/Pdo/PostgresqlTest.php
@@ -143,6 +143,28 @@ class PostgresqlTest extends UnitTest
     }
 
     /**
+     * Tests Postgresql::describeReferences
+     *
+     * @test
+     * @author Sergii Svyrydenko <sergey.v.sviridenko@gmail.com>
+     * @since  201-07-12
+     */
+    public function shouldCreateReferenceObject()
+    {
+        $this->specify(
+            "Created reference object isn't proper",
+            function ($expected) {
+                $reference = $this->connection->describeReferences('foreign_key_child', 'public');
+
+                expect($reference)->equals($expected);
+            },
+            [
+                'examples' => $this->getReferenceObject()
+            ]
+        );
+    }
+
+    /**
      * Tests Postgresql::describeColumns for Postgresql autoincrement column
      *
      * @issue  https://github.com/phalcon/phalcon-devtools/issues/853

--- a/tests/unit/Paginator/Adapter/QueryBuilderTest.php
+++ b/tests/unit/Paginator/Adapter/QueryBuilderTest.php
@@ -5,6 +5,7 @@ namespace Phalcon\Test\Unit\Paginator\Adapter;
 use Helper\ModelTrait;
 use Phalcon\Di;
 use Phalcon\Paginator\Adapter\QueryBuilder;
+use Phalcon\Test\Models\Robos;
 use Phalcon\Test\Models\Stock;
 use Phalcon\Test\Module\UnitTest;
 
@@ -124,6 +125,43 @@ class QueryBuilderTest extends UnitTest
                         "limit"   => 1,
                         "page"    => 2,
                         "columns" => "id,stock"
+                    ]
+                ))->getPaginate();
+
+                expect($paginate->total_pages)->equals(2);
+                expect($paginate->total_items)->equals(2);
+            }
+        );
+    }
+
+    /**
+     * Tests query builder pagination with having and group with a different db service than 'db'
+     *
+     * @author David Napierata
+     * @since  2017-07-18
+     */
+    public function testIssue12957()
+    {
+        $this->specify(
+            "Query builder paginator doesn't work correctly with a different db service",
+            function () {
+                $modelsManager = $this->setUpModelsManager();
+                $di = $modelsManager->getDI();
+                $di->set(
+                    'dbTwo',
+                    $di->get('db')
+                );
+                $builder = $modelsManager->createBuilder()
+                    ->columns("COUNT(*) as robos_count")
+                    ->from(['Robos' => Robos::class])
+                    ->groupBy('type')
+                    ->having('MAX(Robos.year) > 1970');
+
+                $paginate = (new QueryBuilder(
+                    [
+                        "builder" => $builder,
+                        "limit"   => 1,
+                        "page"    => 2
                     ]
                 ))->getPaginate();
 

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -689,22 +689,26 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($describeIndexes, $expectedIndexes);
 
 		//References
-		$expectedReferences = array(
-			'robots_parts_ibfk_1' => Phalcon\Db\Reference::__set_state(array(
-			'_referenceName' => 'robots_parts_ibfk_1',
-			'_referencedTable' => 'robots',
-			'_columns' => array('robots_id'),
-				'_referencedColumns' => array('id'),
-				'_referencedSchema' => 'phalcon_test'
-			)),
-			'robots_parts_ibfk_2' => Phalcon\Db\Reference::__set_state(array(
-				'_referenceName' => 'robots_parts_ibfk_2',
-				'_referencedTable' => 'parts',
-				'_columns' => array('parts_id'),
-				'_referencedColumns' => array('id'),
-				'_referencedSchema' => 'phalcon_test',
-			)),
-		);
+		$expectedReferences = [
+            'robots_parts_ibfk_1' => Phalcon\Db\Reference::__set_state([
+                '_referenceName' => 'robots_parts_ibfk_1',
+                '_referencedTable' => 'robots',
+                '_columns' => ['robots_id'],
+                '_referencedColumns' => ['id'],
+                '_referencedSchema' => 'phalcon_test',
+                '_onDelete' => 'NO ACTION',
+                '_onUpdate' => 'NO ACTION'
+			]),
+            'robots_parts_ibfk_2' => Phalcon\Db\Reference::__set_state([
+                '_referenceName' => 'robots_parts_ibfk_2',
+                '_referencedTable' => 'parts',
+                '_columns' => ['parts_id'],
+                '_referencedColumns' => ['id'],
+                '_referencedSchema' => 'phalcon_test',
+                '_onDelete' => 'NO ACTION',
+                '_onUpdate' => 'NO ACTION'
+			]),
+		];
 
 		$describeReferences = $connection->describeReferences('robots_parts');
 		$this->assertEquals($describeReferences, $expectedReferences);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/phalcon-devtools/issues/438

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

- Fixed `Phalcon\Db\Dialect\Postgresql::describeReferences` to generate correct SQL
- Added `Phalcon\Db\Adapter\Pdo\Postgresql::describeReferences` for proper creating `Reference` object [phalcon/phalcon-devtools#438](https://github.com/phalcon/phalcon-devtools/issues/438)

Thanks
