### PR TITLE
Fixes #13501: getJsonRawBody() handles empty body and JSON decode errors

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -33,3 +33,4 @@
 - Fixed `Phalcon\Mvc\Model::setSnapshotData` to properly sets the old snapshot
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)
 - Fixed `Phalcon\Mvc\Model\Query::execute` to properly bind parameters to sub queries [#11605](https://github.com/phalcon/cphalcon/issues/11605)
+- Fixed `Phalcon\Http\Request::getJsonRawBody` [#13501](https://github.com/phalcon/cphalcon/issues/13501). It will now return false when the body content is empty, as well as when it encounters an error whilst decoding the JSON content.

--- a/phalcon/http/request.zep
+++ b/phalcon/http/request.zep
@@ -398,14 +398,20 @@ class Request implements RequestInterface, InjectionAwareInterface
 	 */
 	public function getJsonRawBody(boolean associative = false) -> <\stdClass> | array | boolean
 	{
-		var rawBody;
+		var rawBody, data;
 
 		let rawBody = this->getRawBody();
-		if typeof rawBody != "string" {
+		if empty rawBody {
 			return false;
 		}
 
-		return json_decode(rawBody, associative);
+		let data = json_decode(rawBody, associative);
+
+		if json_last_error() !== JSON_ERROR_NONE {
+			return false;
+		}
+
+		return data;
 	}
 
 	/**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [#13501](https://github.com/phalcon/cphalcon/issues/13501)

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: As suggested by @michalzielanski we check if the request is empty instead of not a string type, to decide whether we continue or return false. JSON decode errors are also handled politely now as well.

Thanks