### PR TITLE
Update model to set old snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ before_install:
   - export $(cut -d= -f1 $TRAVIS_BUILD_DIR/tests/_ci/environment)
 
 install:
-  - composer install -q -n --no-ansi --no-progress --dev --prefer-dist --no-suggest --ignore-platform-reqs
+  - composer install -q -n --no-ansi --no-progress --dev --prefer-dist --no-suggest #--ignore-platform-reqs
   # We'll do this in future for the all 7.x series
   - |
       if [ "${PHP_MAJOR}.${PHP_MINOR}" = "7.2" ] || [ "${PHP_MAJOR}.${PHP_MINOR}" = "7.3" ]; then

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -20,3 +20,4 @@
 - Fixed `Phalcon\Mvc\Model::_doLowUpdate` to correctly work with `Phalcon\Db\RawValue` [#13170](https://github.com/phalcon/cphalcon/issues/13170)
 - Fixed `Phalcon\Mvc\Model::allowEmptyStringValues` to correct works with saving empty string values when DEFAULT not set in SQL
 - Fixed `Phalcon\Mvc\Model\Behavior\SoftDelete` to correctly update snapshots after deleting item
+- Fixed `Phalcon\Mvc\Model` to set old snapshot when no fields are changed when dynamic update is enabled

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -2611,6 +2611,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  		 * If there is no fields to update we return true
  		 */
  		if !count(fields) {
+ 			if useDynamicUpdate {
+ 				let this->_oldSnapshot = snapshot;
+ 			}
  			return true;
  		}
 

--- a/tests/_data/models/Snapshot/Personas.php
+++ b/tests/_data/models/Snapshot/Personas.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Phalcon\Test\Models\Snapshot;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * Phalcon\Test\Models\Dynamic\Personas
+ *
+ * @package Phalcon\Test\Models\Dynamic
+ *
+ * @property string $cedula
+ * @property int $tipo_documento_id
+ * @property string $nombres
+ * @property string $telefono
+ * @property string $direccion
+ * @property string $email
+ * @property string $fecha_nacimiento
+ * @property int $ciudad_id
+ * @property int $creado_at
+ * @property float $cupo
+ * @property string $estado
+ *
+ * @method static Personas findFirst($parameters = null)
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class Personas extends Model
+{
+    public function initialize()
+    {
+        $this->keepSnapshots(true);
+        $this->useDynamicUpdate(true);
+    }
+}

--- a/tests/unit/Mvc/Model/SnapshotTest.php
+++ b/tests/unit/Mvc/Model/SnapshotTest.php
@@ -4,6 +4,7 @@ namespace Phalcon\Test\Unit\Mvc\Model;
 
 use Helper\ModelTrait;
 use Phalcon\Mvc\Model;
+use Phalcon\Test\Models\Snapshot\Personas;
 use Phalcon\Test\Models\Snapshot\Subscribers;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Test\Models\Snapshot\Robots;
@@ -527,6 +528,27 @@ class SnapshotTest extends UnitTest
                 expect($subscriber->getUpdatedFields())->equals(['email', 'created_at', 'status', 'id']);
                 expect($subscriber->delete())->true();
                 expect($subscriber->getUpdatedFields())->equals(['status']);
+            }
+        );
+    }
+
+    public function testIssue13202()
+    {
+        $this->specify(
+            "When using dynamic update saving model without changes getUpdatedFields shouldn't return full array",
+            function () {
+                $this->setUpModelsManager();
+                $personas = Personas::findFirst();
+                expect($personas->getChangedFields())->equals([]);
+                try {
+                    $personas->getUpdatedFields();
+                } catch (\Exception $e) {
+                    expect($e->getMessage())->equals(
+                        "Change checking cannot be performed because the object has not been persisted or is deleted"
+                    );
+                }
+                expect($personas->save())->true();
+                expect($personas->getUpdatedFields())->equals([]);
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13202

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: this sets old snapshot when no fields are changed when dynamic update is enabled

Thanks

