### PR TITLE
Fixed Request::getPut to provide json content-type support

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -2,7 +2,8 @@
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter
 - Fixed `Phalcon\Validaiton\Validator\Uniqueness::isUniquenessModel` to properly get value of primary key when it has different name in column map [#13398](https://github.com/phalcon/cphalcon/issues/13398)
 - Fixed bad performance for repeated `Phalcon\Mvc\Router::getRouteByName` and `Phalcon\Mvc\Router::getRouteById` calls for applications with many routes
-- Fixed incorrect tinyblob bind type ([#13423](https://github.com/phalcon/cphalcon/issues/13423)) in `Phalcon\Db\Adapter\Pdo\Mysql::describeColumns`
+- Fixed incorrect tinyblob bind type in `Phalcon\Db\Adapter\Pdo\Mysql::describeColumns` [#13423](https://github.com/phalcon/cphalcon/issues/13423)
+- Fixed `Phalcon\Http\Request::getPut` to provide json content-type support [#12892](https://github.com/phalcon/cphalcon/issues/12892), [#13418](https://github.com/phalcon/cphalcon/issues/13418)
 
 # [3.4.0](https://github.com/phalcon/cphalcon/releases/tag/v3.4.0) (2018-05-28)
 - Added `Phalcon\Mvc\Router::attach` to add `Route` object directly into `Router` [#13326](https://github.com/phalcon/cphalcon/issues/13326)

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -126,13 +126,21 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 */
 	public function getPut(string! name = null, var filters = null, var defaultValue = null, boolean notAllowEmpty = false, boolean noRecursive = false) -> var
 	{
-		var put;
+		var put, contentType;
 
 		let put = this->_putCache;
 
 		if typeof put != "array" {
-			let put = [];
-			parse_str(this->getRawBody(), put);
+			let contentType = this->getContentType();
+			if typeof contentType == "string" && stripos(contentType, "json") != false {
+				let put = this->getJsonRawBody(true);
+				if (typeof put != "array") {
+					let put = [];
+				}
+			} else {
+				let put = [];
+				parse_str(this->getRawBody(), put);
+			}
 
 			let this->_putCache = put;
 		}

--- a/tests/_output/tests/stream/.gitignore
+++ b/tests/_output/tests/stream/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/_support/Helper/Http/PhpStream.php
+++ b/tests/_support/Helper/Http/PhpStream.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Helper\Http;
+
+/**
+ * Helper\Http\PhpStream
+ *
+ * @link http://php.net/manual/en/class.streamwrapper.php
+ * @link http://php.net/manual/en/stream.streamwrapper.example-1.php
+ *
+ * @codingStandardsIgnoreFile
+ * @package Helper
+ */
+class PhpStream
+{
+    protected $index = 0;
+    protected $length = 0;
+    protected $data = '';
+
+    public function __construct()
+    {
+        if (file_exists($this->getBufferFilename())) {
+            $this->data = file_get_contents($this->getBufferFilename());
+        }
+
+        $this->index = 0;
+        $this->length = strlen($this->data);
+    }
+
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        return true;
+    }
+
+    public function stream_close()
+    {
+    }
+
+    public function stream_stat()
+    {
+        return [];
+    }
+
+    public function stream_flush()
+    {
+        return true;
+    }
+
+    public function stream_read($count)
+    {
+        if (null === $this->length) {
+            $this->length = strlen($this->data);
+        }
+
+        $length = min($count, $this->length - $this->index);
+        $data = substr($this->data, $this->index);
+        $this->index = $this->index + $length;
+
+        return $data;
+    }
+
+    public function stream_eof()
+    {
+        return ($this->index >= $this->length ? true : false);
+    }
+
+    public function stream_seek($offset, $whence)
+    {
+        if (null === $this->length) {
+            $this->length = strlen($this->data);
+        }
+
+        switch ($whence) {
+            case SEEK_SET:
+                if ($offset < $this->length && $offset >= 0) {
+                    $this->index = $offset;
+                    return true;
+                } else {
+                    return false;
+                }
+            case SEEK_CUR:
+                if ($offset >= 0) {
+                    $this->index += $offset;
+                    return true;
+                } else {
+                    return false;
+                }
+            case SEEK_END:
+                if ($this->length + $offset >= 0) {
+                    $this->index = $this->length + $offset;
+                    return true;
+                } else {
+                    return false;
+                }
+            default:
+                return false;
+        }
+    }
+
+    public function stream_write($data)
+    {
+        return file_put_contents($this->getBufferFilename(), $data);
+    }
+
+    public function unlink()
+    {
+        if (file_exists($this->getBufferFilename())) {
+            unlink($this->getBufferFilename());
+        }
+
+        $this->data = '';
+        $this->index = 0;
+        $this->length = 0;
+    }
+
+    protected function getBufferFilename()
+    {
+        return codecept_output_dir('tests/stream/php_input.txt');
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12892, #13418

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Fixed `Phalcon\Http\Request::getPut` to provide json content-type support.

Thanks

