### PR TITLE
Add `Phalcon\Http\Response\Cookies::getCookies`.

### DIFF
--- a/phalcon/http/response/cookies.zep
+++ b/phalcon/http/response/cookies.zep
@@ -284,6 +284,14 @@ class Cookies implements CookiesInterface, InjectionAwareInterface
 		return cookie;
 	}
 
+    /**
+     * Gets all cookies from the bag
+     */
+	public function getCookies() -> array
+	{
+	    return this->_cookies;
+	}
+
 	/**
 	 * Check if a cookie is defined in the bag or exists in the _COOKIE superglobal
 	 */

--- a/tests/unit/Http/Response/CookiesTest.php
+++ b/tests/unit/Http/Response/CookiesTest.php
@@ -2,8 +2,13 @@
 
 namespace Phalcon\Test\Unit\Http\Response;
 
+use Phalcon\Di;
+use Phalcon\Http\Cookie;
+use Phalcon\Http\CookieInterface;
+use Phalcon\Http\Response;
 use Phalcon\Http\Response\Cookies;
 use Phalcon\Test\Unit\Http\Helper\HttpBase;
+use Phalcon\Session\Adapter\Files as SessionAdapter;
 
 /**
  * Phalcon\Test\Unit\Http\Response\Http\CookiesTest
@@ -38,6 +43,55 @@ class CookiesTest extends HttpBase
             "The internal cookies property is not initialized or iterable",
             function () {
                 expect((new Cookies())->send())->true();
+            }
+        );
+    }
+
+    /**
+     * Tests getCookies is work.
+     * @author limx <715557344@qq.com>
+     */
+    public function testGetCookies()
+    {
+        $cookies = new Cookies();
+
+        Di::reset();
+        $di = new Di();
+        $di->set('response', function () {
+            return new Response();
+        });
+        $di->set('session', function () {
+            return new SessionAdapter();
+        });
+
+        $cookies->setDI($di);
+
+        $cookies->set('x-token', '1bf0bc92ed7dcc80d337a5755f879878');
+        $cookies->set('x-user-id', 1);
+
+        $this->specify(
+            "The cookies is not a array.",
+            function () use ($cookies) {
+                expect(is_array($cookies->getCookies()))->true();
+            }
+        );
+
+        $this->specify(
+            "The cookie is not instance of CookieInterface",
+            function () use ($cookies) {
+                $cookieArray = $cookies->getCookies();
+                expect($cookieArray['x-token'] instanceof CookieInterface)->true();
+                expect($cookieArray['x-user-id'] instanceof CookieInterface)->true();
+            }
+        );
+
+        $this->specify(
+            "The cookie is not correct.",
+            function () use ($cookies) {
+                /** @var Cookie[] $cookieArray */
+                $cookieArray = $cookies->getCookies();
+                expect($cookieArray['x-token']->getValue())->equals('1bf0bc92ed7dcc80d337a5755f879878');
+                expect($cookieArray['x-user-id']->getValue())->equals(1);
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type:  new feature 

**When I want to get all the cookies, I need to use this method.**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Thanks

