### PR TITLE
Validator's "allowEmpty" list cannot handle Objects

### DIFF
--- a/tests/unit/ValidationTest.php
+++ b/tests/unit/ValidationTest.php
@@ -2,6 +2,7 @@
 
 namespace Phalcon\Test\Unit;
 
+use Phalcon\Db\RawValue;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Test\Models\Users;
 use Phalcon\Test\Module\UnitTest;
@@ -229,7 +230,7 @@ class ValidationTest extends UnitTest
             }
         );
     }
-    
+
     /**
      * Tests that empty values behaviour.
      *
@@ -259,35 +260,51 @@ class ValidationTest extends UnitTest
                     ->add('email', new Validation\Validator\Email(array(
                         'message' => 'The email is not valid.',
                         'allowEmpty' => [null, false],
+                    )))
+                    ->add('price', new Validation\Validator\Numericality(array(
+                        'message' => 'The price is not valid.',
+                        'allowEmpty' => [null, new RawValue('NULL')],
                     )));
 
                 $messages = $validation->validate([
                     'name' => '',
                     'url' => null,
                     'email' => '',
+                    'price' => null,
                 ]);
                 expect($messages)->count(2);
-                
+
                 $messages = $validation->validate([
                     'name' => 'MyName',
                     'url' => '',
                     'email' => '',
+                    'price' => null,
                 ]);
                 expect($messages)->count(1);
-                
+
                 $messages = $validation->validate([
                     'name' => 'MyName',
                     'url' => false,
                     'email' => null,
+                    'price' => null,
                 ]);
                 expect($messages)->count(0);
-                
+
                 $messages = $validation->validate([
                     'name' => 'MyName',
                     'url' => 0,
                     'email' => 0,
+                    'price' => null,
                 ]);
                 expect($messages)->count(1);
+
+                $messages = $validation->validate([
+                    'name' => 'MyName',
+                    'url' => '',
+                    'email' => null,
+                    'price' => new RawValue('NULL'),
+                ]);
+                expect($messages)->count(0);
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: tests update
* Link to issue: #12519

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:
Objects should be listable in Validator's `allowEmpty` as a possible "empty" value, i.e.
* `new \Phalcon\Db\RawValue('NULL')`, `__toString()` can be used for comparing values

As a temporary workaround I'm using currently smth. like this:
```php
namespace Your\Namespace;

use Phalcon\Db\RawValue;
use Phalcon\Validation;
use Phalcon\Validation\Validator\Numericality as BaseNumericality;

class Numericality extends BaseNumericality
{
    public function isAllowEmpty(Validation $validation, string $fieldName): bool
    {
        $value = $validation->getValue($fieldName);
        if ($value instanceof RawValue) {
            $value = $value->getValue();
        }
        return ! $value || $value === 'NULL';
    }
}
```

Thanks

