### PR TITLE
Allow custom authorization headers

### DIFF
--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -989,7 +989,7 @@ class Request implements RequestInterface, InjectionAwareInterface
 					}
 				} elseif stripos(authHeader, "digest ") === 0 && !fetch digest, _SERVER["PHP_AUTH_DIGEST"] {
 					let headers["Php-Auth-Digest"] = authHeader;
-				} elseif stripos(authHeader, "bearer ") === 0 {
+				} else {
 					let headers["Authorization"] = authHeader;
 				}
 			}


### PR DESCRIPTION
Is there any reason to drop any auth header except "basic", "digest" and "bearer"?

Hello!

* Type: bug fix 
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [ ] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.
- [X] none of those above
