### PR TITLE
Collection map via

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -10,6 +10,7 @@
 - Added ability to use PDO option aliases on database connect [#13010](https://github.com/phalcon/cphalcon/issues/13010)
 - Added `Phalcon\Mvc\Model\MetaData\Apcu` [#13078](https://github.com/phalcon/cphalcon/issues/13078)
 - Added ability to use string(file path) as a argument in `Phalcon\Config\Factory::load()`
+- Added `Phalcon\Mvc\Mico\Collection::mapVia` to map routes via methods
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
 - Fixed `Phalcon\Db\Dialect\Postgresql::createTable` to produce valid SQL for table definition with `BOOLEAN` types [#13132](https://github.com/phalcon/cphalcon/issues/13132)
 - Fixed `Phalcon\Db\Dialect\Postgresql::_castDefault` to return correct value for `BOOLEAN` type [#13132](https://github.com/phalcon/cphalcon/issues/13132), [phalcon/phalcon-devtools#1118](https://github.com/phalcon/phalcon-devtools/issues/1118)

--- a/phalcon/mvc/micro/collection.zep
+++ b/phalcon/mvc/micro/collection.zep
@@ -57,7 +57,7 @@ class Collection implements CollectionInterface
 	 * @param mixed handler
 	 * @param string name
 	 */
-	protected function _addMap(string! method, var routePattern, var handler, var name)
+	protected function _addMap(var method, var routePattern, var handler, var name)
 	{
 		let this->_handlers[] = [method, routePattern, handler, name];
 	}
@@ -140,6 +140,22 @@ class Collection implements CollectionInterface
 	public function map(string! routePattern, var handler, var name = null) -> <Collection>
 	{
 		this->_addMap(null, routePattern, handler, name);
+		return this;
+	}
+
+	/**
+	 * Maps a route to a handler via methods
+	 *
+	 * @param  string routePattern
+	 * @param  callable handler
+	 * @param  string|array method
+	 * @param  string name
+	 * @return \Phalcon\Mvc\Micro\Collection
+	 */
+	public function mapVia(string! routePattern, var handler, var method, var name = null) -> <Collection>
+	{
+		this->_addMap(method, routePattern, handler, name);
+
 		return this;
 	}
 

--- a/tests/unit/Mvc/MicroTest.php
+++ b/tests/unit/Mvc/MicroTest.php
@@ -102,6 +102,7 @@ class MicroTest extends UnitTest
                 $micro->afterBinding(
                     function () use ($micro) {
                         $micro->stop();
+
                         return false;
                     }
                 );
@@ -218,7 +219,7 @@ class MicroTest extends UnitTest
      * @issue T169
      * @author Nikos Dimopoulos <nikos@niden.net>
      * @since 2012-11-06
-    */
+     */
     public function testMicroNotFoundT169()
     {
         $this->specify(
@@ -334,22 +335,31 @@ class MicroTest extends UnitTest
 
                 $app = new Micro();
 
-                $app->after(function () use (&$trace) {
-                    $trace[] = 1;
-                });
+                $app->after(
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
 
-                $app->after(function () use ($app, &$trace) {
-                    $trace[] = 1;
-                    $app->stop();
-                });
+                $app->after(
+                    function () use ($app, &$trace) {
+                        $trace[] = 1;
+                        $app->stop();
+                    }
+                );
 
-                $app->after(function () use (&$trace) {
-                    $trace[] = 1;
-                });
+                $app->after(
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
 
-                $app->map('/blog', function () use (&$trace) {
-                    $trace[] = 1;
-                });
+                $app->map(
+                    '/blog',
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
 
                 $app->handle('/blog');
 
@@ -357,7 +367,6 @@ class MicroTest extends UnitTest
             }
         );
     }
-
 
     public function testMicroFinishHandlers()
     {
@@ -403,22 +412,31 @@ class MicroTest extends UnitTest
 
                 $app = new Micro();
 
-                $app->finish(function () use (&$trace) {
-                    $trace[] = 1;
-                });
+                $app->finish(
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
 
-                $app->finish(function () use ($app, &$trace) {
-                    $trace[] = 1;
-                    $app->stop();
-                });
+                $app->finish(
+                    function () use ($app, &$trace) {
+                        $trace[] = 1;
+                        $app->stop();
+                    }
+                );
 
-                $app->finish(function () use (&$trace) {
-                    $trace[] = 1;
-                });
+                $app->finish(
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
 
-                $app->map('/blog', function () use (&$trace) {
-                    $trace[] = 1;
-                });
+                $app->map(
+                    '/blog',
+                    function () use (&$trace) {
+                        $trace[] = 1;
+                    }
+                );
 
                 $app->handle('/blog');
 
@@ -426,7 +444,6 @@ class MicroTest extends UnitTest
             }
         );
     }
-
 
     public function testMicroEvents()
     {
@@ -458,16 +475,17 @@ class MicroTest extends UnitTest
 
                 expect($trace)->equals(
                     [
-                        'beforeHandleRoute'  => true,
+                        'beforeHandleRoute' => true,
                         'beforeExecuteRoute' => true,
-                        'afterExecuteRoute'  => true,
-                        'afterHandleRoute'   => true,
-                        'afterBinding'       => true,
+                        'afterExecuteRoute' => true,
+                        'afterHandleRoute' => true,
+                        'afterBinding' => true,
                     ]
                 );
             }
         );
     }
+
     public function testMicroMiddlewareSimple()
     {
         $this->specify(
@@ -620,7 +638,6 @@ class MicroTest extends UnitTest
         );
     }
 
-
     public function testMicroResponseAlreadySentError()
     {
         $this->specify(
@@ -640,6 +657,26 @@ class MicroTest extends UnitTest
                     }
                 );
                 expect($app->handle('/api'))->equals('success');
+            }
+        );
+    }
+
+    public function testMicroCollectionVia()
+    {
+        $this->specify(
+            "Adding collection via doesn't work as exepected",
+            function () {
+                $app = new Micro();
+                $collection = new Micro\Collection();
+                $collection->setHandler(new \Test2Controller());
+                $collection->mapVia(
+                    "/test",
+                    'indexAction',
+                    ["POST", "GET"],
+                    "test"
+                );
+                $app->mount($collection);
+                expect($app->getRouter()->getRouteByName("test")->getHttpMethods())->equals(["POST", "GET"]);
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: currently there is no option in `Phalcon\Mvc\Micro\Collection` to map routes/handlers via methods. Since we can't change map method to not break anything i added new method. In Phalcon 4 we should just update map method.

Thanks

