### PR TITLE
Method to check if relationship was loaded for 4.0.x

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -16,6 +16,7 @@
 - Added global setting `orm.case_insensitive_column_map` to attempt to find value in the column map case-insensitively. Can be also enabled by setting `caseInsensitiveColumnMap` key in `\Phalcon\Mvc\Model::setup()`. [#11802](https://github.com/phalcon/cphalcon/pull/11802)
 - Added `Phalcon\Mvc\Model\Query\BuilderInterface::offset` [#13599](https://github.com/phalcon/cphalcon/pull/13599)
 - Added `Phalcon\Http\Response\Cookies::getCookies` [#13591](https://github.com/phalcon/cphalcon/pull/13591)
+- Added `Phalcon\Mvc\Model::isRelationshipLoaded` to check if relationship is loaded
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [PR-13456](https://github.com/phalcon/cphalcon/pull/13456)

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -267,11 +267,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 				let this->{lowerProperty} = result;
 
 				/**
-				 * For belongs-to relations we store the object in the related bag
+				 * We store relationship objects in the related bag
 				 */
-				if result instanceof ModelInterface {
-					let this->_related[lowerProperty] = result;
-				}
+				let this->_related[lowerProperty] = result;
 			}
 
 			return result;
@@ -1567,6 +1565,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		 * Call the 'getRelationRecords' in the models manager
 		 */
 		return manager->getRelationRecords(relation, null, this, arguments);
+	}
+
+	public function isRelationshipLoaded(string relationshipAlias) -> boolean
+	{
+		return isset this->_related[relationshipAlias];
 	}
 
 	/**

--- a/tests/_data/models/AlbumORama/Albums.php
+++ b/tests/_data/models/AlbumORama/Albums.php
@@ -32,7 +32,7 @@ class Albums extends Model
     {
         $this->belongsTo(
             'artists_id',
-            'AlbumORama:Artists',
+            Artists::class,
             'id',
             ['alias' => 'artist']
         );

--- a/tests/_data/models/AlbumORama/Artists.php
+++ b/tests/_data/models/AlbumORama/Artists.php
@@ -28,7 +28,7 @@ class Artists extends Model
     {
         $this->hasMany(
             'id',
-            'AlbumORama:Albums',
+            Albums::class,
             'artists_id',
             ['alias' => 'albums']
         );

--- a/tests/unit/Mvc/Model/RelationsTest.php
+++ b/tests/unit/Mvc/Model/RelationsTest.php
@@ -9,6 +9,7 @@ use Phalcon\Test\Module\UnitTest;
 use Phalcon\Test\Models\Language;
 use Phalcon\Test\Models\LanguageI18n;
 use Phalcon\Mvc\Model\Resultset\Simple;
+use Phalcon\Test\Models\AlbumORama;
 
 class RelationsTest extends UnitTest
 {
@@ -59,5 +60,29 @@ class RelationsTest extends UnitTest
         $di = Di::getDefault();
 
         return $di->getShared('modelsManager');
+    }
+
+    public function testRelationshipLoaded()
+    {
+        $this->specify(
+            'Unable to test if "hasMany" relationship exist',
+            function () {
+                $hasManyModel = AlbumORama\Artists::findFirst();
+                expect($hasManyModel->isRelationshipLoaded('albums'))->equals(false);
+                $hasManyModel->albums;
+                expect($hasManyModel->isRelationshipLoaded('albums'))->equals(true);
+            }
+        );
+
+        $this->specify(
+            'Unable to test if "belongsTo" relationship exist',
+            function () {
+                
+                $belongsToModel = AlbumORama\Albums::findFirst();
+                expect($belongsToModel->isRelationshipLoaded('artist'))->equals(false);
+                $belongsToModel->artist;
+                expect($belongsToModel->isRelationshipLoaded('artist'))->equals(true);
+            }
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to -issue- existing pull request: https://github.com/phalcon/cphalcon/pull/12772

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: This pull request adds a method to check if a relationship is loaded. It also changes the way we cache relationships. For _some_ reason we only stored `hasOne` and `belongsTo` relationships (those that return a model). Now we store resultset as well, which enables caching for `hasMany`, `hasManyToMany` etc.

Co-authored-by: Erik Wiesenthal <erikforo@hotmail.com>

Thanks

