### PR TITLE
Fixed Builder::whare, Builder::having for bind types

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,4 +5,5 @@
 - Added `Phalcon\Http\Response::getReasonPhrase` to retrieve the reason phrase from the `Status` header [#13314](https://github.com/phalcon/cphalcon/pull/13314)
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
+- Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -144,7 +144,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 	 * however if a model got a transaction set inside it will use the local transaction instead of this one
 	 */
 	protected _transaction { get };
-	
+
 	static protected _irPhqlCache;
 
 	const TYPE_SELECT = 309;
@@ -3530,7 +3530,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 	{
 		var currentBindTypes;
 
-		if merge {
+		if unlikely merge {
 			let currentBindTypes = this->_bindTypes;
 			if typeof currentBindTypes == "array" {
 				let this->_bindTypes = currentBindTypes + bindTypes;

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -582,7 +582,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 		 */
 		if typeof bindTypes == "array" {
 			let currentBindTypes = this->_bindTypes;
-			if typeof currentBindParams == "array" {
+			if typeof currentBindTypes == "array" {
 				let this->_bindTypes = currentBindTypes + bindTypes;
 			} else {
 				let this->_bindTypes = bindTypes;
@@ -792,7 +792,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 		 */
 		if typeof bindTypes == "array" {
 			let currentBindTypes = this->_bindTypes;
-			if typeof currentBindParams == "array" {
+			if typeof currentBindTypes == "array" {
 				let this->_bindTypes = currentBindTypes + bindTypes;
 			} else {
 				let this->_bindTypes = bindTypes;
@@ -1408,7 +1408,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 			query->setBindParams(bindParams);
 		}
 
-		// Set default bind params
+		// Set default bind types
 		let bindTypes = this->_bindTypes;
 		if typeof bindTypes == "array" {
 			query->setBindTypes(bindTypes);

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -757,10 +757,10 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * $builder->having("SUM(Robots.price) > 0");
 	 *
 	 * $builder->having(
-	 * 		"SUM(Robots.price) > :sum:",
-	 *   	[
-	 *    		"sum" => 100,
-	 *      ]
+	 *     "SUM(Robots.price) > :sum:",
+	 *     [
+	 *         "sum" => 100,
+	 *     ]
 	 * );
 	 *</code>
 	 *
@@ -809,10 +809,10 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * $builder->andHaving("SUM(Robots.price) > 0");
 	 *
 	 * $builder->andHaving(
-	 * 		"SUM(Robots.price) > :sum:",
-	 *   	[
-	 *    		"sum" => 100,
-	 *      ]
+	 *     "SUM(Robots.price) > :sum:",
+	 *     [
+	 *         "sum" => 100,
+	 *     ]
 	 * );
 	 *</code>
 	 *
@@ -844,10 +844,10 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	 * $builder->orHaving("SUM(Robots.price) > 0");
 	 *
 	 * $builder->orHaving(
-	 * 		"SUM(Robots.price) > :sum:",
-	 *   	[
-	 *    		"sum" => 100,
-	 *      ]
+	 *     "SUM(Robots.price) > :sum:",
+	 *     [
+	 *         "sum" => 100,
+	 *     ]
 	 * );
 	 *</code>
 	 *

--- a/tests/unit/Mvc/Model/Query/BuilderTest.php
+++ b/tests/unit/Mvc/Model/Query/BuilderTest.php
@@ -43,6 +43,85 @@ class BuilderTest extends UnitTest
         $this->di = $app->getDI();
     }
 
+    /**
+     * Tests merge bind types for Builder::where
+     *
+     * @test
+     * @issue https://github.com/phalcon/cphalcon/issues/11487
+     */
+    public function shouldMergeBinTypesForWhere()
+    {
+        $this->specify(
+            'Query builder does not merge bind types as expected.',
+            function () {
+                $builder = new Builder();
+                $builder->setDi($this->di);
+
+                $builder
+                    ->from(Robots::class)
+                    ->where(
+                        'id = :id:',
+                        [':id:' => 3],
+                        [':id:' => \PDO::PARAM_INT]
+                    );
+
+                $builder->where(
+                    'name = :name:',
+                    [':name:' => 'Terminator'],
+                    [':name:' => \PDO::PARAM_STR]
+                );
+
+                $actual = $builder->getQuery()->getBindTypes();
+                $expected = [':id:' => 1, ':name:' => 2];
+
+                expect($actual)->equals($expected);
+            }
+        );
+    }
+
+    /**
+     * Tests merge bind types for Builder::having
+     *
+     * @test
+     * @issue https://github.com/phalcon/cphalcon/issues/11487
+     */
+    public function shouldMergeBinTypesForHaving()
+    {
+        $this->specify(
+            'Query builder does not merge bind types as expected.',
+            function () {
+                $builder = new Builder();
+                $builder->setDi($this->di);
+
+                $builder
+                    ->from(Robots::class)
+                    ->columns(
+                        [
+                            'COUNT(id)',
+                            'name'
+                        ]
+                    )
+                    ->groupBy('COUNT(id)')
+                    ->having(
+                        'COUNT(id) > :cnt:',
+                        [':cnt:' => 5],
+                        [':cnt:' => \PDO::PARAM_INT]
+                    );
+
+                $builder->having(
+                    "CONCAT('is_', type) = :type:",
+                    [':type:' => 'mechanical'],
+                    [':type:' => \PDO::PARAM_STR]
+                );
+
+                $actual = $builder->getQuery()->getBindTypes();
+                $expected = [':cnt:' => 1, ':type:' => 2];
+
+                expect($actual)->equals($expected);
+            }
+        );
+    }
+
     public function testAction()
     {
         $this->specify(


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #11487

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types.

#### `where`

```php
$builder = new Builder();
$builder->setDi($di);

$builder
    ->from(Robots::class)
    ->where(
        'id > :id:',
        [':id:' => 1],
        [':id:' => \PDO::PARAM_INT]
    );

$builder->where(
    'name = :name:',
    [':name:' => 'Terminator'],
    [':name:' => \PDO::PARAM_STR]
);
```
**Actual**
```php
assert($builder->getQuery()->getBindTypes() === [':name:' => 2])
```

**Expected**
```php
assert($builder->getQuery()->getBindTypes() === [':id:' => 1, ':name:' => 2])
```

#### `having`

```php
$builder = new Builder();
$builder->setDi($di);

$builder
    ->from(Robots::class)
    ->columns(
        [
            'COUNT(id)',
            'name'
        ]
    )
    ->groupBy('COUNT(id)')
    ->having(
        'COUNT(id) > :cnt:',
        [':cnt:' => 5],
        [':cnt:' => \PDO::PARAM_INT]
    );

$builder->having(
    "CONCAT('is_', type) = :type:",
    [':type:' => 'is_mechanical'],
    [':type:' => \PDO::PARAM_STR]
);
```

**Actual**
```php
assert($builder->getQuery()->getBindTypes() === [':type:' => 2])
```

**Expected**
```php
assert($builder->getQuery()->getBindTypes() === [':cnt:' => 1, ':type:' => 2])
```

Thanks

