### PR TITLE
Feature/t13547 tag enhancements

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -10,7 +10,7 @@
 - Added ability to set a custom template for the Flash Messenger. [#13445](https://github.com/phalcon/cphalcon/issues/13445)
 - Added `forUpdate` in the Sqlite dialect to override the method from the base dialect. [#13539](https://github.com/phalcon/cphalcon/issues/13539)
 - Added `TYPE_ENUM` in the Mysql adapter. [#11368](https://github.com/phalcon/cphalcon/issues/11368)
-- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
+- Added `Phalcon\Tag::renderTitle()` that renders the title enclosed in `<title>` tags. [13547](https://github.com/phalcon/cphalcon/issues/13547)
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)
@@ -27,6 +27,8 @@
 - Changed `Phalcon\Mvc\Model` to use the `Phalcon\Messages\Message` object for its messages [#13114](https://github.com/phalcon/cphalcon/issues/13114)
 - Changed `Phalcon\Validation\*` to use the `Phalcon\Messages\Message` object for its messages [#13114](https://github.com/phalcon/cphalcon/issues/13114)
 - Collections now use the Validation component [#12376](https://github.com/phalcon/cphalcon/pull/12376)
+- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
+- Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [13547](https://github.com/phalcon/cphalcon/issues/13547) 
 
 ## Removed
 - PHP < 7.0 no longer supported

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1237,7 +1237,7 @@ class Tag
 	 * {{ render_title() }}
 	 * </code>
 	 */
-	public static function getRenderTitle() -> string
+	public static function renderTitle() -> string
 	{
 		return "<title>" . self::getTitle() . "</title>" . PHP_EOL;
 	}

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1154,14 +1154,21 @@ class Tag
 	 * The title will be automatically escaped.
 	 *
 	 * <code>
-	 * echo Phalcon\Tag::getTitle();
+	 * Tag::prependTitle('Hello');
+	 * Tag::setTitle('World');
+	 * Tag::appendTitle('from Phalcon');
+	 *
+	 * echo Tag::getTitle();             // Hello World from Phalcon
+	 * echo Tag::getTitle(false);        // World from Phalcon
+	 * echo Tag::getTitle(true, false);  // Hello World
+	 * echo Tag::getTitle(false, false); // World
 	 * </code>
 	 *
 	 * <code>
 	 * {{ get_title() }}
 	 * </code>
 	 */
-	public static function getTitle(boolean tags = true) -> string
+	public static function getTitle(boolean prepend = true, boolean append = true) -> string
 	{
 		var items, output, title, documentTitle, documentAppendTitle, documentPrependTitle, documentTitleSeparator, escaper;
 
@@ -1171,22 +1178,18 @@ class Tag
 		let documentTitle = escaper->escapeHtml(self::_documentTitle);
 		let documentTitleSeparator = escaper->escapeHtml(self::_documentTitleSeparator);
 
-		if typeof self::_documentAppendTitle == "null" {
-			let self::_documentAppendTitle = [];
-		}
+		if prepend {
+			if typeof self::_documentPrependTitle == "null" {
+				let self::_documentPrependTitle = [];
+			}
 
-		let documentAppendTitle = self::_documentAppendTitle;
+			let documentPrependTitle = self::_documentPrependTitle;
 
-		if typeof self::_documentPrependTitle == "null" {
-			let self::_documentPrependTitle = [];
-		}
-
-		let documentPrependTitle = self::_documentPrependTitle;
-
-		if !empty documentPrependTitle {
-			var tmp = array_reverse(documentPrependTitle);
-			for title in tmp {
-				let items[] = escaper->escapeHtml(title);
+			if !empty documentPrependTitle {
+				var tmp = array_reverse(documentPrependTitle);
+				for title in tmp {
+					let items[] = escaper->escapeHtml(title);
+				}
 			}
 		}
 
@@ -1194,9 +1197,17 @@ class Tag
 			let items[] = documentTitle;
 		}
 
-		if !empty documentAppendTitle {
-			for title in documentAppendTitle {
-				let items[] = escaper->escapeHtml(title);
+		if append {
+			if typeof self::_documentAppendTitle == "null" {
+				let self::_documentAppendTitle = [];
+			}
+
+			let documentAppendTitle = self::_documentAppendTitle;
+
+			if !empty documentAppendTitle {
+				for title in documentAppendTitle {
+					let items[] = escaper->escapeHtml(title);
+				}
 			}
 		}
 
@@ -1208,11 +1219,27 @@ class Tag
 			let output = implode(documentTitleSeparator, items);
 		}
 
-		if tags {
-			return "<title>" . output . "</title>" . PHP_EOL;
-		}
-
 		return output;
+	}
+
+	/**
+	 * Renders the title with title tags. The title is automaticall escaped
+	 *
+	 * <code>
+	 * Tag::prependTitle('Hello');
+	 * Tag::setTitle('World');
+	 * Tag::appendTitle('from Phalcon');
+	 *
+	 * echo Tag::renderTitle(); // <title>Hello World From Phalcon</title>
+	 * </code>
+	 *
+	 * <code>
+	 * {{ render_title() }}
+	 * </code>
+	 */
+	public static function getRenderTitle() -> string
+	{
+		return "<title>" . self::getTitle() . "</title>" . PHP_EOL;
 	}
 
 	/**

--- a/tests/unit/Tag/TagTitleTest.php
+++ b/tests/unit/Tag/TagTitleTest.php
@@ -40,9 +40,29 @@ class TagTitleTest extends UnitTest
                 $value = "Hello </title><script>alert('Got your nose!');</script><title>";
 
                 Tag::setTitle($value);
-                $expected = "<title>Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;</title>" . PHP_EOL;
+                $expected = "Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;" . PHP_EOL;
 
                 expect(Tag::getTitle())->equals($expected);
+            }
+        );
+    }
+
+    /**
+     * Tests malicious content in the title
+     * @since  2018-11-01
+     */
+    public function testRenderTitleWithoutMaliciousContent()
+    {
+        $this->specify(
+            "getTitle returns malicious content",
+            function () {
+                Tag::resetInput();
+                $value = "Hello </title><script>alert('Got your nose!');</script><title>";
+
+                Tag::setTitle($value);
+                $expected = "<title>Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;</title>" . PHP_EOL;
+
+                expect(Tag::renderTitle())->equals($expected);
             }
         );
     }
@@ -62,9 +82,9 @@ class TagTitleTest extends UnitTest
                 $value = 'This is my title';
                 Tag::setTitle($value);
 
-                expect(Tag::getTitle())->equals("<title>{$value}</title>" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>{$value}</title>" . PHP_EOL);
 
-                expect(Tag::getTitle(false))->equals("{$value}");
+                expect(Tag::getTitle())->equals("{$value}");
             }
         );
     }
@@ -85,14 +105,18 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('Title');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("TitleClass" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
                 Tag::setTitle('This is my title');
                 Tag::appendTitle(' - Welcome!');
 
-                expect(Tag::getTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("This is my title - Welcome!" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -100,7 +124,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Title|Class" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -109,7 +135,9 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle('Title');
 
-                expect(Tag::getTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -117,7 +145,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::appendTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -126,7 +156,9 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle([]);
 
-                expect(Tag::getTitle())->equals("<title>Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );
     }
@@ -148,7 +180,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('This is my title');
                 Tag::prependTitle('PhalconPHP - ');
 
-                expect(Tag::getTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("PhalconPHP - This is my title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -156,7 +190,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::prependTitle('Class');
 
-                expect(Tag::getTitle())->equals('<title>Class|Title</title>' . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Class|Title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Class|Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -165,7 +201,9 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle('Title');
 
-                expect(Tag::getTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -173,7 +211,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::prependTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -182,7 +222,9 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle([]);
 
-                expect(Tag::getTitle())->equals("<title>Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );
     }
@@ -222,7 +264,7 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('-');
                 Tag::appendTitle('PhalconPHP');
 
-                expect(Tag::getTitle())->equals("<title>This is my title-PhalconPHP</title>" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>This is my title-PhalconPHP</title>" . PHP_EOL);
             }
         );
     }
@@ -243,7 +285,7 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('-');
                 Tag::prependTitle('PhalconPHP');
 
-                expect(Tag::getTitle())->equals("<title>PhalconPHP-This is my title</title>" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>PhalconPHP-This is my title</title>" . PHP_EOL);
             }
         );
     }

--- a/tests/unit/Tag/TagTitleTest.php
+++ b/tests/unit/Tag/TagTitleTest.php
@@ -40,7 +40,7 @@ class TagTitleTest extends UnitTest
                 $value = "Hello </title><script>alert('Got your nose!');</script><title>";
 
                 Tag::setTitle($value);
-                $expected = "Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;" . PHP_EOL;
+                $expected = "Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;";
 
                 expect(Tag::getTitle())->equals($expected);
             }
@@ -105,8 +105,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('Title');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("TitleClass" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title");
+                expect(Tag::getTitle(false, true))->equals("TitleClass");
                 expect(Tag::renderTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -114,8 +114,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('This is my title');
                 Tag::appendTitle(' - Welcome!');
 
-                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("This is my title - Welcome!" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title");
+                expect(Tag::getTitle(false, true))->equals("This is my title - Welcome!");
                 expect(Tag::renderTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -124,8 +124,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Title|Class" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title");
+                expect(Tag::getTitle(false, true))->equals("Title|Class");
                 expect(Tag::renderTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -135,8 +135,8 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle('Title');
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title");
                 expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -145,8 +145,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::appendTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title");
                 expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -156,8 +156,8 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle([]);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(false, true))->equals("Main");
                 expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );
@@ -180,8 +180,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('This is my title');
                 Tag::prependTitle('PhalconPHP - ');
 
-                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("PhalconPHP - This is my title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title");
+                expect(Tag::getTitle(true, false))->equals("PhalconPHP - This is my title");
                 expect(Tag::renderTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -190,8 +190,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::prependTitle('Class');
 
-                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Class|Title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title");
+                expect(Tag::getTitle(true, false))->equals("Class|Title");
                 expect(Tag::renderTitle())->equals("<title>Class|Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -201,8 +201,8 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle('Title');
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main");
                 expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -211,8 +211,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::prependTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main");
                 expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -222,8 +222,8 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle([]);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(true, false))->equals("Main");
                 expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13547 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Changed `Phalcon\Tag::getTitle()`. It returns only the text set with `setTitle()`. If there has been prepend and append text it will be returned by default. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title.

Added `Phalcon\Tag::renderTitle()` that renders the title enclosed in `<title>` tags.

Thanks

