### PR TITLE
Introduced an ability to sign encrypted cookie

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -6,7 +6,8 @@
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
 - Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construct time
-- Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class.
+- Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code
+- Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -6,6 +6,7 @@
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
 - Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construct time
+- Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class.
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -7,6 +7,7 @@
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
 - Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construction without the need to call `setCipher` explicitly
 - Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code
+- Added `Phalcon\Http\Response\Cookies::setSignKey` to set sign key used to generate a message authentication code
 - Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -6,7 +6,7 @@
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
 - Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construct time
-- Changed Phalcon\Crypt::setCipher so that IV length will be reconfigured during setting the cipher algorithm
+- Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,7 +5,7 @@
 - Added `Phalcon\Http\Response::getReasonPhrase` to retrieve the reason phrase from the `Status` header [#13314](https://github.com/phalcon/cphalcon/pull/13314)
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
-- Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construct time
+- Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construction without the need to call `setCipher` explicitly
 - Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code
 - Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -135,7 +135,7 @@ class Crypt implements CryptInterface
 	 * Good key:
 	 * "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3"
 	 *
-	 * @see \Phalcon\Security\Random::bytes
+	 * @see \Phalcon\Security\Random
 	 */
 	public function setKey(string! key) -> <Crypt>
 	{

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -95,10 +95,10 @@ class Crypt implements CryptInterface
 	}
 
 	/**
-	 * Sets the cipher algorithm.
+	 * Sets the cipher algorithm for data encryption and decryption.
 	 *
-	 * The `aes-256-gcm' is preferable cipher, but not usable until
-	 * the openssl library is enhanced, which is due in PHP 7.1.
+	 * The `aes-256-gcm' is the preferable cipher, but it is not usable
+	 * until the openssl library is upgraded, which is available in PHP 7.1.
 	 *
 	 * The `aes-256-ctr' is arguably the best choice for cipher
 	 * algorithm for current openssl library version.

--- a/phalcon/http/cookie.zep
+++ b/phalcon/http/cookie.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ | Copyright (c) 2011-2018 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file LICENSE.txt.                             |
@@ -23,12 +23,14 @@ use Phalcon\DiInterface;
 use Phalcon\CryptInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Http\Response\Exception;
+use Phalcon\Http\Cookie\Exception as CookieException;
+use Phalcon\Http\Cookie\Mismatch;
 use Phalcon\Session\AdapterInterface as SessionInterface;
 
 /**
  * Phalcon\Http\Cookie
  *
- * Provide OO wrappers to manage a HTTP cookie
+ * Provide OO wrappers to manage a HTTP cookie.
  */
 class Cookie implements CookieInterface, InjectionAwareInterface
 {
@@ -58,18 +60,23 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	protected _httpOnly = true;
 
 	/**
-	 * Phalcon\Http\Cookie constructor
-	 *
-	 * @param string name
-	 * @param mixed value
-	 * @param int expire
-	 * @param string path
-	 * @param boolean secure
-	 * @param string domain
-	 * @param boolean httpOnly
+	 * The cookie's sign key.
+	 * @var string|null
+     */
+	protected signKey = null;
+
+	/**
+	 * Phalcon\Http\Cookie constructor.
 	 */
-	public function __construct(string! name, var value = null, expire = 0, path = "/", secure = null, domain = null, httpOnly = null)
-	{
+	public function __construct(
+		string! name,
+		var value = null,
+		int expire = 0,
+		string path = "/",
+		boolean secure = null,
+		string domain = null,
+		boolean httpOnly = null
+	) {
 		let this->_name = name;
 
 		if value !== null {
@@ -93,6 +100,28 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 		if httpOnly !== null {
 			let this->_httpOnly = httpOnly;
 		}
+	}
+
+	/**
+	 * Sets the cookie's sign key.
+	 *
+	 * The key MUST be at least 32 characters long
+	 * and generated using a cryptographically secure pseudo random generator.
+	 *
+	 * Use NULL to disable cookie signing.
+	 *
+	 * @see \Phalcon\Security\Random
+	 * @throws \Phalcon\Http\Cookie\Exception
+	 */
+	public function setSignKey(string signKey = null) -> <CookieInterface>
+	{
+		if signKey !== null {
+			this->assertSignKeyIsLongEnough(signKey);
+		}
+
+		let this->signKey = signKey;
+
+		return this;
 	}
 
 	/**
@@ -125,40 +154,73 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	}
 
 	/**
-	 * Returns the cookie's value
+	 * Returns the cookie's value.
 	 *
-	 * @param string|array filters
-	 * @param string defaultValue
-	 * @return mixed
+	 * @throws \Phalcon\Http\Cookie\Mismatch
 	 */
-	public function getValue(filters = null, defaultValue = null)
+	public function getValue(var filters = null, var defaultValue = null) -> var
 	{
-		var dependencyInjector, value, crypt, decryptedValue, filter;
+		var dependencyInjector, value, crypt, decryptedValue, filter,
+			hmac, hmacGiven, originalValue, signKey, name;
 
 		if !this->_restored {
 			this->restore();
 		}
 
-		let dependencyInjector = null;
+		let dependencyInjector = null,
+			name = this->_name;
 
 		if this->_readed === false {
 
-			if fetch value, _COOKIE[this->_name] {
+			if fetch value, _COOKIE[name] {
 
 				if this->_useEncryption {
 
 					let dependencyInjector = <DiInterface> this->_dependencyInjector;
 					if typeof dependencyInjector != "object" {
-						throw new Exception("A dependency injection object is required to access the 'filter' service");
+						throw new Exception(
+							"A dependency injection object is required to access the 'filter' service"
+						);
 					}
 
-					let crypt = dependencyInjector->getShared("crypt");
+					let crypt = <CryptInterface> dependencyInjector->getShared("crypt");
+					if typeof crypt != "object" {
+						throw new Exception(
+							"A dependency which implements CryptInterface is required to use encryption"
+						);
+					}
 
 					/**
-					 * Decrypt the value also decoding it with base64
+					 * Verify the cookie's value if the sign key was set
 					 */
-					let decryptedValue = crypt->decryptBase64(value);
+					let signKey = this->signKey;
+					if typeof signKey === "string" {
+						let hmacGiven = mb_substr(value, 0, 64),
+							originalValue = mb_substr(value, 64);
 
+						let hmac = hash_hmac(
+							"sha256",
+							name . originalValue,
+							signKey
+						);
+
+						/**
+						 * Compares two hashes using the same time whether they're equal or not.
+						 */
+						if hash_equals(hmac, hmacGiven) === false {
+							throw new Mismatch("Request forgery detected.");
+						}
+
+						/**
+						 * Decrypt the value also decoding it with base64
+						 */
+						let decryptedValue = crypt->decryptBase64(originalValue);
+					} else {
+						/**
+						 * Decrypt the value also decoding it with base64
+						 */
+						let decryptedValue = crypt->decryptBase64(value);
+					}
 				} else {
 					let decryptedValue = value;
 				}
@@ -175,7 +237,9 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 						if dependencyInjector === null {
 							let dependencyInjector = <DiInterface> this->_dependencyInjector;
 							if typeof dependencyInjector != "object" {
-								throw new Exception("A dependency injection object is required to access the 'filter' service");
+								throw new Exception(
+									"A dependency injection object is required to access the 'filter' service"
+								);
 							}
 						}
 
@@ -198,13 +262,14 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	}
 
 	/**
-	 * Sends the cookie to the HTTP client
-	 * Stores the cookie definition in session
+	 * Sends the cookie to the HTTP client.
+	 *
+	 * Stores the cookie definition in session.
 	 */
 	public function send() -> <CookieInterface>
 	{
 		var name, value, expire, domain, path, secure, httpOnly,
-			dependencyInjector, definition, session, crypt, encryptValue;
+			dependencyInjector, definition, session, crypt, encryptValue, hmac, signKey;
 
 		let name = this->_name,
 			value = this->_value,
@@ -257,16 +322,36 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 			if !empty value {
 
 				if typeof dependencyInjector != "object" {
-					throw new Exception("A dependency injection object is required to access the 'filter' service");
+					throw new Exception(
+						"A dependency injection object is required to access the 'filter' service"
+					);
 				}
 
 				let crypt = <CryptInterface> dependencyInjector->getShared("crypt");
+				if typeof crypt != "object" {
+					throw new Exception(
+						"A dependency which implements CryptInterface is required to use encryption"
+					);
+				}
 
 				/**
 				 * Encrypt the value also coding it with base64
 				 */
 				let encryptValue = crypt->encryptBase64((string) value);
 
+				/**
+				 * Sign the cookie's value if the sign key was set
+				 */
+				let signKey = this->signKey;
+				if typeof signKey === "string" {
+					let hmac = hash_hmac(
+						"sha256",
+						name . encryptValue,
+						signKey
+					);
+
+					let encryptValue = hmac . encryptValue;
+				}
 			} else {
 				let encryptValue = value;
 			}
@@ -284,8 +369,9 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	}
 
 	/**
-	 * Reads the cookie-related info from the SESSION to restore the cookie as it was set
-	 * This method is automatically called internally so normally you don't need to call it
+	 * Reads the cookie-related info from the SESSION to restore the cookie as it was set.
+	 *
+	 * This method is automatically called internally so normally you don't need to call it.
 	 */
 	public function restore() -> <CookieInterface>
 	{
@@ -503,5 +589,25 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	public function __toString() -> string
 	{
 		return (string) this->getValue();
+	}
+
+	/**
+	 * Assert the cookie's key is enough long.
+	 *
+	 * @throws \Phalcon\Http\Cookie\Exception
+	 */
+	protected function assertSignKeyIsLongEnough(string! signKey) -> void
+	{
+		var length;
+
+		let length = mb_strlen(signKey);
+		if length < 32 {
+			throw new CookieException(
+				sprintf(
+					"The cookie's key should be at least 32 characters long. Current length is %d.",
+					length
+				)
+			);
+		}
 	}
 }

--- a/phalcon/http/cookie.zep
+++ b/phalcon/http/cookie.zep
@@ -105,7 +105,7 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 	/**
 	 * Sets the cookie's sign key.
 	 *
-	 * The key MUST be at least 32 characters long
+	 * The `$signKey' MUST be at least 32 characters long
 	 * and generated using a cryptographically secure pseudo random generator.
 	 *
 	 * Use NULL to disable cookie signing.

--- a/phalcon/http/cookie/mismatch.zep
+++ b/phalcon/http/cookie/mismatch.zep
@@ -20,10 +20,10 @@
 namespace Phalcon\Http\Cookie;
 
 /**
- * Phalcon\Http\Cookie\Exception
+ * Phalcon\Http\Cookie\Mismatch
  *
  * Exceptions thrown in Phalcon\Http\Cookie will use this class.
  */
-class Exception extends \Phalcon\Exception
+class Mismatch extends Exception
 {
 }

--- a/phalcon/http/cookieinterface.zep
+++ b/phalcon/http/cookieinterface.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ | Copyright (c) 2011-2018 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file LICENSE.txt.                             |
@@ -34,14 +34,10 @@ interface CookieInterface
 	public function setValue(value) -> <CookieInterface>;
 
 	/**
-	 * Returns the cookie's value
-	 *
-	 * @param string|array filters
-	 * @param string defaultValue
-	 * @return mixed
+	 * Returns the cookie's value.
 	 */
-	public function getValue(filters = null, defaultValue = null);
-	
+	public function getValue(var filters = null, var defaultValue = null) -> var;
+
 	/**
 	 * Sends the cookie to the HTTP client
 	 */
@@ -61,7 +57,7 @@ interface CookieInterface
 	 * Check if the cookie is using implicit encryption
 	 */
 	public function isUsingEncryption() -> boolean;
-	
+
 	/**
 	 * Sets the cookie's expiration time
 	 */

--- a/phalcon/http/response/exception.zep
+++ b/phalcon/http/response/exception.zep
@@ -3,7 +3,7 @@
  +------------------------------------------------------------------------+
  | Phalcon Framework                                                      |
  +------------------------------------------------------------------------+
- | Copyright (c) 2011-2017 Phalcon Team (https://phalconphp.com)          |
+ | Copyright (c) 2011-2018 Phalcon Team (https://phalconphp.com)          |
  +------------------------------------------------------------------------+
  | This source file is subject to the New BSD License that is bundled     |
  | with this package in the file LICENSE.txt.                             |
@@ -22,10 +22,8 @@ namespace Phalcon\Http\Response;
 /**
  * Phalcon\Http\Response\Exception
  *
- * Exceptions thrown in Phalcon\Http\Response will use this class
- *
+ * Exceptions thrown in Phalcon\Http\Response will use this class.
  */
 class Exception extends \Phalcon\Exception
 {
-
 }

--- a/tests/_support/Helper/CookieAwareTrait.php
+++ b/tests/_support/Helper/CookieAwareTrait.php
@@ -39,7 +39,7 @@ trait CookieAwareTrait
             $headers = headers_list();
         }
 
-        foreach($headers as $header) {
+        foreach ($headers as $header) {
             if (strpos($header, 'Set-Cookie: ') === 0) {
                 $value = str_replace('&', urlencode('&'), substr($header, 12));
                 parse_str(current(explode(';', $value, 1)), $pair);

--- a/tests/_support/Helper/CookieAwareTrait.php
+++ b/tests/_support/Helper/CookieAwareTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Helper;
+
+use RuntimeException;
+
+/**
+ * Helper\CookieAwareTrait
+ *
+ * @package Helper
+ */
+trait CookieAwareTrait
+{
+    /**
+     * Gets a value set with setcookie.
+     *
+     * A clean and transparent way to get a value set with setcookie() within the same request
+     *
+     * @link  http://tools.ietf.org/html/rfc6265#section-4.1.1
+     *
+     * @param  string $name
+     * @return string|array|null
+     *
+     * @throws RuntimeException
+     */
+    public function getCookie($name)
+    {
+        $cookies = [];
+
+        if (PHP_SAPI == 'cli') {
+            if (!extension_loaded('xdebug')) {
+                throw new RuntimeException(
+                    'The xdebug extension is not loaded.'
+                );
+            }
+
+            $headers = xdebug_get_headers();
+        } else {
+            $headers = headers_list();
+        }
+
+        foreach($headers as $header) {
+            if (strpos($header, 'Set-Cookie: ') === 0) {
+                $value = str_replace('&', urlencode('&'), substr($header, 12));
+                parse_str(current(explode(';', $value, 1)), $pair);
+                $cookies = array_merge_recursive($cookies, $pair);
+            }
+        }
+
+        return array_key_exists($name, $cookies) ? $cookies[$name] : null;
+    }
+}

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -44,7 +44,7 @@ class CryptTest extends UnitTest
     public function shouldThrowExceptionIfCipherIsUnknown()
     {
         $this->specify(
-            'Crypt does not validate cipher algorithm as exapected',
+            'Crypt does not validate cipher algorithm as expected',
             function () {
                 $crypt = new Crypt();
                 $crypt->setCipher('xxx-yyy-zzz');

--- a/tests/unit/Http/CookieTest.php
+++ b/tests/unit/Http/CookieTest.php
@@ -4,14 +4,17 @@ namespace Phalcon\Test\Unit\Http;
 
 use Phalcon\Crypt;
 use Phalcon\Http\Cookie;
+use Phalcon\Http\Cookie\Exception;
 use Phalcon\DI\FactoryDefault;
 use Phalcon\Test\Unit\Http\Helper\HttpBase;
+use Helper\CookieAwareTrait;
+use Phalcon\Http\Cookie\Mismatch;
 
 /**
  * Phalcon\Test\Unit\Http\CookieTest
  * Tests the Phalcon\Http\Cookie component
  *
- * @copyright (c) 2011-2017 Phalcon Team
+ * @copyright (c) 2011-2018 Phalcon Team
  * @link      https://phalconphp.com
  * @author    Andres Gutierrez <andres@phalconphp.com>
  * @author    Nikolaos Dimopoulos <nikos@phalconphp.com>
@@ -26,6 +29,129 @@ use Phalcon\Test\Unit\Http\Helper\HttpBase;
  */
 class CookieTest extends HttpBase
 {
+    use CookieAwareTrait;
+
+    /**
+     * Tests Cookie::setSignKey
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-05-06
+     */
+    public function shouldThrowExceptionIfSignKeyIsUnenoughLong()
+    {
+        $this->specify(
+            'Cookie does not validate sign key cipher length as expected',
+            function () {
+                $cookie = new Cookie('test-cookie', 'test', time() + 3600);
+                $cookie->setSignKey('1234567890');
+            },
+            [
+                'throws' => [
+                    Exception::class,
+                    "The cookie's key should be at least 32 characters long. Current length is 10."
+                ]
+            ]
+        );
+    }
+
+    /**
+     * Tests Cookie::getValue using message authentication code and request forgery
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-05-06
+     */
+    public function shouldThrowExceptionIfMessageAuthenticationCodeIsMismatch()
+    {
+        if (!extension_loaded('xdebug')) {
+            $this->markTestSkipped('Warning: xdebug extension is not loaded');
+        }
+
+        $this->specify(
+            'Cookie object unable to detected that message authentication code is mismatch',
+            function () {
+                $di = new FactoryDefault();
+
+                $di->setShared('crypt', function () {
+                    $crypt = new Crypt();
+                    $crypt->setKey('cryptkeycryptkey');
+
+                    return $crypt;
+                });
+
+                $cookieName  = 'test-signed-name1';
+                $cookieValue = 'test-signed-value';
+
+                $cookie = new Cookie($cookieName, $cookieValue, time() + 3600);
+
+                $cookie->setDI($di);
+                $cookie->useEncryption(true);
+                $cookie->setSignKey('12345678901234567890123456789012');
+
+                $cookie->send();
+
+                $this->tester->setProtectedProperty($cookie, '_readed', false);
+
+                $rawCookie = $this->getCookie($cookieName);
+                $rawValue  = explode(';', $rawCookie)[0];
+
+                $originalValue = mb_substr($rawValue, 64);
+
+                $_COOKIE[$cookieName] = str_repeat('X', 64) . $originalValue;
+                $cookie->getValue();
+            },
+            ['throws' => [Mismatch::class, 'Request forgery detected.']]
+        );
+    }
+
+    /**
+     * Tests Cookie::getValue using message authentication code
+     *
+     * @test
+     * @author Serghei Iakovlev <serghei@phalconphp.com>
+     * @since  2018-05-06
+     */
+    public function shouldDecryptValueByUsingMessageAuthenticationCode()
+    {
+        if (!extension_loaded('xdebug')) {
+            $this->markTestSkipped('Warning: xdebug extension is not loaded');
+        }
+
+        $this->specify(
+            'Cookie object does not work with message authentication code as expected',
+            function () {
+                $di = new FactoryDefault();
+
+                $di->setShared('crypt', function () {
+                    $crypt = new Crypt();
+                    $crypt->setKey('cryptkeycryptkey');
+
+                    return $crypt;
+                });
+
+                $cookieName  = 'test-signed-name2';
+                $cookieValue = 'test-signed-value';
+
+                $cookie = new Cookie($cookieName, $cookieValue, time() + 3600);
+
+                $cookie->setDI($di);
+                $cookie->useEncryption(true);
+                $cookie->setSignKey('12345678901234567890123456789012');
+
+                $cookie->send();
+
+                $this->tester->setProtectedProperty($cookie, '_readed', false);
+
+                $rawCookie = $this->getCookie($cookieName);
+                $rawValue  = explode(';', $rawCookie)[0];
+
+                $_COOKIE[$cookieName] = $rawValue;
+                expect($cookie->getValue())->equals($cookieValue);
+            }
+        );
+    }
+
     /**
      * Tests Cookie::getValue with using encryption and default crypt algo.
      *


### PR DESCRIPTION
Hello!

* Type: new feature

Small description of change:

- Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code
- Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class

Typical usage:

```php
use Phalcon\DI\FactoryDefault;
use Phalcon\Crypt;
use Phalcon\Http\Cookie;

$di = new FactoryDefault();

/**
 * Registering a crypt instance
 */
$di->setShared('crypt', function () {
    $crypt = new Crypt();
    
    /**
     * The `$key' should have been previously generated in a cryptographically safe way.
     *
     * @see \Phalcon\Security\Random
     */
    $key = "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3";
    $crypt->setKey($key);

    return $crypt;
});

$cookieName  = 'top-secret';
$cookieValue = 'enigma';

$cookie = new Cookie($cookieName, $cookieValue, time() + 3600);
$cookie->setDI($di);
$cookie->useEncryption(true);

/**
 * The key MUST be at least 32 characters long
 * and generated using a cryptographically secure pseudo random generator.
 *
 * Use NULL to disable cookie signing.
 *
 * @see \Phalcon\Security\Random
 */
$key = "#1dj8$=dp?.ak//j1V$~%*0XaK\xb1\x8d\xa9\x98\x054t7w!z%C*F-Jk\x98\x05\\\x5c";

$cookie->setSignKey($key);

// Send the cookie to the HTTP client.
$cookie->send();
```

Also there is an ability to set sign key globally using the `Phalcon\Http\Response\Cookies`:
```php
use Phalcon\Di;
use Phalcon\Crypt;
use Phalcon\Http\Response\Cookies;

$di = new Di();

$di->set(
    'crypt',
    function () {
        $crypt = new Crypt();

        // The `$key' should have been previously generated in a cryptographically safe way.
        $key = "T4\xb1\x8d\xa9\x98\x05\\\x8c\xbe\x1d\x07&[\x99\x18\xa4~Lc1\xbeW\xb3";
        $crypt->setKey($key);

        return $crypt;
    }
);

$di->set(
    'cookies',
    function () {
        // This class is a bag to manage the cookies.
        $cookies = new Cookies();

        // The `$key' MUST be at least 32 characters long and generated using a
        // cryptographically secure pseudo random generator.
        $key = "#1dj8$=dp?.ak//j1V$~%*0XaK\xb1\x8d\xa9\x98\x054t7w!z%C*F-Jk\x98\x05\\\x5c";
        $cookies->setSignKey($key);

        return $cookies;
    }
);
```
