### PR TITLE
Service class API change and addition of helper class

### DIFF
--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -20,6 +20,7 @@ use Phalcon\Config;
 use Phalcon\Di\Service;
 use Phalcon\DiInterface;
 use Phalcon\Di\Exception;
+use Phalcon\Di\Exception\ServiceResolutionException;
 use Phalcon\Config\Adapter\Php;
 use Phalcon\Config\Adapter\Yaml;
 use Phalcon\Di\ServiceInterface;
@@ -127,7 +128,7 @@ class Di implements DiInterface
 	public function set(string! name, var definition, boolean shared = false) -> <ServiceInterface>
 	{
 		var service;
-		let service = new Service(name, definition, shared),
+		let service = new Service(definition, shared),
 			this->_services[name] = service;
 		return service;
 	}
@@ -160,7 +161,7 @@ class Di implements DiInterface
 		var service;
 
 		if !isset this->_services[name] {
-			let service = new Service(name, definition, shared),
+			let service = new Service(definition, shared),
 				this->_services[name] = service;
 			return service;
 		}
@@ -210,7 +211,7 @@ class Di implements DiInterface
 	 */
 	public function get(string! name, parameters = null) -> var
 	{
-		var service, eventsManager, instance = null;
+		var service, eventsManager, instance = null, e = null;
 
 		let eventsManager = <ManagerInterface> this->_eventsManager;
 
@@ -227,7 +228,11 @@ class Di implements DiInterface
 				/**
 				 * The service is registered in the DI
 				 */
-				let instance = service->resolve(parameters, this);
+				try {
+					let instance = service->resolve(parameters, this);
+				} catch ServiceResolutionException, e {
+					throw new Exception("Service '" . name . "' cannot be resolved");
+				}
 			} else {
 				/**
 				 * The DI also acts as builder for any class even if it isn't defined in the DI

--- a/phalcon/di/exception/serviceResolutionException.zep
+++ b/phalcon/di/exception/serviceResolutionException.zep
@@ -1,0 +1,30 @@
+
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file LICENSE.txt.                             |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
+ |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Di\Exception;
+
+use Phalcon\Di\Exception\ServiceResolutionException;
+
+/**
+ * Phalcon\Di\Exception\ServiceResolutionException
+ *
+ */
+class ServiceResolutionException extends \Phalcon\Di\Exception
+{
+}

--- a/phalcon/di/exception/serviceresolutionexception.zep
+++ b/phalcon/di/exception/serviceresolutionexception.zep
@@ -12,8 +12,7 @@
  | obtain it through the world-wide-web, please send an email             |
  | to license@phalconphp.com so we can send you a copy immediately.       |
  +------------------------------------------------------------------------+
- | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
- |          Eduar Carvajal <eduar@phalconphp.com>                         |
+ | Authors: David Schissler <david.schissler@gmail.com                    |
  +------------------------------------------------------------------------+
  */
 

--- a/phalcon/di/factorydefault.zep
+++ b/phalcon/di/factorydefault.zep
@@ -37,27 +37,27 @@ class FactoryDefault extends \Phalcon\Di
 		parent::__construct();
 
 		let this->_services = [
-			"router":             new Service("router", "Phalcon\\Mvc\\Router", true),
-			"dispatcher":         new Service("dispatcher", "Phalcon\\Mvc\\Dispatcher", true),
-			"url":                new Service("url", "Phalcon\\Mvc\\Url", true),
-			"modelsManager":      new Service("modelsManager", "Phalcon\\Mvc\\Model\\Manager", true),
-			"modelsMetadata":     new Service("modelsMetadata", "Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
-			"response":           new Service("response", "Phalcon\\Http\\Response", true),
-			"cookies":            new Service("cookies", "Phalcon\\Http\\Response\\Cookies", true),
-			"request":            new Service("request", "Phalcon\\Http\\Request", true),
-			"filter":             new Service("filter", "Phalcon\\Filter", true),
-			"escaper":            new Service("escaper", "Phalcon\\Escaper", true),
-			"security":           new Service("security", "Phalcon\\Security", true),
-			"crypt":              new Service("crypt", "Phalcon\\Crypt", true),
-			"annotations":        new Service("annotations", "Phalcon\\Annotations\\Adapter\\Memory", true),
-			"flash":              new Service("flash", "Phalcon\\Flash\\Direct", true),
-			"flashSession":       new Service("flashSession", "Phalcon\\Flash\\Session", true),
-			"tag":                new Service("tag", "Phalcon\\Tag", true),
-			"session":            new Service("session", "Phalcon\\Session\\Adapter\\Files", true),
-			"sessionBag":         new Service("sessionBag", "Phalcon\\Session\\Bag"),
-			"eventsManager":      new Service("eventsManager", "Phalcon\\Events\\Manager", true),
-			"transactionManager": new Service("transactionManager", "Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
-			"assets":             new Service("assets", "Phalcon\\Assets\\Manager", true)
+			"router":             new Service("Phalcon\\Mvc\\Router", true),
+			"dispatcher":         new Service("Phalcon\\Mvc\\Dispatcher", true),
+			"url":                new Service("Phalcon\\Mvc\\Url", true),
+			"modelsManager":      new Service("Phalcon\\Mvc\\Model\\Manager", true),
+			"modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
+			"response":           new Service("Phalcon\\Http\\Response", true),
+			"cookies":            new Service("Phalcon\\Http\\Response\\Cookies", true),
+			"request":            new Service("Phalcon\\Http\\Request", true),
+			"filter":             new Service("Phalcon\\Filter", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"security":           new Service("Phalcon\\Security", true),
+			"crypt":              new Service("Phalcon\\Crypt", true),
+			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
+			"flash":              new Service("Phalcon\\Flash\\Direct", true),
+			"flashSession":       new Service("Phalcon\\Flash\\Session", true),
+			"tag":                new Service("Phalcon\\Tag", true),
+			"session":            new Service("Phalcon\\Session\\Adapter\\Files", true),
+			"sessionBag":         new Service("Phalcon\\Session\\Bag"),
+			"eventsManager":      new Service("Phalcon\\Events\\Manager", true),
+			"transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
+			"assets":             new Service("Phalcon\\Assets\\Manager", true)
 		];
 	}
 }

--- a/phalcon/di/factorydefault/cli.zep
+++ b/phalcon/di/factorydefault/cli.zep
@@ -41,16 +41,16 @@ class Cli extends FactoryDefault
 		parent::__construct();
 
 		let this->_services = [
-			"router":             new Service("router", "Phalcon\\Cli\\Router", true),
-			"dispatcher":         new Service("dispatcher", "Phalcon\\Cli\\Dispatcher", true),
-			"modelsManager":      new Service("modelsManager", "Phalcon\\Mvc\\Model\\Manager", true),
-			"modelsMetadata":     new Service("modelsMetadata", "Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
-			"filter":             new Service("filter", "Phalcon\\Filter", true),
-			"escaper":            new Service("escaper", "Phalcon\\Escaper", true),
-			"annotations":        new Service("annotations", "Phalcon\\Annotations\\Adapter\\Memory", true),
-			"security":           new Service("security", "Phalcon\\Security", true),
-			"eventsManager":      new Service("eventsManager", "Phalcon\\Events\\Manager", true),
-			"transactionManager": new Service("transactionManager", "Phalcon\\Mvc\\Model\\Transaction\\Manager", true)
+			"router":             new Service("Phalcon\\Cli\\Router", true),
+			"dispatcher":         new Service("Phalcon\\Cli\\Dispatcher", true),
+			"modelsManager":      new Service("Phalcon\\Mvc\\Model\\Manager", true),
+			"modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
+			"filter":             new Service("Phalcon\\Filter", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
+			"security":           new Service("Phalcon\\Security", true),
+			"eventsManager":      new Service("Phalcon\\Events\\Manager", true),
+			"transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true)
 		];
 	}
 }

--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Di;
 
 use Phalcon\DiInterface;
 use Phalcon\Di\Exception;
+use Phalcon\Di\Exception\ServiceResolutionException;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Di\Service\Builder;
 
@@ -40,9 +41,6 @@ use Phalcon\Di\Service\Builder;
  */
 class Service implements ServiceInterface
 {
-
-	protected _name;
-
 	protected _definition;
 
 	protected _shared = false;
@@ -55,20 +53,12 @@ class Service implements ServiceInterface
 	 * Phalcon\Di\Service
 	 *
 	 * @param mixed definition
+	 * @param boolean shared
 	 */
-	public final function __construct(string! name, definition, boolean shared = false)
+	public function __construct(definition, boolean shared = false)
 	{
-		let this->_name = name,
-			this->_definition = definition,
+		let this->_definition = definition,
 			this->_shared = shared;
-	}
-
-	/**
-	 * Returns the service's name
-	 */
-	public function getName() -> string
-	{
-		return this->_name;
 	}
 
 	/**
@@ -121,6 +111,7 @@ class Service implements ServiceInterface
 	 * Resolves the service
 	 *
 	 * @param array parameters
+	 * @param \Phalcon\DiInterface dependencyInjector
 	 * @return mixed
 	 */
 	public function resolve(parameters = null, <DiInterface> dependencyInjector = null)
@@ -202,7 +193,7 @@ class Service implements ServiceInterface
 		 * If the service can't be built, we must throw an exception
 		 */
 		if found === false  {
-			throw new Exception("Service '" . this->_name . "' cannot be resolved");
+			throw new ServiceResolutionException();
 		}
 
 		/**
@@ -254,6 +245,7 @@ class Service implements ServiceInterface
 	/**
 	 * Returns a parameter in a specific position
 	 *
+	 * @param int position
 	 * @return array
 	 */
 	public function getParameter(int position)
@@ -291,10 +283,6 @@ class Service implements ServiceInterface
 	public static function __set_state(array! attributes) -> <Service>
 	{
 		var name, definition, shared;
-
-		if !fetch name, attributes["_name"] {
-			throw new Exception("The attribute '_name' is required");
-		}
 
 		if !fetch definition, attributes["_definition"] {
 			throw new Exception("The attribute '_definition' is required");

--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -282,6 +282,6 @@ class Service implements ServiceInterface
 			throw new Exception("The attribute '_shared' is required");
 		}
 
-		return new self(name, definition, shared);
+		return new self(definition, shared);
 	}
 }

--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -52,10 +52,8 @@ class Service implements ServiceInterface
 	/**
 	 * Phalcon\Di\Service
 	 *
-	 * @param mixed definition
-	 * @param boolean shared
 	 */
-	public function __construct(definition, boolean shared = false)
+	public function __construct(var definition, boolean shared = false)
 	{
 		let this->_definition = definition,
 			this->_shared = shared;
@@ -80,9 +78,8 @@ class Service implements ServiceInterface
 	/**
 	 * Sets/Resets the shared instance related to the service
 	 *
-	 * @param mixed sharedInstance
 	 */
-	public function setSharedInstance(sharedInstance) -> void
+	public function setSharedInstance(var sharedInstance) -> void
 	{
 		let this->_sharedInstance = sharedInstance;
 	}
@@ -90,9 +87,8 @@ class Service implements ServiceInterface
 	/**
 	 * Set the service definition
 	 *
-	 * @param mixed definition
 	 */
-	public function setDefinition(definition) -> void
+	public function setDefinition(var definition) -> void
 	{
 		let this->_definition = definition;
 	}
@@ -100,7 +96,6 @@ class Service implements ServiceInterface
 	/**
 	 * Returns the service definition
 	 *
-	 * @return mixed
 	 */
 	public function getDefinition()
 	{
@@ -110,11 +105,8 @@ class Service implements ServiceInterface
 	/**
 	 * Resolves the service
 	 *
-	 * @param array parameters
-	 * @param \Phalcon\DiInterface dependencyInjector
-	 * @return mixed
 	 */
-	public function resolve(parameters = null, <DiInterface> dependencyInjector = null)
+	public function resolve(var parameters = null, <DiInterface> dependencyInjector = null)
 	{
 		boolean found;
 		var shared, definition, sharedInstance, instance, builder;
@@ -245,10 +237,8 @@ class Service implements ServiceInterface
 	/**
 	 * Returns a parameter in a specific position
 	 *
-	 * @param int position
-	 * @return array
 	 */
-	public function getParameter(int position)
+	public function getParameter(int position) -> array | null
 	{
 		var definition, arguments, parameter;
 

--- a/phalcon/di/service/serviceregistry.zep
+++ b/phalcon/di/service/serviceregistry.zep
@@ -1,0 +1,115 @@
+namespace Phalcon\Di\Service;
+
+use Phalcon\DiInterface;
+use Phalcon\Di\Exception;
+use Phalcon\Di\ServiceInterface;
+use Phalcon\Config\Adapter\Yaml;
+
+/**
+ * Phalcon\Di\Service\ServiceRegistry
+ *
+ **/
+class ServiceRegistry
+{
+
+	/**
+	 *
+	 */
+	protected di;
+
+	/**
+	 *
+	 */
+	public function __construct(<DiInterface> di)
+	{
+		let this->di = di;
+	}
+
+	/**
+	 *
+	 */
+	public function registerDir(dirPath)
+	{
+		var dirPathItem;
+
+		switch (gettype(dirPath)) {
+			case "string":
+				this->_registerDir(dirPath);
+				break;
+			case "array":
+			case "object":
+				for dirPathItem in iterator(dirPath) {
+					this->_registerDir(dirPathItem);
+				}
+				break;
+			default:
+				throw new Exception("Invalid services.");
+				break;
+		}
+	}
+
+	/**
+	 *
+	 */
+	protected function _registerDir(string! dirPath)
+	{
+		var dir, fileinfo, extension, serviceNameSection, forceShared, serviceName;
+
+		let dir = new \DirectoryIterator(dirPath);
+		for fileinfo in iterator(dir) {
+			if (fileinfo->isDir()) {
+				continue;
+			}
+
+			let extension = fileinfo->getExtension();
+			let serviceNameSection = fileinfo->getBasename("." . extension);
+
+			let forceShared = substr(serviceNameSection, -7) === "_shared";
+			let serviceName = forceShared ? substr(serviceNameSection, 0, -7) : serviceNameSection;
+
+			this->_registerFile(fileinfo->getPathname(), serviceName, extension, forceShared);
+		}
+	}
+
+	/**
+	 *
+	 */
+	protected function _registerFile(string! path, string! serviceName, string! extension, boolean forceShared)
+	{
+		var serviceDef;
+
+		switch (extension) {
+			case "php":
+				let serviceDef = require path;
+
+				switch (gettype(serviceDef)) {
+					case "object":
+						if (serviceDef instanceof ServiceInterface) {
+							if (forceShared) {
+								serviceDef->setShared(true);
+							}
+							this->di->setRaw(serviceName, serviceDef);
+						} elseif (is_callable(serviceDef)) {
+							this->di->set(serviceName, serviceDef, forceShared);
+						} else {
+							throw new Exception("Invalid service object definiton.");
+						}
+						break;
+					case "array":
+					case "string":
+						this->di->set(serviceName, serviceDef, forceShared);
+						break;
+					default:
+						throw new Exception("Invalid service definiton.");
+				}
+				break;
+			case "yml":
+				let serviceDef = new Yaml(path);
+				this->di->set(serviceName, serviceDef->toArray(), forceShared);
+				break;
+			default:
+				throw new Exception("Invalid service definition type.");
+				break;
+		}
+	}
+}

--- a/phalcon/di/service/serviceregistry.zep
+++ b/phalcon/di/service/serviceregistry.zep
@@ -25,22 +25,22 @@ class ServiceRegistry
 	/**
 	 *
 	 */
-	public function registerDir(dirPath)
+	public function registerDirectory(dirPath)
 	{
 		var dirPathItem;
 
-		switch (gettype(dirPath)) {
+		switch typeof dirPath {
 			case "string":
-				this->registerDirInternal(dirPath);
+				this->registerDirectoryInternal(dirPath);
 				break;
 			case "array":
 			case "object":
 				for dirPathItem in iterator(dirPath) {
-					this->registerDirInternal(dirPathItem);
+					this->registerDirectoryInternal(dirPathItem);
 				}
 				break;
 			default:
-				throw new Exception("Invalid services.");
+				throw new Exception("Invalid service directory variable type.");
 				break;
 		}
 	}
@@ -48,13 +48,15 @@ class ServiceRegistry
 	/**
 	 *
 	 */
-	protected function registerDirInternal(string! dirPath)
+	protected function registerDirectoryInternal(string! dirPath)
 	{
 		var dir, fileinfo, extension, serviceNameSection, forceShared, serviceName;
 
 		let dir = new \DirectoryIterator(dirPath);
 		for fileinfo in iterator(dir) {
-			if (fileinfo->isDir()) {
+
+			// Only handle normal files within a directory.
+			if (!fileinfo->isFile()) {
 				continue;
 			}
 
@@ -64,14 +66,14 @@ class ServiceRegistry
 			let forceShared = substr(serviceNameSection, -7) === "_shared";
 			let serviceName = forceShared ? substr(serviceNameSection, 0, -7) : serviceNameSection;
 
-			this->registerFile(fileinfo->getPathname(), serviceName, extension, forceShared);
+			this->registerFileInternal(fileinfo->getPathname(), serviceName, extension, forceShared);
 		}
 	}
 
 	/**
 	 *
 	 */
-	protected function registerFile(string! path, string! serviceName, string! extension, boolean forceShared)
+	protected function registerFileInternal(string! path, string! serviceName, string! extension, boolean forceShared)
 	{
 		var serviceDef;
 
@@ -89,7 +91,7 @@ class ServiceRegistry
 						} elseif (is_callable(serviceDef)) {
 							this->di->set(serviceName, serviceDef, forceShared);
 						} else {
-							throw new Exception("Invalid service object definiton.");
+							throw new Exception("Invalid service definition object.");
 						}
 						break;
 					case "array":
@@ -97,7 +99,7 @@ class ServiceRegistry
 						this->di->set(serviceName, serviceDef, forceShared);
 						break;
 					default:
-						throw new Exception("Invalid service definiton.");
+						throw new Exception("Invalid service definiton variable type.");
 				}
 				break;
 			case "yml":
@@ -105,7 +107,7 @@ class ServiceRegistry
 				this->di->set(serviceName, serviceDef->toArray(), forceShared);
 				break;
 			default:
-				throw new Exception("Invalid service definition type.");
+				throw new Exception("Invalid service definition file extension.");
 				break;
 		}
 	}

--- a/phalcon/di/service/serviceregistry.zep
+++ b/phalcon/di/service/serviceregistry.zep
@@ -12,9 +12,6 @@ use Phalcon\Config\Adapter\Yaml;
 class ServiceRegistry
 {
 
-	/**
-	 *
-	 */
 	protected di;
 
 	/**
@@ -34,12 +31,12 @@ class ServiceRegistry
 
 		switch (gettype(dirPath)) {
 			case "string":
-				this->_registerDir(dirPath);
+				this->registerDirInternal(dirPath);
 				break;
 			case "array":
 			case "object":
 				for dirPathItem in iterator(dirPath) {
-					this->_registerDir(dirPathItem);
+					this->registerDirInternal(dirPathItem);
 				}
 				break;
 			default:
@@ -51,7 +48,7 @@ class ServiceRegistry
 	/**
 	 *
 	 */
-	protected function _registerDir(string! dirPath)
+	protected function registerDirInternal(string! dirPath)
 	{
 		var dir, fileinfo, extension, serviceNameSection, forceShared, serviceName;
 
@@ -67,22 +64,22 @@ class ServiceRegistry
 			let forceShared = substr(serviceNameSection, -7) === "_shared";
 			let serviceName = forceShared ? substr(serviceNameSection, 0, -7) : serviceNameSection;
 
-			this->_registerFile(fileinfo->getPathname(), serviceName, extension, forceShared);
+			this->registerFile(fileinfo->getPathname(), serviceName, extension, forceShared);
 		}
 	}
 
 	/**
 	 *
 	 */
-	protected function _registerFile(string! path, string! serviceName, string! extension, boolean forceShared)
+	protected function registerFile(string! path, string! serviceName, string! extension, boolean forceShared)
 	{
 		var serviceDef;
 
-		switch (extension) {
+		switch extension {
 			case "php":
 				let serviceDef = require path;
 
-				switch (gettype(serviceDef)) {
+				switch typeof serviceDef {
 					case "object":
 						if (serviceDef instanceof ServiceInterface) {
 							if (forceShared) {

--- a/phalcon/di/service/sharedservice.zep
+++ b/phalcon/di/service/sharedservice.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2017 Phalcon Team (http://www.phalconphp.com)       |
+ | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file LICENSE.txt.                             |
@@ -15,59 +15,34 @@
  | Authors: Andres Gutierrez <andres@phalconphp.com>                      |
  |          Eduar Carvajal <eduar@phalconphp.com>                         |
  +------------------------------------------------------------------------+
-*/
+ */
 
-namespace Phalcon\Di;
+namespace Phalcon\Di\Service;
 
-use Phalcon\DiInterface;
+use Phalcon\Di\Service;
 
 /**
- * Phalcon\Di\ServiceInterface
+ * Phalcon\Di\Service\SharedService
  *
- * Represents a service in the services container
+ *
+ *<code>
+ * $service = new \Phalcon\Di\Service\SharedService(
+ *     "request",
+ *     "Phalcon\\Http\\Request"
+ * );
+ *
+ * $request = service->resolve();
+ *</code>
  */
-interface ServiceInterface
+class SharedService extends Service
 {
 	/**
-	 * Sets if the service is shared or not
-	 */
-	public function setShared(boolean shared);
-
-	/**
-	 * Check whether the service is shared or not
-	 */
-	public function isShared() -> boolean;
-
-	/**
-	 * Set the service definition
+	 * Phalcon\Di\Service\SharedService
 	 *
 	 * @param mixed definition
 	 */
-	public function setDefinition(definition);
-
-	/**
-	 * Returns the service definition
-	 *
-	 * @return mixed
-	 */
-	public function getDefinition();
-
-	/**
-	 * Resolves the service
-	 *
-	 * @param array parameters
-	 * @return mixed
-	 */
-	public function resolve(parameters = null, <DiInterface> dependencyInjector = null);
-
-	/**
-	 * Changes a parameter in the definition without resolve the service
-	 */
-	public function setParameter(int position, array! parameter) -> <ServiceInterface>;
-
-	/**
-	 * Restore the internal state of a service
-	 */
-	public static function __set_state(array! attributes) -> <ServiceInterface>;
-
+	public final function __construct(definition)
+	{
+		parent::__construct(definition, true);
+	}
 }

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -257,13 +257,11 @@ class DiTest extends UnitTest
             function () {
                 $expectedServices = [
                     'service1' => Service::__set_state([
-                        '_name'           => 'service1',
                         '_definition'     => 'some-service',
                         '_shared'         => false,
                         '_sharedInstance' => null,
                     ]),
                     'service2' => Service::__set_state([
-                        '_name'           => 'service2',
                         '_definition'     => 'some-other-service',
                         '_shared'         => false,
                         '_sharedInstance' => null,


### PR DESCRIPTION
I removed the name parameter from the Service class since the only place where it is used in the Phalcon code is for throwing an exception when there was a problem with the service.  I added a new exception class which the DI catches and since the DI knows what the name of the service should be it is able to provide the same error reporting capabilities.

This API change allows for `Phalcon\Di\Service` classes to more gracefully wrap service closures.

I added a `Phalcon\Di\Service\SharedService` class which simply offers API sugar to make the second parameter unnecessary when using a shared service.

I added a new helper class `Phalcon\Di\Service\ServiceRegistry` for registering a directory of service files in either yaml or php.  These files can return a php array with a static definition, a closure, a `Service` object or a string for the class name.

[edit] I'm going to take a week off from this and then I'll take down this pull request and start over with a clean repo with just 2-3 commits.  I'm going to redesign the API a bit, modify the tests, etc.