### PR TITLE
Don't send dispatcher parameters

### DIFF
--- a/phalcon/mvc/application.zep
+++ b/phalcon/mvc/application.zep
@@ -347,8 +347,7 @@ class Application extends BaseApplication
 							 */
 							view->render(
 								dispatcher->getControllerName(),
-								dispatcher->getActionName(),
-								dispatcher->getParams()
+								dispatcher->getActionName()
 							);
 						}
 					}


### PR DESCRIPTION
* Type: bug fix
* Link to issue: #13121 

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
These will erase previously set variables, and dispatcher's params were never accessible this way so far, so removing the argument in this function is fine.

