### PR TITLE
Allow PDO option aliases

### DIFF
--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -129,6 +129,16 @@ abstract class Pdo extends Adapter
 		}
 
 		/**
+		 * Check for \PDO::XXX class constant aliases
+		 */
+        for key, value in options {
+            if typeof key == "string" && defined(\PDO::class . "::" . key->upper()) {
+                options[constant(\PDO::class . "::" . key->upper())] = value;
+                unset options[key];
+            }
+        }
+
+		/**
 		 * Check if the connection must be persistent
 		 */
 		if fetch persistent, descriptor["persistent"] {

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -132,8 +132,8 @@ abstract class Pdo extends Adapter
 		 * Check for \PDO::XXX class constant aliases
 		 */
         for key, value in options {
-            if typeof key == "string" && defined(\PDO::class . "::" . key->upper()) {
-                options[constant(\PDO::class . "::" . key->upper())] = value;
+            if typeof key == "string" && defined("\PDO::" . key->upper()) {
+                let options[constant("\PDO::" . key->upper())] = value;
                 unset options[key];
             }
         }


### PR DESCRIPTION
Hello!

PLS **somebody check if this is valid** zep code.
Looked into the zep docu and tried my best 
(its actually not much at all but f.e. i could not find a way to optimize the `constant()` call).

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/13010

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Allowing aliases in options to be able to merge multiple configs.

option: `\PDO::MYSQL_ATTR_INIT_COMMAND`
Alias: `mysql_attr_init_command`

Thanks
cottton
