### PR TITLE
* add function hasHeader to request

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,3 +1,4 @@
 # [3.3.0](https://github.com/phalcon/cphalcon/releases/tag/v3.3.0) (2017-XX-XX)
 - Added support for `switch/case` syntax to the Volt Engine [#13107](https://github.com/phalcon/cphalcon/issues/13107)
 - Added `Phalcon\Logger\Adapter\Blackhole` [#13074](https://github.com/phalcon/cphalcon/issues/13074)
+- Added function hasHeader to `Phalcon\Http\Request`

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,4 +1,4 @@
 # [3.3.0](https://github.com/phalcon/cphalcon/releases/tag/v3.3.0) (2017-XX-XX)
 - Added support for `switch/case` syntax to the Volt Engine [#13107](https://github.com/phalcon/cphalcon/issues/13107)
 - Added `Phalcon\Logger\Adapter\Blackhole` [#13074](https://github.com/phalcon/cphalcon/issues/13074)
-- Added function hasHeader to `Phalcon\Http\Request`
+- Added `Phalcon\Http\Request::hasHeader` to check if certain header exists

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -253,6 +253,26 @@ class Request implements RequestInterface, InjectionAwareInterface
 		return isset _SERVER[name];
 	}
 
+    /**
+     * Checks whether headers has certain index
+     */
+    public final function hasHeader(string! header) -> boolean
+    {
+        var name;
+
+        let name = strtoupper(strtr(header, "-", "_"));
+
+        if isset _SERVER[name] {
+            return true;
+        }
+
+        if isset _SERVER["HTTP_" . name] {
+            return true;
+        }
+
+        return false;
+    }
+
 	/**
 	 * Gets HTTP header from request data
 	 */

--- a/tests/unit/Http/RequestTest.php
+++ b/tests/unit/Http/RequestTest.php
@@ -132,7 +132,6 @@ class RequestTest extends HttpBase
                 expect($request->hasHeader('HTTP_FOO'))->true();
                 expect($request->hasHeader('AUTH'))->true();
                 expect($request->hasHeader('HTTP_FOO'))->true();
-
             }
         );
     }

--- a/tests/unit/Http/RequestTest.php
+++ b/tests/unit/Http/RequestTest.php
@@ -114,6 +114,30 @@ class RequestTest extends HttpBase
     }
 
     /**
+     * Tests hasHeader
+     *
+     * @author limx <715557344@qq.com>
+     * @since  2017-10-26
+     */
+    public function testHttpRequestCustomHeaderHas()
+    {
+        $this->specify(
+            "hasHeader does not returns correct result",
+            function () {
+                $_SERVER['HTTP_FOO'] = 'Bar';
+                $_SERVER['HTTP_AUTH'] = true;
+
+                $request = $this->getRequestObject();
+
+                expect($request->hasHeader('HTTP_FOO'))->true();
+                expect($request->hasHeader('AUTH'))->true();
+                expect($request->hasHeader('HTTP_FOO'))->true();
+
+            }
+        );
+    }
+    
+    /**
      * Tests isAjax default
      *
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

When I use getHeader to take some value out of headers, those the value don't exist,I will get empty string. But I expect it is null. So I add a function, called hasHeader to solve the problem.

Thanks

