### PR TITLE
Fixed Response::setFileToSend to append `;` at the end of line

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,5 +1,6 @@
 # [3.4.2](https://github.com/phalcon/cphalcon/releases/tag/v3.4.2) (2018-XX-XX)
 - Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
+- Fixed  `\Phalcon\Http\Response::setFileToSend` filename last much _ 
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -664,7 +664,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 		if attachment {
 			this->setRawHeader("Content-Description: File Transfer");
 			this->setRawHeader("Content-Type: application/octet-stream");
-			this->setRawHeader("Content-Disposition: attachment; filename=" . basePath);
+			this->setRawHeader("Content-Disposition: attachment; filename=" . basePath . ';');
 			this->setRawHeader("Content-Transfer-Encoding: binary");
 		}
 

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -664,7 +664,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 		if attachment {
 			this->setRawHeader("Content-Description: File Transfer");
 			this->setRawHeader("Content-Type: application/octet-stream");
-			this->setRawHeader("Content-Disposition: attachment; filename=" . basePath . ';');
+			this->setRawHeader("Content-Disposition: attachment; filename=" . basePath . ";");
 			this->setRawHeader("Content-Transfer-Encoding: binary");
 		}
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed  `Phalcon\Http\Response::setFileToSend` to append `;` at the end of line

Thanks

