### PR TITLE
Added HTML escaping to Phalcon\Tag::textArea

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -38,6 +38,7 @@
 - Fixed  `\Phalcon\Http\Response::setFileToSend` filename last much _ 
 - Changed `Phalcon\Tag::getTitle()`. It returns only the text. It accepts `prepend`, `append` booleans to prepend or append the relevant text to the title. [#13547](https://github.com/phalcon/cphalcon/issues/13547) 
 - Changed `Phalcon\Di\Service` constructor to no longer takes the name of the service.
+- Changed `Phalon\Tag::textArea` to use `htmlspecialchars` to prevent XSS injection. [#12428](https://github.com/phalcon/cphalcon/issues/12428)
 
 ## Removed
 - PHP < 7.0 no longer supported

--- a/phalcon/tag.zep
+++ b/phalcon/tag.zep
@@ -1014,7 +1014,7 @@ class Tag
 		}
 
 		let code = self::renderAttributes("<textarea", params),
-			code .= ">" . content . "</textarea>";
+			code .= ">" . htmlspecialchars(content) . "</textarea>";
 
 		return code;
 	}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12428

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Textarea content is passed through `htmlspecialchars` before it's outputted to prevent XSS as explained in #12428.

Thanks

