### PR TITLE
Fixed RawValue objects being prepared instead of inserted 4.0

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,5 +1,15 @@
 # [3.4.2](https://github.com/phalcon/cphalcon/releases/tag/v3.4.2) (2018-XX-XX)
 - Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
+- Added missing Volt tags to array helper in `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` [#13447](https://github.com/phalcon/cphalcon/issues/13447)
+- Added the ability to explicitly define nullable columns (especially timestamp ones). [#13099](https://github.com/phalcon/cphalcon/issues/13099)
+- Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
+- Fixed `Phalcon\Validation\Validator\Numericality` to accept float numbers on locales with comma decimal point [#13450](https://github.com/phalcon/cphalcon/issues/13450)
+- Fixed `Phalcon\Tag` so it unsets `parameters` before passing options array to `self::renderAttributes`
+- Fixed `Phalcon\Http\Response::setFileToSend` filename; when file downloaded it had an extra `_`
+- Fixed `Phalcon\Mvc\Model\Query::execute` to properly bind parameters to sub queries [#11605](https://github.com/phalcon/cphalcon/issues/11605)
+- Fixed `Phalcon\Http\Request::getJsonRawBody` [#13501](https://github.com/phalcon/cphalcon/issues/13501). It will now return false when the body content is empty, as well as when it encounters an error whilst decoding the JSON content.
+- Fixed `Phalcon\Validation::preChecking` to allow use `Phalcon\Db\RawValue` as an empty container for `isAllowEmpty` option [#13549](https://github.com/phalcon/cphalcon/pull/13549), [#13573](https://github.com/phalcon/cphalcon/issues/13573), [#12519](https://github.com/phalcon/cphalcon/pull/12519)
+- Fixed object binding and placeholder creation in `Phalcon\Db\Adapter::insert` and `Phalcon\Db\Adapter::update` [#13058](https://github.com/phalcon/cphalcon/issues/13058).
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
             "Phalcon\\Test\\Unit\\": "tests/unit/",
             "Phalcon\\Test\\Integration\\": "tests/integration/",
             "Phalcon\\Test\\Module\\": "tests/_support/Module/",
-            "Phalcon\\Test\\Listener\\": "tests/_data/listener/"
+            "Phalcon\\Test\\Listener\\": "tests/_data/listener/",
+            "Phalcon\\Test\\Db\\": "tests/_data/db/"
         }
     },
     "support": {

--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -692,9 +692,13 @@ abstract class Adapter implements AdapterInterface, EventsAwareInterface
 		 * Objects are casted using __toString, null values are converted to string "null", everything else is passed as "?"
 		 */
 		for position, value in values {
-			if typeof value == "object" {
+			if typeof value == "object" && value instanceof RawValue {
 				let placeholders[] = (string) value;
 			} else {
+				if typeof value == "object" {
+					let value = (string) value;
+				}
+
 				if typeof value == "null" {
 					let placeholders[] = "null";
 				} else {
@@ -1022,10 +1026,13 @@ abstract class Adapter implements AdapterInterface, EventsAwareInterface
 			}
 
 			let escapedField = this->escapeIdentifier(field);
-
-			if typeof value == "object" {
-				let placeholders[] = escapedField . " = " . value;
+			if typeof value == "object" && value instanceof RawValue {
+				let placeholders[] = escapedField . " = " . (string) value;
 			} else {
+				if typeof value == "object" {
+					let value = (string) value;
+				}
+
 				if typeof value == "null" {
 					let placeholders[] = escapedField . " = null";
 				} else {

--- a/tests/_data/db/DateTime.php
+++ b/tests/_data/db/DateTime.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Phalcon\Test\Db;
+
+class DateTime extends \DateTime
+{
+    public function __toString()
+    {
+    	return $this->format('Y-m-d H:i:s');
+    }
+}

--- a/tests/unit/Mvc/ModelTest.php
+++ b/tests/unit/Mvc/ModelTest.php
@@ -897,4 +897,26 @@ class ModelTest extends UnitTest
             }
         );
     }
+
+    /**
+     * Tests binding of non-scalar values by casting to string and binding them.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/13058
+     * @author Cameron Hall <me@chall.id.au>
+     * @since  2018-11-06
+     */
+    public function testIssue13058()
+    {
+        $this->specify(
+            'Issue 13058 is happening, non-scalar values are not being casted and bound.',
+            function () {
+                $robots = new Robots();
+                $robots->name = '';
+                $robots->datetime = new \Phalcon\Test\Db\DateTime();
+                $robots->text = 'text';
+                $result = $robots->save();
+                expect($result)->true();
+            }
+        );
+    }
 }


### PR DESCRIPTION
Hello!

Type: bug fix
Link to issue: #13058

In raising this pull request, I confirm the following:

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Fixed missing placeholder creation when objects `__toString` method are invoked.

Thanks