### PR TITLE
Add hasHeader in Response

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -10,7 +10,7 @@
 - Added ability to set a custom template for the Flash Messenger. [#13445](https://github.com/phalcon/cphalcon/issues/13445)
 - Added `forUpdate` in the Sqlite dialect to override the method from the base dialect. [#13539](https://github.com/phalcon/cphalcon/issues/13539)
 - Added `TYPE_ENUM` in the Mysql adapter. [#11368](https://github.com/phalcon/cphalcon/issues/11368)
-- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
+- Added `Phalcon\Tag::renderTitle()` that renders the title enclosed in `<title>` tags. [13547](https://github.com/phalcon/cphalcon/issues/13547)
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)
@@ -27,6 +27,8 @@
 - Changed `Phalcon\Mvc\Model` to use the `Phalcon\Messages\Message` object for its messages [#13114](https://github.com/phalcon/cphalcon/issues/13114)
 - Changed `Phalcon\Validation\*` to use the `Phalcon\Messages\Message` object for its messages [#13114](https://github.com/phalcon/cphalcon/issues/13114)
 - Collections now use the Validation component [#12376](https://github.com/phalcon/cphalcon/pull/12376)
+- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
+- Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [13547](https://github.com/phalcon/cphalcon/issues/13547) 
 
 ## Removed
 - PHP < 7.0 no longer supported

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -11,23 +11,24 @@
 - Added `forUpdate` in the Sqlite dialect to override the method from the base dialect. [#13539](https://github.com/phalcon/cphalcon/issues/13539)
 - Added `TYPE_ENUM` in the Mysql adapter. [#11368](https://github.com/phalcon/cphalcon/issues/11368)
 - Added `Phalcon\Acl\Adapter\Memory::addRole` support multiple inherited
-- Added `Phalcon\Tag::renderTitle()` that renders the title enclosed in `<title>` tags. [13547](https://github.com/phalcon/cphalcon/issues/13547)
+- Added `Phalcon\Tag::renderTitle()` that renders the title enclosed in `<title>` tags. [#13547](https://github.com/phalcon/cphalcon/issues/13547)
+- Added `hasHeader()` method to `Phalcon\Http\Response` to provide the ability to check if a header exists. [PR-12189](https://github.com/phalcon/cphalcon/pull/12189)
 
 ## Changed
-- By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13456](https://github.com/phalcon/cphalcon/pull/13456)
+- By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [PR-13456](https://github.com/phalcon/cphalcon/pull/13456)
 - Now Phalcon requires the [PSR PHP extension](https://github.com/jbboehr/php-psr) to be installed and enabled
-- The `Phalcon\Mvc\Application`, `Phalcon\Mvc\Micro` and `Phalcon\Mvc\Router` now must have a URI to process [#12380](https://github.com/phalcon/cphalcon/pull/12380)
-- Response headers and cookies are no longer prematurely sent [#12378](https://github.com/phalcon/cphalcon/pull/12378)
+- The `Phalcon\Mvc\Application`, `Phalcon\Mvc\Micro` and `Phalcon\Mvc\Router` now must have a URI to process [PR-12380](https://github.com/phalcon/cphalcon/pull/12380)
+- Response headers and cookies are no longer prematurely sent [PR-12378](https://github.com/phalcon/cphalcon/pull/12378)
 - You can no longer assign data to models whilst saving them [#12317](https://github.com/phalcon/cphalcon/issues/12317)
 - The `Phalcon\Mvc\Model\Manager::load` no longer reuses already initialized models [#12317](https://github.com/phalcon/cphalcon/issues/12317)
 - Changed `Phalcon\Db\Dialect\Postgresql::describeReferences` to generate correct SQL, added "on update" and "on delete" constraints
 - Changed catch `Exception` to `Throwable` [#12288](https://github.com/phalcon/cphalcon/issues/12288)
-- Changed `Phalcon\Mvc\Model\Query\Builder::addFrom` to remove third parameter `$with` [#13109](https://github.com/phalcon/cphalcon/pull/13109)
-- `Phalcon\Forms\Form::clear` will no longer call `Phalcon\Forms\Element::clear`, instead it will clear/set default value itself, and `Phalcon\Forms\Element::clear` will now call `Phalcon\Forms\Form::clear` if it's assigned to the form, otherwise it will just clear itself. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
-- `Phalcon\Forms\Form::getValue` will now also try to get the value by calling `Tag::getValue` or element's `getDefault` method before returning `null`, and `Phalcon\Forms\Element::getValue` calls `Tag::getDefault` only if it's not added to the form. [#13500](https://github.com/phalcon/cphalcon/pull/13500)
+- Changed `Phalcon\Mvc\Model\Query\Builder::addFrom` to remove third parameter `$with` [PR-13109](https://github.com/phalcon/cphalcon/pull/13109)
+- `Phalcon\Forms\Form::clear` will no longer call `Phalcon\Forms\Element::clear`, instead it will clear/set default value itself, and `Phalcon\Forms\Element::clear` will now call `Phalcon\Forms\Form::clear` if it's assigned to the form, otherwise it will just clear itself. [PR-13500](https://github.com/phalcon/cphalcon/pull/13500)
+- `Phalcon\Forms\Form::getValue` will now also try to get the value by calling `Tag::getValue` or element's `getDefault` method before returning `null`, and `Phalcon\Forms\Element::getValue` calls `Tag::getDefault` only if it's not added to the form. [PR-13500](https://github.com/phalcon/cphalcon/pull/13500)
 - Changed `Phalcon\Mvc\Model` to use the `Phalcon\Messages\Message` object for its messages [#13114](https://github.com/phalcon/cphalcon/issues/13114)
 - Changed `Phalcon\Validation\*` to use the `Phalcon\Messages\Message` object for its messages [#13114](https://github.com/phalcon/cphalcon/issues/13114)
-- Collections now use the Validation component [#12376](https://github.com/phalcon/cphalcon/pull/12376)
+- Collections now use the Validation component [PR-12376](https://github.com/phalcon/cphalcon/pull/12376)
 - Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename last much _ 
 - Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [13547](https://github.com/phalcon/cphalcon/issues/13547) 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -31,7 +31,7 @@
 - Collections now use the Validation component [PR-12376](https://github.com/phalcon/cphalcon/pull/12376)
 - Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename last much _ 
-- Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [13547](https://github.com/phalcon/cphalcon/issues/13547) 
+- Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [#13547](https://github.com/phalcon/cphalcon/issues/13547) 
 
 ## Removed
 - PHP < 7.0 no longer supported

--- a/phalcon/acl/adapter/memory.zep
+++ b/phalcon/acl/adapter/memory.zep
@@ -231,7 +231,7 @@ class Memory extends Adapter
      */
 	public function addInherit(string roleName, var roleToInherits) -> boolean
 	{
-		var roleInheritName, rolesNames, deepInheritName, roleToInherit, checkRoleToInherit,
+		var roleInheritName, rolesNames, roleToInherit, checkRoleToInherit,
 		 checkRoleToInherits, usedRoleToInherits, roleToInheritList, usedRoleToInherit;
 
 		let rolesNames = this->_rolesNames;
@@ -584,7 +584,7 @@ class Memory extends Adapter
 	public function isAllowed(var roleName, var resourceName, string access, array parameters = null) -> boolean
 	{
 		var eventsManager, accessList, accessKey,
-			haveAccess = null, roleInherits, inheritedRole, rolesNames,
+			haveAccess = null, rolesNames,
 			funcAccess = null, resourceObject = null, roleObject = null, funcList,
 			reflectionFunction, reflectionParameters, parameterNumber, parametersForFunction,
 			numberOfRequiredParameters, userParametersSizeShouldBe, reflectionClass, parameterToCheck,

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -288,6 +288,24 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	}
 
 	/**
+	 * Checks if a header exists
+	 *
+	 *<code>
+	 * $response->hasHeader("Content-Type");
+	 *</code>
+	 */
+	public function hasHeader(string name) -> boolean
+	{
+		var header;
+
+		if fetch header, this->_headers[name] {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Overwrites a header in the response
 	 *
 	 *<code>

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -296,13 +296,10 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	 */
 	public function hasHeader(string name) -> boolean
 	{
-		var header;
+		var headers;
+		let headers = this->getHeaders();
 
-		if !fetch header, this->_headers[name] {
-			return false;
-		}
-
-		return true;
+		return headers->has(name);
 	}
 
 	/**

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -298,7 +298,7 @@ class Response implements ResponseInterface, InjectionAwareInterface
 	{
 		var header;
 
-		if fetch header, this->_headers[name] {
+		if !fetch header, this->_headers[name] {
 			return false;
 		}
 

--- a/phalcon/http/response/headers.zep
+++ b/phalcon/http/response/headers.zep
@@ -33,6 +33,20 @@ class Headers implements HeadersInterface
 	/**
 	 * Sets a header to be sent at the end of the request
 	 */
+	public function has(string name) -> boolean
+	{
+		var header;
+
+		if !fetch header, this->_headers[name] {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Sets a header to be sent at the end of the request
+	 */
 	public function set(string name, string value)
 	{
 		let this->_headers[name] = value;

--- a/phalcon/http/response/headers.zep
+++ b/phalcon/http/response/headers.zep
@@ -35,13 +35,7 @@ class Headers implements HeadersInterface
 	 */
 	public function has(string name) -> boolean
 	{
-		var header;
-
-		if !fetch header, this->_headers[name] {
-			return false;
-		}
-
-		return true;
+		return isset(this->_headers);
 	}
 
 	/**

--- a/phalcon/http/response/headers.zep
+++ b/phalcon/http/response/headers.zep
@@ -35,7 +35,7 @@ class Headers implements HeadersInterface
 	 */
 	public function has(string name) -> boolean
 	{
-		return isset(this->_headers);
+		return isset(this->_headers[name]);
 	}
 
 	/**

--- a/phalcon/http/response/headersinterface.zep
+++ b/phalcon/http/response/headersinterface.zep
@@ -28,6 +28,11 @@ interface HeadersInterface
 {
 
 	/**
+	 * Returns true if the header is set, false otherwise
+	 */
+	public function has(string name) -> boolean;
+
+	/**
 	 * Sets a header to be sent at the end of the request
 	 */
 	public function set(string name, string value);

--- a/phalcon/http/responseinterface.zep
+++ b/phalcon/http/responseinterface.zep
@@ -41,6 +41,11 @@ interface ResponseInterface
 	public function getHeaders() -> <HeadersInterface>;
 
 	/**
+	 * Checks if a header exists
+	 */
+	public function hasHeader(string name) -> boolean;
+
+	/**
 	 * Overwrites a header in the response
 	 */
 	public function setHeader(string name, value) -> <ResponseInterface>;

--- a/phalcon/mvc/model/metadata/strategy/introspection.zep
+++ b/phalcon/mvc/model/metadata/strategy/introspection.zep
@@ -20,6 +20,7 @@
 namespace Phalcon\Mvc\Model\MetaData\Strategy;
 
 use Phalcon\DiInterface;
+use Phalcon\Db\AdapterInterface;
 use Phalcon\Db\Column;
 use Phalcon\Mvc\ModelInterface;
 use Phalcon\Mvc\Model\Exception;

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1237,7 +1237,7 @@ class Tag
 	 * {{ render_title() }}
 	 * </code>
 	 */
-	public static function getRenderTitle() -> string
+	public static function renderTitle() -> string
 	{
 		return "<title>" . self::getTitle() . "</title>" . PHP_EOL;
 	}

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1154,14 +1154,21 @@ class Tag
 	 * The title will be automatically escaped.
 	 *
 	 * <code>
-	 * echo Phalcon\Tag::getTitle();
+	 * Tag::prependTitle('Hello');
+	 * Tag::setTitle('World');
+	 * Tag::appendTitle('from Phalcon');
+	 *
+	 * echo Tag::getTitle();             // Hello World from Phalcon
+	 * echo Tag::getTitle(false);        // World from Phalcon
+	 * echo Tag::getTitle(true, false);  // Hello World
+	 * echo Tag::getTitle(false, false); // World
 	 * </code>
 	 *
 	 * <code>
 	 * {{ get_title() }}
 	 * </code>
 	 */
-	public static function getTitle(boolean tags = true) -> string
+	public static function getTitle(boolean prepend = true, boolean append = true) -> string
 	{
 		var items, output, title, documentTitle, documentAppendTitle, documentPrependTitle, documentTitleSeparator, escaper;
 
@@ -1171,22 +1178,18 @@ class Tag
 		let documentTitle = escaper->escapeHtml(self::_documentTitle);
 		let documentTitleSeparator = escaper->escapeHtml(self::_documentTitleSeparator);
 
-		if typeof self::_documentAppendTitle == "null" {
-			let self::_documentAppendTitle = [];
-		}
+		if prepend {
+			if typeof self::_documentPrependTitle == "null" {
+				let self::_documentPrependTitle = [];
+			}
 
-		let documentAppendTitle = self::_documentAppendTitle;
+			let documentPrependTitle = self::_documentPrependTitle;
 
-		if typeof self::_documentPrependTitle == "null" {
-			let self::_documentPrependTitle = [];
-		}
-
-		let documentPrependTitle = self::_documentPrependTitle;
-
-		if !empty documentPrependTitle {
-			var tmp = array_reverse(documentPrependTitle);
-			for title in tmp {
-				let items[] = escaper->escapeHtml(title);
+			if !empty documentPrependTitle {
+				var tmp = array_reverse(documentPrependTitle);
+				for title in tmp {
+					let items[] = escaper->escapeHtml(title);
+				}
 			}
 		}
 
@@ -1194,9 +1197,17 @@ class Tag
 			let items[] = documentTitle;
 		}
 
-		if !empty documentAppendTitle {
-			for title in documentAppendTitle {
-				let items[] = escaper->escapeHtml(title);
+		if append {
+			if typeof self::_documentAppendTitle == "null" {
+				let self::_documentAppendTitle = [];
+			}
+
+			let documentAppendTitle = self::_documentAppendTitle;
+
+			if !empty documentAppendTitle {
+				for title in documentAppendTitle {
+					let items[] = escaper->escapeHtml(title);
+				}
 			}
 		}
 
@@ -1208,11 +1219,27 @@ class Tag
 			let output = implode(documentTitleSeparator, items);
 		}
 
-		if tags {
-			return "<title>" . output . "</title>" . PHP_EOL;
-		}
-
 		return output;
+	}
+
+	/**
+	 * Renders the title with title tags. The title is automaticall escaped
+	 *
+	 * <code>
+	 * Tag::prependTitle('Hello');
+	 * Tag::setTitle('World');
+	 * Tag::appendTitle('from Phalcon');
+	 *
+	 * echo Tag::renderTitle(); // <title>Hello World From Phalcon</title>
+	 * </code>
+	 *
+	 * <code>
+	 * {{ render_title() }}
+	 * </code>
+	 */
+	public static function getRenderTitle() -> string
+	{
+		return "<title>" . self::getTitle() . "</title>" . PHP_EOL;
 	}
 
 	/**

--- a/tests/unit/Http/Response/HeadersTest.php
+++ b/tests/unit/Http/Response/HeadersTest.php
@@ -65,6 +65,26 @@ class HeadersTest extends HttpBase
     }
 
     /**
+     * Tests the has of the response headers
+     *
+     * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
+     * @since  2018-11-02
+     */
+    public function testHttpResponseHeadersHas()
+    {
+        $this->specify(
+            "Has Response Headers is not correct",
+            function () {
+                $responseHeaders = new Headers();
+                $responseHeaders->set('Content-Type', 'text/html');
+
+                expect($responseHeaders->has('Content-Type'))->true();
+                expect($responseHeaders->has('unknown-header'))->false();
+            }
+        );
+    }
+
+    /**
      * Tests the set of the response status headers
      *
      * @test

--- a/tests/unit/Http/Response/HeadersTest.php
+++ b/tests/unit/Http/Response/HeadersTest.php
@@ -65,6 +65,26 @@ class HeadersTest extends HttpBase
     }
 
     /**
+     * Tests the hasHeader
+     *
+     * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
+     * @since  2018-11-02
+     */
+    public function testHttpResponseHasHeader()
+    {
+        $this->specify(
+            "hasHeader does not return the correct result",
+            function () {
+                $responseHeaders = new Headers();
+                $responseHeaders->set('Content-Type', 'text/html');
+
+                expect($responseHeaders->hasHeader('Content-Type'))->true();
+                expect($responseHeaders->hasHeader('some-random-stuff'))->false();
+            }
+        );
+    }
+
+    /**
      * Tests the set of the response status headers
      *
      * @test

--- a/tests/unit/Http/Response/HeadersTest.php
+++ b/tests/unit/Http/Response/HeadersTest.php
@@ -65,26 +65,6 @@ class HeadersTest extends HttpBase
     }
 
     /**
-     * Tests the hasHeader
-     *
-     * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
-     * @since  2018-11-02
-     */
-    public function testHttpResponseHasHeader()
-    {
-        $this->specify(
-            "hasHeader does not return the correct result",
-            function () {
-                $responseHeaders = new Headers();
-                $responseHeaders->set('Content-Type', 'text/html');
-
-                expect($responseHeaders->hasHeader('Content-Type'))->true();
-                expect($responseHeaders->hasHeader('some-random-stuff'))->false();
-            }
-        );
-    }
-
-    /**
      * Tests the set of the response status headers
      *
      * @test

--- a/tests/unit/Http/ResponseTest.php
+++ b/tests/unit/Http/ResponseTest.php
@@ -85,10 +85,10 @@ class ResponseTest extends HttpBase
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
      * @since  2014-10-08
      */
-    public function testHttpResponseSetStatusCode()
+    public function testHttpResponseHasHeader()
     {
         $this->specify(
-            "setStatusCode is not setting the header status properly",
+            "hasHeader is not returning the correct value",
             function () {
                 $response = $this->getResponseObject();
                 $response->resetHeaders();
@@ -103,6 +103,27 @@ class ResponseTest extends HttpBase
                     ]
                 );
                 expect($response->getHeaders())->equals($expected);
+            }
+        );
+    }
+
+    /**
+     * Tests the setStatusCode
+     *
+     * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
+     * @since  2014-10-08
+     */
+    public function testHttpResponseSetStatusCode()
+    {
+        $this->specify(
+            "setStatusCode is not setting the header status properly",
+            function () {
+                $response = $this->getResponseObject();
+                $response->resetHeaders();
+                $response->setHeader('Content-Type', 'text/html');
+
+                expect($response->hasHeader('Content-Type'))->true();
+                expect($response->hasHeader('some-unknown-header'))->false();
             }
         );
     }

--- a/tests/unit/Http/ResponseTest.php
+++ b/tests/unit/Http/ResponseTest.php
@@ -80,7 +80,7 @@ class ResponseTest extends HttpBase
     }
 
     /**
-     * Tests the setStatusCode
+     * Tests the hasHeader
      *
      * @author Nikolaos Dimopoulos <nikos@phalconphp.com>
      * @since  2014-10-08
@@ -92,17 +92,10 @@ class ResponseTest extends HttpBase
             function () {
                 $response = $this->getResponseObject();
                 $response->resetHeaders();
-                $response->setStatusCode(404, "Not Found");
+                $response->setHeader('Content-Type', 'text/html');
 
-                $expected = Headers::__set_state(
-                    [
-                        '_headers' => [
-                            'HTTP/1.1 404 Not Found' => '',
-                            'Status'                 => '404 Not Found'
-                        ]
-                    ]
-                );
-                expect($response->getHeaders())->equals($expected);
+                expect($response->hasHeader('Content-Type'))->true();
+                expect($response->hasHeader('some-unknown-header'))->false();
             }
         );
     }
@@ -120,10 +113,16 @@ class ResponseTest extends HttpBase
             function () {
                 $response = $this->getResponseObject();
                 $response->resetHeaders();
-                $response->setHeader('Content-Type', 'text/html');
-
-                expect($response->hasHeader('Content-Type'))->true();
-                expect($response->hasHeader('some-unknown-header'))->false();
+                $response->setStatusCode(404, "Not Found");
+                $expected = Headers::__set_state(
+                    [
+                        '_headers' => [
+                            'HTTP/1.1 404 Not Found' => '',
+                            'Status'                 => '404 Not Found'
+                        ]
+                    ]
+                );
+                expect($response->getHeaders())->equals($expected);
             }
         );
     }

--- a/tests/unit/Tag/TagTitleTest.php
+++ b/tests/unit/Tag/TagTitleTest.php
@@ -40,9 +40,29 @@ class TagTitleTest extends UnitTest
                 $value = "Hello </title><script>alert('Got your nose!');</script><title>";
 
                 Tag::setTitle($value);
-                $expected = "<title>Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;</title>" . PHP_EOL;
+                $expected = "Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;" . PHP_EOL;
 
                 expect(Tag::getTitle())->equals($expected);
+            }
+        );
+    }
+
+    /**
+     * Tests malicious content in the title
+     * @since  2018-11-01
+     */
+    public function testRenderTitleWithoutMaliciousContent()
+    {
+        $this->specify(
+            "getTitle returns malicious content",
+            function () {
+                Tag::resetInput();
+                $value = "Hello </title><script>alert('Got your nose!');</script><title>";
+
+                Tag::setTitle($value);
+                $expected = "<title>Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;</title>" . PHP_EOL;
+
+                expect(Tag::renderTitle())->equals($expected);
             }
         );
     }
@@ -62,9 +82,9 @@ class TagTitleTest extends UnitTest
                 $value = 'This is my title';
                 Tag::setTitle($value);
 
-                expect(Tag::getTitle())->equals("<title>{$value}</title>" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>{$value}</title>" . PHP_EOL);
 
-                expect(Tag::getTitle(false))->equals("{$value}");
+                expect(Tag::getTitle())->equals("{$value}");
             }
         );
     }
@@ -85,14 +105,18 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('Title');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("TitleClass" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
                 Tag::setTitle('This is my title');
                 Tag::appendTitle(' - Welcome!');
 
-                expect(Tag::getTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("This is my title - Welcome!" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -100,7 +124,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Title|Class" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -109,7 +135,9 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle('Title');
 
-                expect(Tag::getTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -117,7 +145,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::appendTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -126,7 +156,9 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle([]);
 
-                expect(Tag::getTitle())->equals("<title>Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, true))->equals("Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );
     }
@@ -148,7 +180,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('This is my title');
                 Tag::prependTitle('PhalconPHP - ');
 
-                expect(Tag::getTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("PhalconPHP - This is my title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -156,7 +190,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::prependTitle('Class');
 
-                expect(Tag::getTitle())->equals('<title>Class|Title</title>' . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Class|Title" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Class|Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -165,7 +201,9 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle('Title');
 
-                expect(Tag::getTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -173,7 +211,9 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::prependTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
 
@@ -182,7 +222,9 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle([]);
 
-                expect(Tag::getTitle())->equals("<title>Main</title>" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(true, false))->equals("Main" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );
     }
@@ -222,7 +264,7 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('-');
                 Tag::appendTitle('PhalconPHP');
 
-                expect(Tag::getTitle())->equals("<title>This is my title-PhalconPHP</title>" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>This is my title-PhalconPHP</title>" . PHP_EOL);
             }
         );
     }
@@ -243,7 +285,7 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('-');
                 Tag::prependTitle('PhalconPHP');
 
-                expect(Tag::getTitle())->equals("<title>PhalconPHP-This is my title</title>" . PHP_EOL);
+                expect(Tag::renderTitle())->equals("<title>PhalconPHP-This is my title</title>" . PHP_EOL);
             }
         );
     }

--- a/tests/unit/Tag/TagTitleTest.php
+++ b/tests/unit/Tag/TagTitleTest.php
@@ -40,7 +40,7 @@ class TagTitleTest extends UnitTest
                 $value = "Hello </title><script>alert('Got your nose!');</script><title>";
 
                 Tag::setTitle($value);
-                $expected = "Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;" . PHP_EOL;
+                $expected = "Hello &lt;/title&gt;&lt;script&gt;alert(&#039;Got your nose!&#039;);&lt;/script&gt;&lt;title&gt;";
 
                 expect(Tag::getTitle())->equals($expected);
             }
@@ -105,8 +105,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('Title');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("TitleClass" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title");
+                expect(Tag::getTitle(false, true))->equals("TitleClass");
                 expect(Tag::renderTitle())->equals("<title>TitleClass</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -114,8 +114,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('This is my title');
                 Tag::appendTitle(' - Welcome!');
 
-                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("This is my title - Welcome!" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title");
+                expect(Tag::getTitle(false, true))->equals("This is my title - Welcome!");
                 expect(Tag::renderTitle())->equals("<title>This is my title - Welcome!</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -124,8 +124,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::appendTitle('Class');
 
-                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Title|Class" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title");
+                expect(Tag::getTitle(false, true))->equals("Title|Class");
                 expect(Tag::renderTitle())->equals("<title>Title|Class</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -135,8 +135,8 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle('Title');
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title");
                 expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -145,8 +145,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::appendTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Main - Category - Title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(false, true))->equals("Main - Category - Title");
                 expect(Tag::renderTitle())->equals("<title>Main - Category - Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -156,8 +156,8 @@ class TagTitleTest extends UnitTest
                 Tag::appendTitle('Category');
                 Tag::appendTitle([]);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(false, true))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(false, true))->equals("Main");
                 expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );
@@ -180,8 +180,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitle('This is my title');
                 Tag::prependTitle('PhalconPHP - ');
 
-                expect(Tag::getTitle(false, false))->equals("This is my title" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("PhalconPHP - This is my title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("This is my title");
+                expect(Tag::getTitle(true, false))->equals("PhalconPHP - This is my title");
                 expect(Tag::renderTitle())->equals("<title>PhalconPHP - This is my title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -190,8 +190,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator('|');
                 Tag::prependTitle('Class');
 
-                expect(Tag::getTitle(false, false))->equals("Title" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Class|Title" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Title");
+                expect(Tag::getTitle(true, false))->equals("Class|Title");
                 expect(Tag::renderTitle())->equals("<title>Class|Title</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -201,8 +201,8 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle('Title');
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main");
                 expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -211,8 +211,8 @@ class TagTitleTest extends UnitTest
                 Tag::setTitleSeparator(' - ');
                 Tag::prependTitle(['Category', 'Title']);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Title - Category - Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(true, false))->equals("Title - Category - Main");
                 expect(Tag::renderTitle())->equals("<title>Title - Category - Main</title>" . PHP_EOL);
 
                 Tag::resetInput();
@@ -222,8 +222,8 @@ class TagTitleTest extends UnitTest
                 Tag::prependTitle('Category');
                 Tag::prependTitle([]);
 
-                expect(Tag::getTitle(false, false))->equals("Main" . PHP_EOL);
-                expect(Tag::getTitle(true, false))->equals("Main" . PHP_EOL);
+                expect(Tag::getTitle(false, false))->equals("Main");
+                expect(Tag::getTitle(true, false))->equals("Main");
                 expect(Tag::renderTitle())->equals("<title>Main</title>" . PHP_EOL);
             }
         );


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: [PR-12189](https://github.com/phalcon/cphalcon/pull/12189)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Added `hasHeader` in `Phalcon\Http\Response` to allow checking for a valid header existence

Thanks

