### PR TITLE
Replace deprecated `each()` function with for...in loop

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -1,6 +1,7 @@
 # [3.3.2](https://github.com/phalcon/cphalcon/releases/tag/v3.3.2) (2018-XX-XX)
 - Fixed `Phalcon\Db\Dialect\Mysql::modifyColumn` to produce valid SQL for renaming the column [#13012](https://github.com/phalcon/cphalcon/issues/13012)
 - Fixed `Phalcon\Forms\Form::getMessages` to return back previous behaviour: return array of messages with element name as key [#13294](https://github.com/phalcon/cphalcon/issues/13294)
+- Fixed `E_DEPRECATED` error for `each()` in `Phalcon\Debug\Dump` [#13253](https://github.com/phalcon/cphalcon/issues/13253)
 
 # [3.3.1](https://github.com/phalcon/cphalcon/releases/tag/v3.3.1) (2018-01-08)
 - Fixed a boolean logic error in the CSS minifier and a corresponding unit test so that whitespace is stripped [#13200](https://github.com/phalcon/cphalcon/pull/13200)

--- a/phalcon/debug/dump.zep
+++ b/phalcon/debug/dump.zep
@@ -193,17 +193,7 @@ class Dump
 				}
 			} else {
 				// Debug all properties
-				do {
-
-					let attr = each(variable);
-
-					if !attr {
-						continue;
-					}
-
-					let key = attr["key"],
-						value = attr["value"];
-
+				for key, value in variable {
 					if !key {
 						continue;
 					}
@@ -221,8 +211,7 @@ class Dump
 
 					let output .= str_repeat(space, tab) . strtr("-><span style=':style'>:key</span> (<span style=':style'>:type</span>) = ", [":style": this->getStyle("obj"), ":key": end(key), ":type": type]);
 					let output .= this->output(value, "", tab + 1) . "\n";
-
-				} while attr;
+				}
 			}
 
 			let attr = get_class_methods(variable);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13253

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

The `each()` function in `Phalcon\Debug\Dump` is deprecated. I have replaced it with of `for...in` loop.

Thanks

