### PR TITLE
Added Phalcon\Mvc\Router::attach

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,0 +1,2 @@
+# [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-XX-XX)
+- Added `Phalcon\Mvc\Router\Route::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ To see what we changed in particular framework branch refer to the relevant chan
 
 ## Index
 
+- [**`3.4.x`**](CHANGELOG-3.4.md)
 - [**`3.3.x`**](CHANGELOG-3.3.md)
 - [**`3.2.x`**](CHANGELOG-3.2.md)
 - [**`3.1.x`**](CHANGELOG-3.1.md)

--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -674,6 +674,43 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	}
 
 	/**
+	 * Attach Route object to the routes stack.
+	 *
+	 * <code>
+	 * use Phalcon\Mvc\Router;
+	 * use Phalcon\Mvc\Router\Route;
+	 *
+	 * class CustomRoute extends Route {
+     *      // ...
+     * }
+     *
+     * $router = new Router();
+     *
+     * $router->attach(
+     *     new CustomRoute("/about", "About::index", ["GET", "HEAD"]),
+     *     Router::POSITION_FIRST
+     * );
+	 * </code>
+	 *
+	 * @todo Add to the interface for 4.0.0
+	 */
+	public function attach(<RouteInterface> route, var position = Router::POSITION_LAST) -> <RouterInterface>
+	{
+		switch position {
+			case self::POSITION_LAST:
+				let this->_routes[] = route;
+				break;
+			case self::POSITION_FIRST:
+				let this->_routes = array_merge([route], this->_routes);
+				break;
+			default:
+				throw new Exception("Invalid route position");
+		}
+
+		return this;
+	}
+
+	/**
 	 * Adds a route to the router without any HTTP constraint
 	 *
 	 *<code>
@@ -693,19 +730,7 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 		 */
 		let route = new Route(pattern, paths, httpMethods);
 
-		switch position {
-
-			case self::POSITION_LAST:
-				let this->_routes[] = route;
-				break;
-
-			case self::POSITION_FIRST:
-				let this->_routes = array_merge([route], this->_routes);
-				break;
-
-			default:
-				throw new Exception("Invalid route position");
-		}
+		this->attach(route, position);
 
 		return route;
 	}

--- a/tests/unit/Mvc/RouterTest.php
+++ b/tests/unit/Mvc/RouterTest.php
@@ -19,7 +19,6 @@ namespace Phalcon\Test\Unit\Mvc;
 
 use Helper\Mvc\RouterTrait;
 use Phalcon\Mvc\Router;
-use Phalcon\Http\Request;
 use Phalcon\Mvc\Router\Route;
 use Phalcon\Test\Module\UnitTest;
 
@@ -261,6 +260,30 @@ class RouterTest extends UnitTest
             [
                 'examples' => include_once PATH_FIXTURES . 'mvc/router_test/matching_with_path_provider.php'
             ]
+        );
+    }
+
+    /**
+     * @test
+     * @issue  13326
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-03-24
+     */
+    public function shouldAttachRoute()
+    {
+        $this->specify(
+            'Err',
+            function () {
+                $router = $this->getRouter(false);
+                expect($router->getRoutes())->count(0);
+
+                $router->attach(
+                    new Route("/about", "About::index", ["GET", "HEAD"]),
+                    Router::POSITION_FIRST
+                );
+
+                expect($router->getRoutes())->count(1);
+            }
         );
     }
 


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13326 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router`:

```php
use Phalcon\Mvc\Router;
use Phalcon\Mvc\Router\Route;

class CustomRoute extends Route {
    // ...
}

$router = new Router();

$router->attach(
    new CustomRoute("/about", "About::index", ["GET", "HEAD"]),
    Router::POSITION_FIRST
);
```

Thanks

