### PR TITLE
Fixed Phalcon\Validation::preChecking

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,13 +1,13 @@
 # [3.4.2](https://github.com/phalcon/cphalcon/releases/tag/v3.4.2) (2018-XX-XX)
-- Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
-- Fixed `Phalcon\Tag` so it unsets `parameters` before passing options array to `self::renderAttributes`
-- Fixed  `\Phalcon\Http\Response::setFileToSend` filename; when file downloaded it had an extra `_`
+- Added missing Volt tags to array helper in `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` [#13447](https://github.com/phalcon/cphalcon/issues/13447)
 - Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099](https://github.com/phalcon/cphalcon/issues/13099)
 - Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
+- Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
+- Fixed `Phalcon\Tag` so it unsets `parameters` before passing options array to `self::renderAttributes`
+- Fixed `Phalcon\Http\Response::setFileToSend` filename; when file downloaded it had an extra `_`
 - Fixed `Phalcon\Mvc\Model\Query::execute` to properly bind parameters to sub queries [#11605](https://github.com/phalcon/cphalcon/issues/11605)
-- Added missing Volt tags to array helper in `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` [#13447](https://github.com/phalcon/cphalcon/issues/13447)
 - Fixed `Phalcon\Http\Request::getJsonRawBody` [#13501](https://github.com/phalcon/cphalcon/issues/13501). It will now return false when the body content is empty, as well as when it encounters an error whilst decoding the JSON content.
-
+- Fixed `Phalcon\Validation::preChecking` to allow use `Phalcon\Db\RawValue` as an empty container for `isAllowEmpty` option [#13549](https://github.com/phalcon/cphalcon/pull/13549), [#13573](https://github.com/phalcon/cphalcon/issues/13573), [#12519](https://github.com/phalcon/cphalcon/pull/12519) 
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -227,7 +227,7 @@ abstract class Adapter implements AdapterInterface, EventsAwareInterface
 	 */
 	public function fetchAll(string sqlQuery, var fetchMode = Db::FETCH_ASSOC, var bindParams = null, var bindTypes = null) -> array
 	{
-		var results, result, row;
+		var results, result;
 
 		let results = [],
 			result = this->{"query"}(sqlQuery, bindParams, bindTypes);

--- a/phalcon/validation.zep
+++ b/phalcon/validation.zep
@@ -580,6 +580,7 @@ class Validation extends Injectable implements ValidationInterface
 	protected function preChecking(var field, <ValidatorInterface> validator) -> boolean
 	{
 		var singleField, allowEmpty, emptyValue, value, result;
+
 		if typeof field == "array" {
 			for singleField in field {
 				let result = this->preChecking(singleField, validator);
@@ -587,22 +588,41 @@ class Validation extends Injectable implements ValidationInterface
 					return result;
 				}
 			}
-		}
-		else {
+		} else {
 			let allowEmpty = validator->getOption("allowEmpty", false);
+
 			if allowEmpty {
 				if method_exists(validator, "isAllowEmpty") {
 					return validator->isAllowEmpty(this, field);
 				}
+
 				let value = this->getValue(field);
+
+				// 'allowEmpty' => [null, false, RawValue('NULL')]
 				if typeof allowEmpty == "array" {
 					for emptyValue in allowEmpty {
 						if emptyValue === value {
 							return true;
+						} elseif typeof emptyValue == "object" && typeof value == "object" && emptyValue == value {
+							return true;
 						}
 					}
-					return false;						
+
+					return false;
 				}
+
+				var raw;
+
+				// Workaround for \Phalcon\Db\RawValue('NULL')
+				if unlikely typeof value == "object" && method_exists(value, "__toString") {
+					// NULL -> null
+					let raw = strtolower(value->__toString());
+
+					if in_array(raw, ["null", "false", ""], true) {
+						return true;
+					}
+				}
+
 				return empty value;
 			}
 		}

--- a/tests/unit/ValidationTest.php
+++ b/tests/unit/ValidationTest.php
@@ -247,24 +247,24 @@ class ValidationTest extends UnitTest
                 $validation->setDI(new FactoryDefault());
 
                 $validation
-                    ->add('name', new Validation\Validator\Alpha(array(
+                    ->add('name', new Validation\Validator\Alpha([
                         'message' => 'The name is not valid',
-                    )))
-                    ->add('name', new Validation\Validator\PresenceOf(array(
+                    ]))
+                    ->add('name', new Validation\Validator\PresenceOf([
                         'message' => 'The name is required',
-                    )))
-                    ->add('url', new Validation\Validator\Url(array(
+                    ]))
+                    ->add('url', new Validation\Validator\Url([
                         'message' => 'The url is not valid.',
                         'allowEmpty' => true,
-                    )))
-                    ->add('email', new Validation\Validator\Email(array(
+                    ]))
+                    ->add('email', new Validation\Validator\Email([
                         'message' => 'The email is not valid.',
                         'allowEmpty' => [null, false],
-                    )))
-                    ->add('price', new Validation\Validator\Numericality(array(
+                    ]))
+                    ->add('price', new Validation\Validator\Numericality([
                         'message' => 'The price is not valid.',
                         'allowEmpty' => [null, new RawValue('NULL')],
-                    )));
+                    ]));
 
                 $messages = $validation->validate([
                     'name' => '',


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [#13549](https://github.com/phalcon/cphalcon/pull/13549), [#13573](https://github.com/phalcon/cphalcon/issues/13573), [#12519](https://github.com/phalcon/cphalcon/pull/12519)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed `Phalcon\Validation::preChecking` to allow use `Phalcon\Db\RawValue` as an empty container for `isAllowEmpty` option. Please see  https://github.com/phalcon/cphalcon/issues/13573 for the reproducible test.

Thanks

