### PR TITLE
PostgreSQL. Duplicate table: 7 ERROR: relation" PRIMARY "already exists" 4.0.x

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -55,6 +55,7 @@
 - Changed `paginate()` in the place of `getPaginate`. Added `previous` in the place of `before`. [#13492](https://github.com/phalcon/cphalcon/issues/13492)
 - Scope SQL Column Aliases (on nesting level), in `Phalcon\Mvc\Model\Query`, to prevent overwrite _root_ query's `_sqlColumnAliases` by sub-queries. [#13006](https://github.com/phalcon/cphalcon/issues/13006), [#12548](https://github.com/phalcon/cphalcon/issues/12548) and [#1731](https://github.com/phalcon/cphalcon/issues/1731)
 - CLI parameters now work like MVC parameters [#12375](https://github.com/phalcon/cphalcon/pull/12375)
+- Changed `Phalcon\Db\Dialect\Postgresql::addPrimaryKey` to make primary key contraints names unique by prefixing them with the table name. [#12629](https://github.com/phalcon/cphalcon/pull/12629)
 
 ## Removed
 - PHP < 7.2 no longer supported

--- a/phalcon/db/dialect/postgresql.zep
+++ b/phalcon/db/dialect/postgresql.zep
@@ -282,7 +282,7 @@ class Postgresql extends Dialect
 	 */
 	public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> string
 	{
-		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD CONSTRAINT \"PRIMARY\" PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
+		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD CONSTRAINT \"" . tableName . "_PRIMARY\" PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
 	}
 
 	/**
@@ -290,7 +290,7 @@ class Postgresql extends Dialect
 	 */
 	public function dropPrimaryKey(string! tableName, string! schemaName) -> string
 	{
-		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP CONSTRAINT \"PRIMARY\"";
+		return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP CONSTRAINT \"" . tableName . "_PRIMARY\"";
 	}
 
 	/**

--- a/tests/integration/Db/Dialect/Postgresql/AddIndexCest.php
+++ b/tests/integration/Db/Dialect/Postgresql/AddIndexCest.php
@@ -52,8 +52,8 @@ class AddIndexCest
             ['schema', 'index1', 'CREATE INDEX "index1" ON "schema"."table" ("column1")'],
             ['', 'index2', 'CREATE INDEX "index2" ON "table" ("column1", "column2")'],
             ['schema', 'index2', 'CREATE INDEX "index2" ON "schema"."table" ("column1", "column2")'],
-            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
-            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
+            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
+            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
             ['', 'index4', 'CREATE UNIQUE INDEX "index4" ON "table" ("column4")'],
             ['schema', 'index4', 'CREATE UNIQUE INDEX "index4" ON "schema"."table" ("column4")'],
         ];

--- a/tests/integration/Db/Dialect/Postgresql/AddPrimaryKeyCest.php
+++ b/tests/integration/Db/Dialect/Postgresql/AddPrimaryKeyCest.php
@@ -48,8 +48,8 @@ class AddPrimaryKeyCest
     protected function getAddPrimaryKeyFixtures(): array
     {
         return [
-            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
-            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
+            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
+            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
         ];
     }
 }

--- a/tests/integration/Db/Dialect/PostgresqlCest.php
+++ b/tests/integration/Db/Dialect/PostgresqlCest.php
@@ -242,8 +242,8 @@ class PostgresqlCest extends DialectBase
             ['schema', 'index1', 'CREATE INDEX "index1" ON "schema"."table" ("column1")'],
             ['', 'index2', 'CREATE INDEX "index2" ON "table" ("column1", "column2")'],
             ['schema', 'index2', 'CREATE INDEX "index2" ON "schema"."table" ("column1", "column2")'],
-            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
-            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
+            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
+            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
             ['', 'index4', 'CREATE UNIQUE INDEX "index4" ON "table" ("column4")'],
             ['schema', 'index4', 'CREATE UNIQUE INDEX "index4" ON "schema"."table" ("column4")'],
         ];
@@ -255,8 +255,8 @@ class PostgresqlCest extends DialectBase
     protected function getAddPrimaryKeyFixtures(): array
     {
         return [
-            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
-            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "PRIMARY" PRIMARY KEY ("column3")'],
+            ['', 'PRIMARY', 'ALTER TABLE "table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
+            ['schema', 'PRIMARY', 'ALTER TABLE "schema"."table" ADD CONSTRAINT "table_PRIMARY" PRIMARY KEY ("column3")'],
         ];
     }
 
@@ -615,8 +615,8 @@ class PostgresqlCest extends DialectBase
     protected function getDropPrimaryKeyFixtures(): array
     {
         return [
-            ['', 'ALTER TABLE "table" DROP CONSTRAINT "PRIMARY"'],
-            ['schema', 'ALTER TABLE "schema"."table" DROP CONSTRAINT "PRIMARY"'],
+            ['', 'ALTER TABLE "table" DROP CONSTRAINT "table_PRIMARY"'],
+            ['schema', 'ALTER TABLE "schema"."table" DROP CONSTRAINT "table_PRIMARY"'],
         ];
     }
 


### PR DESCRIPTION
CONSTRAINT must be unique

Hello!

Type: bug fix
Link to existing PR: [#12629](https://github.com/phalcon/cphalcon/pull/12629)
In raising this pull request, I confirm the following:

- [x]  I have read and understood the Contributing Guidelines?
- [x] I have checked that another pull request for this purpose does not exist.
- [x]  I wrote some tests for this PR.
Small description of change:

Postgresql in CONSTRAINT must specify a unique name for this CONSTRAINT, otherwise it leads to mistakes.

> ERROR: SQLSTATE [42P07]: Duplicate table: 7 ERROR: relation" PRIMARY "already exists

Thanks