### PR TITLE
Fix get relation when new array

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4448,9 +4448,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		if typeof relation == "object" {
 
 			/*
-			 Not fetch a relation if it is on CamelCase
+			 Do not fetch a relation if it is on CamelCase or if it is an Array of new Objects for this relation
 			 */
-			if isset this->{lowerProperty} && typeof this->{lowerProperty} == "object" {
+			if isset this->{lowerProperty} && (typeof this->{lowerProperty} == "object" || typeof this->{lowerProperty} == "array") {
 				return this->{lowerProperty};
 			}
 			/**

--- a/tests/_data/models/Parts.php
+++ b/tests/_data/models/Parts.php
@@ -23,6 +23,17 @@ use Phalcon\Mvc\Model;
  */
 class Parts extends Model
 {
+
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var string
+     */
+    public $name;
+
     public function initialize()
     {
         $this->hasMany(

--- a/tests/_data/models/Robots.php
+++ b/tests/_data/models/Robots.php
@@ -33,9 +33,39 @@ class Robots extends Model
     public $wasSetterUsed = false;
 
     /**
+     * @var int
+     */
+    public $id;
+
+    /**
      * @var string
      */
     protected $name;
+
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * @var int
+     */
+    public $year;
+
+    /**
+     * @var datetime
+     */
+    public $datetime;
+
+    /**
+     * @var datetime
+     */
+    public $deleted;
+
+    /**
+     * @var string
+     */
+    public $text;
 
     public function initialize()
     {
@@ -59,5 +89,10 @@ class Robots extends Model
         $this->wasSetterUsed = true;
 
         return $this;
+    }
+
+    public function getName()
+    {
+        return $this->name;
     }
 }

--- a/tests/_data/models/RobotsParts.php
+++ b/tests/_data/models/RobotsParts.php
@@ -22,6 +22,22 @@ use Phalcon\Mvc\Model;
  */
 class RobotsParts extends Model
 {
+
+    /**
+     * @var int
+     */
+    public $id;
+
+    /**
+     * @var int
+     */
+    public $robots_id;
+
+    /**
+     * @var int
+     */
+    public $parts_id;
+
     public function initialize()
     {
         $this->belongsTo('parts_id', Parts::class, 'id', ['foreignKey' => true]);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: none created

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

When working with a model and you set a relation with an Array of objects that might not be saved but you want to work on, if you try to call that relation the model will not try and return a ResultSet

i.e.
$artist->albums = [$a1, $a2];

Thanks

