### PR TITLE
3.4.x Fix performance of getRouteByName/Id

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,5 +1,6 @@
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-XX-XX)
 - Fixed `Phalcon\Validaiton\Validator\Uniqueness::isUniquenessModel` to properly get value of primary key when it has different name in column map [#13398](https://github.com/phalcon/cphalcon/issues/13398)
+- Fixed bad performance for repeated `Phalcon\Mvc\Router::getRouteByName` and `Phalcon\Mvc\Router::getRouteById` calls for applications with many routes
 
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-05-28)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)

--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -95,6 +95,10 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 
 	protected _notFoundPaths;
 
+	protected _keyRouteNames = [] { get, set };
+
+	protected _idRouteNames = [] { get, set };
+
 	const URI_SOURCE_GET_URL = 0;
 
 	const URI_SOURCE_SERVER_REQUEST_URI = 1;
@@ -961,14 +965,23 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	 */
 	public function getRouteById(var id) -> <RouteInterface> | boolean
 	{
-		var route;
+		var route, size, routeId, key;
 
-		for route in this->_routes {
-			if route->getRouteId() == id {
-				return route;
-			}
-		}
+        if fetch key, this->_idRouteNames[id] {
+            return this->_routes[key];
+        }
 
+        let size = count(this->_routes);
+
+        for key in range(0, size) {
+            let route = this->_routes[key];
+            let routeId = route->getRouteId();
+            let this->_keyRouteNames[routeId] = key;
+
+            if routeId == id {
+                return route;
+            }
+        }
 		return false;
 	}
 
@@ -977,13 +990,23 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	 */
 	public function getRouteByName(string! name) -> <RouteInterface> | boolean
 	{
-		var route;
+		var route, size, routeName, key;
 
-		for route in this->_routes {
-			if route->getName() == name {
-				return route;
-			}
-		}
+        if fetch key, this->_keyRouteNames[name] {
+            return this->_routes[key];
+        }
+
+        let size = count(this->_routes);
+
+        for key in range(0, size) {
+            let route = this->_routes[key];
+            let routeName = route->getName();
+            let this->_keyRouteNames[routeName] = key;
+
+            if routeName == name {
+                return route;
+            }
+        }
 		return false;
 	}
 

--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -967,21 +967,21 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	{
 		var route, size, routeId, key;
 
-        if fetch key, this->_idRouteNames[id] {
-            return this->_routes[key];
-        }
+		if fetch key, this->_idRouteNames[id] {
+			return this->_routes[key];
+		}
 
-        let size = count(this->_routes);
+		let size = count(this->_routes);
 
-        for key in range(0, size) {
-            let route = this->_routes[key];
-            let routeId = route->getRouteId();
-            let this->_keyRouteNames[routeId] = key;
+		for key in range(0, size) {
+			let route = this->_routes[key];
+			let routeId = route->getRouteId();
+			let this->_keyRouteNames[routeId] = key;
 
-            if routeId == id {
-                return route;
-            }
-        }
+			if routeId == id {
+				return route;
+			}
+		}
 		return false;
 	}
 
@@ -992,21 +992,21 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	{
 		var route, size, routeName, key;
 
-        if fetch key, this->_keyRouteNames[name] {
-            return this->_routes[key];
-        }
+		if fetch key, this->_keyRouteNames[name] {
+			return this->_routes[key];
+		}
 
-        let size = count(this->_routes);
+		let size = count(this->_routes);
 
-        for key in range(0, size) {
-            let route = this->_routes[key];
-            let routeName = route->getName();
-            let this->_keyRouteNames[routeName] = key;
+		for key in range(0, size) {
+			let route = this->_routes[key];
+			let routeName = route->getName();
+			let this->_keyRouteNames[routeName] = key;
 
-            if routeName == name {
-                return route;
-            }
-        }
+			if routeName == name {
+				return route;
+			}
+		}
 		return false;
 	}
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Actually i would consider it as a hotfix because currently it's pretty big performance hit for big applications which are generating many urls using phalcon services and have many routes. In our app we have 725 routes and we have 50 links generation for single page. It was taking 270ms for doing this. With similar changes like here now it's taking 0.133ms(cached) or 18ms(not cached).

There are already tests for getRouteByName/getRouteById, it won't change anyhow logic of this, well the only case is if we after adding two routes we will swap names of them after already using getRouteByName for their names - but im not sure even why do this and this is a very rare case.

Thanks

