### PR TITLE
3.3.x aclfix

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -21,3 +21,4 @@
 - Fixed `Phalcon\Mvc\Model::allowEmptyStringValues` to correct works with saving empty string values when DEFAULT not set in SQL
 - Fixed `Phalcon\Mvc\Model\Behavior\SoftDelete` to correctly update snapshots after deleting item
 - Fixed `Phalcon\Mvc\Model` to set old snapshot when no fields are changed when dynamic update is enabled
+- Fixed `Phalcon\Acl\Adapter\Memory::isAllowed` to properly pass role and resource objects to custom function if they are objects of the same class

--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -540,7 +540,7 @@ class Memory extends Adapter
 			inheritedRoles, funcAccess = null, resourceObject = null, roleObject = null, funcList,
 			reflectionFunction, reflectionParameters, parameterNumber, parametersForFunction,
 			numberOfRequiredParameters, userParametersSizeShouldBe, reflectionClass, parameterToCheck,
-			reflectionParameter;
+			reflectionParameter, hasRole = false, hasResource = false;
 
 		if typeof roleName == "object" {
 			if roleName instanceof RoleAware {
@@ -714,7 +714,8 @@ class Memory extends Adapter
 
 				if reflectionClass !== null {
 					// roleObject is this class
-					if roleObject !== null && reflectionClass->isInstance(roleObject) {
+					if roleObject !== null && reflectionClass->isInstance(roleObject) && !hasRole {
+						let hasRole = true;
 						let parametersForFunction[] = roleObject;
 						let userParametersSizeShouldBe--;
 
@@ -722,7 +723,8 @@ class Memory extends Adapter
 					}
 
 					// resourceObject is this class
-					if resourceObject !== null && reflectionClass->isInstance(resourceObject) {
+					if resourceObject !== null && reflectionClass->isInstance(resourceObject) && !hasResource {
+						let hasResource = true;
 						let parametersForFunction[] = resourceObject;
 						let userParametersSizeShouldBe--;
 

--- a/tests/_config/bootstrap.php
+++ b/tests/_config/bootstrap.php
@@ -50,7 +50,8 @@ $loader->registerNamespaces(
         'Phalcon\Test\Resultsets'  => $config->get('application')->resultsetsDir,
         'Phalcon\Test\Collections' => $config->get('application')->collectionsDir,
         'Phalcon\Test\Modules\Frontend\Controllers' => $config->get('application')->modulesDir . 'frontend/controllers/',
-        'Phalcon\Test\Modules\Backend\Controllers'  => $config->get('application')->modulesDir . 'backend/controllers/'
+        'Phalcon\Test\Modules\Backend\Controllers'  => $config->get('application')->modulesDir . 'backend/controllers/',
+        'Phalcon\Test\Acl' => $config->get('application')->aclDir,
     ]
 );
 

--- a/tests/_config/global.php
+++ b/tests/_config/global.php
@@ -13,6 +13,7 @@ return [
         'controllersDir' => PATH_DATA . 'controllers/',
         'tasksDir' => PATH_DATA . 'tasks/',
         'microDir' => PATH_DATA . 'micro/',
+        'aclDir' => PATH_DATA . 'acl/'
     ],
     'database' => [
         'adapter'  => 'Mysql',

--- a/tests/_data/acl/TestRoleAware.php
+++ b/tests/_data/acl/TestRoleAware.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Phalcon\Test\Acl;
+
 use Phalcon\Acl\RoleAware;
 
 /**

--- a/tests/_data/acl/TestRoleResourceAware.php
+++ b/tests/_data/acl/TestRoleResourceAware.php
@@ -3,10 +3,10 @@
 namespace Phalcon\Test\Acl;
 
 use Phalcon\Acl\ResourceAware;
+use Phalcon\Acl\RoleAware;
 
 /**
- * TestResourceAware
- * Resource class for \Phalcon\Acl\Resource component
+ * TestRoleResourceAware
  *
  * @copyright (c) 2011-2017 Phalcon Team
  * @link      http://www.phalconphp.com
@@ -19,7 +19,7 @@ use Phalcon\Acl\ResourceAware;
  * through the world-wide-web, please send an email to license@phalconphp.com
  * so that we can send you a copy immediately.
  */
-class TestResourceAware implements ResourceAware
+class TestRoleResourceAware implements RoleAware, ResourceAware
 {
     /**
      * @var int
@@ -32,21 +32,20 @@ class TestResourceAware implements ResourceAware
     protected $resourceName;
 
     /**
+     * @var string
+     */
+    protected $roleName;
+
+    /**
      * @param $user
      * @param $resourceName
+     * @param $roleName
      */
-    public function __construct($user, $resourceName)
+    public function __construct($user, $resourceName, $roleName)
     {
         $this->user = $user;
         $this->resourceName = $resourceName;
-    }
-
-    /**
-     * @return int
-     */
-    public function getUser()
-    {
-        return $this->user;
+        $this->roleName = $roleName;
     }
 
     /**
@@ -55,5 +54,21 @@ class TestResourceAware implements ResourceAware
     public function getResourceName()
     {
         return $this->resourceName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRoleName()
+    {
+        return $this->roleName;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUser()
+    {
+        return $this->user;
     }
 }

--- a/tests/unit/Acl/Adapter/MemoryTest.php
+++ b/tests/unit/Acl/Adapter/MemoryTest.php
@@ -5,6 +5,9 @@ namespace Phalcon\Test\Unit\Acl\Adapter;
 use Phalcon\Acl;
 use Phalcon\Acl\Role;
 use Phalcon\Acl\Resource;
+use Phalcon\Test\Acl\TestResourceAware;
+use Phalcon\Test\Acl\TestRoleAware;
+use Phalcon\Test\Acl\TestRoleResourceAware;
 use PHPUnit_Framework_Exception;
 use Phalcon\Test\Module\UnitTest;
 use Phalcon\Acl\Adapter\Memory;
@@ -490,9 +493,6 @@ class MemoryTest extends UnitTest
         $this->specify(
             'The function in allow should be called and isAllowed should return correct values when using function in allow method',
             function () {
-                require_once PATH_DATA . 'acl/TestResourceAware.php';
-                require_once PATH_DATA . 'acl/TestRoleAware.php';
-
                 $acl = new Memory;
                 $acl->setDefaultAction(Acl::DENY);
                 $acl->addRole('Guests');
@@ -500,14 +500,14 @@ class MemoryTest extends UnitTest
                 $acl->addRole('Admins', 'Members');
                 $acl->addResource('Post', ['update']);
 
-                $guest = new \TestRoleAware(1, 'Guests');
-                $member = new \TestRoleAware(2, 'Members');
-                $anotherMember = new \TestRoleAware(3, 'Members');
-                $admin = new \TestRoleAware(4, 'Admins');
-                $model = new \TestResourceAware(2, 'Post');
+                $guest = new TestRoleAware(1, 'Guests');
+                $member = new TestRoleAware(2, 'Members');
+                $anotherMember = new TestRoleAware(3, 'Members');
+                $admin = new TestRoleAware(4, 'Admins');
+                $model = new TestResourceAware(2, 'Post');
 
                 $acl->deny('Guests', 'Post', 'update');
-                $acl->allow('Members', 'Post', 'update', function (\TestRoleAware $user, \TestResourceAware $model) {
+                $acl->allow('Members', 'Post', 'update', function (TestRoleAware $user, TestResourceAware $model) {
                     return $user->getId() == $model->getUser();
                 });
                 $acl->allow('Admins', 'Post', 'update');
@@ -575,9 +575,6 @@ class MemoryTest extends UnitTest
         $this->specify(
             'The function in allow should be called and isAllowed should return correct values when using function in allow method',
             function () {
-                require_once PATH_DATA . 'acl/TestResourceAware.php';
-                require_once PATH_DATA . 'acl/TestRoleAware.php';
-
                 $acl = new Memory;
                 $acl->setDefaultAction(Acl::ALLOW);
                 $acl->setNoArgumentsDefaultAction(Acl::DENY);
@@ -586,11 +583,11 @@ class MemoryTest extends UnitTest
                 $acl->addRole('Admins', 'Members');
                 $acl->addResource('Post', ['update']);
 
-                $guest = new \TestRoleAware(1, 'Guests');
-                $member = new \TestRoleAware(2, 'Members');
-                $anotherMember = new \TestRoleAware(3, 'Members');
-                $admin = new \TestRoleAware(4, 'Admins');
-                $model = new \TestResourceAware(2, 'Post');
+                $guest = new TestRoleAware(1, 'Guests');
+                $member = new TestRoleAware(2, 'Members');
+                $anotherMember = new TestRoleAware(3, 'Members');
+                $admin = new TestRoleAware(4, 'Admins');
+                $model = new TestResourceAware(2, 'Post');
 
                 $acl->allow('Guests', 'Post', 'update', function ($parameter) {
                     return $parameter % 2 == 0;
@@ -621,9 +618,6 @@ class MemoryTest extends UnitTest
         $this->specify(
             'The function in allow should be called and isAllowed should return correct values when using function in allow method',
             function () {
-                require_once PATH_DATA . 'acl/TestResourceAware.php';
-                require_once PATH_DATA . 'acl/TestRoleAware.php';
-
                 $acl = new Memory;
                 $acl->setDefaultAction(Acl::ALLOW);
                 $acl->setNoArgumentsDefaultAction(Acl::DENY);
@@ -632,11 +626,11 @@ class MemoryTest extends UnitTest
                 $acl->addRole('Admins', 'Members');
                 $acl->addResource('Post', ['update']);
 
-                $guest = new \TestRoleAware(1, 'Guests');
-                $member = new \TestRoleAware(2, 'Members');
-                $anotherMember = new \TestRoleAware(3, 'Members');
-                $admin = new \TestRoleAware(4, 'Admins');
-                $model = new \TestResourceAware(2, 'Post');
+                $guest = new TestRoleAware(1, 'Guests');
+                $member = new TestRoleAware(2, 'Members');
+                $anotherMember = new TestRoleAware(3, 'Members');
+                $admin = new TestRoleAware(4, 'Admins');
+                $model = new TestResourceAware(2, 'Post');
 
                 $acl->allow('Guests', 'Post', 'update', function ($parameter) {
                     return $parameter % 2 == 0;
@@ -766,5 +760,32 @@ class MemoryTest extends UnitTest
                 expect($acl->isAllowed($role, $resource, 'update'))->false();
             }
         );
+    }
+
+    /**
+     * Tests role and resource objects as isAllowed parameters of the same class
+     *
+     * @author  Wojciech Slawski <jurigag@gmail.com>
+     * @since   2017-02-15
+     */
+    public function testRoleResourceSameClassObjects()
+    {
+        $acl = new Memory();
+        $acl->setDefaultAction(Acl::DENY);
+        $role = new TestRoleResourceAware(1, 'User', 'Admin');
+        $resource = new TestRoleResourceAware(2, 'User', 'Admin');
+        $acl->addRole('Admin');
+        $acl->addResource('User', ['update']);
+        $acl->allow(
+            'Admin',
+            'User',
+            ['update'],
+            function (TestRoleResourceAware $admin, TestRoleResourceAware $user) {
+                return $admin->getUser() == $user->getUser();
+            }
+        );
+        expect($acl->isAllowed($role, $resource, 'update'))->false();
+        expect($acl->isAllowed($role, $role, 'update'))->true();
+        expect($acl->isAllowed($resource, $resource, 'update'))->true();
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: when doing `Memory::isAllowed` with role and resource of the same class our role object will be passed both as role and resource to our custom function used for checking additional access. This PR fixes it

Thanks

