### PR TITLE
[NFR] add dataType JSON support for  MySQL dialect.

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -13,6 +13,7 @@
 - Added `Phalcon\Mvc\Mico\Collection::mapVia` to map routes via methods
 - Added `Phalcon\Mvc\Model::setOldSnapshotData` to set old snapshot data separately to current snapshot data
 - Added `Phalcon\Http\Response::removeHeader` to remove specific header from response
+- Added support JSON dataType for MySQL dialect.
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to correct generate PHQL in argument's array when using order DESC or ASC [#11827](https://github.com/phalcon/cphalcon/issues/11827)
 - Fixed `Phalcon\Db\Dialect\Postgresql::createTable` to produce valid SQL for table definition with `BOOLEAN` types [#13132](https://github.com/phalcon/cphalcon/issues/13132)
 - Fixed `Phalcon\Db\Dialect\Postgresql::_castDefault` to return correct value for `BOOLEAN` type [#13132](https://github.com/phalcon/cphalcon/issues/13132), [phalcon/phalcon-devtools#1118](https://github.com/phalcon/phalcon-devtools/issues/1118)
@@ -21,4 +22,3 @@
 - Fixed `Phalcon\Mvc\Model::allowEmptyStringValues` to correct works with saving empty string values when DEFAULT not set in SQL
 - Fixed `Phalcon\Mvc\Model\Behavior\SoftDelete` to correctly update snapshots after deleting item
 - Fixed `Phalcon\Mvc\Model` to set old snapshot when no fields are changed when dynamic update is enabled
-- Added support JSON dataType for MySQL dialect. [#13216](https://github.com/phalcon/cphalcon/pull/13216)

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -21,3 +21,4 @@
 - Fixed `Phalcon\Mvc\Model::allowEmptyStringValues` to correct works with saving empty string values when DEFAULT not set in SQL
 - Fixed `Phalcon\Mvc\Model\Behavior\SoftDelete` to correctly update snapshots after deleting item
 - Fixed `Phalcon\Mvc\Model` to set old snapshot when no fields are changed when dynamic update is enabled
+- Added support JSON dataType for MySQL dialect. [#13216](https://github.com/phalcon/cphalcon/pull/13216)

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -188,6 +188,11 @@ class Mysql extends PdoAdapter
 				 * Blob
 				 */
 				let definition["type"] = Column::TYPE_BLOB;
+			} elseif memstr(columnType, "json") {
+				/**
+				 * JSON
+				 */
+				let definition["type"] = Column::TYPE_JSON;
 			} else {
 				/**
 				 * By default is string

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -192,6 +192,12 @@ class Mysql extends Dialect
 				}
 				break;
 
+			case Column::TYPE_JSON:
+				if empty columnSql {
+					let columnSql .= "JSON";
+				}
+				break;
+
 			default:
 				if empty columnSql {
 					throw new Exception("Unrecognized MySQL data type at column " . column->getName());

--- a/phalcon/mvc/model/metadata/strategy/annotations.zep
+++ b/phalcon/mvc/model/metadata/strategy/annotations.zep
@@ -191,6 +191,11 @@ class Annotations implements StrategyInterface
 						fieldBindTypes[columnName] = Column::BIND_PARAM_BLOB;
 					break;
 
+				case "json":
+					let fieldTypes[columnName] = Column::TYPE_JSON,
+						fieldBindTypes[columnName] = Column::BIND_PARAM_STR;
+					break;
+
 				default:
 					/**
 					 * By default all columns are varchar/string

--- a/tests/_data/schemas/mysql/phalcon_test.sql
+++ b/tests/_data/schemas/mysql/phalcon_test.sql
@@ -653,6 +653,19 @@ INSERT INTO `table_with_string_field` VALUES
 /*!40000 ALTER TABLE `table_with_string_field` ENABLE KEYS */;
 UNLOCK TABLES;
 
+DROP TABLE IF EXISTS `table_with_json_field`;
+CREATE TABLE `table_with_json_field` (
+    `id` INT(10)   UNSIGNED    NOT NULL AUTO_INCREMENT,
+    `field` JSON NOT NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+LOCK TABLES `table_with_json_field` WRITE;
+INSERT INTO `table_with_json_field` VALUES
+  (1,'{}'),
+  (2,'{"code":0,"msg":"ok","items":[{"id":1,"name":"data-1"},{"id":2,"name":"data-2"}]}');
+UNLOCK TABLES;
+
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/tests/unit/Db/Adapter/Pdo/MysqlTest.php
+++ b/tests/unit/Db/Adapter/Pdo/MysqlTest.php
@@ -2,8 +2,13 @@
 
 namespace Phalcon\Test\Unit\Db\Adapter\Pdo;
 
+use Phalcon\Acl\Exception;
 use Phalcon\Db;
 use Phalcon\Db\Reference;
+use Phalcon\Events\Manager;
+use Phalcon\Paginator\Adapter\QueryBuilder;
+use Phalcon\Test\Models\Robos;
+use Phalcon\Test\Models\TableWithJsonField;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Db\Adapter\Pdo\Mysql;
 use Helper\Dialect\MysqlTrait;
@@ -160,6 +165,30 @@ class MysqlTest extends UnitTest
                         "expected"   => "```schema```.`rob``ots`",
                     ],
                 ]
+            ]
+        );
+    }
+
+    /**
+     * Tests MySQL JSON dataType
+     *
+     * @test
+     * @author gavin <mfkickdx78@126.com>
+     * @since  2017-12-17
+     */
+    public function testDetectJsonDataTypeField ()
+    {
+        $oModel    = new \Phalcon\Test\Models\TableWithJsonField();
+        $dataTypes = $oModel->getModelsMetaData()->getDataTypes($oModel);
+        $this->specify(
+            "JSON dataType not supported",
+            function ($expected, $actual) {
+                $this->assertEquals($expected, $actual, "Detected field datatype is not equal to Column::TYPE_JSON!");
+            },
+            [
+                'examples' => [
+                    [TRUE, $dataTypes['field'] == \Phalcon\Db\Column::TYPE_JSON],
+                ],
             ]
         );
     }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #12546, #12985, #13214

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Thanks

