### PR TITLE
Removed no longer used "_with" parameter from the QueryBuilder

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 - Fixed `Phalcon\Validation\Validator\File::validate` to work properly with parameter 'message' [#12947](https://github.com/phalcon/cphalcon/issues/12947)
 - Fixed `Phalcon\Mvc\View::render` to render a view with params [#13046](https://github.com/phalcon/cphalcon/issues/13046)
 - Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to work properly with provided columns [#12972](https://github.com/phalcon/cphalcon/issues/12972)
+- Mark as deprecated no longer used `Phalcon\Mvc\Model\Query\Builder::$_with` parameter [#13023](https://github.com/phalcon/cphalcon/issues/13023)
 
 # [3.2.2](https://github.com/phalcon/cphalcon/releases/tag/v3.2.2) (2017-08-14)
 - Fixed `Phalcon\Db\Adapter\Pdo\Postgresql::describeColumns` to work properly with `DOUBLE PRECISION` and `REAL` data types [#12842](https://github.com/phalcon/cphalcon/issues/12842)

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -71,6 +71,9 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 
 	protected _joins;
 
+	/**
+	 * @deprecated Will be removed in version 4.0.0
+     */
 	protected _with;
 
 	protected _conditions;
@@ -107,7 +110,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 			singleConditionArray, limit, offset, fromClause,
 			mergedConditions, mergedParams, mergedTypes,
 			singleCondition, singleParams, singleTypes,
-			with, distinct, bind, bindTypes;
+			distinct, bind, bindTypes;
 
 		if typeof params == "array" {
 
@@ -197,13 +200,6 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 			 */
 			if fetch joinsClause, params["joins"] {
 				let this->_joins = joinsClause;
-			}
-
-			/**
-			 * Check if the resultset must be eager loaded
-			 */
-			if fetch with, params["with"] {
-				let this->_with = with;
 			}
 
 			/**
@@ -389,32 +385,26 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	/**
 	 * Add a model to take part of the query
 	 *
+	 * NOTE: The third parameter $with is deprecated and will be removed in future releases.
+	 *
 	 *<code>
 	 * // Load data from models Robots
 	 * $builder->addFrom("Robots");
 	 *
 	 * // Load data from model 'Robots' using 'r' as alias in PHQL
 	 * $builder->addFrom("Robots", "r");
-	 *
-	 * // Load data from model 'Robots' using 'r' as alias in PHQL
-	 * // and eager load model 'RobotsParts'
-	 * $builder->addFrom("Robots", "r", "RobotsParts");
-	 *
-	 * // Load data from model 'Robots' using 'r' as alias in PHQL
-	 * // and eager load models 'RobotsParts' and 'Parts'
-	 * $builder->addFrom(
-	 *     "Robots",
-	 *     "r",
-	 *     [
-	 *         "RobotsParts",
-	 *         "Parts",
-	 *     ]
-	 * );
 	 *</code>
 	 */
 	public function addFrom(var model, var alias = null, var with = null) -> <Builder>
 	{
 		var models, currentModel;
+
+		if typeof with != "null" {
+			trigger_error(
+				"The third parameter 'with' is deprecated and will be removed in future releases.",
+				E_DEPRECATED
+			);
+		}
 
 		let models = this->_models;
 		if typeof models != "array" {

--- a/tests/_support/Helper/Db/Connection/AbstractFactory.php
+++ b/tests/_support/Helper/Db/Connection/AbstractFactory.php
@@ -10,7 +10,7 @@ namespace Helper\Db\Connection;
 abstract class AbstractFactory
 {
     /**
-     * Creates database connection
+     * Creates a database connection
      *
      * @return \Phalcon\Db\Adapter\Pdo
      */

--- a/tests/unit/Mvc/Model/MetaData/ResetCest.php
+++ b/tests/unit/Mvc/Model/MetaData/ResetCest.php
@@ -2,7 +2,6 @@
 
 namespace Phalcon\Test\Unit\Mvc\Model\MetaData;
 
-use Phalcon\Di;
 use UnitTester;
 use Phalcon\Mvc\Model;
 use Codeception\Example;


### PR DESCRIPTION
The third parameter `$with` of the `Query\Builder::addFrom` is deprecated and will be removed in future releases.

This feature was introduced at [Jun 1, 2015][1] was removed at [Aug 6, 2015][2]. Actually this feature was never used in stable releases.

Mark this feature as deprecated to avoid misunderstandings for future developers.

[1]: https://github.com/phalcon/cphalcon/commit/3e43192750367ae0343fbe42c65a97fd04b3444b
[2]: https://github.com/phalcon/cphalcon/commit/3ca25046ff484aedb7c38ac5aa994f183cba2415

Refs: #13023