### PR TITLE
Fixed Phalcon\Config->merge not merging config with numeric properties properly 4.0.x

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -11,6 +11,14 @@
 - Fixed `Phalcon\Validation::preChecking` to allow use `Phalcon\Db\RawValue` as an empty container for `isAllowEmpty` option [#13549](https://github.com/phalcon/cphalcon/pull/13549), [#13573](https://github.com/phalcon/cphalcon/issues/13573), [#12519](https://github.com/phalcon/cphalcon/pull/12519)
 - Fixed object binding and placeholder creation in `Phalcon\Db\Adapter::insert` and `Phalcon\Db\Adapter::update` [#13058](https://github.com/phalcon/cphalcon/issues/13058).
 - Fixed `Phalcon\Config\Adapter\Ini` not building config objects properly for numerical keys [#12725](https://github.com/phalcon/cphalcon/issues/12725), [#13604](https://github.com/phalcon/cphalcon/issues/13604)
+- Fixed object binding and placeholder creation in `Phalcon\Db\Adapter::insert` and `Phalcon\Db\Adapter::update` [#13058](https://github.com/phalcon/cphalcon/issues/13058)
+- Fixed incorrect scope of view variables
+  [#12176](https://github.com/phalcon/cphalcon/issues/12176),
+  [#12385](https://github.com/phalcon/cphalcon/issues/12385),
+  [#12648](https://github.com/phalcon/cphalcon/issues/12648),
+  [#12705](https://github.com/phalcon/cphalcon/issues/12705),
+  [#13288](https://github.com/phalcon/cphalcon/pull/13288)
+- Fixed `Phalcon\Config::_merge` not merging config with numeric properties properly [#13351](https://github.com/phalcon/cphalcon/issues/13351).
 
 # [3.4.1](https://github.com/phalcon/cphalcon/releases/tag/v3.4.1) (2018-08-04)
 - Changed `Phalcon\Cache\Backend\Redis` to support connection timeout parameter
@@ -37,8 +45,6 @@
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
-- Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918),
-[#13351](https://github.com/phalcon/cphalcon/issues/13351)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)
 - Fixed `Phalcon\Mvc\Model::setSnapshotData` to properly sets the old snapshot
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -37,6 +37,8 @@
 - Changed `Phalcon\Crypt::setCipher` so that IV length will be reconfigured during setting the cipher algorithm
 - Changed `Phalcon\Crypt::setCipher` so that method will throw `Phalcon\Crypt\Exception` if a cipher is unavailable
 - Fixed regression ([#13308](https://github.com/phalcon/cphalcon/pull/13308)) for `Phalcon\Debug\Dump::output` to correctly work with detailed mode [#13315](https://github.com/phalcon/cphalcon/issues/13315)
+- Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918),
+[#13351](https://github.com/phalcon/cphalcon/issues/13351)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::having` and `Phalcon\Mvc\Model\Query\Builder::where` to correctly merge the bind types [#11487](https://github.com/phalcon/cphalcon/issues/11487)
 - Fixed `Phalcon\Mvc\Model::setSnapshotData` to properly sets the old snapshot
 - Do not throw Exception when superglobal does not exist [#13252](https://github.com/phalcon/cphalcon/issues/13252), [#13254](https://github.com/phalcon/cphalcon/issues/13254), [#12918](https://github.com/phalcon/cphalcon/issues/12918)

--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -297,7 +297,7 @@ class Config implements \ArrayAccess, \Countable
 	 */
 	protected final function _merge(<Config> config, <Config> instance = null) -> <Config>
 	{
-		var key, originalKey, value, number, localObject, property;
+		var key, value, number, localObject, property;
 
 		if typeof instance !== "object" {
 			let instance = this;
@@ -318,15 +318,13 @@ class Config implements \ArrayAccess, \Countable
 			}
 
 			if is_numeric(key) {
-				let originalKey = key;
-				let key = strval(number);
-				if this->offsetExists(key) {
-					//@link https://github.com/phalcon/cphalcon/issues/13351
-					//use originalKey to avoid overwriting incorrect key
-					let key = strval(originalKey);
+				let key = strval(key);
+				while instance->offsetExists(key) {
+					// increment the number afterwards, because "number" starts at one not zero.
+					let key = strval(number);
+					let number++;
 				}
-				let number++;
-			}
+ 			}
 			let instance->{key} = value;
 		}
 

--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -297,7 +297,7 @@ class Config implements \ArrayAccess, \Countable
 	 */
 	protected final function _merge(<Config> config, <Config> instance = null) -> <Config>
 	{
-		var key, value, number, localObject, property;
+		var key, originalKey, value, number, localObject, property;
 
 		if typeof instance !== "object" {
 			let instance = this;
@@ -318,8 +318,14 @@ class Config implements \ArrayAccess, \Countable
 			}
 
 			if is_numeric(key) {
-				let key = strval(number),
-					number++;
+				let originalKey = key;
+				let key = strval(number);
+				if this->offsetExists(key) {
+					//@link https://github.com/phalcon/cphalcon/issues/13351
+					//use originalKey to avoid overwriting incorrect key
+					let key = strval(originalKey);
+				}
+				let number++;
 			}
 			let instance->{key} = value;
 		}

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -351,4 +351,61 @@ class ConfigTest extends ConfigBase
             ]
         );
     }
+
+    /**
+     * Tests issue 13351
+     *
+     * @link https://github.com/phalcon/cphalcon/issues/13351
+     * @author Zamrony P. Juhara <zamronypj@yahoo.com>
+     * @since  2018-04-27
+     */
+    public function testIssue13351MergeNonZeroBasedNumericKey()
+    {
+        $config = new Config([1 => 'Apple']);
+        $config2 = new Config([2 => 'Banana']);
+        $config->merge($config2);
+        expect($config->toArray())->equals(
+            [
+                1 => 'Apple',
+                2 => 'Banana',
+            ]
+        );
+
+        $config = new Config([0 => 'Apple']);
+        $config2 = new Config([1 => 'Banana']);
+        $config->merge($config2);
+        expect($config->toArray())->equals(
+            [
+                0 => 'Apple',
+                1 => 'Banana',
+            ]
+        );
+
+        $config = new Config([1 => 'Apple', 'p' => 'Pineapple']);
+        $config2 = new Config([2 => 'Banana']);
+        $config->merge($config2);
+        expect($config->toArray())->equals(
+            [
+                1 => 'Apple',
+                'p' => 'Pineapple',
+                2 => 'Banana',
+            ]
+        );
+
+        $config  = new Config([
+            'One' => [1 => 'Apple', 'p' => 'Pineapple'],
+            'Two' => [1 => 'Apple'],
+        ]);
+        $config2 = new Config([
+            'One' => [2 => 'Banana'],
+            'Two' => [2 => 'Banana'],
+        ]);
+        $config->merge($config2);
+        expect($config->toArray())->equals(
+            [
+                'One' => [1 => 'Apple', 'p' => 'Pineapple', 2 => 'Banana'],
+                'Two' => [1 => 'Apple', 2 => 'Banana'],
+            ]
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #13351

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Numeric config properties can now be merged properly

Thanks

