### PR TITLE
Install PSR extension on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,26 +61,28 @@ before_install:
   # Setting up test the environment
   - source $TRAVIS_BUILD_DIR/tests/_ci/environment
   - export $(cut -d= -f1 $TRAVIS_BUILD_DIR/tests/_ci/environment)
+  # Use `-g -O0' for debug purposes
+  - export CFLAGS="-g3 -O1 -std=gnu90 -Wall"
 
 install:
+  - bash tests/_ci/install_prereqs.sh
+  - bash tests/_ci/install-re2c $RE2C_VERSION
+  - bash tests/_ci/install_zephir_parser.sh
+  # Install PHP dependencies
   - if [[ -d "$HOME/.cache/composer/vendor" ]]; then cp -R $HOME/.cache/composer/vendor $TRAVIS_BUILD_DIR/vendor; fi;
   - composer install --no-ansi --no-progress --no-suggest
   # Improve performance
   - rm -rf $HOME/.cache/composer
   - mkdir -p $HOME/.cache/composer/vendor
   - cp -R $TRAVIS_BUILD_DIR/vendor $HOME/.cache/composer/vendor
-  # Install dependencies
-  - bash tests/_ci/install_prereqs.sh
-  - bash tests/_ci/install-re2c $RE2C_VERSION
-  - bash tests/_ci/install_zephir_parser.sh
+  # Install Zephir
   - bash tests/_ci/install_zephir.sh
+  # Generate C-code
   - zephir generate --backend=ZendEngine3
-  # Use `-g -O0' for debug purposes
-  - export CFLAGS="-g3 -O1 -std=gnu90 -Wall"
-  - cd ${TRAVIS_BUILD_DIR}/ext
   # Creating precompiled headers.
   # If a `*.gch' file is not found then the normal header files will be used.
   # For more see: http://en.wikipedia.org/wiki/Precompiled_header
+  - cd ${TRAVIS_BUILD_DIR}/ext
   - |
       for file in `find kernel -name "*.h"`; do
           echo -e "Creating a precompiled header: ext/${file} => ext/${file}.ghc ...";
@@ -99,8 +101,10 @@ install:
   - $(phpenv which php) -v
   - $(phpenv which php) -m
   - $(phpenv which php) --ri phalcon
+  - $(phpenv which php) --ri psr
 
 before_script:
+
   - ulimit -c unlimited -S || true
   # Uncomment for debug purposes
   # - echo '/tmp/core_%e.%p' | sudo tee /proc/sys/kernel/core_pattern &> /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,6 @@ install:
   - $(phpenv which php) --ri psr
 
 before_script:
-
   - ulimit -c unlimited -S || true
   # Uncomment for debug purposes
   # - echo '/tmp/core_%e.%p' | sudo tee /proc/sys/kernel/core_pattern &> /dev/null

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 - Added `Phalcon\Mvc\ModelInterface::getModelsMetaData` [#13070](https://github.com/phalcon/cphalcon/issues/13402)
 
 ## Changed
+- Now Phalcon requires the [PSR PHP extension](https://github.com/jbboehr/php-psr) to be installed and enabled
 - The `Phalcon\Mvc\Application`, `Phalcon\Mvc\Micro` and `Phalcon\Mvc\Router` now must have a URI to process [#12380](https://github.com/phalcon/cphalcon/pull/12380)
 - Response headers and cookies are no longer prematurely sent [#12378](https://github.com/phalcon/cphalcon/pull/12378)
 - You can no longer assign data to models whilst saving them [#12317](https://github.com/phalcon/cphalcon/issues/12317)
@@ -15,6 +16,7 @@
 - Changed `Phalcon\Mvc\Model\Query\Builder::addFrom` to remove third parameter `$with` [#13109](https://github.com/phalcon/cphalcon/pull/13109)
 
 ## Removed
+- PHP < 7.0 no longer supported
 - Removed `Phalcon\Model::reset` [#12317](https://github.com/phalcon/cphalcon/issues/12317)
 - Removed deprecated `Phalcon\Cli\Console::addModules`
 - Removed deprecated `Phalcon\Debug::getMajorVersion`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Phalcon is written in [Zephir/C](https://zephir-lang.com/) with platform indepen
 As a result, Phalcon is available on Microsoft Windows, GNU/Linux, FreeBSD and MacOS.
 You can either download a binary package for the system of your choice or build it from source.
 
+
+**NOTE:** Phalcon requires the [PSR PHP extension](https://github.com/jbboehr/php-psr) to be installed and enabled.
+
 ### Windows
 
 To install Phalcon on Windows:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ environment:
     PARSER_VERSION: 1.1.2
     PARSER_RELEASE: 290
     PHALCON_STABLE_VERSION: 3.3.2
+    PSR_PECL_VERSION: 0.4.0
 
 matrix:
     fast_finish: true
@@ -72,6 +73,7 @@ install:
     - ps: InstallSdk
     - ps: InstallPhp
     - ps: InstallPhpDevPack
+    - ps: InstallPsrExtension
     - ps: InstallStablePhalcon
     - ps: InstallParser
     - ps: TuneUpPhp

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,6 @@
 {
     "name": "phalcon/cphalcon",
-
     "description": "Phalcon is an open source web framework delivered as a C extension for the PHP language providing high performance and lower resource consumption.",
-
     "keywords": [
         "extension",
         "phalcon",
@@ -10,30 +8,7 @@
         "high load",
         "mvc"
     ],
-
-    "require": {
-        "php": ">=7.0 <8.0"
-    },
-
-    "require-dev": {
-        "ext-dom": "*",
-        "ext-json": "*",
-        "ext-libxml": "*",
-        "ext-mbstring": "*",
-        "ext-xml": "*",
-        "codeception/codeception": "^2.4",
-        "codeception/specify": "1.0.*",
-        "codeception/verify": "1.0.*",
-        "mustache/mustache": "^2.11",
-        "phalcon/zephir": "^0.10",
-        "phpunit/phpunit": "^6.4",
-        "predis/predis": "^1.1",
-        "squizlabs/php_codesniffer": "^3.2",
-        "twig/twig": "~1.35"
-    },
-
     "license": "BSD-3-Clause",
-
     "authors": [
         {
             "name": "Phalcon Team",
@@ -45,7 +20,41 @@
             "homepage": "https://github.com/phalcon/cphalcon/graphs/contributors"
         }
     ],
-
+    "require": {
+        "php": ">=7.0 <8.0"
+    },
+    "provide": {
+        "psr/cache": "^1",
+        "psr/container": "^1",
+        "psr/http-message": "^1",
+        "psr/http-server-handler": "^1",
+        "psr/http-server-middleware": "^1",
+        "psr/link": "^1",
+        "psr/log": "^1",
+        "psr/simple-cache": "^1"
+    },
+    "require-dev": {
+        "ext-dom": "*",
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "ext-mbstring": "*",
+        "ext-psr": "*",
+        "ext-xml": "*",
+        "codeception/codeception": "^2.4",
+        "codeception/specify": "1.0.*",
+        "codeception/verify": "1.0.*",
+        "mustache/mustache": "^2.11",
+        "phalcon/zephir": "^0.10",
+        "phpunit/phpunit": "^6.4",
+        "predis/predis": "^1.1",
+        "squizlabs/php_codesniffer": "^3.2",
+        "twig/twig": "~1.35"
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": "dist",
+        "sort-packages": true
+    },
     "autoload-dev": {
         "psr-4": {
             "Zephir\\Optimizers\\": "optimizers/",
@@ -55,21 +64,14 @@
             "Phalcon\\Test\\Listener\\": "tests/_data/listener/"
         }
     },
-
     "support": {
+        "email": "support@phalconphp.com",
         "issues": "https://github.com/phalcon/cphalcon/issues",
-        "source": "https://github.com/phalcon/cphalcon",
         "forum": "https://forum.phalconphp.com/",
-        "docs": "https://docs.phalconphp.com/",
         "wiki": "https://github.com/phalcon/cphalcon/wiki",
         "irc": "irc://irc.freenode.org/phalconphp",
-        "rss" : "https://blog.phalconphp.com/rss",
-        "email": "support@phalconphp.com"
-    },
-
-    "config": {
-        "preferred-install": "dist",
-        "sort-packages": true,
-        "optimize-autoloader": true
+        "source": "https://github.com/phalcon/cphalcon",
+        "docs": "https://docs.phalconphp.com/",
+        "rss": "https://blog.phalconphp.com/rss"
     }
 }

--- a/tests/_ci/appveyor.psm1
+++ b/tests/_ci/appveyor.psm1
@@ -262,6 +262,7 @@ Function TuneUpPhp {
 	Write-Output "extension = php_gd2.dll"           | Out-File -Encoding "ASCII" -Append $IniFile
 	Write-Output "extension = ${Env:EXTENSION_FILE}" | Out-File -Encoding "ASCII" -Append $IniFile
 	Write-Output "extension = php_zephir_parser.dll" | Out-File -Encoding "ASCII" -Append $IniFile
+	Write-Output "extension = php_psr.dll"           | Out-File -Encoding "ASCII" -Append $IniFile
 }
 
 Function InstallPhpDevPack {
@@ -284,6 +285,30 @@ Function InstallPhpDevPack {
 
 		Move-Item -Path $DestinationUnzipPath -Destination $Env:PHP_DEVPACK
 	}
+}
+
+Function InstallPsrExtension {
+    Write-Host "Install PSR extension: ${Env:PSR_PECL_VERSION}" -foregroundcolor Cyan
+
+    If ($Env:BUILD_TYPE -eq 'nts-Win32') {
+        $BuildType = 'nts'
+    } Else {
+        $BuildType = 'ts'
+    }
+
+    $FileName = "php_psr-${Env:PSR_PECL_VERSION}-${Env:PHP_MINOR}-${BuildType}-vc${Env:VC_VERSION}-${Env:PLATFORM}.zip"
+
+    $RemoteUrl = "https://windows.php.net/downloads/pecl/releases/psr/${Env:PSR_PECL_VERSION}/${FileName}"
+    $DestinationPath = "C:\Downloads\${FileName}"
+
+    If (-not (Test-Path "${Env:PHP_PATH}\ext\php_psr.dll")) {
+        If (-not [System.IO.File]::Exists($DestinationPath)) {
+            Write-Host "Downloading PSR extension: ${RemoteUrl} ..."
+            DownloadFile $RemoteUrl $DestinationPath
+        }
+
+        Expand-Item7zip $DestinationPath "${Env:PHP_PATH}\ext"
+    }
 }
 
 Function InstallStablePhalcon {

--- a/tests/_ci/install_prereqs.sh
+++ b/tests/_ci/install_prereqs.sh
@@ -15,6 +15,7 @@ printf "\n" | pecl install --force apcu_bc &> /dev/null
 printf "\n" | pecl install --force igbinary &> /dev/null
 printf "\n" | pecl install --force imagick &> /dev/null
 printf "\n" | pecl install --force yaml-2.0.0 &> /dev/null
+printf "\n" | pecl install --force psr &> /dev/null
 
 # See https://pear.php.net/bugs/bug.php?id=21007
 sed -i '1s/^/extension="apcu.so"\n/' "$(phpenv root)/versions/$(phpenv version-name)/etc/php.ini"

--- a/tests/_ci/install_zephir.sh
+++ b/tests/_ci/install_zephir.sh
@@ -16,7 +16,9 @@ TRAVIS_BUILD_DIR="${TRAVIS_BUILD_DIR:-$(dirname $(dirname $CURRENT_DIR))}"
 ZEPHIRDIR=${TRAVIS_BUILD_DIR}/vendor/phalcon/zephir
 
 if [ ! -d "${ZEPHIRDIR}" ]; then
-  echo -e "The ${ZEPHIRDIR} directory does not exists. First run 'composer install --dev'"
+  echo -e "The ${ZEPHIRDIR} directory does not exists."
+  echo -e "Most likely the project dependencies were not installed."
+  echo -e "First run 'composer install' from the project root"
   exit 1;
 fi
 


### PR DESCRIPTION
Hello!

* Type: testing/build
* Link to issue: #13434

- [x] Install PSR PHP extension on Travis CI (`psr.so`)
- [x] Install PSR PHP extension on AppVeyor (`php_psr.dll`)
- [x] Do not require `psr/*` packages from the Packagist
- [x] Update docs

As everyone can see there is project's dependencies cause the given package to be installed:

```shell
#!/usr/bin/env bash

packages=(
  "psr/cache"
  "psr/container"
  "psr/http-message"
  "psr/http-server-handler"
  "psr/http-server-middleware"
  "psr/link"
  "psr/log"
  "psr/simple-cache"
)

for package in "${packages[@]}"; do
  composer depends "${package}" 2>/dev/null || true
done
```
All dependencies are satisfied and this is why tests passed. This PR show that in real world we don't need the source code (`psr.h`) of the PSR PHP extension and don't need install `psr/*` packages from the Packagist. To work properly Phalcon 4 will require only PSR extension to be installed and enabled.

/cc @phalcon/framework-team 

P.S. I think to _compile_ Phalcon we'll need to install `psr.h`  first (to the common PHP includes path) as well as `psr.so`. Users will need only  `psr.so`.
