### PR TITLE
Single-write handler and action suffix issue fix :

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -335,12 +335,11 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			handler = null,
 			numberDispatches = 0,
 
-			handlerSuffix = this->_handlerSuffix,
-			actionSuffix = this->_actionSuffix,
-
 			this->_finished = false;
 
 		while !this->_finished {
+			let handlerSuffix = this->_handlerSuffix,
+				actionSuffix = this->_actionSuffix;
 
 			let numberDispatches++;
 


### PR DESCRIPTION
# Issue Description

* Type: bug fix

We have a heavily event-driven solution built using PhalconPHP in-depth. Therefore, while the dispatch-loop is running, there are certain occasions when we naturally perform forwards, handle exceptions and so on.

We use multiple different controller action suffixes based on execution context (managed by undisclosed preconditions).

The **problem** we were facing was, that whenever one of our listeners were forwarding **and** modifying the suffix of the running dispatcher, the new suffix was not taken into consideration.

I have found in the source code, that the problem's root cause is, that the **controller action suffix** is read once, before the dispatch loop (the while cycle) kicks off. This can easily be fixed, and I do not expect unwanted side-effects based on the source code, common sense, and local testing.

## Patched versions / release branches 

| Version |                                       Patch applied                                     |
| ------- | --------------------------------------------------------------------------------------- |
| 2.0.0   | moved local value definition within while loop                                          |
| 2.0.x   | changed action method value assignment to getter instead of local string concatenation. |
| 2.1.x   | changed action method value assignment to getter instead of local string concatenation. |
| 3.0.x   | changed action method value assignment to getter instead of local string concatenation. |
| 3.1.x   | changed action method value assignment to getter instead of local string concatenation. |
| 3.2.x   | changed action method value assignment to getter instead of local string concatenation. |
| 4.0.x   | changed action method value assignment to getter instead of local string concatenation. |

## Patch explanation

My aim with the changes was to do as little change as possible with little to no possibility for unexpected side-effects.

### moved local value definition within while loop

On version 2.0.0 the move refactor seemed to be the least risky and smallest change as I could not find the expected getter for the Controller. The patch would have felt half-assed if I'd only fix the action part.

### changed action method value assignment to getter instead of local string concatenation.

On all other versions I could see, that the controller suffix was always part of the loop. Therefore, I just had to change the action method definition from string concatenation to the getter. The getter is a better approach as it respects the object state. 

From : `let actionMethod = actionName . actionSuffix;`  
To   : `let actionMethod = this->getActiveMethod();`

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

The given method has no proper test coverage, and to write up the proper mocking, preconditions, post-conditions and assertions to assure, that this trivial change works would consume too much of my free time. We are talking about a ~275ish line long method, with a cyclomatic complexity way over 12 (just by looking at it, not counting). 