### PR TITLE
Corrected models that wrongly assign the DI in unit tests

### DIFF
--- a/tests/unit/Mvc/Model/MetaData/MemoryCest.php
+++ b/tests/unit/Mvc/Model/MetaData/MemoryCest.php
@@ -62,7 +62,7 @@ class MemoryCest
 
         $di = $I->getApplication()->getDI();
 
-        $robotto = new Robotto($di);
+        $robotto = new Robotto();
 
         //Robots
         $pAttributes = array(

--- a/unit-tests/ModelsMetadataStrategyTest.php
+++ b/unit-tests/ModelsMetadataStrategyTest.php
@@ -142,7 +142,7 @@ class ModelsMetadataStrategyTest extends PHPUnit_Framework_TestCase
 
 		$metaData = $di['modelsMetadata'];
 
-		$robots = new Robots($di);
+		$robots = new Robots();
 
 		$meta = $metaData->readMetaData($robots);
 		$this->assertEquals($meta, $this->_expectedMeta);

--- a/unit-tests/ModelsMetadataTest.php
+++ b/unit-tests/ModelsMetadataTest.php
@@ -114,7 +114,7 @@ class ModelsMetadataTest extends PHPUnit_Framework_TestCase
 
 		$metaData = $di->getShared('modelsMetadata');
 
-		$personas = new Personas($di);
+		$personas = new Personas();
 
 		$pAttributes = array(
 			0 => 'cedula',
@@ -222,7 +222,7 @@ class ModelsMetadataTest extends PHPUnit_Framework_TestCase
 		$modelDefValues = $metaData->getDefaultValues($personas);
 		$this->assertEquals($defValues, $modelDefValues);
 
-		$robots = new Robots($di);
+		$robots = new Robots();
 
 		//Robots
 		$pAttributes = array(

--- a/unit-tests/ModelsTest.php
+++ b/unit-tests/ModelsTest.php
@@ -373,7 +373,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		}
 		$this->assertEquals($number, 20);
 
-		$persona = new Personas($di);
+		$persona = new Personas();
 		$persona->cedula = 'CELL' . mt_rand(0, 999999);
 		$this->assertFalse($persona->save());
 
@@ -403,7 +403,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($persona->getMessages(), $messages);
 
 		//Save
-		$persona = new Personas($di);
+		$persona = new Personas();
 		$persona->cedula = 'CELL' . mt_rand(0, 999999);
 		$persona->tipo_documento_id = 1;
 		$persona->nombres = 'LOST';
@@ -412,7 +412,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$persona->estado = 'A';
 		$this->assertTrue($persona->save());
 
-		$persona = new Personas($di);
+		$persona = new Personas();
 		$persona->cedula = 'CELL' . mt_rand(0, 999999);
 		$persona->tipo_documento_id = 1;
 		$persona->nombres = 'LOST LOST';
@@ -452,7 +452,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($persona->telefono, '2121');
 
 		//Create
-		$persona = new Personas($di);
+		$persona = new Personas();
 		$persona->cedula = 'CELL' . mt_rand(0, 999999);
 		$persona->tipo_documento_id = 1;
 		$persona->nombres = 'LOST CREATE';
@@ -461,7 +461,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$persona->estado = 'A';
 		$this->assertTrue($persona->create());
 
-		$persona = new Personas($di);
+		$persona = new Personas();
 		$persona->assign(array(
 			'cedula' => 'CELL' . mt_rand(0, 999999),
 			'tipo_documento_id' => 1,
@@ -671,7 +671,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		}
 		$this->assertEquals($number, 20);
 
-		$personer = new Personers($di);
+		$personer = new Personers();
 		$personer->borgerId = 'CELL'.mt_rand(0, 999999);
 		$this->assertFalse($personer->save());
 
@@ -701,7 +701,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($personer->getMessages(), $messages);
 
 		//Save
-		$personer = new Personers($di);
+		$personer = new Personers();
 		$personer->borgerId = 'CELL'.mt_rand(0, 999999);
 		$personer->slagBorgerId = 1;
 		$personer->navnes = 'LOST';
@@ -710,7 +710,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$personer->status = 'A';
 		$this->assertTrue($personer->save());
 
-		$personer = new Personers($di);
+		$personer = new Personers();
 		$personer->borgerId = 'CELL'.mt_rand(0, 999999);
 		$personer->slagBorgerId = 1;
 		$personer->navnes = 'LOST LOST';
@@ -750,7 +750,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$this->assertEquals($personer->telefon, '2121');
 
 		//Create
-		$personer = new Personers($di);
+		$personer = new Personers();
 		$personer->borgerId = 'CELL'.mt_rand(0, 999999);
 		$personer->slagBorgerId = 1;
 		$personer->navnes = 'LOST CREATE';
@@ -759,7 +759,7 @@ class ModelsTest extends PHPUnit_Framework_TestCase
 		$personer->status = 'A';
 		$this->assertTrue($personer->save());
 
-		$personer = new Personers($di);
+		$personer = new Personers();
 		$personer->assign(array(
 			'borgerId' => 'CELL'.mt_rand(0, 999999),
 			'slagBorgerId' => 1,

--- a/unit-tests/ModelsTransactionsTest.php
+++ b/unit-tests/ModelsTransactionsTest.php
@@ -144,7 +144,7 @@ class ModelsTransactionsTest extends PHPUnit_Framework_TestCase {
 
 			$p = 100;
 			for ($i = 0; $i < 10; $i++) {
-				$persona = new Personas($di);
+				$persona = new Personas();
 				$persona->setTransaction($transaction1);
 				$persona->cedula            = 'T-Cx' . $i;
 				$persona->tipo_documento_id = 1;
@@ -188,7 +188,7 @@ class ModelsTransactionsTest extends PHPUnit_Framework_TestCase {
 
 			$p = 200;
 			for ($i = 0; $i < 15; $i++) {
-				$persona = new Personas($di);
+				$persona = new Personas();
 				$persona->setTransaction($transaction2);
 				$persona->cedula = 'T-Cx'.$p;
 				$persona->tipo_documento_id = 1;


### PR DESCRIPTION
Hello!

* Type: bug fix / code quality

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR. (sort of... :wink: )

Some of the model instantiations in the unit tests were wrongly assigning the DI as the first parameter (it should be second). As this has had no impact on the unit tests so far, I've just removed it completely instead of writing something like `new Robots(null, $di)`.

Please note: I've submitted this to the 4.0.x branch as it will help streamline the data mapper changes I plan to make and it is not absolutely necessary for the 3.x.x branches.

