### PR TITLE
Fixed Mysql::modifyColumn to produce valid SQL

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,3 +1,6 @@
+# [3.3.2](https://github.com/phalcon/cphalcon/releases/tag/v3.3.2) (2018-XX-XX)
+- Fixed `Phalcon\Db\Dialect\Mysql::modifyColumn` to produce valid SQL for renaming the column [#13012](https://github.com/phalcon/cphalcon/issues/13012)
+
 # [3.3.1](https://github.com/phalcon/cphalcon/releases/tag/v3.3.1) (2018-01-08)
 - Fixed a boolean logic error in the CSS minifier and a corresponding unit test so that whitespace is stripped [#13200](https://github.com/phalcon/cphalcon/pull/13200)
 - Fixed `default` Volt filter [#13242](https://github.com/phalcon/cphalcon/issues/13242), [#13244](https://github.com/phalcon/cphalcon/issues/13244)

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -257,9 +257,20 @@ class Mysql extends Dialect
 	 */
 	public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
 	{
-		var afterPosition, sql, defaultValue;
+		var afterPosition, sql, defaultValue, columnDefinition;
 
-		let sql = "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " MODIFY `" . column->getName() . "` " . this->getColumnDefinition(column);
+		let columnDefinition = this->getColumnDefinition(column),
+			sql = "ALTER TABLE " . this->prepareTable(tableName, schemaName);
+
+		if typeof currentColumn != "object" {
+			let currentColumn = column;
+		}
+
+		if column->getName() !== currentColumn->getName() {
+			let sql .= " CHANGE COLUMN `" . currentColumn->getName() . "` `" . column->getName() . "` " . columnDefinition;
+		} else {
+			let sql .= " MODIFY `" . column->getName() . "` " . columnDefinition;
+		}
 
 		if column->hasDefault() {
 			let defaultValue = column->getDefault();

--- a/tests/unit/Db/Dialect/MysqlTest.php
+++ b/tests/unit/Db/Dialect/MysqlTest.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Unit\Db\Dialect;
 
+use Phalcon\Db\Column;
 use Helper\DialectTrait;
 use Phalcon\Db\Dialect\Mysql;
 use Helper\Dialect\MysqlTrait;
@@ -563,6 +564,30 @@ class MysqlTest extends UnitTest
             [
                 'examples' => $this->getCreateTable()
             ]
+        );
+    }
+
+    /**
+     * Tests Mysql::modifyColumn
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-01-20
+     * @issue  13012
+     */
+    public function shouldRenameColumn()
+    {
+        $this->specify(
+            "Can't rename a Column using MySQL Dialect",
+            function () {
+                $dialect = new Mysql();
+
+                $oldColumn = new Column('old', ['type' => Column::TYPE_VARCHAR]);
+                $newColumn = new Column('new', ['type' => Column::TYPE_VARCHAR]);
+
+                expect($dialect->modifyColumn('table', 'database', $newColumn, $oldColumn))
+                    ->equals('ALTER TABLE `database`.`table` CHANGE COLUMN `old` `new` VARCHAR(0)');
+            }
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13012

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Fixed `Phalcon\Db\Dialect\Mysql::modifyColumn` to produce valid SQL for renaming the column

Thanks

