### PR TITLE
Prevent overwrite _sqlColumnAliases by sub-queries, in Phalcon\Mvc\Model\Query

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -45,6 +45,7 @@
 - Changed `Phalon\Tag::textArea` to use `htmlspecialchars` to prevent XSS injection. [#12428](https://github.com/phalcon/cphalcon/issues/12428)
 - Changed `Phalon\Cache\Backend\*::get` to use only positive numbers for `lifetime`
 - Changed `Phalcon\Logger` to comply with PSR-3. The component has been rewritten to use adapters that alllow logging to different areas. The [#13438](https://github.com/phalcon/cphalcon/issues/13438)
+- Scope SQL Column Aliases (on nesting level), in `Phalcon\Mvc\Model\Query`, to prevent overwrite _root_ query's `_sqlColumnAliases` by sub-queries. [#13006](https://github.com/phalcon/cphalcon/issues/13006), [#12548](https://github.com/phalcon/cphalcon/issues/12548) and [#1731](https://github.com/phalcon/cphalcon/issues/1731)
 
 ## Removed
 - PHP < 7.0 no longer supported


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: 
  * https://github.com/phalcon/cphalcon/issues/13006
  * https://github.com/phalcon/cphalcon/issues/12548
  * https://github.com/phalcon/cphalcon/issues/1731

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

In order to prevent the SQL Column Aliases override in _root_ select, by the sub-queries, I have scoped the sub-queries aliases into another entries in `_sqlColumnAliases`, which is now and array of set-of-aliases entries. The `_sqlColumnAliases[0]` contains the aliases of the root query, the `_sqlColumnAliases[1]` contains the set of aliases of the _last_ parsed sub-query on level 1, and so on.

Thanks