### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/unit-tests/CacheTest.php
+++ b/unit-tests/CacheTest.php
@@ -20,7 +20,9 @@
 
 require_once 'helpers/xcache.php';
 
-class CacheTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class CacheTest extends TestCase
 {
 
 	public function setUp()

--- a/unit-tests/DbBindTest.php
+++ b/unit-tests/DbBindTest.php
@@ -20,8 +20,9 @@
 */
 
 use Phalcon\Db\Column as DbColumn;
+use PHPUnit\Framework\TestCase;
 
-class DbBindTest extends PHPUnit_Framework_TestCase
+class DbBindTest extends TestCase
 {
 	public function testDbBindMysql()
 	{

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -19,7 +19,9 @@
   +------------------------------------------------------------------------+
 */
 
-class DbDescribeTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DbDescribeTest extends TestCase
 {
 
 	public function getExpectedColumnsMysql()

--- a/unit-tests/DbProfilerTest.php
+++ b/unit-tests/DbProfilerTest.php
@@ -18,6 +18,8 @@
   +------------------------------------------------------------------------+
 */
 
+use PHPUnit\Framework\TestCase;
+
 class DbProfiler extends Phalcon\Db\Profiler
 {
 
@@ -71,7 +73,7 @@ class DbProfilerListener
 
 }
 
-class DbProfilerTest extends PHPUnit_Framework_TestCase
+class DbProfilerTest extends TestCase
 {
 
 	public function testDbMysql()

--- a/unit-tests/DbTest.php
+++ b/unit-tests/DbTest.php
@@ -19,7 +19,9 @@
   +------------------------------------------------------------------------+
 */
 
-class DbTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DbTest extends TestCase
 {
 	/**
 	 * @medium

--- a/unit-tests/DispatcherMvcEventsTest.php
+++ b/unit-tests/DispatcherMvcEventsTest.php
@@ -18,6 +18,8 @@
   +------------------------------------------------------------------------+
 */
 
+use PHPUnit\Framework\TestCase;
+
 class DispatcherListener
 {
 
@@ -149,7 +151,7 @@ class DispatcherListenerWithException extends DispatcherListener
 	}
 }
 
-class DispatcherMvcEventsTest extends PHPUnit_Framework_TestCase
+class DispatcherMvcEventsTest extends TestCase
 {
 
 	public function dispatcherAutoloader($className)

--- a/unit-tests/FormsTest.php
+++ b/unit-tests/FormsTest.php
@@ -26,7 +26,8 @@ use
 	Phalcon\Validation\Validator\PresenceOf,
 	Phalcon\Validation\Validator\StringLength,
 	Phalcon\Validation\Validator\Regex,
-	Phalcon\Validation\Message;
+	Phalcon\Validation\Message,
+	PHPUnit\Framework\TestCase;
 
 class ContactFormPublicProperties
 {
@@ -61,7 +62,7 @@ class ContactFormSettersGetters
 	}
 }
 
-class FormsTest extends PHPUnit_Framework_TestCase
+class FormsTest extends TestCase
 {
 
 	public function setUp()

--- a/unit-tests/Issue1801.php
+++ b/unit-tests/Issue1801.php
@@ -19,10 +19,12 @@
   +------------------------------------------------------------------------+
 */
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * This test has to be in a separate file and cannot be combined with ModelsTest
  */
-class Issue1801 extends PHPUnit_Framework_TestCase
+class Issue1801 extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/MicroMvcCollectionsTest.php
+++ b/unit-tests/MicroMvcCollectionsTest.php
@@ -18,6 +18,8 @@
   +------------------------------------------------------------------------+
 */
 
+use PHPUnit\Framework\TestCase;
+
 class PersonasController
 {
 	protected $_entered = 0;
@@ -58,7 +60,7 @@ class PersonasLazyController
 	}
 }
 
-class MicroMvcCollectionsTest extends PHPUnit_Framework_TestCase
+class MicroMvcCollectionsTest extends TestCase
 {
 
 	public function testMicroCollections()

--- a/unit-tests/ModelsCalculationsTest.php
+++ b/unit-tests/ModelsCalculationsTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsCalculationsTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsCalculationsTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsDynamicOperationsTest.php
+++ b/unit-tests/ModelsDynamicOperationsTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsDynamicOperationsTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsDynamicOperationsTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsEventsTest.php
+++ b/unit-tests/ModelsEventsTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsEventsTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsEventsTest extends TestCase
 {
 
 	public function __construct()
@@ -123,7 +125,7 @@ class ModelsEventsTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals($trace, array(
 			'prepareSave' => array(
-				'GossipRobots' => 1	
+				'GossipRobots' => 1
 			),
 			'beforeValidation' => array(
 				'GossipRobots' => 2,
@@ -170,7 +172,7 @@ class ModelsEventsTest extends PHPUnit_Framework_TestCase
 
 		$this->assertEquals($trace, array(
 			'prepareSave' => array(
-				'GossipRobots' => 1	
+				'GossipRobots' => 1
 			),
 			'beforeValidation' => array(
 				'GossipRobots' => 2,

--- a/unit-tests/ModelsForeignKeysTest.php
+++ b/unit-tests/ModelsForeignKeysTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsForeignKeysTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsForeignKeysTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsHydrationTest.php
+++ b/unit-tests/ModelsHydrationTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsHydrationTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsHydrationTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsMetadataStrategyTest.php
+++ b/unit-tests/ModelsMetadataStrategyTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsMetadataStrategyTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsMetadataStrategyTest extends TestCase
 {
 
 	protected $_expectedMeta = array(

--- a/unit-tests/ModelsMetadataTest.php
+++ b/unit-tests/ModelsMetadataTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsMetadataTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsMetadataTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsMultipleSourcesTest.php
+++ b/unit-tests/ModelsMultipleSourcesTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsMultipleSourcesTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsMultipleSourcesTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsQueryExecuteTest.php
+++ b/unit-tests/ModelsQueryExecuteTest.php
@@ -19,8 +19,9 @@
 */
 
 use Phalcon\Mvc\Model\Query as Query;
+use PHPUnit\Framework\TestCase;
 
-class ModelsQueryExecuteTest extends PHPUnit_Framework_TestCase
+class ModelsQueryExecuteTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsRelationsMagicTest.php
+++ b/unit-tests/ModelsRelationsMagicTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsRelationsMagicTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsRelationsMagicTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsRelationsTest.php
+++ b/unit-tests/ModelsRelationsTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsRelationsTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsRelationsTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsResultsetCacheStaticTest.php
+++ b/unit-tests/ModelsResultsetCacheStaticTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsResultsetCacheStaticTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsResultsetCacheStaticTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsResultsetCacheTest.php
+++ b/unit-tests/ModelsResultsetCacheTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsResultsetCacheTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsResultsetCacheTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsResultsetTest.php
+++ b/unit-tests/ModelsResultsetTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsResultsetTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ModelsResultsetTest extends TestCase
 {
 
 	public function __construct()
@@ -542,51 +544,51 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 
 		$this->assertFalse(isset($robots[0]));
 	}
-	
+
 	public function testResultsetAppendIterator()
 	{
 		if (!$this->_prepareTestMysql()) {
 			$this->markTestSkipped("Skipped");
 			return;
 		}
-		
+
 		// see http://php.net/manual/en/appenditerator.construct.php
 		$iterator = new \AppendIterator();
 		$robots_first = Robots::find(array('limit' => 2));
 		$robots_second = Robots::find(array('limit' => 1, 'offset' => 2));
-		
+
 		$robots_first_0 = $robots_first[0];
 		$robots_first_1 = $robots_first[1];
 		$robots_second_0 = $robots_second[0];
-		
+
 		$iterator->append($robots_first);
 		$iterator->append($robots_second);
-		
+
 		$iterator->rewind();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 0);
 		$this->assertEquals($iterator->getIteratorIndex(), 0);
 		$this->assertEquals(get_class($iterator->current()), 'Robots');
 		$this->assertEquals($robots_first_0->name, $iterator->current()->name);
-		
+
 		$iterator->next();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 1);
 		$this->assertEquals($iterator->getIteratorIndex(), 0);
 		$this->assertEquals(get_class($iterator->current()), 'Robots');
 		$this->assertEquals($robots_first_1->name, $iterator->current()->name);
-		
+
 		$iterator->next();
 		$this->assertTrue($iterator->valid());
 		$this->assertEquals($iterator->key(), 0);
 		$this->assertEquals($iterator->getIteratorIndex(), 1);
 		$this->assertEquals(get_class($iterator->current()), 'Robots');
 		$this->assertEquals($robots_second_0->name, $iterator->current()->name);
-		
+
 		$iterator->next();
 		$this->assertFalse($iterator->valid());
 	}
-	
+
 	public function testBigResultsetIteration() {
 		if (!$this->_prepareTestSqlite()) {
 			$this->markTestSkipped("Skipped");
@@ -597,31 +599,31 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		$personas = Personas::find(array(
 			'limit' => 33
 		));
-		
+
 		$this->assertEquals(count($personas), 33);
-		
+
 		$this->assertEquals(get_class($personas->getLast()), 'Personas');
-		
+
 		// take first object as reference
 		$persona_first = $personas[0];
 		$this->assertEquals(get_class($persona_first), 'Personas');
-		
+
 		// make sure objects are the same -> object was not recreared
 		$this->assertSame($personas[0], $persona_first);
 		$this->assertSame($personas->current(), $persona_first);
 		$personas->rewind();
 		$this->assertTrue($personas->valid());
 		$this->assertSame($personas->current(), $persona_first);
-		
+
 		// second element
 		$personas->next();
 		$this->assertTrue($personas->valid());
 		$persona_second = $personas->current();
 		$this->assertSame($persona_second, $personas[1]);
-		
+
 		// move to last element
 		$this->assertSame($personas->getLast(), $personas[32]);
-		
+
 		// invalid element
 		$personas->seek(33);
 		$this->assertFalse($personas->valid());
@@ -633,28 +635,28 @@ class ModelsResultsetTest extends PHPUnit_Framework_TestCase
 		catch(Exception $e){
 			$this->assertEquals($e->getMessage(), 'The index does not exist in the cursor');
 		}
-		
+
 		// roll-back-cursor -> query needs to be reexecuted
 		// first object was now recreated... different instance, but equal content
 		$this->assertNotSame($personas[0], $persona_first);
 		$this->assertEquals($personas[0], $persona_first);
 		$persona_first = $personas[0];
-		
+
 		// toArray also re-executes the query and invalidates internal pointer
 		$array = $personas->toArray();
 		$this->assertEquals(count($array), 33);
-		
-		// internal query is re-executed again and set to first 
+
+		// internal query is re-executed again and set to first
 		$this->assertNotSame($personas[0], $persona_first);
 		$this->assertEquals($personas[0], $persona_first);
-		
+
 		// move to second element and validate
 		$personas->next();
 		$this->assertTrue($personas->valid());
 		$this->assertEquals(get_class($personas[1]), 'Personas');
 		$this->assertSame($personas->current(), $personas[1]);
 		$this->assertEquals($persona_second, $personas[1]);
-		
+
 		// pick some random indices
 		$this->assertEquals(get_class($personas[12]), 'Personas');
 		$this->assertEquals(get_class($personas[23]), 'Personas');

--- a/unit-tests/ModelsTest.php
+++ b/unit-tests/ModelsTest.php
@@ -19,12 +19,13 @@
 */
 
 use Phalcon\Mvc\Model\Message as ModelMessage;
+use PHPUnit\Framework\TestCase;
 
 class Issue_1534 extends \Phalcon\Mvc\Model
 {
 }
 
-class ModelsTest extends PHPUnit_Framework_TestCase
+class ModelsTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ModelsTransactionsTest.php
+++ b/unit-tests/ModelsTransactionsTest.php
@@ -18,7 +18,9 @@
   +------------------------------------------------------------------------+
 */
 
-class ModelsTransactionsTest extends PHPUnit_Framework_TestCase {
+use PHPUnit\Framework\TestCase;
+
+class ModelsTransactionsTest extends TestCase {
 
 	public function __construct()
 	{
@@ -213,4 +215,3 @@ class ModelsTransactionsTest extends PHPUnit_Framework_TestCase {
 	}
 
 }
-

--- a/unit-tests/ModelsValidatorsTest.php
+++ b/unit-tests/ModelsValidatorsTest.php
@@ -18,12 +18,14 @@
   +------------------------------------------------------------------------+
 */
 
+use PHPUnit\Framework\TestCase;
+
 function sqlite_now()
 {
 	return date('Y-m-d H:i:s');
 }
 
-class ModelsValidatorsTest extends PHPUnit_Framework_TestCase
+class ModelsValidatorsTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/PaginatorTest.php
+++ b/unit-tests/PaginatorTest.php
@@ -20,9 +20,10 @@
 
 use Phalcon\Logger\Adapter\File as FileLogger,
     Phalcon\Db\Adapter\Pdo\Mysql as DbAdapter,
-    Phalcon\Events\Manager as EventsManager;
+    Phalcon\Events\Manager as EventsManager,
+    PHPUnit\Framework\TestCase;
 
-class PaginatorTest extends PHPUnit_Framework_TestCase
+class PaginatorTest extends TestCase
 {
 
 	public function __construct()

--- a/unit-tests/ViewEnginesVoltTest.php
+++ b/unit-tests/ViewEnginesVoltTest.php
@@ -27,6 +27,7 @@ use Phalcon\Escaper;
 use Phalcon\Mvc\Url;
 use Phalcon\Tag;
 use Phalcon\Di;
+use PHPUnit\Framework\TestCase;
 
 class SomeObject implements Iterator, Countable
 {
@@ -96,7 +97,7 @@ function phalcon_prepare_virtual_path($path, $separator) {
 	return $virtual_str;
 }
 
-class ViewEnginesVoltTest extends PHPUnit_Framework_TestCase
+class ViewEnginesVoltTest extends TestCase
 {
 	public function testVoltCompileFileExtends()
 	{


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).