### PR TITLE
Phalcon/cache/backend/redis Fix issue with retuned keys by queryKeys

### DIFF
--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -201,8 +201,8 @@ class Redis extends Backend
 			let lastKey = this->_lastKey;
 			let prefixedKey = substr(lastKey, 5);
 		} else {
-			let prefixedKey = this->_prefix . keyName,
-				lastKey = "_PHCR" . prefixedKey,
+			let prefixedKey = keyName,
+				lastKey = "_PHCR" . this->_prefix . prefixedKey,
 				this->_lastKey = lastKey;
 		}
 
@@ -300,8 +300,8 @@ class Redis extends Backend
 		}
 
 		let prefix = this->_prefix;
-		let prefixedKey = prefix . keyName;
-		let lastKey = "_PHCR" . prefixedKey;
+		let prefixedKey = keyName;
+		let lastKey = "_PHCR" . prefix . prefixedKey;
 		let options = this->_options;
 
 		if !fetch specialKey, options["statsKey"] {
@@ -477,7 +477,7 @@ class Redis extends Backend
 		let keys = redis->sMembers(specialKey);
 		if typeof keys == "array" {
 			for key in keys {
-				let lastKey = "_PHCR" . key;
+				let lastKey = "_PHCR" . this->_prefix . key;
 				redis->sRem(specialKey, key);
 				redis->delete(lastKey);
 			}


### PR DESCRIPTION
Hello!
Consider you want to use `phalcon/cache/backend/redis`.   
When you have a configuration for both `prefix` and `statsKey` you can not retrieve keys correctly by `queryKeys`. It gives you keys with prefix and if you want to delete that key, you have to remove prefix first.

* Type: bug fix | backward incompatible

**In raising this pull request, I confirm the following (please checkboxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
Removing prefix from keys which are storing in a list.  

Thanks

