### PR TITLE
Fix allow empty string functionality

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,1 +1,6 @@
 # [3.3.0](https://github.com/phalcon/cphalcon/releases/tag/v3.3.0) (2017-XX-XX)
+- Added support for `switch/case` syntax to the Volt Engine [#13107](https://github.com/phalcon/cphalcon/issues/13107)
+- Added `Phalcon\Logger\Adapter\Blackhole` [#13074](https://github.com/phalcon/cphalcon/issues/13074)
+- Added `Phalcon\Http\Request::hasHeader` to check if certain header exists
+- Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
+- Fixed `Phalcon\Mvc\Model::allowEmptyStringValues` to correct works with saving empty string values when DEFAULT not set in SQL 

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3613,7 +3613,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
 		let keysAttributes = [];
 		for attribute in attributes {
-			let keysAttributes[attribute] = null;
+			let keysAttributes[attribute] = true;
 		}
 
 		this->getModelsMetaData()->setEmptyStringAttributes(this, keysAttributes);

--- a/tests/_data/models/ModelWithStringField.php
+++ b/tests/_data/models/ModelWithStringField.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Phalcon\Test\Models;
+
+
+use Phalcon\Mvc\Model;
+
+/**
+ * \Phalcon\Test\Models\ModelWithStringField
+ *
+ *
+ * @copyright 2011-2017 Phalcon Team
+ * @link      http://www.phalconphp.com
+ * @author    Nikolay Sumrak <nikolassumrak@gmail.com>
+ * @package   Phalcon\Test\Models
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class ModelWithStringField extends Model
+{
+    /**
+     * @var int
+     */
+    public $id;
+    /**
+     * @var string
+     */
+    public $field;
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return 'table_with_string_field';
+    }
+
+    public function allowEmptyStringValue()
+    {
+        $this->allowEmptyStringValues([
+            'field'
+        ]);
+    }
+
+    public function disallowEmptyStringValue()
+    {
+        $this->allowEmptyStringValues([]);
+    }
+}

--- a/tests/_data/schemas/mysql/phalcon_test.sql
+++ b/tests/_data/schemas/mysql/phalcon_test.sql
@@ -623,6 +623,22 @@ CREATE TABLE `foreign_key_child` (
     KEY (`child_int`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+DROP TABLE IF EXISTS `table_with_string_field`;
+CREATE TABLE `table_with_string_field` (
+    `id` INT(10)   UNSIGNED    NOT NULL AUTO_INCREMENT,
+    `field` VARCHAR(70) NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `table_with_string_field` WRITE;
+/*!40000 ALTER TABLE `table_with_string_field` DISABLE KEYS */;
+INSERT INTO `table_with_string_field` VALUES
+  (1,'String one'),
+  (2,'String two'),
+  (3,'Another one string');
+/*!40000 ALTER TABLE `table_with_string_field` ENABLE KEYS */;
+UNLOCK TABLES;
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/tests/_data/schemas/postgresql/phalcon_test.sql
+++ b/tests/_data/schemas/postgresql/phalcon_test.sql
@@ -6943,6 +6943,25 @@ ALTER TABLE ONLY robots_parts
 
 
 --
+-- Name: table_with_string_field; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+CREATE TABLE table_with_string_field (
+    id integer NOT NULL,
+    field character varying(70) NOT NULL
+);
+
+--
+-- Data for Name: table_with_string_field; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY robots (id, field) FROM stdin;
+1	String one
+2	String two
+3	Another one string
+\.
+
+--
 -- Name: public; Type: ACL; Schema: -; Owner: postgres
 --
 

--- a/tests/_data/schemas/sqlite/phalcon_test.sql
+++ b/tests/_data/schemas/sqlite/phalcon_test.sql
@@ -6529,4 +6529,13 @@ CREATE TABLE COMPANY (
 CREATE INDEX salary_index ON COMPANY (salary);
 CREATE UNIQUE INDEX name_index ON COMPANY (name);
 
+DROP TABLE IF EXISTS `table_with_string_field`;
+CREATE TABLE `table_with_string_field` (
+  `id` INTEGER NOT NULL PRIMARY KEY,
+  `field` varchar(70) NOT NULL
+);
+INSERT INTO "table_with_string_field" VALUES(1,'String one');
+INSERT INTO "table_with_string_field" VALUES(2,'String two');
+INSERT INTO "table_with_string_field" VALUES(3,'Another one string');
+
 COMMIT;

--- a/tests/unit/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/unit/Db/Adapter/Pdo/MysqlTest.php
@@ -91,6 +91,7 @@ class MysqlTest extends UnitTest
                     'stats',
                     'stock',
                     'subscriptores',
+                    'table_with_string_field',
                     'tipo_documento',
                     'users',
                 ];

--- a/tests/unit/Db/Adapter/Pdo/PostgresqlTest.php
+++ b/tests/unit/Db/Adapter/Pdo/PostgresqlTest.php
@@ -77,6 +77,7 @@ class PostgresqlTest extends UnitTest
                     'robots',
                     'robots_parts',
                     'subscriptores',
+                    'table_with_string_field',
                     'tipo_documento',
                 ];
 

--- a/tests/unit/Mvc/ModelTest.php
+++ b/tests/unit/Mvc/ModelTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use Helper\ModelTrait;
 use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\Message;
+use Phalcon\Test\Models\ModelWithStringField;
 use Phalcon\Test\Models\Users;
 use Phalcon\Cache\Backend\Apc;
 use Phalcon\Test\Models\Robots;
@@ -705,6 +706,44 @@ class ModelTest extends UnitTest
                 Model::setup(
                     [
                         'disableAssignSetters' => false,
+                    ]
+                );
+            }
+        );
+    }
+
+    /**
+     * Test check allowEmptyStringValues
+     *
+     * @author Nikolay Sumrak <nikolassumrak@gmail.com>
+     * @since 2017-11-16
+     */
+    public function testAllowEmptyStringFields()
+    {
+        $this->specify(
+            'Allow empty string value',
+            function () {
+                Model::setup(
+                    [
+                        'notNullValidations' => true,
+                        'exceptionOnFailedSave' => false,
+                    ]
+                );
+
+                $model = new ModelWithStringField();
+                $model->field = '';
+                $model->disallowEmptyStringValue();
+                $status = $model->save();
+                expect($status)->false();
+
+                $model->allowEmptyStringValue();
+                $status = $model->save();
+                expect($status)->true();
+
+                Model::setup(
+                    [
+                        'notNullValidations' => false,
+                        'exceptionOnFailedSave' => true,
                     ]
                 );
             }

--- a/unit-tests/DbDescribeTest.php
+++ b/unit-tests/DbDescribeTest.php
@@ -740,7 +740,8 @@ class DbDescribeTest extends PHPUnit_Framework_TestCase
 			10 => 'robots_parts',
 			11 => 'sqlite_sequence',
 			12 => 'subscriptores',
-			13 => 'tipo_documento',
+			13 => 'table_with_string_field',
+			14 => 'tipo_documento',
 		);
 
 		$tables = $connection->listTables();


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
In model.zep at 2104 line:
```if isset emptyStringValues[field]```
if we have array $array = ['field' => null]; - function isset returns false!

*Steps for reproducing*
1. Have model
```php
class ModelWithField extends \Phalcon\Mvc\Model
{
    protected $field;

    protected function initialize()
    {
        $this->allowEmptyStringValues([
            'field'
        ]);
    }
}
```
2. Have mysql table
```sql
create table `model_with_field` (
   `field` VARCHAR(255) NOT NULL
)
```
3. Have config
```ini
phalcon.orm.not_null_validations = On
phalcon.orm.exception_on_failed_save = On
```
4.
```php
$model = new ModelWithField();
$model->save([
    'field' => ''
]); // return false and throws ValidationFailed exception
```

Thanks

