### PR TITLE
Changes implementation of form's and element's getValue() and clear() methods

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,8 @@
 - Added `Phalcon\Mvc\ModelInterface::getModelsMetaData` [#13070](https://github.com/phalcon/cphalcon/issues/13402)
 
 ## Changed
+- `Phalcon\Forms\Form::clear` will no longer call `Phalcon\Forms\Element::clear`, instead it will clear/set default value itself, and `Phalcon\Forms\Element::clear` will now call `Phalcon\Forms\Form::clear` if it's assigned to the form, otherwise it will just clear itself. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
+- `Phalcon\Forms\Form::getValue` will now also try to get the value by calling `Tag::getValue` or element's `getDefault` method before returning `null`, and `Phalcon\Forms\Element::getValue` calls `Tag::getDefault` only if it's not added to the form. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)
 - Now Phalcon requires the [PSR PHP extension](https://github.com/jbboehr/php-psr) to be installed and enabled
 - The `Phalcon\Mvc\Application`, `Phalcon\Mvc\Micro` and `Phalcon\Mvc\Router` now must have a URI to process [#12380](https://github.com/phalcon/cphalcon/pull/12380)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,8 +6,6 @@
 - Added `Phalcon\Mvc\ModelInterface::getModelsMetaData` [#13070](https://github.com/phalcon/cphalcon/issues/13402)
 
 ## Changed
-- `Phalcon\Forms\Form::clear` will no longer call `Phalcon\Forms\Element::clear`, instead it will clear/set default value itself, and `Phalcon\Forms\Element::clear` will now call `Phalcon\Forms\Form::clear` if it's assigned to the form, otherwise it will just clear itself. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
-- `Phalcon\Forms\Form::getValue` will now also try to get the value by calling `Tag::getValue` or element's `getDefault` method before returning `null`, and `Phalcon\Forms\Element::getValue` calls `Tag::getDefault` only if it's not added to the form. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)
 - Now Phalcon requires the [PSR PHP extension](https://github.com/jbboehr/php-psr) to be installed and enabled
 - The `Phalcon\Mvc\Application`, `Phalcon\Mvc\Micro` and `Phalcon\Mvc\Router` now must have a URI to process [#12380](https://github.com/phalcon/cphalcon/pull/12380)
@@ -17,6 +15,8 @@
 - Changed `Phalcon\Db\Dialect\Postgresql::describeReferences` to generate correct SQL, added "on update" and "on delete" constraints
 - Changed catch `Exception` to `Throwable` [#12288](https://github.com/phalcon/cphalcon/issues/12288)
 - Changed `Phalcon\Mvc\Model\Query\Builder::addFrom` to remove third parameter `$with` [#13109](https://github.com/phalcon/cphalcon/pull/13109)
+- `Phalcon\Forms\Form::clear` will no longer call `Phalcon\Forms\Element::clear`, instead it will clear/set default value itself, and `Phalcon\Forms\Element::clear` will now call `Phalcon\Forms\Form::clear` if it's assigned to the form, otherwise it will just clear itself. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
+- `Phalcon\Forms\Form::getValue` will now also try to get the value by calling `Tag::getValue` or element's `getDefault` method before returning `null`, and `Phalcon\Forms\Element::getValue` calls `Tag::getDefault` only if it's not added to the form. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
 
 ## Removed
 - PHP < 7.0 no longer supported

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -414,7 +414,7 @@ abstract class Element implements ElementInterface
 	{
 		var name, form, value;
 
-		let name = this->_name,
+		let name  = this->_name,
 			value = null;
 
 		/**
@@ -426,14 +426,6 @@ abstract class Element implements ElementInterface
 			 * Gets the possible value for the widget
 			 */
 			let value = form->getValue(name);
-
-			/**
-			 * Check if the tag has a default value
-			 */
-			if typeof value == "null" && Tag::hasValue(name) {
-				let value = Tag::getValue(name);
-			}
-
 		}
 
 		/**
@@ -482,11 +474,20 @@ abstract class Element implements ElementInterface
 	}
 
 	/**
-	 * Clears every element in the form to its default value
+	 * Clears element to its default value
 	 */
 	public function clear() -> <Element>
 	{
-		Tag::setDefault(this->_name, null);
+		var form  = this->_form,
+			name  = this->_name,
+			value = this->_value;
+
+		if typeof form == "object" {
+			form->clear(name);
+		} else {
+			Tag::setDefault(name, value);
+		}
+
 		return this;
 	}
 

--- a/phalcon/forms/element.zep
+++ b/phalcon/forms/element.zep
@@ -408,28 +408,30 @@ abstract class Element implements ElementInterface
 	}
 
 	/**
-	 * Returns the element value
+	 * Returns the element's value
 	 */
 	public function getValue() -> var
 	{
-		var name, form, value;
-
-		let name  = this->_name,
+		var name  = this->_name,
+		    form  = this->_form,
 			value = null;
-
+		
 		/**
-		 * Get the related form
+		 * If element belongs to the form, get value from the form
 		 */
-		let form = this->_form;
 		if typeof form == "object" {
-			/**
-			 * Gets the possible value for the widget
-			 */
-			let value = form->getValue(name);
+			return form->getValue(name);
+		}
+		
+		/**
+		 * Otherwise check Phalcon\Tag
+		 */
+		if Tag::hasValue(name) {
+			let value = Tag::getValue(name);
 		}
 
 		/**
-		 * Assign the default value if there is no form available
+		 * Assign the default value if there is no form available or Phalcon\Tag returns null
 		 */
 		if typeof value == "null" {
 			let value = this->_value;

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -687,7 +687,7 @@ class Form extends Injectable implements \Countable, \Iterator
 			let data = [];
 		} else {
 			if typeof fields == "array" {
-				for field in fields {
+				for element in elements {
 					if isset data[field] {
 						unset data[field];
 					}

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -19,6 +19,7 @@
 
 namespace Phalcon\Forms;
 
+use Phalcon\Tag;
 use Phalcon\Validation;
 use Phalcon\ValidationInterface;
 use Phalcon\DiInterface;
@@ -552,7 +553,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	 */
 	public function getValue(string! name) -> var | null
 	{
-		var entity, method, value, data, $internal, forbidden;
+		var entity, method, value, data, $internal, forbidden, element;
 
 		let entity = this->_entity;
 		let data = this->_data;
@@ -621,6 +622,20 @@ class Form extends Injectable implements \Countable, \Iterator
 		let method = "get" . camelize(name);
 		if method_exists(this, method) {
 			return this->{method}();
+		}
+		
+		/**
+		 * Check if the tag has a default value
+		 */
+		if Tag::hasValue(name) {
+			return Tag::getValue(name);
+		}
+
+		/**
+		 * Check if element has default value
+		 */
+		if fetch element, this->_elements[name] {
+			return element->getDefault();
 		}
 
 		return null;

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -683,7 +683,7 @@ class Form extends Injectable implements \Countable, \Iterator
 		var elements, element, data, field;
 
 		let data = this->_data;
-		if is_null(fields) {
+		if fields === null {
 			let data = [];
 		} else {
 			if typeof fields == "array" {
@@ -708,7 +708,7 @@ class Form extends Injectable implements \Countable, \Iterator
         * If null, clear all
         */
         if typeof elements == "array" {
-            if is_null(fields) {
+            if fields === null {
                 for element in elements {
                     Tag::setDefault(element->getName(), element->getDefault());
                 }

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -676,7 +676,7 @@ class Form extends Injectable implements \Countable, \Iterator
 	/**
 	 * Clears every element in the form to its default value
 	 *
-	 * @param array fields
+	 * @param array|string|null fields
 	 */
 	public function clear(var fields = null) -> <Form>
 	{
@@ -702,17 +702,30 @@ class Form extends Injectable implements \Countable, \Iterator
 		let this->_data = data,
 			elements = this->_elements;
 
-		if typeof elements == "array" {
-			for element in elements {
-				if typeof fields != "array" {
-					element->clear();
-				} else {
-					if in_array(element->getName(), fields) {
-						element->clear();
-					}
-				}
-			}
-		}
+		/**
+        * If fields is string, clear just that field.
+        * If it's array, clear only fields in array.
+        * If null, clear all
+        */
+        if typeof elements == "array" {
+            if is_null(fields) {
+                for element in elements {
+                    Tag::setDefault(element->getName(), element->getDefault());
+                }
+            } else {
+                if typeof fields == "array" {
+                    for field in fields {
+                        if in_array(element->getName(), fields) {
+                            Tag::setDefault(element->getName(), element->getDefault());
+                        }
+                    }
+                } else {
+                    if fetch element, elements[fields] {
+                        Tag::setDefault(element->getName(), element->getDefault());
+                    }
+                }
+            }
+        }
 		return this;
 	}
 

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -687,7 +687,7 @@ class Form extends Injectable implements \Countable, \Iterator
 			let data = [];
 		} else {
 			if typeof fields == "array" {
-				for element in elements {
+				for field in fields {
 					if isset data[field] {
 						unset data[field];
 					}
@@ -714,7 +714,7 @@ class Form extends Injectable implements \Countable, \Iterator
                 }
             } else {
                 if typeof fields == "array" {
-                    for field in fields {
+                    for element in elements {
                         if in_array(element->getName(), fields) {
                             Tag::setDefault(element->getName(), element->getDefault());
                         }


### PR DESCRIPTION
This addresses #13498

* Type: enchancement and possibly bug fix
* Link to issue: #13498

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:
- `Phalcon\Forms\Form::clear()` method will no longer call `Phalcon\Forms\Element::clear()`, instead it will clear element's value itself
- `Phalcon\Forms\Element::clear()` will now call `Phalcon\Forms\Form::clear()` passing its name or will clear itself if form does not exist
- `Phalcon\Forms\Element::getValue()` will now call `Phalcon\Forms\Form::getValue()` or return its default value (instead of hardcoded `null`) if form does not exist
- `Phalcon\Forms\Form::getValue()` will now try to get element's value from the `Tag` or by calling element's `getDefault()` method before returning `null`

More info: #13498