### PR TITLE
Don't send dispatcher parameters

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -1,3 +1,6 @@
+# [3.2.4](https://github.com/phalcon/cphalcon/releases/tag/v3.2.4) (TBA)
+- Fixed regression of [#13046](https://github.com/phalcon/cphalcon/issues/13046) by removing injection of dispatcher's parameters (which were never available anyway) [#13121](https://github.com/phalcon/cphalcon/issues/13121)
+
 # [3.2.3](https://github.com/phalcon/cphalcon/releases/tag/v3.2.3) (2017-10-12)
 - Fixed `Phalcon\Mvc\Model\Query::_executeSelect` threw RuntimeException, if db:beforeQuery() returned false
 - Internal cookies property is now always an array [#12978](https://github.com/phalcon/cphalcon/issues/12978)

--- a/phalcon/mvc/application.zep
+++ b/phalcon/mvc/application.zep
@@ -347,8 +347,7 @@ class Application extends BaseApplication
 							 */
 							view->render(
 								dispatcher->getControllerName(),
-								dispatcher->getActionName(),
-								dispatcher->getParams()
+								dispatcher->getActionName()
 							);
 						}
 					}


### PR DESCRIPTION
* Type: bug fix
* Link to issue: #13121 

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
These will erase previously set variables, and dispatcher's params were never accessible this way so far, so removing the argument in this function is fine.

