### PR TITLE
Improved Phalcon\Crypt

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,6 +5,8 @@
 - Added `Phalcon\Http\Response::getReasonPhrase` to retrieve the reason phrase from the `Status` header [#13314](https://github.com/phalcon/cphalcon/pull/13314)
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
+- Added `Phalcon\Crypt::assertAvailableCipher` to assert a cipher is available
+- Added `Phalcon\Crypt::__construct` so now available ciphers will be set at construct time
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -6,7 +6,8 @@
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
 - Added `Phalcon\Crypt::assertAvailableCipher` to assert a cipher is available
-- Added `Phalcon\Crypt::__construct` so now available ciphers will be set at construct time
+- Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construct time
+- Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured after setting cipher algorithm
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,9 +5,9 @@
 - Added `Phalcon\Http\Response::getReasonPhrase` to retrieve the reason phrase from the `Status` header [#13314](https://github.com/phalcon/cphalcon/pull/13314)
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
-- Added `Phalcon\Crypt::assertAvailableCipher` to assert a cipher is available
 - Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construct time
-- Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured after setting cipher algorithm
+- Changed Phalcon\Crypt::setCipher so that IV length will be reconfigured during setting the cipher algorithm
+- Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -105,7 +105,7 @@ class Crypt implements CryptInterface
 	 */
 	public function setCipher(string! cipher) -> <Crypt>
 	{
-		this->assertAvailableCipher(cipher);
+		this->assertCipherIsAvailable(cipher);
 
 		let this->ivLength = this->getIvLength(cipher),
 			this->_cipher  = cipher;
@@ -130,7 +130,7 @@ class Crypt implements CryptInterface
 	 * "le password"
 	 *
 	 * Better (but still unsafe):
-	 * "#1dj8$=dp?.ak//j1V$"
+	 * "#1dj8$=dp?.ak//j1V$~%*0X"
 	 *
 	 * Good key:
 	 * "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3"
@@ -340,7 +340,7 @@ class Crypt implements CryptInterface
 		let cipher = this->_cipher;
 		let mode = strtolower(substr(cipher, strrpos(cipher, "-") - strlen(cipher)));
 
-		this->assertAvailableCipher(cipher);
+		this->assertCipherIsAvailable(cipher);
 
 		let ivLength = this->ivLength;
 		if likely ivLength > 0 {
@@ -388,7 +388,7 @@ class Crypt implements CryptInterface
 		let cipher = this->_cipher;
 		let mode = strtolower(substr(cipher, strrpos(cipher, "-") - strlen(cipher)));
 
-		this->assertAvailableCipher(cipher);
+		this->assertCipherIsAvailable(cipher);
 
 		let ivLength = this->ivLength;
 		if likely ivLength > 0 {
@@ -453,14 +453,19 @@ class Crypt implements CryptInterface
 	 *
 	 * @throws \Phalcon\Crypt\Exception
 	 */
-	public function assertAvailableCipher(string! cipher) ->void
+	protected function assertCipherIsAvailable(string! cipher) -> void
 	{
 		var availableCiphers;
 
 		let availableCiphers = this->getAvailableCiphers();
 
 		if !in_array(cipher, availableCiphers) {
-			throw new Exception("Cipher algorithm is unknown");
+			throw new Exception(
+				sprintf(
+					"The cipher algorithm \"%s\" is not supported on this system.",
+					cipher
+				)
+			);
 		}
 	}
 

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -48,6 +48,9 @@ class Crypt implements CryptInterface
 
 	protected _padding = 0;
 
+	/**
+	 * @todo Change default cipher to aes-256-gcm for PHP 7.1+
+     */
 	protected _cipher = "aes-256-cfb";
 
 	/**
@@ -73,6 +76,7 @@ class Crypt implements CryptInterface
 	/**
 	 * Phalcon\Crypt constructor
 	 *
+	 * @todo Change default cipher to aes-256-gcm for PHP 7.1+
 	 * @throws \Phalcon\Crypt\Exception
 	 */
 	public function __construct(string! cipher = "aes-256-cfb")
@@ -94,10 +98,11 @@ class Crypt implements CryptInterface
 	/**
 	 * Sets the cipher algorithm.
 	 *
-	 * The `aes-256-gcm' is preferable cipher , but not usable until
+	 * The `aes-256-gcm' is preferable cipher, but not usable until
 	 * the openssl library is enhanced, which is due in PHP 7.1.
+	 *
 	 * The `aes-256-ctr' is arguably the best choice for cipher
-	 * algorithm for PHP 5.6+.
+	 * algorithm for current openssl library version.
 	 *
 	 * @throws \Phalcon\Crypt\Exception
 	 */
@@ -121,6 +126,15 @@ class Crypt implements CryptInterface
 	 * Sets the encryption key.
 	 *
 	 * The `$key' should have been previously generated in a cryptographically safe way.
+	 *
+	 * Bad key:
+	 * "le password"
+	 *
+	 * Better (but still unsafe):
+	 * "#1dj8$=dp?.ak//j1V$"
+	 *
+	 * Good key:
+	 * "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3"
 	 *
 	 * @see \Phalcon\Security\Random::bytes
 	 */

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -77,7 +77,7 @@ class Crypt implements CryptInterface
 	const PADDING_SPACE = 6;
 
 	/**
-	 * Phalcon\Crypt constructor
+	 * Phalcon\Crypt constructor.
 	 */
 	public function __construct(string! cipher = "aes-256-cfb")
 	{
@@ -86,7 +86,7 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Changes the padding scheme used
+	 * Changes the padding scheme used.
 	 */
 	public function setPadding(int! scheme) -> <CryptInterface>
 	{
@@ -107,8 +107,9 @@ class Crypt implements CryptInterface
 	{
 		this->assertAvailableCipher(cipher);
 
-		let this->ivLength = this->getIvLength(cipher);
-		let this->_cipher = cipher;
+		let this->ivLength = this->getIvLength(cipher),
+			this->_cipher  = cipher;
+
 		return this;
 	}
 
@@ -151,7 +152,7 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Pads texts before encryption
+	 * Pads texts before encryption.
 	 *
 	 * @link http://www.di-mgt.com.au/cryptopad.html
 	 */
@@ -313,10 +314,13 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Encrypts a text
+	 * Encrypts a text.
 	 *
 	 * <code>
-	 * $encrypted = $crypt->encrypt("Ultra-secret text", "encrypt password");
+	 * $encrypted = $crypt->encrypt(
+	 *     "Top secret",
+	 *     "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3"
+	 * );
 	 * </code>
 	 */
 	public function encrypt(string! text, string! key = null) -> string
@@ -358,10 +362,13 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Decrypts an encrypted text
+	 * Decrypts an encrypted text.
 	 *
 	 * <code>
-	 * echo $crypt->decrypt($encrypted, "decrypt password");
+	 * $encrypted = $crypt->decrypt(
+	 *     $encrypted,
+	 *     "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3"
+	 * );
 	 * </code>
 	 */
 	public function decrypt(string! text, key = null) -> string
@@ -404,7 +411,7 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Encrypts a text returning the result as a base64 string
+	 * Encrypts a text returning the result as a base64 string.
 	 */
 	public function encryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{
@@ -415,7 +422,7 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Decrypt a text that is coded as a base64 string
+	 * Decrypt a text that is coded as a base64 string.
 	 */
 	public function decryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{
@@ -426,7 +433,7 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Returns a list of available ciphers
+	 * Returns a list of available ciphers.
 	 */
 	public function getAvailableCiphers() -> array
 	{
@@ -476,12 +483,12 @@ class Crypt implements CryptInterface
 	 *
 	 * @throws \Phalcon\Crypt\Exception
 	 */
-	protected function initializeAvailableCiphers(bool aliases = true) -> void
+	protected function initializeAvailableCiphers() -> void
 	{
 		if !function_exists("openssl_get_cipher_methods") {
 			throw new Exception("openssl extension is required");
 		}
 
-		let this->availableCiphers = openssl_get_cipher_methods(aliases);
+		let this->availableCiphers = openssl_get_cipher_methods(true);
 	}
 }

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -3,13 +3,14 @@
 namespace Phalcon\Test\Unit;
 
 use Phalcon\Crypt;
+use Phalcon\Crypt\Exception;
 use Phalcon\Test\Module\UnitTest;
 
 /**
- * \Phalcon\Test\Unit\CryptTest
- * Tests the \Phalcon\Crypt component
+ * Phalcon\Test\Unit\CryptTest
+ * Tests the Phalcon\Crypt component
  *
- * @copyright (c) 2011-2017 Phalcon Team
+ * @copyright (c) 2011-2018 Phalcon Team
  * @link      https://phalconphp.com
  * @author    Andres Gutierrez <andres@phalconphp.com>
  * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
@@ -31,6 +32,30 @@ class CryptTest extends UnitTest
         if (!extension_loaded('openssl')) {
             $this->markTestSkipped('Warning: openssl extension is not loaded');
         }
+    }
+
+    /**
+     * Tests the Crypt::setCipher
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-05-06
+     */
+    public function shouldThrowExceptionIfCipherIsUnknown()
+    {
+        $this->specify(
+            'Crypt does not validate cipher algorithm as exapected',
+            function () {
+                $crypt = new Crypt();
+                $crypt->setCipher('xxx-yyy-zzz');
+            },
+            [
+                'throws' => [
+                    Exception::class,
+                    'The cipher algorithm "xxx-yyy-zzz" is not supported on this system.'
+                ]
+            ]
+        );
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: new feature

Small description of change:

- Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set object construction
- Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
- Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable

