### PR TITLE
Refactor Phalcon\Db\Adapter\Pdo::query

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -3,8 +3,7 @@
 - Fixed `Phalcon\Tag` so it unsets `parameters` before passing options array to `self::renderAttributes`
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename; when file downloaded it had an extra `_`
 - Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099](https://github.com/phalcon/cphalcon/issues/13099)
-- Refactor `Phalcon\Db\Adapter\Pdo::query` in fetchOne get All fetch One, `Phalcon\Db\Adapter::queryAll` use `pdo::queryAll`
-
+- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -2,9 +2,9 @@
 - Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
 - Fixed `Phalcon\Tag` so it unsets `parameters` before passing options array to `self::renderAttributes`
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename; when file downloaded it had an extra `_`
-- Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099]
+- Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099](https://github.com/phalcon/cphalcon/issues/13099)
 - Refactor `Phalcon\Db\Adapter\Pdo::query` in fetchOne get All fetch One, `Phalcon\Db\Adapter::queryAll` use `pdo::queryAll`
-(https://github.com/phalcon/cphalcon/issues/13099)
+
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -2,7 +2,9 @@
 - Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
 - Fixed `Phalcon\Tag` so it unsets `parameters` before passing options array to `self::renderAttributes`
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename; when file downloaded it had an extra `_`
-- Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099](https://github.com/phalcon/cphalcon/issues/13099)
+- Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099]
+- Refactor `Phalcon\Db\Adapter\Pdo::query` in fetchOne get All fetch One, `Phalcon\Db\Adapter::queryAll` use `pdo::queryAll`
+(https://github.com/phalcon/cphalcon/issues/13099)
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -236,16 +236,7 @@ abstract class Adapter implements AdapterInterface, EventsAwareInterface
 			if fetchMode !== null {
 				result->setFetchMode(fetchMode);
 			}
-
-			loop {
-
-				let row = result->$fetch();
-				if !row {
-					break;
-				}
-
-				let results[] = row;
-			}
+			let results = result->fetchAll();
 		}
 
 		return results;

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -337,7 +337,7 @@ abstract class Pdo extends Adapter
 	 */
 	public function query(string! sqlStatement, var bindParams = null, var bindTypes = null) -> <ResultInterface> | boolean
 	{
-		var eventsManager, pdo, statement;
+		var eventsManager, pdo, statement, params, types;
 
 		let eventsManager = <ManagerInterface> this->_eventsManager;
 

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -360,7 +360,7 @@ abstract class Pdo extends Adapter
 				let statement = this->executePrepared(statement, bindParams, bindTypes);
 			}
 		} else {
-			let statement = pdo->query(sqlStatement);
+			let statement = pdo->execute(sqlStatement);
 		}
 
 		/**

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -355,13 +355,18 @@ abstract class Pdo extends Adapter
 
 		let pdo = <\Pdo> this->_pdo;
 		if typeof bindParams == "array" {
-			let statement = pdo->prepare(sqlStatement);
-			if typeof statement == "object" {
-				let statement = this->executePrepared(statement, bindParams, bindTypes);
-			}
+			let params = bindParams;
+			let types = bindTypes;
 		} else {
-			let statement = pdo->prepare(sqlStatement);
-			statement->execute();
+			let params = [];
+			let types = [];
+		}
+			
+		let statement = pdo->prepare(sqlStatement);
+		if typeof statement == "object" {
+			let statement = this->executePrepared(statement, params, types);
+		} else {
+			throw new Exception("Cannot prepare statement");
 		}
 
 		/**

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -360,7 +360,8 @@ abstract class Pdo extends Adapter
 				let statement = this->executePrepared(statement, bindParams, bindTypes);
 			}
 		} else {
-			let statement = pdo->execute(sqlStatement);
+			let statement = pdo->prepare(sqlStatement);
+			statement->execute();
 		}
 
 		/**


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute.
- `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll

Thanks

