### PR TITLE
Update tag.zep

### DIFF
--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1379,7 +1379,7 @@ class Tag
 			}
 		}
 
-		if !isset params["type"] {
+		if !isset params["type"] && self::_documentType < self::HTML5 {
 			let params["type"] = "text/javascript";
 		}
 


### PR DESCRIPTION
Fix #13341 w3c validation warning when document type is html5