### PR TITLE
Fix wrong SQL creating table with boolean type in posqgresql

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -3,3 +3,5 @@
 - Added `Phalcon\Logger\Adapter\Blackhole` [#13074](https://github.com/phalcon/cphalcon/issues/13074)
 - Added `Phalcon\Http\Request::hasHeader` to check if certain header exists
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
+- Fixed `Phalcon\Db\Dialect\Postgresql::createTable()` to correct inserting default value to SQL for `boolean` type [#13132](https://github.com/phalcon/cphalcon/issues/13132)
+- Fixed `Phalcon\Db\Dialect\Postgresql::_castDefault()` to correct returning value for `boolean` type

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -341,7 +341,7 @@ class Postgresql extends Dialect
 		var temporary, options, table, createLines, columns,
 			column, indexes, index, reference, references, indexName,
 			indexSql, indexSqlAfterCreate, sql, columnLine, indexType,
-			referenceSql, onDelete, onUpdate, defaultValue, primaryColumns,
+			referenceSql, onDelete, onUpdate, primaryColumns,
 			columnDefinition;
 
 		if !fetch columns, definition["columns"] {
@@ -375,12 +375,7 @@ class Postgresql extends Dialect
 			 * Add a Default clause
 			 */
 			if column->hasDefault() {
-				let defaultValue = this->_castDefault(column);
-				if memstr(strtoupper(columnDefinition), "BOOLEAN") {
-					let sql .= " DEFAULT " . defaultValue;
-				} else {
-					let columnLine .= " DEFAULT " . defaultValue;
-				}
+				let columnLine .= " DEFAULT " . this->_castDefault(column);
 			}
 
 			/**
@@ -655,7 +650,7 @@ class Postgresql extends Dialect
 			columnType = column->getType();
 
 		if memstr(strtoupper(columnDefinition), "BOOLEAN") {
-			return defaultValue ? "true" : "false";
+			return defaultValue;
 		}
 
 		if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") {

--- a/tests/_fixtures/postgresql/example6.sql
+++ b/tests/_fixtures/postgresql/example6.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "table" (
+	"column14" SERIAL NOT NULL,
+	"column15" INT DEFAULT 5 NOT NULL,
+	"column16" CHARACTER VARYING(10) DEFAULT 'column16',
+	"column17" BOOLEAN DEFAULT false NOT NULL,
+	"column18" BOOLEAN DEFAULT true NOT NULL
+);

--- a/tests/_support/Helper/Dialect/PostgresqlTrait.php
+++ b/tests/_support/Helper/Dialect/PostgresqlTrait.php
@@ -746,6 +746,43 @@ trait PostgresqlTrait
                 ],
                 rtrim(file_get_contents(PATH_FIXTURES . 'postgresql/example5.sql')),
             ],
+            'example6' => [
+                null,
+                [
+                    'columns' => [
+                        new Column('column14', [
+                            'type' => Column::TYPE_INTEGER,
+                            'notNull' => true,
+                            'autoIncrement' => true,
+                            'first' => true
+                        ]),
+                        new Column('column15', [
+                            'type' => Column::TYPE_INTEGER,
+                            'default' => 5,
+                            'notNull' => true,
+                            'after' => 'user_id'
+                        ]),
+                        new Column('column16', [
+                            'type'    => Column::TYPE_VARCHAR,
+                            'size'    => 10,
+                            'default' => 'column16'
+                        ]),
+                        new Column('column17', [
+                            'type' => Column::TYPE_BOOLEAN,
+                            'default' => "false",
+                            'notNull' => true,
+                            'after' => 'track_id'
+                        ]),
+                        new Column('column18', [
+                            'type' => Column::TYPE_BOOLEAN,
+                            'default' => "true",
+                            'notNull' => true,
+                            'after' => 'like'
+                        ]),
+                    ],
+                ],
+                rtrim(file_get_contents(PATH_FIXTURES . 'postgresql/example6.sql')),
+            ],
         ];
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13132

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
For type `Boolean` _castDefault() returned wrong value and createTable() inserted wrong default value.

Thanks

