### PR TITLE
Model::_errorMessages is now always an array.

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -93,7 +93,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
 	protected _modelsMetaData;
 
-	protected _errorMessages;
+	protected _errorMessages = [];
 
 	protected _operationMade = 0;
 
@@ -1566,12 +1566,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 */
 	public function validationHasFailed() -> boolean
 	{
-		var errorMessages;
-		let errorMessages = this->_errorMessages;
-		if typeof errorMessages == "array" {
-			return count(errorMessages) > 0;
-		}
-		return false;
+		return count(this->_errorMessages) > 0;
 	}
 
 	/**

--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -67,71 +67,71 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
 	protected _eventsManager;
 
-	protected _customEventsManager;
+	protected _customEventsManager = [];
 
-	protected _readConnectionServices;
+	protected _readConnectionServices = [];
 
-	protected _writeConnectionServices;
+	protected _writeConnectionServices = [];
 
-	protected _aliases;
+	protected _aliases = [];
 
 	protected _modelVisibility = [];
 
 	/**
 	 * Has many relations
 	 */
-	protected _hasMany;
+	protected _hasMany = [];
 
 	/**
 	 * Has many relations by model
 	 */
-	protected _hasManySingle;
+	protected _hasManySingle = [];
 
 	/**
 	 * Has one relations
 	 */
-	protected _hasOne;
+	protected _hasOne = [];
 
 	/**
 	 * Has one relations by model
 	 */
-	protected _hasOneSingle;
+	protected _hasOneSingle = [];
 
 	/**
 	 * Belongs to relations
 	 */
-	protected _belongsTo;
+	protected _belongsTo = [];
 
 	/**
 	 * All the relationships by model
 	 */
-	protected _belongsToSingle;
+	protected _belongsToSingle = [];
 
 	/**
 	 * Has many-Through relations
 	 */
-	protected _hasManyToMany;
+	protected _hasManyToMany = [];
 
 	/**
 	 * Has many-Through relations by model
 	 */
-	protected _hasManyToManySingle;
+	protected _hasManyToManySingle = [];
 
 	/**
 	 * Mark initialized models
 	 */
-	protected _initialized;
+	protected _initialized = [];
 
 	protected _prefix = "";
 
-	protected _sources;
+	protected _sources = [];
 
-	protected _schemas;
+	protected _schemas = [];
 
 	/**
 	 * Models' behaviors
 	 */
-	protected _behaviors;
+	protected _behaviors = [];
 
 	/**
 	 * Last model initialized
@@ -146,16 +146,16 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	/**
 	 * Stores a list of reusable instances
 	 */
-	protected _reusable;
+	protected _reusable = [];
 
-	protected _keepSnapshots;
+	protected _keepSnapshots = [];
 
 	/**
 	 * Does the model use dynamic update, instead of updating all rows?
 	 */
 	protected _dynamicUpdate = [];
 
-	protected _namespaceAliases;
+	protected _namespaceAliases = [];
 
 	/**
 	 * Sets the DependencyInjector container
@@ -645,14 +645,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	public function isKeepingSnapshots(<ModelInterface> model) -> boolean
 	{
-		var keepSnapshots, isKeeping;
-		let keepSnapshots = this->_keepSnapshots;
-		if typeof keepSnapshots == "array" {
-			if fetch isKeeping, keepSnapshots[get_class_lower(model)] {
-				return isKeeping;
-			}
+		var isKeeping;
+
+		if !fetch isKeeping, this->_keepSnapshots[get_class_lower(model)] {
+			return false;
 		}
-		return false;
+
+		return isKeeping;
 	}
 
 	/**
@@ -1434,7 +1433,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	public function clearReusableObjects()
 	{
-		let this->_reusable = null;
+		let this->_reusable = [];
 	}
 
 	/**

--- a/phalcon/mvc/model/manager.zep
+++ b/phalcon/mvc/model/manager.zep
@@ -153,7 +153,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	/**
 	 * Does the model use dynamic update, instead of updating all rows?
 	 */
-	protected _dynamicUpdate;
+	protected _dynamicUpdate = [];
 
 	protected _namespaceAliases;
 
@@ -671,14 +671,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 */
 	public function isUsingDynamicUpdate(<ModelInterface> model) -> boolean
 	{
-		var dynamicUpdate, isUsing;
-		let dynamicUpdate = this->_dynamicUpdate;
-		if typeof dynamicUpdate == "array" {
-			if fetch isUsing, dynamicUpdate[get_class_lower(model)] {
-				return isUsing;
-			}
+		var isUsing;
+
+		if !fetch isUsing, this->_dynamicUpdate[get_class_lower(model)] {
+			return false;
 		}
-		return false;
+
+		return isUsing;
 	}
 
 	/**


### PR DESCRIPTION
* Type: code quality

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Model::_errorMessages is now always an array. Previously, it could be null if not properly initialised.
