### PR TITLE
T13445 ability to change the flash html template

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 - Added `Phalcon\Mvc\Router\RouteInterface::convert` so that calling `Phalcon\Mvc\Router\Group::add` will return an instance that has `convert` method [#13380](https://github.com/phalcon/cphalcon/issues/13380)
 - Added `Phalcon\Mvc\ModelInterface::getModelsMetaData` [#13070](https://github.com/phalcon/cphalcon/issues/13402)
 - Added `paginate()` method as a proxy of `getPaginate`. Added `previous` in the paginator object same as `before`. After 4.0 is released we will deprecate `getPaginate()`, `before` and `total_items` [#13492](https://github.com/phalcon/cphalcon/issues/13492)
+- Added ability to set a custom template for the Flash Messenger. [#13445](https://github.com/phalcon/cphalcon/issues/13445)
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)

--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -41,7 +41,7 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 
 	protected _cssClasses;
 
-	protected _customTemplate = null;
+	protected _customTemplate = "";
 
 	protected _dependencyInjector = null;
 
@@ -92,7 +92,15 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	 */
 	public function getAutoescape() -> bool
 	{
-			return this->_autoescape;
+		return this->_autoescape;
+	}
+
+	/**
+	 * Returns the custom template set
+	 */
+	public function getCustomTemplate() -> string
+	{
+		return this->_customTemplate;
 	}
 
 	/**
@@ -163,6 +171,15 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	public function setCssClasses(array! cssClasses) -> <FlashInterface>
 	{
 		let this->_cssClasses = cssClasses;
+		return this;
+	}
+
+	/**
+	 * Set an custom template for showing the messages
+	 */
+	public function setCustomTemplate(string! customTemplate) -> <FlashInterface>
+	{
+		let this->_customTemplate = customTemplate;
 		return this;
 	}
 
@@ -311,6 +328,16 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 		return this->{"message"}("warning", message);
 	}
 
+
+	private function getTemplate() -> string
+	{
+		if ("" === template) {
+			return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+		}
+
+		return this->_customTemplate;
+	}
+
 	/**
 	 * Prepares the HTML output for the message
 	 */
@@ -328,23 +355,10 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 			} else {
 				let cssClasses = typeClasses;
 			}
-
-			if (!customTemplate)} {
-				if typeof typeClasses == "array" {
-					let cssClasses = " class=\"" . cssClasses . "\"";
-				} else {
-					let cssClasses = " class=\"" . cssClasses . "\"";
-				}
-			}
 		} else {
 			let cssClasses = "";
 		}
 
-		if (customTemplate) {
-			return str_replace(["%cssClass%", "%message%"], [cssClasses, message], this->_customTemplate);
-
-		} else {
-			return "<div" . cssClasses . ">" . message . "</div>" . PHP_EOL;
-		}
+		return str_replace(["%cssClass%", "%message%"], [cssClasses, message], this->getTemplate());
 	}
 }

--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -235,7 +235,7 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	public function outputMessage(string type, var message)
 	{
 		boolean automaticHtml, implicitFlush;
-		var content, classes, typeClasses, eol, msg,
+		var content, classes, msg,
 			htmlMessage, autoEscape, escaper, preparedMsg;
 
 		let autoEscape = (bool) this->_autoescape;
@@ -334,7 +334,7 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	 */
 	private function prepareEscapedMessage(string message) -> string
 	{
-		var autoEscape;
+		var autoEscape, escaper;
 
 		let autoEscape = (bool) this->_autoescape;
 

--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -319,10 +319,14 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	}
 
 
-	private function getTemplate() -> string
+	private function getTemplate(string cssClassses) -> string
 	{
 		if ("" === this->_customTemplate) {
-			return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+			if ("" === cssClassses) {
+				return "<div>%message%</div>" . PHP_EOL;
+			} else {
+				return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+			}
 		}
 
 		return this->_customTemplate;

--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -234,15 +234,9 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	 */
 	public function outputMessage(string type, var message)
 	{
-		boolean automaticHtml, implicitFlush;
-		var content, classes, msg,
-			htmlMessage, autoEscape, escaper, preparedMsg;
-
-		let autoEscape = (bool) this->_autoescape;
-
-		if autoEscape === true {
-			let escaper = this->getEscaperService();
-		}
+		boolean implicitFlush;
+		var content, msg,
+			htmlMessage, preparedMsg;
 
 		let implicitFlush = (bool) this->_implicitFlush;
 		if typeof message == "array" {
@@ -372,7 +366,7 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 				let cssClasses = "";
 			}
 
-			return str_replace(["%cssClass%", "%message%"], [cssClasses, message], this->getTemplate());
+			return str_replace(["%cssClass%", "%message%"], [cssClasses, message], this->getTemplate(cssClasses));
 		} else {
 			return message;
 		}

--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -235,7 +235,7 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	public function outputMessage(string type, var message)
 	{
 		boolean automaticHtml, implicitFlush;
-		var content, cssClasses, classes, typeClasses, eol, msg,
+		var content, classes, typeClasses, eol, msg,
 			htmlMessage, autoEscape, escaper, preparedMsg;
 
 		let autoEscape = (bool) this->_autoescape;
@@ -321,7 +321,7 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 
 	private function getTemplate() -> string
 	{
-		if ("" === template) {
+		if ("" === this->_customTemplate) {
 			return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
 		}
 

--- a/phalcon/flash.zep
+++ b/phalcon/flash.zep
@@ -258,20 +258,15 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 			 * We create the message with implicit flush or other
 			 */
 			for msg in message {
-				if autoEscape === true {
-					let preparedMsg = escaper->escapeHtml(msg);
-				} else {
-					let preparedMsg = msg;
-				}
+				/**
+				 * Check if the message needs to be escaped
+				 */
+				let preparedMsg = this->prepareEscapedMessage(msg);
 
 				/**
 				 * We create the applying formatting or not
 				 */
-				if automaticHtml === true {
-					let htmlMessage = this->prepareHtml(type, preparedMsg);
-				} else {
-					let htmlMessage = preparedMsg;
-				}
+				let htmlMessage = this->prepareHtmlMessage(type, preparedMsg);
 
 				if implicitFlush === true {
 					echo htmlMessage;
@@ -289,20 +284,15 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 			}
 
 		} else {
-			if autoEscape === true {
-				let preparedMsg = escaper->escapeHtml(message);
-			} else {
-				let preparedMsg = message;
-			}
+			/**
+			 * Check if the message needs to be escaped
+			 */
+			let preparedMsg = this->prepareEscapedMessage(message);
 
 			/**
 			 * We create the applying formatting or not
 			 */
-			if automaticHtml === true {
-				let htmlMessage = this->prepareHtml(type, preparedMsg);
-			} else {
-				let htmlMessage = preparedMsg;
-			}
+			let htmlMessage = this->prepareHtmlMessage(type, preparedMsg);
 
 			/**
 			 * We return the message as string if the implicit_flush is turned off
@@ -339,26 +329,48 @@ abstract class Flash implements FlashInterface, InjectionAwareInterface
 	}
 
 	/**
-	 * Prepares the HTML output for the message
+	 * Returns the message escaped if the autoEscape is true, otherwise the
+	 * original message is returned
 	 */
-	private function prepareHtml(string type, string message) -> string
+	private function prepareEscapedMessage(string message) -> string
 	{
-		var classes, cssClasses, typeClasses, automaticHtml, customTemplate;
+		var autoEscape;
 
-		let automaticHtml = (bool) this->_automaticHtml,
-			customTemplate = this->_customTemplate;
+		let autoEscape = (bool) this->_autoescape;
 
-		let classes = this->_cssClasses;
-		if fetch typeClasses, classes[type] {
-			if typeof typeClasses == "array" {
-				let cssClasses = join(" ", typeClasses);
-			} else {
-				let cssClasses = typeClasses;
-			}
+		if autoEscape === true {
+			let escaper = this->getEscaperService();
+			return escaper->escapeHtml(message);
 		} else {
-			let cssClasses = "";
+			return message;
 		}
+	}
 
-		return str_replace(["%cssClass%", "%message%"], [cssClasses, message], this->getTemplate());
+	/**
+	 * Prepares the HTML output for the message. If automaticHtml is not set then
+	 * the original message is returned
+	 */
+	private function prepareHtmlMessage(string type, string message) -> string
+	{
+		var classes, cssClasses, typeClasses, automaticHtml;
+
+		let automaticHtml = (bool) this->_automaticHtml;
+
+		if automaticHtml === true {
+			let classes = this->_cssClasses;
+			if fetch typeClasses, classes[type] {
+				if typeof typeClasses == "array" {
+					let cssClasses = join(" ", typeClasses);
+				} else {
+					let cssClasses = typeClasses;
+				}
+			} else {
+				let cssClasses = "";
+			}
+
+			return str_replace(["%cssClass%", "%message%"], [cssClasses, message], this->getTemplate());
+		} else {
+			return message;
+		}
 	}
 }

--- a/phalcon/flashinterface.zep
+++ b/phalcon/flashinterface.zep
@@ -33,6 +33,11 @@ interface FlashInterface
 	public function error(message);
 
 	/**
+	 * Outputs a message
+	 */
+	public function message(string type, var message);
+
+	/**
 	 * Shows a HTML notice/information message
 	 */
 	public function notice(message);
@@ -46,9 +51,4 @@ interface FlashInterface
 	 * Shows a HTML warning message
 	 */
 	public function warning(message);
-
-	/**
-	 * Outputs a message
-	 */
-	public function message(string type, var message);
 }

--- a/tests/unit/Flash/SessionTest.php
+++ b/tests/unit/Flash/SessionTest.php
@@ -222,4 +222,54 @@ class SessionTest extends UnitTest
             ]
         );
     }
+
+    /**
+     * Test custom template getter/setter
+     *
+     * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
+     * @issue  https://github.com/phalcon/cphalcon/issues/13445
+     * @since  2018-10-16
+     */
+    public function testCustomTemplateGetterSetter()
+    {
+        $this->specify(
+            "The custom template getter/setter does not return correct data",
+            function () {
+                $flash    = $this->getFlash();
+                $template = '<span class="%cssClasses%">%message%</span>';
+                $flash->setCustomTemplate($template);
+
+                expect($flash->getCustomTemplate())->equals($template);
+            }
+        );
+    }
+
+    /**
+     * Test custom message
+     *
+     * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
+     * @issue  https://github.com/phalcon/cphalcon/issues/13445
+     * @since  2018-10-16
+     */
+    public function testCustomFormat()
+    {
+        $this->specify(
+            "The output() method outputs custom template formatted messages incorrectly",
+            function () {
+                $flash    = $this->getFlash();
+                $template = '<span class="%cssClasses%">%message%</span>';
+                $flash->setCustomTemplate($template);
+
+                $message  = 'sample message';
+                $expected = '<span class="success">sample message</span>';
+                ob_start();
+                $flash->success($message);
+                $flash->output();
+                $actual = ob_get_contents();
+                ob_end_clean();
+
+                expect($actual)->equals($expected);
+            }
+        );
+    }
 }

--- a/tests/unit/Flash/SessionTest.php
+++ b/tests/unit/Flash/SessionTest.php
@@ -257,11 +257,11 @@ class SessionTest extends UnitTest
             "The output() method outputs custom template formatted messages incorrectly",
             function () {
                 $flash    = $this->getFlash();
-                $template = '<span class="%cssClass%">%message%</span>';
+                $template = '<span class="%cssClass%" aria-label="clickme">%message%</span>';
                 $flash->setCustomTemplate($template);
 
                 $message  = 'sample message';
-                $expected = '<span class="success">sample message</span>';
+                $expected = '<span class="successMessage" aria-label="clickme">sample message</span>';
                 ob_start();
                 $flash->success($message);
                 $flash->output();

--- a/tests/unit/Flash/SessionTest.php
+++ b/tests/unit/Flash/SessionTest.php
@@ -257,7 +257,7 @@ class SessionTest extends UnitTest
             "The output() method outputs custom template formatted messages incorrectly",
             function () {
                 $flash    = $this->getFlash();
-                $template = '<span class="%cssClasses%">%message%</span>';
+                $template = '<span class="%cssClass%">%message%</span>';
                 $flash->setCustomTemplate($template);
 
                 $message  = 'sample message';


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13445 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Added the ability to use a custom template for the flash messenger. The template *must* contain two strings `%cssClass%` and `%message%` so that the classes and message can be injected.

Thanks

