### PR TITLE
Fixed example

### DIFF
--- a/phalcon/assets/collection.zep
+++ b/phalcon/assets/collection.zep
@@ -97,9 +97,9 @@ class Collection implements \Countable, \Iterator
 	 * use Phalcon\Assets\Collection;
 	 *
 	 * $collection = new Collection();
-	 *
 	 * $resource = new Resource("js", "js/jquery.js");
-	 * $resource->has($resource); // true
+	 * $collection->add($resource);
+	 * $collection->has($resource); // true
 	 * </code>
 	 */
 	public function has(<ResourceInterface> $resource) -> boolean


### PR DESCRIPTION
The example of `has()` method was incorrect, it even produced an error

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks

