### PR TITLE
JSON column type to be recognised for mysql

### DIFF
--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -191,6 +191,12 @@ class Mysql extends Dialect
 					let columnSql .= "LONGBLOB";
 				}
 				break;
+				
+			case Column::TYPE_JSON:
+				if empty columnSql {
+					let columnSql .= "JSON";
+				}
+				break;
 
 			default:
 				if empty columnSql {


### PR DESCRIPTION
* Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR. (no db-specific column tests appear to exist?)

Small description of change:
Adding case to handle `TYPE_JSON` in table column definitions as MySQL 5.7+ adds the JSON data type

Thanks

