### PR TITLE
Added Phalcon\Loader::setFileCheckingCallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ lemon
 .libs/
 .temp/
 autom4te.cache/
-vendor/
+/vendor/
 ide/
 
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ env:
   global:
     - CC="ccache gcc"
     - PATH="$PATH:$HOME/bin"
-    - ZEPHIR_PARSER_VERSION="v1.1.1"
+    - ZEPHIR_PARSER_VERSION="v1.1.2"
     - RE2C_VERSION="1.0.3"
     - REPORT_EXIT_STATUS=1
     - NO_INTERACTION=1

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -3,5 +3,6 @@
 - Added the ability to listen `request:beforeAuthorizationResolve` and `request:afterAuthorizationResolve` events. This ability enables using custom authorization resolvers [#13327](https://github.com/phalcon/cphalcon/pull/13327)
 - Added call event `afterFetch` in `Phalcon\Mvc\Model:refresh` [#12220](https://github.com/phalcon/cphalcon/issues/12220)
 - Added `Phalcon\Http\Response::getReasonPhrase` to retrieve the reason phrase from the `Status` header [#13314](https://github.com/phalcon/cphalcon/pull/13314)
+- Added `Phalcon\Loader::setFileCheckingCallaback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ environment:
     COMPOSER_NO_INTERACTION: 1
     PARSER_VERSION: 1.1.2
     PARSER_RELEASE: 290
-    PHALCON_STABLE_VERSION: 3.3.1
+    PHALCON_STABLE_VERSION: 3.3.2
 
 matrix:
     fast_finish: true

--- a/phalcon/loader.zep
+++ b/phalcon/loader.zep
@@ -19,6 +19,7 @@
 
 namespace Phalcon;
 
+use Phalcon\Loader\Exception;
 use Phalcon\Events\ManagerInterface;
 use Phalcon\Events\EventsAwareInterface;
 
@@ -69,6 +70,38 @@ class Loader implements EventsAwareInterface
 	protected _files = [];
 
 	protected _registered = false;
+
+	protected fileCheckingCallback = "is_file";
+
+	/**
+	 * Sets the file check callback.
+	 *
+	 * <code>
+	 * // Default behavior.
+	 * $loader->setFileCheckingCallback("is_file");
+	 *
+	 * // Faster than `is_file()`, but implies some issues if
+	 * // the file is removed from the filesystem.
+	 * $loader->setFileCheckingCallback("stream_resolve_include_path");
+	 *
+	 * // Do not check file existence.
+	 * $loader->setFileCheckingCallback(null);
+	 * </code>
+     */
+	public function setFileCheckingCallback(var callback = null) -> <Loader>
+	{
+		if likely is_callable(callback) {
+			let this->fileCheckingCallback = callback;
+		} elseif callback === null {
+			let this->fileCheckingCallback = function (file) {
+				return true;
+			};
+		} else {
+			throw new Exception("The 'callbak' parameter must be either a callable or NULL.");
+		}
+
+		return this;
+	}
 
 	/**
 	 * Sets the events manager
@@ -258,7 +291,9 @@ class Loader implements EventsAwareInterface
 	 */
 	public function loadFiles()
 	{
-		var filePath;
+		var filePath, fileCheckingCallback;
+
+		let fileCheckingCallback = this->fileCheckingCallback;
 
 		for filePath in this->_files {
 			if typeof this->_eventsManager == "object" {
@@ -269,7 +304,7 @@ class Loader implements EventsAwareInterface
 			/**
 			 * Check if the file specified even exists
 			 */
-			if is_file(filePath) {
+			if call_user_func(fileCheckingCallback, filePath) {
 
 				/**
 				 * Call 'pathFound' event
@@ -294,7 +329,7 @@ class Loader implements EventsAwareInterface
 	{
 		var eventsManager, classes, extensions, filePath, ds, fixedDirectory,
 			directories, ns, namespaces, nsPrefix,
-			directory, fileName, extension, nsClassName;
+			directory, fileName, extension, nsClassName, fileCheckingCallback;
 
 		let eventsManager = this->_eventsManager;
 		if typeof eventsManager == "object" {
@@ -323,6 +358,8 @@ class Loader implements EventsAwareInterface
 		 * Checking in namespaces
 		 */
 		let namespaces = this->_namespaces;
+
+		let fileCheckingCallback = this->fileCheckingCallback;
 
 		for nsPrefix, directories in namespaces {
 
@@ -365,7 +402,7 @@ class Loader implements EventsAwareInterface
 					/**
 					 * This is probably a good path, let's check if the file exists
 					 */
-					if is_file(filePath) {
+					if call_user_func(fileCheckingCallback, filePath) {
 
 						if typeof eventsManager == "object" {
 							let this->_foundPath = filePath;
@@ -418,7 +455,7 @@ class Loader implements EventsAwareInterface
 				/**
 				 * Check in every directory if the class exists here
 				 */
-				if is_file(filePath) {
+				if call_user_func(fileCheckingCallback, filePath) {
 
 					/**
 					 * Call 'pathFound' event

--- a/tests/_data/vendor/Example/Engines/LeEngine2.php
+++ b/tests/_data/vendor/Example/Engines/LeEngine2.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Example\Engines;
+
+class LeEngine2
+{
+}

--- a/tests/_data/vendor/Example/Other/NoClass3.php
+++ b/tests/_data/vendor/Example/Other/NoClass3.php
@@ -1,0 +1,9 @@
+<?php
+
+function noClass3Foo()
+{
+}
+
+function noClass3Bar()
+{
+}

--- a/tests/unit/LoaderTest.php
+++ b/tests/unit/LoaderTest.php
@@ -318,4 +318,73 @@ class LoaderTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests Loader::setFileCheckingCallback
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-04-29
+     * @issue  https://github.com/phalcon/cphalcon/issues/13360
+     * @issue  https://github.com/phalcon/cphalcon/issues/10472
+     */
+    public function shouldNotFindFilesWithFalseCallback()
+    {
+        $this->specify(
+            'File checking does not work as expected',
+            function () {
+                $loader = new Loader();
+                $loader->setFileCheckingCallback(function ($file) {
+                    return false;
+                });
+
+                $loader->registerFiles([
+                    PATH_DATA . 'vendor/Example/Other/NoClass3.php'
+                ]);
+
+                $loader->registerNamespaces([
+                    'Example' => PATH_DATA . 'vendor/Example/'
+                ], true);
+
+                $loader->register();
+
+                expect(function_exists('noClass3Foo'))->false();
+                expect(function_exists('noClass3Bar'))->false();
+            }
+        );
+    }
+
+    /**
+     * Tests Loader::setFileCheckingCallback
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-04-29
+     * @issue  https://github.com/phalcon/cphalcon/issues/13360
+     * @issue  https://github.com/phalcon/cphalcon/issues/10472
+     */
+    public function shouldWorkWithCustomFileCheckCallback()
+    {
+        $this->specify(
+            'File checking does not work as expected',
+            function () {
+                $loader = new Loader();
+                $loader->setFileCheckingCallback('stream_resolve_include_path');
+
+                $loader->registerFiles([
+                    PATH_DATA . 'vendor/Example/Other/NoClass3.php'
+                ]);
+
+                $loader->registerNamespaces([
+                    'Example' => PATH_DATA . 'vendor/Example/'
+                ], true);
+
+                $loader->register();
+
+                expect(function_exists('noClass3Foo'))->true();
+                expect(function_exists('noClass3Bar'))->true();
+                expect(class_exists('\Example\Engines\LeEngine2'))->true();
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13360

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver.
```php
// Default behavior.
$loader->setFileCheckingCallback("is_file");

// Faster than `is_file()`, but implies some issues if
// the file is removed from the filesystem.
$loader->setFileCheckingCallback("stream_resolve_include_path");

// Do not check file existence.
$loader->setFileCheckingCallback(null);
```

Thanks

----

/cc @dugwood
