### PR TITLE
Composer in Travis no longer ignores platform requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ before_install:
   - bash tests/_ci/setup_dbs.sh
 
 install:
-  - travis_retry composer install --quiet --no-interaction --no-ansi --no-progress --optimize-autoloader --dev --prefer-dist --no-suggest --ignore-platform-reqs
+  - travis_retry composer install --quiet --no-interaction --no-ansi --no-progress --optimize-autoloader --dev --prefer-dist --no-suggest
   - bash tests/_ci/install_prereqs_$PHP_MAJOR.sh
   - bash tests/_ci/install_zephir_parser.sh
   - bash tests/_ci/install_zephir.sh


### PR DESCRIPTION
* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Whilst working on another PR, I noticed [Travis failed under PHP 5](https://travis-ci.org/phalcon/cphalcon/builds/259617571) due to the latest version of doctrine/instantiator requiring PHP 7. When installing the Composer dependencies, the platform requirement (^7.1) was ignored and lead to a [parse error and unexpected exit](https://travis-ci.org/phalcon/cphalcon/jobs/259617573#L658).
