### PR TITLE
Phalcon/cache/backend/redis Fix issue with retuned keys by queryKeys

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 - Added `Phalcon\Mvc\ModelInterface::getModelsMetaData` [#13070](https://github.com/phalcon/cphalcon/issues/13402)
 
 ## Changed
+- By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)
 - Now Phalcon requires the [PSR PHP extension](https://github.com/jbboehr/php-psr) to be installed and enabled
 - The `Phalcon\Mvc\Application`, `Phalcon\Mvc\Micro` and `Phalcon\Mvc\Router` now must have a URI to process [#12380](https://github.com/phalcon/cphalcon/pull/12380)
 - Response headers and cookies are no longer prematurely sent [#12378](https://github.com/phalcon/cphalcon/pull/12378)

--- a/tests/unit/Cache/Backend/RedisCest.php
+++ b/tests/unit/Cache/Backend/RedisCest.php
@@ -393,4 +393,28 @@ class RedisCest
 
         $I->assertNull($cache->get($key));
     }
+
+    public function queryKeysWithStatsKeyAndPrefix(UnitTester $I)
+    {
+        $I->wantTo('Get cache data with prefix and statsKey configuration');
+
+        $cache = new Redis(new Data(['lifetime' => 20]), [
+            'host'  => env('TEST_RS_HOST', '127.0.0.1'),
+            'port'  => env('TEST_RS_PORT', 6379),
+            'index' => env('TEST_RS_DB', 0),
+            'prefix' => 'prefix',
+            'statsKey' => '_PHCR'
+        ]);
+        $cache->flush();
+        $data = [uniqid(), gethostname(), microtime(), get_include_path(), time()];
+        $cache->save('a', $data);
+        $cache->save('b', $data);
+
+        $keys = $cache->queryKeys();
+        sort($keys);
+
+        $I->assertEquals(['a', 'b'], $keys);
+        $I->assertEquals($data, $cache->get('a'));
+        $I->assertEquals($data, $cache->get('b'));
+    }
 }


### PR DESCRIPTION
Hello!
When you have a configuration for `prefix` and `statsKey` you can not retrieve keys correctly by `queryKeys`. It gives you keys with prefix and if you want to delete that key, you have to remove prefix first.

* Type: bug fix | backward incompatible

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Remove prefix of keys which are storing in a list when using `statsKey` configuration

Thanks

