### PR TITLE
Crypt: Introduced the calculating message digest

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -5,10 +5,13 @@
 - Added `Phalcon\Http\Response::getReasonPhrase` to retrieve the reason phrase from the `Status` header [#13314](https://github.com/phalcon/cphalcon/pull/13314)
 - Added `Phalcon\Loader::setFileCheckingCallback` to set internal file existence resolver [#13360](https://github.com/phalcon/cphalcon/issues/13360)
 - Added ability to pass aggregation options for `Phalcon\Mvc\Collection::aggregate` [#12302](https://github.com/phalcon/cphalcon/pull/12302)
-- Added `Phalcon\Crypt::__construct` so now available ciphers and IV length will be set at object construction without the need to call `setCipher` explicitly
-- Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code
-- Added `Phalcon\Http\Response\Cookies::setSignKey` to set sign key used to generate a message authentication code
-- Added `Phalcon\Http\Cookie\Mismatch`. Exception thrown in `Phalcon\Http\Cookie` will use this class
+- Added `Phalcon\Crypt::setHashAlgo` to set the name of hashing algorithm used to the calculating message digest [#13379](https://github.com/phalcon/cphalcon/issues/13379)
+- Added `Phalcon\Crypt::getHashAlgo` to get the name of hashing algorithm used to the calculating message digest [#13379](https://github.com/phalcon/cphalcon/issues/13379)
+- Added `Phalcon\Crypt::useSigning` to set if the calculating message digest must used (NOTE: This feature will be enabled by default in Phalcon 4.0.0) [#13379](https://github.com/phalcon/cphalcon/issues/13379)
+- Added `Phalcon\Crypt::__construct` so now the cipher can be set at object construction and the calculating message digest can be enabled without the need to call `setCipher` or `useSigning` explicitly [#13379](https://github.com/phalcon/cphalcon/issues/13379)
+- Added `Phalcon\Crypt\Mismatch`. Exceptions thrown in `Phalcon\Crypt` will use this class [#13379](https://github.com/phalcon/cphalcon/issues/13379)
+- Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code (eg. message digest)
+- Added `Phalcon\Http\Response\Cookies::setSignKey` to set sign key used to generate a message authentication code (eg. message digest)
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -8,6 +8,7 @@
 - Added `Phalcon\Crypt::setHashAlgo` to set the name of hashing algorithm used to the calculating message digest [#13379](https://github.com/phalcon/cphalcon/issues/13379)
 - Added `Phalcon\Crypt::getHashAlgo` to get the name of hashing algorithm used to the calculating message digest [#13379](https://github.com/phalcon/cphalcon/issues/13379)
 - Added `Phalcon\Crypt::useSigning` to set if the calculating message digest must used (NOTE: This feature will be enabled by default in Phalcon 4.0.0) [#13379](https://github.com/phalcon/cphalcon/issues/13379)
+- Added `Phalcon\Crypt::getAvailableHashAlgos` to get a list of registered hashing algorithms suitable for calculating message digest [#13379](https://github.com/phalcon/cphalcon/issues/13379)
 - Added `Phalcon\Crypt::__construct` so now the cipher can be set at object construction and the calculating message digest can be enabled without the need to call `setCipher` or `useSigning` explicitly [#13379](https://github.com/phalcon/cphalcon/issues/13379)
 - Added `Phalcon\Crypt\Mismatch`. Exceptions thrown in `Phalcon\Crypt` will use this class [#13379](https://github.com/phalcon/cphalcon/issues/13379)
 - Added `Phalcon\Http\Cookie::setSignKey` to set sign key used to generate a message authentication code (eg. message digest)

--- a/phalcon/crypt.zep
+++ b/phalcon/crypt.zep
@@ -475,7 +475,7 @@ class Crypt implements CryptInterface
 			}
 
 			/**
-			 * Check the text's message digest using the HMAC method.
+			 * Checkson the decrypted's message digest using the HMAC method.
 			 */
 			if hash_hmac(hashAlgo, decrypted, decryptKey, true) !== hash {
 				throw new Mismatch("Hash does not match.");
@@ -507,6 +507,8 @@ class Crypt implements CryptInterface
 
 	/**
 	 * Decrypt a text that is coded as a base64 string.
+	 *
+	 * @throws \Phalcon\Crypt\Mismatch
 	 */
 	public function decryptBase64(string! text, key = null, boolean! safe = false) -> string
 	{

--- a/phalcon/crypt/mismatch.zep
+++ b/phalcon/crypt/mismatch.zep
@@ -17,12 +17,12 @@
  +------------------------------------------------------------------------+
  */
 
-namespace Phalcon\Http\Cookie;
+namespace Phalcon\Crypt;
 
 /**
- * Phalcon\Http\Cookie\Mismatch
+ * Phalcon\Crypt\Mismatch
  *
- * Exceptions thrown in Phalcon\Http\Cookie will use this class.
+ * Exceptions thrown in Phalcon\Crypt will use this class.
  */
 class Mismatch extends Exception
 {

--- a/tests/unit/CryptTest.php
+++ b/tests/unit/CryptTest.php
@@ -86,7 +86,7 @@ class CryptTest extends UnitTest
                 $encrypted = $crypt->encrypt($text);
                 $decrypted = $crypt->decrypt($encrypted);
 
-                expect(hash_equals($text, $decrypted))->true();
+                expect($text)->equals($decrypted);
             }
         );
     }

--- a/tests/unit/Http/CookieTest.php
+++ b/tests/unit/Http/CookieTest.php
@@ -8,7 +8,7 @@ use Phalcon\Http\Cookie\Exception;
 use Phalcon\DI\FactoryDefault;
 use Phalcon\Test\Unit\Http\Helper\HttpBase;
 use Helper\CookieAwareTrait;
-use Phalcon\Http\Cookie\Mismatch;
+use Phalcon\Crypt\Mismatch;
 
 /**
  * Phalcon\Test\Unit\Http\CookieTest
@@ -76,6 +76,7 @@ class CookieTest extends HttpBase
                 $di->setShared('crypt', function () {
                     $crypt = new Crypt();
                     $crypt->setKey('cryptkeycryptkey');
+                    $crypt->useSigning(true);
 
                     return $crypt;
                 });
@@ -101,7 +102,7 @@ class CookieTest extends HttpBase
                 $_COOKIE[$cookieName] = str_repeat('X', 64) . $originalValue;
                 $cookie->getValue();
             },
-            ['throws' => [Mismatch::class, 'Request forgery detected.']]
+            ['throws' => new Mismatch()]
         );
     }
 


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13379 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

- Added `Phalcon\Crypt::setHashAlgo` to set the name of hashing algorithm used to the calculating message digest

- Added `Phalcon\Crypt::getHashAlgo` to get the name of hashing algorithm used to the calculating message digest

- Added `Phalcon\Crypt::useSigning` to set if the calculating message digest must used

- Added `Phalcon\Crypt::getAvailableHashAlgos` to get a list of registered hashing algorithms suitable for calculating message digest 

- Changed `Phalcon\Crypt::__construct` so now the cipher can be set at object construction and the calculating message digest can be enabled without the need to call `setCipher` or `useSigning` explicitly

----

NOTICE 

The calculating message digest feature is **disabled by default for Phalcon 3.x** to not break existent applications but it will be enabled by default for Phalcon 4.0.0.

To use this feature for Phalcon 3.x you'll need to call `Phalcon\Crypt::useSigning(true)` or pass `TRUE` as the second argument to the `Phalcon\Crypt::__construct`.

Finally the ability to sign encrypted cookie introduced in the #13367 will also use this mechanism. Thus you must enable calculating message digest for `Crypt` to  sign encrypted cookie .


IMPORTANT:

After enabling the calculating message digest the `Phalcon\Crypt::decrypt` and `Phalcon\Crypt::decryptBase64`  will throws `Phalcon\Crypt\Mismatch` in case of request forgery detected (eg. hash mismatch).
