### PR TITLE
4.0.x Remove name property from Phalcon\Di\Service so that it can be used as a better closure wrapper

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -34,6 +34,7 @@
 - Refactored `Phalcon\Db\Adapter\Pdo::query` to use PDO's prepare and execute. `Phalcon\Db\Adapter::fetchAll` to use PDO's fetchAll
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename last much _ 
 - Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [#13547](https://github.com/phalcon/cphalcon/issues/13547) 
+- Changed `Phalcon\Di\Service` constructor to no longer takes the name of the service.
 
 ## Removed
 - PHP < 7.0 no longer supported

--- a/phalcon/di/exception/serviceresolutionexception.zep
+++ b/phalcon/di/exception/serviceresolutionexception.zep
@@ -1,0 +1,26 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2018 Phalcon Team (https://phalconphp.com)          |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file LICENSE.txt.                             |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ */
+
+namespace Phalcon\Di\Exception;
+
+use Phalcon\Di\Exception\ServiceResolutionException;
+
+/**
+ * Phalcon\Di\Exception\ServiceResolutionException
+ *
+ */
+class ServiceResolutionException extends \Phalcon\Di\Exception
+{
+}

--- a/phalcon/di/factorydefault.zep
+++ b/phalcon/di/factorydefault.zep
@@ -37,27 +37,27 @@ class FactoryDefault extends \Phalcon\Di
 		parent::__construct();
 
 		let this->_services = [
-			"router":             new Service("router", "Phalcon\\Mvc\\Router", true),
-			"dispatcher":         new Service("dispatcher", "Phalcon\\Mvc\\Dispatcher", true),
-			"url":                new Service("url", "Phalcon\\Mvc\\Url", true),
-			"modelsManager":      new Service("modelsManager", "Phalcon\\Mvc\\Model\\Manager", true),
-			"modelsMetadata":     new Service("modelsMetadata", "Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
-			"response":           new Service("response", "Phalcon\\Http\\Response", true),
-			"cookies":            new Service("cookies", "Phalcon\\Http\\Response\\Cookies", true),
-			"request":            new Service("request", "Phalcon\\Http\\Request", true),
-			"filter":             new Service("filter", "Phalcon\\Filter", true),
-			"escaper":            new Service("escaper", "Phalcon\\Escaper", true),
-			"security":           new Service("security", "Phalcon\\Security", true),
-			"crypt":              new Service("crypt", "Phalcon\\Crypt", true),
-			"annotations":        new Service("annotations", "Phalcon\\Annotations\\Adapter\\Memory", true),
-			"flash":              new Service("flash", "Phalcon\\Flash\\Direct", true),
-			"flashSession":       new Service("flashSession", "Phalcon\\Flash\\Session", true),
-			"tag":                new Service("tag", "Phalcon\\Tag", true),
-			"session":            new Service("session", "Phalcon\\Session\\Adapter\\Files", true),
-			"sessionBag":         new Service("sessionBag", "Phalcon\\Session\\Bag"),
-			"eventsManager":      new Service("eventsManager", "Phalcon\\Events\\Manager", true),
-			"transactionManager": new Service("transactionManager", "Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
-			"assets":             new Service("assets", "Phalcon\\Assets\\Manager", true)
+			"router":             new Service("Phalcon\\Mvc\\Router", true),
+			"dispatcher":         new Service("Phalcon\\Mvc\\Dispatcher", true),
+			"url":                new Service("Phalcon\\Mvc\\Url", true),
+			"modelsManager":      new Service("Phalcon\\Mvc\\Model\\Manager", true),
+			"modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
+			"response":           new Service("Phalcon\\Http\\Response", true),
+			"cookies":            new Service("Phalcon\\Http\\Response\\Cookies", true),
+			"request":            new Service("Phalcon\\Http\\Request", true),
+			"filter":             new Service("Phalcon\\Filter", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"security":           new Service("Phalcon\\Security", true),
+			"crypt":              new Service("Phalcon\\Crypt", true),
+			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
+			"flash":              new Service("Phalcon\\Flash\\Direct", true),
+			"flashSession":       new Service("Phalcon\\Flash\\Session", true),
+			"tag":                new Service("Phalcon\\Tag", true),
+			"session":            new Service("Phalcon\\Session\\Adapter\\Files", true),
+			"sessionBag":         new Service("Phalcon\\Session\\Bag"),
+			"eventsManager":      new Service("Phalcon\\Events\\Manager", true),
+			"transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
+			"assets":             new Service("Phalcon\\Assets\\Manager", true)
 		];
 	}
 }

--- a/phalcon/di/factorydefault/cli.zep
+++ b/phalcon/di/factorydefault/cli.zep
@@ -41,16 +41,16 @@ class Cli extends FactoryDefault
 		parent::__construct();
 
 		let this->_services = [
-			"router":             new Service("router", "Phalcon\\Cli\\Router", true),
-			"dispatcher":         new Service("dispatcher", "Phalcon\\Cli\\Dispatcher", true),
-			"modelsManager":      new Service("modelsManager", "Phalcon\\Mvc\\Model\\Manager", true),
-			"modelsMetadata":     new Service("modelsMetadata", "Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
-			"filter":             new Service("filter", "Phalcon\\Filter", true),
-			"escaper":            new Service("escaper", "Phalcon\\Escaper", true),
-			"annotations":        new Service("annotations", "Phalcon\\Annotations\\Adapter\\Memory", true),
-			"security":           new Service("security", "Phalcon\\Security", true),
-			"eventsManager":      new Service("eventsManager", "Phalcon\\Events\\Manager", true),
-			"transactionManager": new Service("transactionManager", "Phalcon\\Mvc\\Model\\Transaction\\Manager", true)
+			"router":             new Service("Phalcon\\Cli\\Router", true),
+			"dispatcher":         new Service("Phalcon\\Cli\\Dispatcher", true),
+			"modelsManager":      new Service("Phalcon\\Mvc\\Model\\Manager", true),
+			"modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
+			"filter":             new Service("Phalcon\\Filter", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
+			"security":           new Service("Phalcon\\Security", true),
+			"eventsManager":      new Service("Phalcon\\Events\\Manager", true),
+			"transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true)
 		];
 	}
 }

--- a/phalcon/di/service.zep
+++ b/phalcon/di/service.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Di;
 
 use Phalcon\DiInterface;
 use Phalcon\Di\Exception;
+use Phalcon\Di\Exception\ServiceResolutionException;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Di\Service\Builder;
 
@@ -41,8 +42,6 @@ use Phalcon\Di\Service\Builder;
 class Service implements ServiceInterface
 {
 
-	protected _name;
-
 	protected _definition;
 
 	protected _shared = false;
@@ -56,19 +55,10 @@ class Service implements ServiceInterface
 	 *
 	 * @param mixed definition
 	 */
-	public final function __construct(string! name, definition, boolean shared = false)
+	public final function __construct(definition, boolean shared = false)
 	{
-		let this->_name = name,
-			this->_definition = definition,
+		let this->_definition = definition,
 			this->_shared = shared;
-	}
-
-	/**
-	 * Returns the service's name
-	 */
-	public function getName() -> string
-	{
-		return this->_name;
 	}
 
 	/**
@@ -201,8 +191,8 @@ class Service implements ServiceInterface
 		/**
 		 * If the service can't be built, we must throw an exception
 		 */
-		if found === false  {
-			throw new Exception("Service '" . this->_name . "' cannot be resolved");
+		if found === false {
+			throw new ServiceResolutionException();
 		}
 
 		/**
@@ -292,10 +282,6 @@ class Service implements ServiceInterface
 	{
 		var name, definition, shared;
 
-		if !fetch name, attributes["_name"] {
-			throw new Exception("The attribute '_name' is required");
-		}
-
 		if !fetch definition, attributes["_definition"] {
 			throw new Exception("The attribute '_definition' is required");
 		}
@@ -304,6 +290,6 @@ class Service implements ServiceInterface
 			throw new Exception("The attribute '_shared' is required");
 		}
 
-		return new self(name, definition, shared);
+		return new self(definition, shared);
 	}
 }

--- a/phalcon/di/serviceinterface.zep
+++ b/phalcon/di/serviceinterface.zep
@@ -29,11 +29,6 @@ use Phalcon\DiInterface;
 interface ServiceInterface
 {
 	/**
-	 * Returns the service's name
-	 */
-	public function getName() -> string;
-
-	/**
 	 * Sets if the service is shared or not
 	 */
 	public function setShared(boolean shared);

--- a/tests/unit/DiTest.php
+++ b/tests/unit/DiTest.php
@@ -257,13 +257,11 @@ class DiTest extends UnitTest
             function () {
                 $expectedServices = [
                     'service1' => Service::__set_state([
-                        '_name'           => 'service1',
                         '_definition'     => 'some-service',
                         '_shared'         => false,
                         '_sharedInstance' => null,
                     ]),
                     'service2' => Service::__set_state([
-                        '_name'           => 'service2',
                         '_definition'     => 'some-other-service',
                         '_shared'         => false,
                         '_sharedInstance' => null,


### PR DESCRIPTION
The current design of the Service class doesn't make it well suited for acting as a closure wrapper and the name property is unnecessary.  There is only one place where the name property is used and that is in the DI and it already has access to the name of the service due to having just having received the name via a method parameter.  I added a single exception class that is to be thrown when this one situation occurs.  I think that this is a good use of an exception since it is an exceptional event.  Otherwise the design of Phalcon suffers only to satisfy this one moment.

Accepting this pull request will allow frameworks to use one service per file designs.

```php
return function() {
    // This is a service closure
}
```

In addition to the following two options;

```php
    return new Service(function() {

    });
```

and

```php
    return new Service(function() {

    }, true);
```

and then later by an additional pull request:

```php
    return new SharedService(function() {

    });
```

If this pull request is not accepted then it must be done like:

```php
    return new Service("this_is_bullshit", function() {

    });
```

and then hoping to not create a collision.  However for purposes of sanity this entire use of `Service` is essentially unavailable and for no good reason

This pull request is derived from an old pull request that I pulled down from before when Phalcon was in its neglected state.  I relied on the actual PR to run the tests for me and if I missed something here or something changed then I'll fix it and then if the fix or fixes become too messy then I will resubmit with a local copy-paste of the completed passing code.  Obviously that isn't an ideal development process and is already being addressed elsewhere by the Team.