### PR TITLE
Fix documentation at `Phalcon\Validation::setFilters`

### DIFF
--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -250,7 +250,7 @@ class Validation extends Injectable implements ValidationInterface
 	/**
 	 * Adds filters to the field
 	 *
-	 * @param string field
+	 * @param array|string field
 	 * @param array|string filters
 	 * @return \Phalcon\Validation
 	 */


### PR DESCRIPTION
Hello!

* Type: documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?


Small description of change:

Docs at setFilters
```
@param string field
```

should be 

```
@param array|string field
```

This error is reflected in documentation page too

Thanks

