### PR TITLE
[NFR] Added events response:beforeSendHeaders, response:afterSendHeaders

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -21,6 +21,7 @@
 - Added `Phalcon\Mvc\Model::isRelationshipLoaded` to check if relationship is loaded
 - Added an easy way to work with Phalcon and run the tests locally, using [nanobox.io](https://nanobox.io) [#13578](https://github.com/phalcon/cphalcon/issues/13578)
 - Added response handler to `Phalcon\Mvc\Micro`, `Phalcon\Mvc\Micro::setResponseHandler`, to allow use of a custom response handler. [#12452](https://github.com/phalcon/cphalcon/pull/12452)
+- Added two new events `response::beforeSendHeaders` and `response::afterSendHeaders` to `Phalcon\Http\Response` [#10689](https://github.com/phalcon/cphalcon/issue/10689)
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [PR-13456](https://github.com/phalcon/cphalcon/pull/13456)

--- a/phalcon/http/response.zep
+++ b/phalcon/http/response.zep
@@ -630,7 +630,7 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
 	/**
 	 * Sends headers to the client
 	 */
-	public function sendHeaders() -> <Response> | boolean
+	public function sendHeaders() -> <ResponseInterface> | boolean
 	{
 		var headers, eventsManager;
 


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #10689
* Link to existing PR: https://github.com/phalcon/cphalcon/pull/10884

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Updated existing pull request to 4.0.x branch. >>Added events `response:beforeSendHeaders` and `response:afterSendHeaders` to `Phalcon\Http`Response`

Thanks