### PR TITLE
Documentation Only: Correct code block syntax in security random

### DIFF
--- a/phalcon/security/random.zep
+++ b/phalcon/security/random.zep
@@ -178,11 +178,11 @@ class Random
 	 * It is similar to `Phalcon\Security\Random:base64` but has been modified to avoid both non-alphanumeric
 	 * characters and letters which might look ambiguous when printed.
 	 *
-	 * <code>
+	 *<code>
 	 * $random = new \Phalcon\Security\Random();
 	 *
 	 * echo $random->base58(); // 4kUgL2pdQMSCQtjE
-	 * </code>
+	 *</code>
 	 *
 	 * @see    \Phalcon\Security\Random:base64
 	 * @link   https://en.wikipedia.org/wiki/Base58
@@ -201,11 +201,11 @@ class Random
 	 * It is similar to `Phalcon\Security\Random:base58` but has been modified to provide the largest value that can
 	 * safely be used in URLs without needing to take extra characters into consideration because it is [A-Za-z0-9].
 	 *
-	 *< code>
+	 *<code>
 	 * $random = new \Phalcon\Security\Random();
 	 *
 	 * echo $random->base62(); // z0RkwHfh8ErDM1xw
-	 * </code>
+	 *</code>
 	 *
 	 * @see    \Phalcon\Security\Random:base58
 	 * @throws Exception If secure random number generator is not available or unexpected partial read


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: phalcon/docs#1184

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.  **Documentation Only**

Small description of change:
Normalizes the syntax of code tags.
Thanks

