### PR TITLE
Make shared instances removable.

### DIFF
--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -549,4 +549,20 @@ class Di implements DiInterface
 			this->set(name, service, isset service["shared"] && service["shared"]);
 		}
 	}
+
+	/**
+	 * Check whether a shared instance exists.
+	 */
+	public function hasSharedInstance(string! name) -> boolean
+	{
+		return isset this->_sharedInstances[name];
+	}
+
+	/**
+	 * Remove a shared instance from DI. Make it recreateable.
+	 */
+	public function removeSharedInstance(string! name)
+	{
+		unset $this->_sharedInstances[name];
+	}
 }


### PR DESCRIPTION
When I use Phalcon  in a multi-process scene,  I have to remove any DB connections copied from parent.

so I add two methods: one check a shared instance for a service exists or not, and another to remove a shared instance. That we can recreate it if needed.

Refs: https://github.com/phalcon/cphalcon/issues/13440

