### PR TITLE
Security Token Retention [PR#12518] and Fixed Security Tests

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -21,6 +21,7 @@
 - Added `Phalcon\Mvc\Model::isRelationshipLoaded` to check if relationship is loaded
 - Added an easy way to work with Phalcon and run the tests locally, using [nanobox.io](https://nanobox.io) [#13578](https://github.com/phalcon/cphalcon/issues/13578)
 - Added response handler to `Phalcon\Mvc\Micro`, `Phalcon\Mvc\Micro::setResponseHandler`, to allow use of a custom response handler. [#12452](https://github.com/phalcon/cphalcon/pull/12452)
+- Added a retainer for the current token to be used during the checkings, so when `Phalcon\Security::getToken` is called the token used for checkings don't change. [#12392](https://github.com/phalcon/cphalcon/issues/12392)
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [PR-13456](https://github.com/phalcon/cphalcon/pull/13456)

--- a/phalcon/security.zep
+++ b/phalcon/security.zep
@@ -60,6 +60,8 @@ class Security implements InjectionAwareInterface
 
 	protected _tokenKey;
 
+	protected _requestToken;
+
 	protected _random;
 
 	protected _defaultHash;
@@ -343,6 +345,7 @@ class Security implements InjectionAwareInterface
 		var dependencyInjector, session;
 
 		if null === this->_token {
+			let this->_requestToken = this->getSessionToken();
 			let this->_token = this->_random->base64Safe(this->_numberBytes);
 
 			let dependencyInjector = <DiInterface> this->_dependencyInjector;
@@ -390,7 +393,7 @@ class Security implements InjectionAwareInterface
 			/**
 			 * We always check if the value is correct in post
 			 */
-			let userToken = request->getPost(tokenKey);
+			let userToken = (string) request->getPost(tokenKey);
 		} else {
 			let userToken = tokenValue;
 		}
@@ -398,7 +401,7 @@ class Security implements InjectionAwareInterface
 		/**
 		 * The value is the same?
 		 */
-		let knownToken = session->get(this->_tokenValueSessionID);
+		let knownToken = this->getRequestToken();
 		let equals = hash_equals(knownToken, userToken);
 
 		/**
@@ -409,6 +412,17 @@ class Security implements InjectionAwareInterface
 		}
 
 		return equals;
+	}
+
+	/**
+	 * Returns the value of the CSRF token for the current request.
+	 */
+	public function getRequestToken() -> string
+	{
+		if empty this->_requestToken {
+			return this->getSessionToken();                    
+		}
+		return this->_requestToken;
 	}
 
 	/**
@@ -449,6 +463,7 @@ class Security implements InjectionAwareInterface
 
 		let this->_token = null;
 		let this->_tokenKey = null;
+		let this->_requestToken = null;
 
 		return this;
 	}

--- a/phalcon/security.zep
+++ b/phalcon/security.zep
@@ -393,7 +393,7 @@ class Security implements InjectionAwareInterface
 			/**
 			 * We always check if the value is correct in post
 			 */
-			let userToken = (string) request->getPost(tokenKey);
+			let userToken = request->getPost(tokenKey, "string");
 		} else {
 			let userToken = tokenValue;
 		}

--- a/tests/unit/Security/SecurityCest.php
+++ b/tests/unit/Security/SecurityCest.php
@@ -249,4 +249,37 @@ class SecurityCest
         $security->setDefaultHash(Security::CRYPT_SHA512);
         $I->assertTrue($security->checkHash($password, $security->hash($password)));
     }
+
+    public function testRequestToken(UnitTester $I)
+    {
+        $di = $this->getDI();
+        // Initialize session.
+        $security = new Security();
+        $security->setDI($di);
+        $security->getToken();
+        // Reinitialize object like if it's a new request.
+        $security = new Security();
+        $security->setDI($di);
+
+        $requestToken = $security->getRequestToken();
+        $sessionToken = $security->getSessionToken();
+        $tokenKey = $security->getTokenKey();
+        $token = $security->getToken();
+        
+        $I->assertEquals($sessionToken, $requestToken);
+        $I->assertNotEquals($token, $sessionToken);
+        $I->assertEquals($security->getRequestToken(), $requestToken);
+        $I->assertNotEquals($token, $security->getRequestToken());
+
+        $_POST = [$tokenKey => $requestToken];
+        $I->assertTrue($security->checkToken(null, null, false));
+        
+        $_POST = [$tokenKey => $token];
+        $I->assertFalse($security->checkToken(null, null, false));
+        
+        $I->assertFalse($security->checkToken());
+        
+        $security->destroyToken();
+        $I->assertNotEquals($security->getRequestToken(), $requestToken);
+    }
 }

--- a/tests/unit/Security/SecurityCest.php
+++ b/tests/unit/Security/SecurityCest.php
@@ -28,10 +28,13 @@ class SecurityCest
     {
         $I->checkExtensionIsLoaded('openssl');
 
-        $this->newDi();
+        $this->setNewFactoryDefault();
 //        $this->setDiEscaper();
 //        $this->setDiUrl();
         $this->setDiSession();
+
+        $_SESSION = [];
+        global $_SESSION;
     }
 
     /**
@@ -119,10 +122,6 @@ class SecurityCest
      */
     public function testOneTokenPerRequest(UnitTester $I)
     {
-        /**
-         * @TODO - Check Segfault
-         */
-        $I->skipTest('TODO: Check segfault');
         $container = $this->getDi();
         $security  = new Security();
         $security->setDI($container);
@@ -150,7 +149,7 @@ class SecurityCest
 
         $expected = $token;
         $actual   = $security->getToken();
-        $I->asserNottEquals($expected, $actual);
+        $I->assertNotEquals($expected, $actual);
 
         $expected = $token;
         $actual   = $security->getSessionToken();
@@ -164,10 +163,6 @@ class SecurityCest
      */
     public function testCheckToken(UnitTester $I)
     {
-        /**
-         * @TODO - Check Segfault
-         */
-        $I->skipTest('TODO: Check segfault');
         $container = $this->getDi();
         $security  = new Security();
         $security->setDI($container);
@@ -252,15 +247,18 @@ class SecurityCest
 
     public function testRequestToken(UnitTester $I)
     {
-        $di = $this->getDI();
+        $container = $this->getDI();
+
         // Initialize session.
         $security = new Security();
-        $security->setDI($di);
+        $security->setDI($container);
+
+        $tokenKey = $security->getTokenKey();
         $security->getToken();
+
         // Reinitialize object like if it's a new request.
         $security = new Security();
-        $security->setDI($di);
-
+        $security->setDI($container);
         $requestToken = $security->getRequestToken();
         $sessionToken = $security->getSessionToken();
         $tokenKey = $security->getTokenKey();


### PR DESCRIPTION
Hello!

* Type: cherry-picked existing PR
* Link to PR: [#12518](https://github.com/phalcon/cphalcon/pull/12518)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Created a retainer for the current session token in order to not break checkToken functionality if getToken is called before. Also fixed the security tests segmentation faults.

Thanks