### PR TITLE
3.2.x Validate date NULL, make required.

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,3 +1,5 @@
+# [3.2.3](https://github.com/phalcon/cphalcon/releases/tag/v3.2.3) (2017-XX-XX)
+
 # [3.2.2](https://github.com/phalcon/cphalcon/releases/tag/v3.2.2) (2017-08-14)
 - Fixed `Phalcon\Db\Adapter\Pdo\Postgresql::describeColumns` to work properly with `DOUBLE PRECISION` and `REAL` data types [#12842](https://github.com/phalcon/cphalcon/issues/12842)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::getPaginate` to use the db connection service of the model [#12957](https://github.com/phalcon/cphalcon/issues/12957)

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,10 +1,12 @@
+# [3.2.3](https://github.com/phalcon/cphalcon/releases/tag/v3.2.2) (2017-XX-XX)
+- Fixed `Phalcon\Mvc\Model\Query::_executeSelect` threw RuntimeException, if db:beforeQuery() returned false
+
 # [3.2.2](https://github.com/phalcon/cphalcon/releases/tag/v3.2.2) (2017-08-14)
 - Fixed `Phalcon\Db\Adapter\Pdo\Postgresql::describeColumns` to work properly with `DOUBLE PRECISION` and `REAL` data types [#12842](https://github.com/phalcon/cphalcon/issues/12842)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::getPaginate` to use the db connection service of the model [#12957](https://github.com/phalcon/cphalcon/issues/12957)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::getPaginate` to escape reserverd words [#12950](https://github.com/phalcon/cphalcon/issues/12950)
 - Fixed `Phalcon\Dispatcher::dispatch` to correct forward with the modified action suffix [#12988](https://github.com/phalcon/cphalcon/pull/12988)
 - Fixed `Phalcon\Forms\Element::_construct` to prevent create form element with empty name [#12954](https://github.com/phalcon/cphalcon/pull/12954)
-- Fixed `Phalcon\Mvc\Model\Query::_executeSelect` threw RuntimeException, if db:beforeQuery() returned false
 
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-07-10)
 - Added `Phalcon\Db\Dialect\Mysql::getForeignKeyChecks` to generate a SQL to check the foreign key settings [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)

--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::getPaginate` to escape reserverd words [#12950](https://github.com/phalcon/cphalcon/issues/12950)
 - Fixed `Phalcon\Dispatcher::dispatch` to correct forward with the modified action suffix [#12988](https://github.com/phalcon/cphalcon/pull/12988)
 - Fixed `Phalcon\Forms\Element::_construct` to prevent create form element with empty name [#12954](https://github.com/phalcon/cphalcon/pull/12954)
+- Fixed `Phalcon\Mvc\Model\Query::_executeSelect` threw RuntimeException, if db:beforeQuery() returned false
 
 # [3.2.1](https://github.com/phalcon/cphalcon/releases/tag/v3.2.1) (2017-07-10)
 - Added `Phalcon\Db\Dialect\Mysql::getForeignKeyChecks` to generate a SQL to check the foreign key settings [#2604](https://github.com/phalcon/cphalcon/issues/2604), [phalcon/phalcon-devtools#556](https://github.com/phalcon/phalcon-devtools/issues/556)

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "name": "phalcon",
     "description": "Web framework delivered as a C-extension for PHP",
     "author": "Phalcon Team and contributors",
-    "version": "3.2.2",
+    "version": "3.2.3",
     "verbose": false,
     "optimizer-dirs": [
         "optimizers"

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -77,7 +77,7 @@ use Phalcon\Validation\Message\Group as ValidationMessageGroup;
  *     $messages = $robot->getMessages();
  *
  *     foreach ($messages as $message) {
- *         echo message;
+ *         echo $message;
  *     }
  * } else {
  *     echo "Great, a new robot was saved successfully!";
@@ -3508,7 +3508,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * generated INSERT/UPDATE statement
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3534,7 +3533,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * generated INSERT statement
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3566,7 +3564,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * generated UPDATE statement
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3598,7 +3595,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * generated UPDATE statement
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3629,7 +3625,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Setup a 1-1 relation between two models
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3649,7 +3644,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Setup a reverse 1-1 or n-1 relation between two models
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class RobotsParts extends \Phalcon\Mvc\Model
 	 * {
@@ -3675,7 +3669,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Setup a 1-n relation between two models
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3701,7 +3694,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Setup an n-n relation between two models, through an intermediate relation
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * class Robots extends \Phalcon\Mvc\Model
 	 * {
@@ -3748,7 +3740,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Setups a behavior in a model
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * use Phalcon\Mvc\Model;
 	 * use Phalcon\Mvc\Model\Behavior\Timestampable;
@@ -3780,7 +3771,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Sets if the model must keep the original record snapshot in memory
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * use Phalcon\Mvc\Model;
 	 *
@@ -4092,7 +4082,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 * Sets if a model must use dynamic update instead of the all-field update
 	 *
 	 *<code>
-	 * <?php
 	 *
 	 * use Phalcon\Mvc\Model;
 	 *

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -22,6 +22,7 @@ namespace Phalcon\Mvc\Model;
 
 use Phalcon\Db\Column;
 use Phalcon\Db\RawValue;
+use Phalcon\Db\ResultInterface;
 use Phalcon\DiInterface;
 use Phalcon\Mvc\Model\Row;
 use Phalcon\Mvc\ModelInterface;
@@ -2760,7 +2761,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 		/**
 		 * Check if the query has data
 		 */
-		if result->numRows(result) {
+		if result instanceof ResultInterface && result->numRows(result) {
 			let resultData = result;
 		} else {
 			let resultData = false;

--- a/phalcon/validation/validator/alnum.zep
+++ b/phalcon/validation/validator/alnum.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Message;
  * Check for alphanumeric character(s)
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Alnum as AlnumValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "username",

--- a/phalcon/validation/validator/alpha.zep
+++ b/phalcon/validation/validator/alpha.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Check for alphabetic character(s)
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Alpha as AlphaValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "username",

--- a/phalcon/validation/validator/between.zep
+++ b/phalcon/validation/validator/between.zep
@@ -30,7 +30,10 @@ use Phalcon\Validation\Validator;
  * For a value x, the test is passed if minimum<=x<=maximum.
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Between;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "price",

--- a/phalcon/validation/validator/callback.zep
+++ b/phalcon/validation/validator/callback.zep
@@ -29,8 +29,11 @@ use Phalcon\Validation\Validator;
  * Calls user function for validation
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Callback as CallbackValidator;
  * use Phalcon\Validation\Validator\Numericality as NumericalityValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     ["user", "admin"],

--- a/phalcon/validation/validator/confirmation.zep
+++ b/phalcon/validation/validator/confirmation.zep
@@ -30,7 +30,10 @@ use Phalcon\Validation\Validator;
  * Checks that two values have the same value
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Confirmation;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "password",

--- a/phalcon/validation/validator/creditcard.zep
+++ b/phalcon/validation/validator/creditcard.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Message;
  * Checks if a value has a valid credit card number
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\CreditCard as CreditCardValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "creditCard",

--- a/phalcon/validation/validator/date.zep
+++ b/phalcon/validation/validator/date.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Message;
  * Checks if a value is a valid date
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Date as DateValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "date",

--- a/phalcon/validation/validator/digit.zep
+++ b/phalcon/validation/validator/digit.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Check for numeric character(s)
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Digit as DigitValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "height",

--- a/phalcon/validation/validator/email.zep
+++ b/phalcon/validation/validator/email.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Checks if a value has a correct e-mail format
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Email as EmailValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "email",

--- a/phalcon/validation/validator/exclusionin.zep
+++ b/phalcon/validation/validator/exclusionin.zep
@@ -30,7 +30,10 @@ use Phalcon\Validation\Exception;
  * Check if a value is not included into a list of values
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\ExclusionIn;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "status",

--- a/phalcon/validation/validator/file.zep
+++ b/phalcon/validation/validator/file.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Checks if a value has a correct file
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\File as FileValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "file",

--- a/phalcon/validation/validator/identical.zep
+++ b/phalcon/validation/validator/identical.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Checks if a value is identical to other
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Identical;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "terms",

--- a/phalcon/validation/validator/inclusionin.zep
+++ b/phalcon/validation/validator/inclusionin.zep
@@ -30,7 +30,10 @@ use Phalcon\Validation\Message;
  * Check if a value is included into a list of values
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\InclusionIn;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "status",

--- a/phalcon/validation/validator/numericality.zep
+++ b/phalcon/validation/validator/numericality.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Check for a valid numeric value
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Numericality;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "price",

--- a/phalcon/validation/validator/presenceof.zep
+++ b/phalcon/validation/validator/presenceof.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Validates that a value is not null or empty string
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\PresenceOf;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "name",

--- a/phalcon/validation/validator/regex.zep
+++ b/phalcon/validation/validator/regex.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Allows validate if the value of a field matches a regular expression
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Regex as RegexValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "created_at",

--- a/phalcon/validation/validator/stringlength.zep
+++ b/phalcon/validation/validator/stringlength.zep
@@ -32,7 +32,10 @@ use Phalcon\Validation\Message;
  * be at least min, and at most max.
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\StringLength as StringLength;
+ *
+ * $validator = new Validation();
  *
  * $validation->add(
  *     "name_last",

--- a/phalcon/validation/validator/uniqueness.zep
+++ b/phalcon/validation/validator/uniqueness.zep
@@ -34,7 +34,10 @@ use Phalcon\Mvc\Collection;
  * Check that a field is unique in the related table
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Uniqueness as UniquenessValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "username",

--- a/phalcon/validation/validator/url.zep
+++ b/phalcon/validation/validator/url.zep
@@ -29,7 +29,10 @@ use Phalcon\Validation\Validator;
  * Checks if a value has a url format
  *
  * <code>
+ * use Phalcon\Validation;
  * use Phalcon\Validation\Validator\Url as UrlValidator;
+ *
+ * $validator = new Validation();
  *
  * $validator->add(
  *     "url",

--- a/phalcon/version.zep
+++ b/phalcon/version.zep
@@ -95,7 +95,7 @@ class Version
 	 */
 	protected static function _getVersion() -> array
 	{
-		return [3, 2, 2, 4, 0];
+		return [3, 2, 3, 4, 0];
 	}
 
 	/**


### PR DESCRIPTION
Its possible when to send null or empty string dont ask the presence, date validator i don't think must have PresenceOf. 

https://github.com/phalcon/cphalcon/blob/master/phalcon/validation/validator/date.zep

Something like

```
if empty value {
      return
}
```

Or 

```
if is_null (value) {
      return
}
```

```

$post['time'] = NULL;

$var = new Text('time');
$var
->setFilters(['string','null'])
 ->addValidator(new Date(['format' => 'Y-m-d H:i:s', 'message' => $this->translate->_('Wrong')]));
```

Return asking a valid date. this should be done by the PresenceOf validator.
