### PR TITLE
Add getStatusCode(): int in Phalcon\Http\ResponseInterface

### DIFF
--- a/phalcon/http/responseinterface.zep
+++ b/phalcon/http/responseinterface.zep
@@ -35,6 +35,11 @@ interface ResponseInterface
 	 */
 	public function setStatusCode(int code, string message = null) -> <ResponseInterface>;
 
+    /**
+     * Returns the status code
+     */
+	public function getStatusCode() -> int | null;
+
 	/**
 	 * Returns headers set by the user
 	 */


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13618

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.

Small description of change:

Add getStatusCode() in Phalcon\Http\ResponseInterface.

Thanks

