### PR TITLE
[NFR] Add cache timeout option support to the redis adapter

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,6 +1,7 @@
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-XX-XX)
 - Fixed `Phalcon\Validaiton\Validator\Uniqueness::isUniquenessModel` to properly get value of primary key when it has different name in column map [#13398](https://github.com/phalcon/cphalcon/issues/13398)
 - Fixed bad performance for repeated `Phalcon\Mvc\Router::getRouteByName` and `Phalcon\Mvc\Router::getRouteById` calls for applications with many routes
+- Added `phalcon/cache/backend/redis` to support set redis timeout
 
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-05-28)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,7 +1,7 @@
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-XX-XX)
+- Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter
 - Fixed `Phalcon\Validaiton\Validator\Uniqueness::isUniquenessModel` to properly get value of primary key when it has different name in column map [#13398](https://github.com/phalcon/cphalcon/issues/13398)
 - Fixed bad performance for repeated `Phalcon\Mvc\Router::getRouteByName` and `Phalcon\Mvc\Router::getRouteById` calls for applications with many routes
-- Added `phalcon/cache/backend/redis` to support set redis timeout
 
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-05-28)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -100,7 +100,9 @@ class Redis extends Backend
 		if !isset options["auth"] {
 			let options["auth"] = "";
 		}
-
+		if !isset options["timeout"] {
+			let options["timeout"] = 0;
+		}
 		parent::__construct(frontend, options);
 	}
 
@@ -114,14 +116,14 @@ class Redis extends Backend
 		let options = this->_options;
 		let redis = new \Redis();
 
-		if !fetch host, options["host"] || !fetch port, options["port"] || !fetch persistent, options["persistent"] {
+		if !fetch host, options["host"] || !fetch port, options["port"] || !fetch persistent, options["persistent"] || !fetch timeout, options["timeout"] {
 			throw new Exception("Unexpected inconsistency in options");
 		}
 
 		if persistent {
-			let success = redis->pconnect(host, port);
+			let success = redis->pconnect(host, port, timeout);
 		} else {
-			let success = redis->connect(host, port);
+			let success = redis->connect(host, port, timeout);
 		}
 
 		if !success {

--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -111,7 +111,7 @@ class Redis extends Backend
 	 */
 	public function _connect()
 	{
-		var options, redis, persistent, success, host, port, auth, index;
+		var options, redis, persistent, success, host, port, auth, index, timeout;
 
 		let options = this->_options;
 		let redis = new \Redis();

--- a/tests/unit/Cache/Backend/RedisCest.php
+++ b/tests/unit/Cache/Backend/RedisCest.php
@@ -365,4 +365,31 @@ class RedisCest
         $I->assertNull($content);
         $I->dontSeeInRedis('_PHCR' . 'test-output');
     }
+
+    public function setTimeout(UnitTester $I)
+    {
+        $I->wantTo('Get data by using Redis as cache backend and set timeout');
+
+        $key = '_PHCR' . 'data-get-timeout';
+        $data = [uniqid(), gethostname(), microtime(), get_include_path(), time()];
+
+        $cache = new Redis(new Data(['lifetime' => 20]), [
+            'host'  => env('TEST_RS_HOST', '127.0.0.1'),
+            'port'  => env('TEST_RS_PORT', 6379),
+            'index' => env('TEST_RS_DB', 0),
+            'timeout' => 1,
+        ]);
+
+        $I->haveInRedis('string', $key, serialize($data));
+        $I->assertEquals($data, $cache->get('data-get-timeout'));
+
+        $I->assertNull($cache->get($key));
+
+        $data = 'sure, nothing interesting';
+
+        $I->haveInRedis('string', $key, serialize($data));
+        $I->assertEquals($data, $cache->get('data-get-timeout'));
+
+        $I->assertNull($cache->get($key));
+    }
 }


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Add cache timeout option support to the redis adapter

Thanks
