### PR TITLE
Added support of 103 (Early Hint) HTTP status code

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -2,6 +2,7 @@
 - Added support for `switch/case` syntax to the Volt Engine [#13107](https://github.com/phalcon/cphalcon/issues/13107)
 - Added `Phalcon\Logger\Adapter\Blackhole` [#13074](https://github.com/phalcon/cphalcon/issues/13074)
 - Added `Phalcon\Http\Request::hasHeader` to check if certain header exists
+- Added support of [`103 (Early Hint)`](https://datatracker.ietf.org/doc/draft-ietf-httpbis-early-hints) HTTP status code 
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
 - Fixed `Phalcon\Db\Dialect\Postgresql::createTable` to produce valid SQL for table definition with `BOOLEAN` types [#13132](https://github.com/phalcon/cphalcon/issues/13132)
 - Fixed `Phalcon\Db\Dialect\Postgresql::_castDefault` to return correct value for `BOOLEAN` type [#13132](https://github.com/phalcon/cphalcon/issues/13132), [phalcon/phalcon-devtools#1118](https://github.com/phalcon/phalcon-devtools/issues/1118)

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -140,6 +140,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 				100 : "Continue",                        // RFC 7231, 6.2.1
 				101 : "Switching Protocols",             // RFC 7231, 6.2.2
 				102 : "Processing",                      // RFC 2518, 10.1
+				103 : "Early Hints",
 				// SUCCESS CODES
 				200 : "OK",                              // RFC 7231, 6.3.1
 				201 : "Created",                         // RFC 7231, 6.3.2

--- a/tests/unit/Http/ResponseTest.php
+++ b/tests/unit/Http/ResponseTest.php
@@ -147,6 +147,18 @@ class ResponseTest extends HttpBase
                 $response = $this->getResponseObject();
                 $response->resetHeaders();
 
+                $response->setStatusCode(103);
+                $expected = Headers::__set_state(
+                    [
+                        '_headers' => [
+                            'HTTP/1.1 103 Early Hints' => '',
+                            'Status'                   => '103 Early Hints'
+                        ]
+                    ]
+                );
+
+                expect($response->getHeaders())->equals($expected);
+
                 $response->setStatusCode(200);
                 $expected = Headers::__set_state(
                     [


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Added support of 103 (Early Hint)  HTTP status code. This informational status code has been approved as status code for indicating hints to client. This is a new status code that lets the server send headers early, before the main headers. For example it may helps with optimizations like preloading. 

More details here [IETF](https://datatracker.ietf.org/doc/draft-ietf-httpbis-early-hints).

Thanks

