### PR TITLE
removes incorrect mysql tinyblob bindtype

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -2,6 +2,7 @@
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter
 - Fixed `Phalcon\Validaiton\Validator\Uniqueness::isUniquenessModel` to properly get value of primary key when it has different name in column map [#13398](https://github.com/phalcon/cphalcon/issues/13398)
 - Fixed bad performance for repeated `Phalcon\Mvc\Router::getRouteByName` and `Phalcon\Mvc\Router::getRouteById` calls for applications with many routes
+- Fixed incorrect tinyblob bind type ([#13423](https://github.com/phalcon/cphalcon/issues/13423)) in `Phalcon\Db\Adapter\Pdo\Mysql::describeColumns`
 
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-05-28)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -171,8 +171,7 @@ class Mysql extends PdoAdapter
 				/**
 				 * Tinyblob
 				 */
-				let definition["type"] = Column::TYPE_TINYBLOB,
-					definition["bindType"] = Column::BIND_PARAM_BOOL;
+				let definition["type"] = Column::TYPE_TINYBLOB;
 			} elseif memstr(columnType, "mediumblob") {
 				/**
 				 * Mediumblob


### PR DESCRIPTION
Removes boolean bind type for tinyblobs (defaults to string bind type like other blobs)

* Type: bug fix
* Link to issue:
https://github.com/phalcon/cphalcon/issues/13423

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
PDO bind type for TinyBlobs were incorrectly set as boolean
