### PR TITLE
Blog is Obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 * [Documentation](https://docs.phalconphp.com/)
 * [Support](https://forum.phalconphp.com)
-* [Blog](https://blog.phalconphp.com)
 * [Zephir](https://zephir-lang.com/)
 * [Twitter](https://twitter.com/phalconphp)
 


### PR DESCRIPTION
Removed blog link from read me.

Hello!

* Type: documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Removed Blog Link from README.

Thanks

