### PR TITLE
Fixed Model::_doLowInsert to work properly with snapshots

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -5,3 +5,4 @@
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
 - Fixed `Phalcon\Db\Dialect\Postgresql::createTable()` to correct inserting default value to SQL for `boolean` type [#13132](https://github.com/phalcon/cphalcon/issues/13132)
 - Fixed `Phalcon\Db\Dialect\Postgresql::_castDefault()` to correct returning value for `boolean` type
+- Fixed ` Phalcon\Mvc\Model::_doLowInsert()` to correct save snapshot on creation/save identityless models [#13166](https://github.com/phalcon/cphalcon/issues/13166)

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2432,16 +2432,17 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 			let this->{attributeField} = lastInsertedId;
 			let snapshot[attributeField] = lastInsertedId;
 
-			if manager->isKeepingSnapshots(this) && globals_get("orm.update_snapshot_on_save") {
-			    let this->_snapshot = snapshot;
-			}
-
 			/**
 			 * Since the primary key was modified, we delete the _uniqueParams
 			 * to force any future update to re-build the primary key
 			 */
 			let this->_uniqueParams = null;
 		}
+
+		if success && manager->isKeepingSnapshots(this) && globals_get("orm.update_snapshot_on_save") {
+			let this->_snapshot = snapshot;
+		}
+
 
 		return success;
 	}

--- a/tests/_data/models/Snapshot/Requests.php
+++ b/tests/_data/models/Snapshot/Requests.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Phalcon\Test\Models\Snapshot;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * Phalcon\Test\Models\Snapshot\Requests
+ *
+ * @package Phalcon\Test\Models\Snapshot
+ *
+ * @property string $method
+ * @property string $uri
+ * @property int $count
+ *
+ * @method static Requests findFirst($parameters = null)
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Requests extends Model
+{
+    public function initialize()
+    {
+        $this->setSource('identityless_requests');
+        $this->keepSnapshots(true);
+    }
+
+    public function columnMap()
+    {
+        return [
+            'method'        => 'method',
+            'requested_uri' => 'uri',
+            'request_count' => 'count',
+        ];
+    }
+}

--- a/tests/_data/schemas/mysql/phalcon_test.sql
+++ b/tests/_data/schemas/mysql/phalcon_test.sql
@@ -298,6 +298,20 @@ INSERT INTO `robots` VALUES (1,'Robotina','mechanical',1972,'1972/01/01 00:00:00
 UNLOCK TABLES;
 
 --
+-- Table structure for table `identityless_requests`
+--
+
+DROP TABLE IF EXISTS `identityless_requests`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `identityless_requests` (
+    `method` ENUM('GET', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'HEAD', 'PATCH', 'PURGE', 'TRACE', 'CONNECT'),
+    `requested_uri` VARCHAR(255),
+    `request_count` int(10) unsigned NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `robots_parts`
 --
 

--- a/tests/unit/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/unit/Db/Adapter/Pdo/MysqlTest.php
@@ -70,6 +70,7 @@ class MysqlTest extends UnitTest
                     'customers',
                     'foreign_key_child',
                     'foreign_key_parent',
+                    'identityless_requests',
                     'issue12071_body',
                     'issue12071_head',
                     'issue_11036',
@@ -96,7 +97,7 @@ class MysqlTest extends UnitTest
                 ];
 
                 expect($this->connection->listTables())->equals($expected);
-                expect($this->connection->listTables(TEST_DB_MYSQL_NAME))->equals($expected);
+                expect($this->connection->listTables(env('TEST_DB_MYSQL_NAME', 'phalcon_test')))->equals($expected);
             }
         );
     }

--- a/tests/unit/Mvc/Model/SnapshotTest.php
+++ b/tests/unit/Mvc/Model/SnapshotTest.php
@@ -6,6 +6,7 @@ use Helper\ModelTrait;
 use Phalcon\Mvc\Model;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Test\Models\Snapshot\Robots;
+use Phalcon\Test\Models\Snapshot\Requests;
 use Phalcon\Test\Models\Snapshot\Robotters;
 
 /**
@@ -29,6 +30,37 @@ use Phalcon\Test\Models\Snapshot\Robotters;
 class SnapshotTest extends UnitTest
 {
     use ModelTrait;
+
+    /**
+     * Tests dynamic update for identityless models
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @issue  13166
+     * @since  2017-11-20
+     */
+    public function shouldSaveSnapshotForIdentitylessModel()
+    {
+        $this->specify(
+            "Snapshot does not work with identityless models on Creation/Save",
+            function () {
+                $requests = new Requests();
+
+                $requests->method = 'GET';
+                $requests->uri = '/api/status';
+                $requests->count = 1;
+
+                expect($requests->save())->true();
+                expect($requests->getChangedFields())->equals([]);
+                expect($requests->getSnapshotData())->notEmpty();
+                expect($requests->getSnapshotData())->equals($requests->toArray());
+
+                expect($requests->method)->equals('GET');
+                expect($requests->uri)->equals('/api/status');
+                expect($requests->count)->equals(1);
+            }
+        );
+    }
 
     /** @test */
     public function shouldWorkWithSimpleResultset()


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13166

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed ` Phalcon\Mvc\Model::_doLowInsert()` to correct save snapshot on creation/save identityless models.

Thanks

/cc @virgofx 
