### PR TITLE
[NFR] Add event router:beforeMount a group

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -9,3 +9,4 @@
 - Fixed `Phalcon\Mvc\Model::_doLowInsert` to correct save snapshot on creation/save identityless models [#13166](https://github.com/phalcon/cphalcon/issues/13166)
 - Fixed `Phalcon\Mvc\Model::_doLowUpdate` to correctly work with `Phalcon\Db\RawValue` [#13170](https://github.com/phalcon/cphalcon/issues/13170)
 - Fixed `Phalcon\Mvc\Model::allowEmptyStringValues` to correct works with saving empty string values when DEFAULT not set in SQL 
+- Added `router:beforeMount` event to `Router::mount` [#13158](https://github.com/phalcon/cphalcon/issues/13158)

--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -795,7 +795,13 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	 */
 	public function mount(<GroupInterface> group) -> <RouterInterface>
 	{
-		var groupRoutes, beforeMatch, hostname, routes, route;
+		var groupRoutes, beforeMatch, hostname, routes, route, eventsManager;
+
+        let eventsManager = this->_eventsManager;
+
+		if typeof eventsManager == "object" {
+     		eventsManager->fire("router:beforeMount", this, group);
+        }
 
 		let groupRoutes = group->getRoutes();
 		if !count(groupRoutes) {


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/13158

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Added event call `router:beforeMount` in `Router::mount`

Thanks

