### PR TITLE
Added call event `afterFetch` in `Phalcon\Mvc\Model:refresh`

### DIFF
--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -3,6 +3,7 @@
 - Fixed `Phalcon\Forms\Form::getMessages` to return back previous behaviour: return array of messages with element name as key [#13294](https://github.com/phalcon/cphalcon/issues/13294)
 - Fixed `Phalcon\Mvc\Model\Behavior\SoftDelete::notify` to solve the exception that soft deletion renamed model [#13302](https://github.com/phalcon/cphalcon/issues/13302), [#13306](https://github.com/phalcon/cphalcon/issues/13306)
 - Fixed `E_DEPRECATED` error for `each()` in `Phalcon\Debug\Dump` [#13253](https://github.com/phalcon/cphalcon/issues/13253)
+- Added call event `afterFetch` in `Phalcon\Mvc\Model:refresh` [#12220](https://github.com/phalcon/cphalcon/issues/12220)
 
 # [3.3.1](https://github.com/phalcon/cphalcon/releases/tag/v3.3.1) (2018-01-08)
 - Fixed a boolean logic error in the CSS minifier and a corresponding unit test so that whitespace is stripped [#13200](https://github.com/phalcon/cphalcon/pull/13200)

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3518,6 +3518,8 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 			}
 		}
 
+		this->fireEvent("afterFetch");
+
 		return this;
 	}
 


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/12220

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Added event call `afterFetch` in `Phalcon\Mvc\Model:refresh`
Thanks

