### PR TITLE
[#13529] - Moved the sharedLock in the dialects. PostgreSql and Sqlit…

### DIFF
--- a/phalcon/db/dialect.zep
+++ b/phalcon/db/dialect.zep
@@ -146,19 +146,6 @@ abstract class Dialect implements DialectInterface
 	}
 
 	/**
-	 * Returns a SQL modified with a LOCK IN SHARE MODE clause
-	 *
-	 *<code>
-	 * $sql = $dialect->sharedLock("SELECT * FROM robots");
-	 * echo $sql; // SELECT * FROM robots LOCK IN SHARE MODE
-	 *</code>
-	 */
-	public function sharedLock(string! sqlQuery) -> string
-	{
-		return sqlQuery . " LOCK IN SHARE MODE";
-	}
-
-	/**
 	 * Gets a list of columns with escaped identifiers
 	 *
 	 * <code>

--- a/phalcon/db/dialect/mysql.zep
+++ b/phalcon/db/dialect/mysql.zep
@@ -752,4 +752,17 @@ class Mysql extends Dialect
 
 		return sql;
 	}
+
+	/**
+	 * Returns a SQL modified with a LOCK IN SHARE MODE clause
+	 *
+	 *<code>
+	 * $sql = $dialect->sharedLock("SELECT * FROM robots");
+	 * echo $sql; // SELECT * FROM robots LOCK IN SHARE MODE
+	 *</code>
+	 */
+	public function sharedLock(string! sqlQuery) -> string
+	{
+		return sqlQuery . " LOCK IN SHARE MODE";
+	}
 }

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -678,4 +678,13 @@ class Postgresql extends Dialect
 	{
 		return "";
 	}
+
+	/**
+	 * Returns a SQL modified a shared lock statement. For now this method
+	 * returns the original query
+	 */
+	public function sharedLock(string! sqlQuery) -> string
+	{
+		return sqlQuery;
+	}
 }

--- a/phalcon/db/dialect/sqlite.zep
+++ b/phalcon/db/dialect/sqlite.zep
@@ -598,4 +598,13 @@ class Sqlite extends Dialect
 	{
 		return "";
 	}
+
+	/**
+	 * Returns a SQL modified a shared lock statement. For now this method
+	 * returns the original query
+	 */
+	public function sharedLock(string! sqlQuery) -> string
+	{
+		return sqlQuery;
+	}
 }


### PR DESCRIPTION
…e return the original query

Hello!

* Type: bug fix
* Link to issue: #13529

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

`sharedLock` was moved to the dialects because it was interfering with PostgreSql and Sqlite

Thanks

