### PR TITLE
Using HMAC to prevent forgery in Crypt

### DIFF
--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -443,6 +443,10 @@ class Crypt implements CryptInterface
 	 */
 	public function getAvailableHashAlgos()
 	{
-		return hash_hmac_algos();
+		if function_exists("hash_hmac_algos") {
+			return hash_hmac_algos();
+		} else {
+			return hash_algos();
+		}
 	}
 }

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -3,6 +3,7 @@
 namespace Phalcon\Test\Unit;
 
 use Phalcon\Crypt;
+use Phalcon\Crypt\Exception;
 use Phalcon\Test\Module\UnitTest;
 
 /**
@@ -182,6 +183,43 @@ class CryptTest extends UnitTest
                 $actual    = $crypt->decryptBase64($encrypted, $key, true);
 
                 expect($actual)->equals($expected);
+            }
+        );
+    }
+
+    /**
+     * Tests the HMAC
+     *
+     * @author k@yejune.com
+     * @since  2018-05-16
+     */
+    public function testCryptHmac()
+    {
+        $this->specify(
+            "hmac comparison test",
+            function () {
+                $crypt = new Crypt();
+
+                $expected = 'https://github.com/phalcon/cphalcon/issues/13379';
+
+                $key1 = 'key1';
+                $key2 = 'key2';
+                $encrypted = $crypt->encrypt($expected, $key1);
+
+                try {
+                    $actual = $crypt->decrypt($encrypted, $key2);
+                } catch (Exception $exception) {
+                    expect($exception->getMessage())->equals("Hash does not match");
+                }
+
+                $expected = '';
+                $encrypted = $crypt->encrypt($expected, $key1);
+
+                try {
+                    $actual = $crypt->decrypt($encrypted, $key2);
+                } catch (Exception $exception) {
+                    expect($exception->getMessage())->equals("Hash does not match");
+                }
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/13379

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Using HMAC to prevent forgery in Crypt.

If HMAC is compared and is not valid, it throws an exception.

Thanks

