### PR TITLE
Return code in date validator

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,6 +1,7 @@
 # [3.3.1](https://github.com/phalcon/cphalcon/releases/tag/v3.3.1) (2018-XX-XX)
 - Fixed a boolean logic error in the CSS minifier and a corresponding unit test so that whitespace is stripped [#13200](https://github.com/phalcon/cphalcon/pull/13200)
 - Fixed `default` Volt filter [#13242](https://github.com/phalcon/cphalcon/issues/13242), [#13244](https://github.com/phalcon/cphalcon/issues/13244)
+- Fixed `Phalcon\Validation\Validator\Date` to return code in validation message
 
 # [3.3.0](https://github.com/phalcon/cphalcon/releases/tag/v3.3.0) (2017-12-23)
 - Added support of PHP 7.2 and initial support of PHP 7.3

--- a/phalcon/validation/validator/date.zep
+++ b/phalcon/validation/validator/date.zep
@@ -95,7 +95,8 @@ class Date extends Validator
 				new Message(
 					strtr(message, replacePairs),
 					field,
-					"Date"
+					"Date",
+					code
 				)
 			);
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13236

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR. - it's trivial enough i think

Small description of change: add code argument to constructor

Thanks


  