### PR TITLE
Fixed #12725: Numeric INI config now builds properly

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -9,6 +9,7 @@
 - Fixed `Phalcon\Http\Request::getJsonRawBody` [#13501](https://github.com/phalcon/cphalcon/issues/13501). It will now return false when the body content is empty, as well as when it encounters an error whilst decoding the JSON content.
 - Fixed `Phalcon\Validation::preChecking` to allow use `Phalcon\Db\RawValue` as an empty container for `isAllowEmpty` option [#13549](https://github.com/phalcon/cphalcon/pull/13549), [#13573](https://github.com/phalcon/cphalcon/issues/13573), [#12519](https://github.com/phalcon/cphalcon/pull/12519)
 - Fixed object binding and placeholder creation in `Phalcon\Db\Adapter::insert` and `Phalcon\Db\Adapter::update` [#13058](https://github.com/phalcon/cphalcon/issues/13058).
+- Fixed `Phalcon\Config\Adapter\Ini` not building config objects properly for numerical keys [#12725](https://github.com/phalcon/cphalcon/issues/12725), [#13604](https://github.com/phalcon/cphalcon/issues/13604)
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter

--- a/phalcon/config/adapter/ini.zep
+++ b/phalcon/config/adapter/ini.zep
@@ -96,7 +96,7 @@ class Ini extends Config
 					let sections[] = this->_parseIniString((string)path, lastValue);
 				}
 				if count(sections) {
-					let config[section] = call_user_func_array("array_merge_recursive", sections);
+					let config[section] = call_user_func_array("array_replace_recursive", sections);
 				}
 			} else {
 				let config[section] = this->_cast(directives);

--- a/tests/_data/config/config.ini
+++ b/tests/_data/config/config.ini
@@ -14,3 +14,12 @@ name = demo
 [test]
 parent.property = On
 parent.property2 = "yeah"
+
+[issue-12725]
+channel.handlers.0.name = stream
+channel.handlers.0.level = debug
+channel.handlers.0.fingersCrossed = info
+channel.handlers.0.filename = channel.log
+channel.handlers.1.name = redis
+channel.handlers.1.level = debug
+channel.handlers.1.fingersCrossed = info

--- a/tests/_data/config/config.json
+++ b/tests/_data/config/config.json
@@ -1,1 +1,38 @@
-{"phalcon":{"baseuri":"\/phalcon\/"},"models":{"metadata":"memory"},"database":{"adapter":"mysql","host":"localhost","username":"user","password":"passwd","name":"demo"},"test":{"parent":{"property":1,"property2":"yeah"}}}
+{
+  "phalcon": {
+    "baseuri": "/phalcon/"
+  },
+  "models": {
+    "metadata": "memory"
+  },
+  "database": {
+    "adapter": "mysql",
+    "host": "localhost",
+    "username": "user",
+    "password": "passwd",
+    "name": "demo"
+  },
+  "test": {
+    "parent": {
+      "property": 1,
+      "property2": "yeah"
+    }
+  },
+  "issue-12725": {
+    "channel": {
+      "handlers": [
+        {
+          "name": "stream",
+          "level": "debug",
+          "fingersCrossed": "info",
+          "filename": "channel.log"
+        },
+        {
+          "name": "redis",
+          "level": "debug",
+          "fingersCrossed": "info"
+        }
+      ]
+    }
+  }
+}

--- a/tests/_data/config/config.php
+++ b/tests/_data/config/config.php
@@ -1,23 +1,40 @@
 <?php
 
-return array(
-        "phalcon" => array(
+return [
+        "phalcon" => [
             "baseuri" => "/phalcon/"
-        ),
-        "models" => array(
+        ],
+        "models" => [
             "metadata" => "memory"
-        ),
-        "database" => array(
+        ],
+        "database" => [
             "adapter" => "mysql",
             "host" => "localhost",
             "username" => "user",
             "password" => "passwd",
             "name" => "demo"
-        ),
-        "test" => array(
-            "parent" => array(
+        ],
+        "test" => [
+            "parent" => [
                 "property" => 1,
                 "property2" => "yeah"
-            ),
-        )
-    );
+            ],
+        ],
+        'issue-12725' => [
+            'channel' => [
+                'handlers' => [
+                    0 => [
+                        'name' => 'stream',
+                        'level' => 'debug',
+                        'fingersCrossed' => 'info',
+                        'filename' => 'channel.log'
+                    ],
+                    1 => [
+                        'name' => 'redis',
+                        'level' => 'debug',
+                        'fingersCrossed' => 'info'
+                    ]
+                ]
+            ]
+        ]
+    ];

--- a/tests/_data/config/config.yml
+++ b/tests/_data/config/config.yml
@@ -12,3 +12,15 @@ test:
   parent:
     property: 1
     property2: yeah
+issue-12725:
+  channel:
+    handlers:
+      0:
+        name: stream
+        level: debug
+        fingersCrossed: info
+        filename: channel.log
+      1:
+        name: redis
+        level: debug
+        fingersCrossed: info

--- a/tests/unit/Config/Helper/ConfigBase.php
+++ b/tests/unit/Config/Helper/ConfigBase.php
@@ -43,6 +43,23 @@ class ConfigBase extends UnitTest
                 'property2' => 'yeah'
             ],
         ],
+        'issue-12725' => [
+            'channel' => [
+                'handlers' => [
+                    0 => [
+                        'name' => 'stream',
+                        'level' => 'debug',
+                        'fingersCrossed' => 'info',
+                        'filename' => 'channel.log'
+                    ],
+                    1 => [
+                        'name' => 'redis',
+                        'level' => 'debug',
+                        'fingersCrossed' => 'info'
+                    ]
+                ]
+            ]
+        ]
     ];
 
     protected function compareConfig(array $actual, Config $expected)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12725, #13604

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: INI configuration with numerically nested keys wouldn't get parsed properly. This is because `array_merge_recursive` cannot handle collisions with nested arrays. As such`array_replace_recursive` needs to be used instead.

Thanks

I'll create a PR for 4.0.x shortly.

