### PR TITLE
Fixes #13447: Added Volt tags to array helper in Volt Compiler

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -33,3 +33,4 @@
 - Fixed `Phalcon\Mvc\Model::setSnapshotData` to properly sets the old snapshot
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)
 - Fixed `Phalcon\Mvc\Model\Query::execute` to properly bind parameters to sub queries [#11605](https://github.com/phalcon/cphalcon/issues/11605)
+- Added missing Volt tags to array helper in `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` [#13447](https://github.com/phalcon/cphalcon/issues/13447)

--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -499,7 +499,15 @@ class Compiler implements InjectionAwareInterface
 						"date_field": true,
 						"tel_field": true,
 						"numeric_field": true,
-						"image_input": true
+						"image_input": true,
+						"url_field": true,
+						"color_field": true,
+						"range_field": true,
+						"date_time_field": true,
+						"date_time_local_field": true,
+						"month_field": true,
+						"time_field": true,
+						"week_field": true
 					];
 					let this->_arrayHelpers = arrayHelpers;
 				}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [#13447](https://github.com/phalcon/cphalcon/issues/13447)

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [X] I wrote some tests for this PR.

Small description of change: Added Volt tags to array helper in Volt Compiler. Full list of tags added are as follows;
* url_field
* color_field
* range_field
* date_time_field
*  date_time_local_field
* month_field
* time_field
* week_field

_Note: I wrote a local test using the [phalcon/mvc](https://github.com/phalcon/mvc) project._

Thanks
