### PR TITLE
3.3.x remove header from response

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -12,6 +12,7 @@
 - Added ability to use string(file path) as a argument in `Phalcon\Config\Factory::load()`
 - Added `Phalcon\Mvc\Mico\Collection::mapVia` to map routes via methods
 - Added `Phalcon\Mvc\Model::setOldSnapshotData` to set old snapshot data separately to current snapshot data
+- Added `Phalcon\Http\Response::removeHeader` to remove specific header from response
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
 - Fixed `Phalcon\Db\Dialect\Postgresql::createTable` to produce valid SQL for table definition with `BOOLEAN` types [#13132](https://github.com/phalcon/cphalcon/issues/13132)
 - Fixed `Phalcon\Db\Dialect\Postgresql::_castDefault` to return correct value for `BOOLEAN` type [#13132](https://github.com/phalcon/cphalcon/issues/13132), [phalcon/phalcon-devtools#1118](https://github.com/phalcon/phalcon-devtools/issues/1118)

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -658,4 +658,19 @@ class Response implements ResponseInterface, InjectionAwareInterface
 
 		return this;
 	}
+
+	/**
+	 * Remove a header in the response
+	 *
+	 *<code>
+	 * $response->removeHeader("Expires");
+	 *</code>
+	 */
+	public function removeHeader(string name) -> <Response>
+	{
+		var headers;
+		let headers = this->getHeaders();
+		headers->remove(name);
+		return this;
+	}
 }

--- a/tests/unit/Http/ResponseTest.php
+++ b/tests/unit/Http/ResponseTest.php
@@ -568,4 +568,30 @@ class ResponseTest extends HttpBase
             }
         );
     }
+
+    /**
+     * Test the removeHeader
+     *
+     * @author Mohamad Rostami <mb.rostami.h@gmail.com>
+     */
+    public function testHttpResponseRemoveHeaderContentType()
+    {
+        $this->specify(
+            "removeHeader is not removing the header properly",
+            function () {
+                $response = $this->getResponseObject();
+                $response->resetHeaders();
+                $response->setHeader('Content-Type', 'text/html');
+                $headers = $response->getHeaders()->toArray();
+
+                $this->assertArrayHasKey('Content-Type', $headers);
+                expect($headers['Content-Type'])->equals('text/html');
+
+                $response->removeHeader('Content-Type');
+                
+                $headers = $response->getHeaders()->toArray();
+                $this->assertArrayNotHasKey('Content-Type', $headers);
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
There is no method to unset header in response class

Thanks

