### PR TITLE
Added the ability to listen authorization events

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,2 +1,3 @@
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-XX-XX)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)
+- Added ability to fire `request:beforeAuthorizationResolve` and `request:afterAuthorizationResolve` events to provide possibility using custom authorization resolvers [#13327](https://github.com/phalcon/cphalcon/pull/13327)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,3 +1,3 @@
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-XX-XX)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)
-- Added ability to fire `request:beforeAuthorizationResolve` and `request:afterAuthorizationResolve` events to provide possibility using custom authorization resolvers [#13327](https://github.com/phalcon/cphalcon/pull/13327)
+- Added the ability to listen `request:beforeAuthorizationResolve` and `request:afterAuthorizationResolve` events. This ability enables using custom authorization resolvers [#13327](https://github.com/phalcon/cphalcon/pull/13327)

--- a/tests/_data/listener/CustomAuthorizationListener.php
+++ b/tests/_data/listener/CustomAuthorizationListener.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Phalcon\Test\Listener;
+
+use Phalcon\Events\Event;
+use Phalcon\Http\Request;
+
+/**
+ * Phalcon\Test\Listener\CustomAuthorizationListener
+ *
+ * @copyright (c) 2011-2018 Phalcon Team
+ * @link      https://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Listener
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class CustomAuthorizationListener
+{
+    public function beforeAuthorizationResolve(Event $event, Request $request, array $data)
+    {
+        return [
+            'Fired-Before'=> $event->getType(),
+        ];
+    }
+
+    public function afterAuthorizationResolve(Event $event, Request $request, array $data)
+    {
+        return [
+            'Fired-After'=> $event->getType(),
+        ];
+    }
+}

--- a/tests/_data/listener/NegotiateAuthorizationListener.php
+++ b/tests/_data/listener/NegotiateAuthorizationListener.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phalcon\Test\Listener;
+
+use Phalcon\Events\Event;
+use Phalcon\Http\Request;
+
+/**
+ * Phalcon\Test\Listener\NegotiateAuthorizationListener
+ *
+ * @copyright (c) 2011-2018 Phalcon Team
+ * @link      https://www.phalconphp.com
+ * @author    Andres Gutierrez <andres@phalconphp.com>
+ * @author    Serghei Iakovlev <serghei@phalconphp.com>
+ * @package   Phalcon\Test\Listener
+ *
+ * The contents of this file are subject to the New BSD License that is
+ * bundled with this package in the file LICENSE.txt
+ *
+ * If you did not receive a copy of the license and are unable to obtain it
+ * through the world-wide-web, please send an email to license@phalconphp.com
+ * so that we can send you a copy immediately.
+ */
+class NegotiateAuthorizationListener
+{
+    public function afterAuthorizationResolve(Event $event, Request $request, array $data)
+    {
+        if (empty($data['server']['CUSTOM_KERBEROS_AUTH'])) {
+            return false;
+        }
+
+        list($type,) = explode(' ', $data['server']['CUSTOM_KERBEROS_AUTH'], 2);
+
+        if (!$type || stripos($type, 'negotiate') !== 0) {
+            return false;
+        }
+
+        return [
+           'Authorization'=> $data['server']['CUSTOM_KERBEROS_AUTH'],
+        ];
+    }
+}

--- a/tests/unit/Http/Request/AuthHeaderTest.php
+++ b/tests/unit/Http/Request/AuthHeaderTest.php
@@ -40,10 +40,11 @@ class AuthHeaderTest extends UnitTest
      */
     public function _before()
     {
+        Di::reset();
         $di = new Di();
 
-        $di->set('filter', Filter::class);
-        $di->set('eventsManager', Manager::class);
+        $di->setShared('filter', Filter::class);
+        $di->setShared('eventsManager', Manager::class);
 
         $this->request = new Request();
         $this->request->setDI($di);

--- a/tests/unit/Http/Request/AuthHeaderTest.php
+++ b/tests/unit/Http/Request/AuthHeaderTest.php
@@ -34,19 +34,12 @@ class AuthHeaderTest extends UnitTest
      */
     protected $request;
 
-    /**
-     * @var array
-     */
-    protected $server;
 
     /**
      * executed before each test
      */
     public function _before()
     {
-        // Backup current $_SERVER
-        $this->server = $_SERVER;
-
         $di = new Di();
 
         $di->set('filter', Filter::class);
@@ -54,15 +47,6 @@ class AuthHeaderTest extends UnitTest
 
         $this->request = new Request();
         $this->request->setDI($di);
-    }
-
-    /**
-     * executed after each test
-     */
-    public function _after()
-    {
-        // Restore old $_SERVER
-        $_SERVER = $this->server;
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13327 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

#### Description

The HTTP authorization header has a format
```
Authorization: <type> <credentials>
````

where `<type>` is an authentication type. A common type is `Basic`. Other types described in:

* [IANA registry of Authentication schemes](http://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml)
* [Authentication for AWS servers (`AWS4-HMAC-SHA256`)](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html)

Thus, in 99.99% use cases the authentication type is:

- `Basic`
- `Bearer`
- `Digest`
- `HOBA`
- `Mutual`
- `Negotiate`
- `OAuth`
- `SCRAM-SHA-1`
- `SCRAM-SHA-256`
- `vapid`
- `AWS4-HMAC-SHA256`

This Pull Request introduces the ability to listen `request:beforeAuthorizationResolve` and `request:afterAuthorizationResolve` events. This ability enables using custom authorization resolvers.

#### Examples

##### Without using custom authorization resolver

**Test**

```php
use Phalcon\Http\Request;

$_SERVER['HTTP_AUTHORIZATION'] = 'Enigma Secret';

$request = new Request();
print_r($request->getHeaders());
```

**Result**

```
Array
(
    [Authorization] => Enigma Secret
)

Type: Enigma
Credentials: Secret
```

##### Using custom authorization resolver

```php
use Phalcon\Di;
use Phalcon\Events\Event;
use Phalcon\Http\Request;
use Phalcon\Events\Manager;

class NegotiateAuthorizationListener
{
    public function afterAuthorizationResolve(Event $event, Request $request, array $data)
    {
        if (empty($data['server']['CUSTOM_KERBEROS_AUTH'])) {
            return false;
        }

        list($type,) = explode(' ', $data['server']['CUSTOM_KERBEROS_AUTH'], 2);

        if (!$type || stripos($type, 'negotiate') !== 0) {
            return false;
        }

        return [
           'Authorization'=> $data['server']['CUSTOM_KERBEROS_AUTH'],
        ];
    }
}

$_SERVER['CUSTOM_KERBEROS_AUTH'] = 'Negotiate a87421000492aa874209af8bc028';

$di = new Di();

$di->set('eventsManager', function () {
    $manager = new Manager();
    $manager->attach('request', new NegotiateAuthorizationListener());

    return $manager;
});

$request = new Request();
$request->setDI($di);

print_r($request->getHeaders());
```

**Result**

```
Array
(
    [Authorization] => Negotiate a87421000492aa874209af8bc028
)

Type: Negotiate
Credentials: a87421000492aa874209af8bc028
```

For more please see tests in this PR.
Thanks

