### PR TITLE
Internal cookies property is now always an array (fixes #12978)

### DIFF
--- a/phalcon/http/response/cookies.zep
+++ b/phalcon/http/response/cookies.zep
@@ -42,6 +42,11 @@ class Cookies implements CookiesInterface, InjectionAwareInterface
 
 	protected _cookies;
 
+	public function __construct()
+	{
+		let this->_cookies = [];
+	}
+
 	/**
 	 * Sets the dependency injector
 	 */


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12978

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Internal cookies property is now always an array

Thanks

