### PR TITLE
[4.0.x] Pagination supports optional aliases and Phalcon\Mvc\Model\Query\Builder supports bind params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ php_test_results_*.txt
 docker-compose.yml
 build/gccarch
 tests/_cache
+.zephir/
+.temp/

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -23,6 +23,8 @@
 - Added two new events `response::beforeSendHeaders` and `response::afterSendHeaders` to `Phalcon\Http\Response` [#10689](https://github.com/phalcon/cphalcon/issue/10689)
 - Added a retainer for the current token to be used during the checkings, so when `Phalcon\Security::getToken` is called the token used for checkings don't change. [#12392](https://github.com/phalcon/cphalcon/issues/12392)
 - Added `Phalcon\Html\Tag`, a component that creates HTML elements. It will replace `Phalcon\Tag` in a future version. This component does not use static method calls. [#12392](https://github.com/phalcon/cphalcon/issues/12392)
+- Added `Phalcon\Paginator\RepositoryInterface` for repository the current state of `paginator` and also optional sets the aliases for properties repository [#10985](https://github.com/phalcon/cphalcon/pull/10985), [#10957](https://github.com/phalcon/cphalcon/issues/10957)
+- Added bind support to `Phalcon\Mvc\Model\Query\Builder`. The Query Builder has the same methods as `Phalcon\Mvc\Model\Query`; `getBindParams`, `setBindParams`, `getBindTypes` and `setBindTypes`. [#13368](https://github.com/phalcon/cphalcon/issues/13368)
 
 ## Changed
 - By configuring `prefix` and `statsKey` the `Phalcon\Cache\Backend\Redis::queryKeys` no longer returns prefixed keys, now it returns original keys without prefix. [#13656](https://github.com/phalcon/cphalcon/pull/13656)

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -1537,4 +1537,61 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 		return this;
 	}
 
+	/**
+	 * Set default bind parameters
+	 */
+	public function setBindParams(array! bindParams, bool merge = false) -> <BuilderInterface>
+	{
+		var currentBindParams;
+
+		if merge {
+			let currentBindParams = this->_bindParams;
+			if typeof currentBindParams == "array" {
+				let this->_bindParams = currentBindParams + bindParams;
+			} else {
+				let this->_bindParams = bindParams;
+			}
+		} else {
+			let this->_bindParams = bindParams;
+		}
+
+		return this;
+	}
+
+	/**
+	 * Returns default bind params
+	 */
+	public function getBindParams() -> array
+	{
+		return this->_bindParams;
+	}
+
+	/**
+	 * Set default bind types
+	 */
+	public function setBindTypes(array! bindTypes, bool merge = false) -> <BuilderInterface>
+	{
+		var currentBindTypes;
+
+		if unlikely merge {
+			let currentBindTypes = this->_bindTypes;
+			if typeof currentBindTypes == "array" {
+				let this->_bindTypes = currentBindTypes + bindTypes;
+			} else {
+				let this->_bindTypes = bindTypes;
+			}
+		} else {
+			let this->_bindTypes = bindTypes;
+		}
+
+		return this;
+	}
+
+	/**
+	 * Returns default bind types
+	 */
+	public function getBindTypes() -> array
+	{
+		return this->_bindTypes;
+	}
 }

--- a/phalcon/mvc/model/query/builderinterface.zep
+++ b/phalcon/mvc/model/query/builderinterface.zep
@@ -202,6 +202,25 @@ interface BuilderInterface
 	/**
 	 * Sets an OFFSET clause
 	 */
-	 public function offset(int offset) -> <BuilderInterface>;
+	public function offset(int offset) -> <BuilderInterface>;
 
+	/**
+	 * Set default bind parameters
+	 */
+	public function setBindParams(array! bindParams, bool merge = false) -> <BuilderInterface>;
+
+	/**
+	 * Set default bind types
+	 */
+	public function setBindTypes(array! bindTypes, bool merge = false) -> <BuilderInterface>;
+	
+	/**
+	 * Returns default bind params
+	 */
+	public function getBindParams() -> array;
+
+	/**
+	 * Returns default bind types
+	 */
+	public function getBindTypes() -> array;
 }

--- a/phalcon/paginator/adapter.zep
+++ b/phalcon/paginator/adapter.zep
@@ -42,10 +42,17 @@ abstract class Adapter implements AdapterInterface
 	protected _repository;
 
 	/**
+	 * Configuration of paginator by model
+	 */
+	protected _config = null;
+
+	/**
 	 * Phalcon\Paginator\Adapter\Model constructor
 	 */
 	public function __construct(array! config)
 	{
+		let this->_config = config;
+
 		if isset config["limit"] {
 			this->setLimit(config["limit"]);
 		}

--- a/phalcon/paginator/adapter.zep
+++ b/phalcon/paginator/adapter.zep
@@ -36,11 +36,27 @@ abstract class Adapter implements AdapterInterface
 	protected _page = null;
 
 	/**
-	 * Get current rows limit
+	 * Repository for pagination
+	 * @var RepositoryInterface
 	 */
-	public function getLimit() -> int
+	private _repository;
+
+	/**
+	 * Phalcon\Paginator\Adapter\Model constructor
+	 */
+	public function __construct(array! config)
 	{
-		return this->_limitRows;
+		if isset config["limit"] {
+			this->setLimit(config["limit"]);
+		}
+
+		if isset config["page"] {
+			this->setCurrentPage(config["page"]);
+		}
+
+		if isset config["repository"] {
+			this->setRepository(config["repository"]);
+		}
 	}
 
 	/**
@@ -59,5 +75,38 @@ abstract class Adapter implements AdapterInterface
 	{
 		let this->_limitRows = limitRows;
 		return this;
+	}
+
+	/**
+	 * Get current rows limit
+	 */
+	public function getLimit() -> int
+	{
+		return this->_limitRows;
+	}
+
+	/**
+	 * Sets current repository for pagination
+	 */
+	public function setRepository(<RepositoryInterface> repository) -> <Adapter>
+	{
+		let this->_repository = repository;
+		return this;
+	}
+
+	/**
+	 * Gets current repository for pagination
+	 */
+	protected function getRepository(array properties = null) -> <RepositoryInterface>
+	{
+		if !this->_repository {
+			let this->_repository = new Repository();
+		}
+
+		if properties !== null {
+			this->_repository->setProperties(properties);
+		}
+
+		return this->_repository;
 	}
 }

--- a/phalcon/paginator/adapter.zep
+++ b/phalcon/paginator/adapter.zep
@@ -39,7 +39,7 @@ abstract class Adapter implements AdapterInterface
 	 * Repository for pagination
 	 * @var RepositoryInterface
 	 */
-	private _repository;
+	protected _repository;
 
 	/**
 	 * Phalcon\Paginator\Adapter\Model constructor
@@ -99,7 +99,7 @@ abstract class Adapter implements AdapterInterface
 	 */
 	protected function getRepository(array properties = null) -> <RepositoryInterface>
 	{
-		if !this->_repository {
+		if typeof this->_repository != "object" {
 			let this->_repository = new Repository();
 		}
 

--- a/phalcon/paginator/adapter/model.zep
+++ b/phalcon/paginator/adapter/model.zep
@@ -22,6 +22,7 @@ namespace Phalcon\Paginator\Adapter;
 
 use Phalcon\Paginator\Exception;
 use Phalcon\Paginator\Adapter;
+use Phalcon\Paginator\RepositoryInterface;
 
 /**
  * Phalcon\Paginator\Adapter\Model
@@ -55,25 +56,16 @@ class Model extends Adapter
 	 */
 	public function __construct(array! config)
 	{
-		var page, limit;
-
+		parent::__construct(config);
 		let this->_config = config;
-
-		if fetch limit, config["limit"] {
-			let this->_limitRows = limit;
-		}
-
-		if fetch page, config["page"] {
-			let this->_page = page;
-		}
 	}
 
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function paginate() -> <\stdClass>
+	public function getPaginate() -> <RepositoryInterface>
 	{
-		var config, items, pageItems, page;
+		var config, items, pageItems;
 		int pageNumber, show, n, start, lastShowPage,
 			i, next, totalPages, previous;
 
@@ -141,16 +133,16 @@ class Model extends Adapter
 			let previous = 1;
 		}
 
-		let page = new \stdClass(),
-			page->items = pageItems,
-			page->first = 1,
-			page->previous = previous,
-			page->current = pageNumber,
-			page->last = totalPages,
-			page->next = next,
-			page->total_items = n,
-			page->limit = this->_limitRows;
-
-		return page;
+		return this->getRepository([
+			RepositoryInterface::PROPERTY_ITEMS 		: pageItems,
+			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
+			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: n,
+			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
+			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : before,
+			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: pageNumber,
+			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
+			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages
+		]);
 	}
 }

--- a/phalcon/paginator/adapter/model.zep
+++ b/phalcon/paginator/adapter/model.zep
@@ -63,7 +63,7 @@ class Model extends Adapter
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <RepositoryInterface>
+	public function paginate() -> <RepositoryInterface>
 	{
 		var config, items, pageItems;
 		int pageNumber, show, n, start, lastShowPage,
@@ -135,11 +135,10 @@ class Model extends Adapter
 
 		return this->getRepository([
 			RepositoryInterface::PROPERTY_ITEMS 		: pageItems,
-			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
 			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: n,
 			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
 			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
-			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : before,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : previous,
 			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: pageNumber,
 			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
 			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages

--- a/phalcon/paginator/adapter/model.zep
+++ b/phalcon/paginator/adapter/model.zep
@@ -45,21 +45,6 @@ use Phalcon\Paginator\RepositoryInterface;
  */
 class Model extends Adapter
 {
-
-	/**
-	 * Configuration of paginator by model
-	 */
-	protected _config = null;
-
-	/**
-	 * Phalcon\Paginator\Adapter\Model constructor
-	 */
-	public function __construct(array! config)
-	{
-		parent::__construct(config);
-		let this->_config = config;
-	}
-
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */

--- a/phalcon/paginator/adapter/nativearray.zep
+++ b/phalcon/paginator/adapter/nativearray.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Paginator\Adapter;
 
 use Phalcon\Paginator\Exception;
 use Phalcon\Paginator\Adapter;
+use Phalcon\Paginator\RepositoryInterface;
 
 /**
  * Phalcon\Paginator\Adapter\NativeArray
@@ -56,25 +57,16 @@ class NativeArray extends Adapter
 	/**
 	 * Phalcon\Paginator\Adapter\NativeArray constructor
 	 */
-	public function __construct(array config)
+	public function __construct(array! config)
 	{
-		var page, limit;
-
+		parent::__construct(config);
 		let this->_config = config;
-
-		if fetch limit, config["limit"] {
-			let this->_limitRows = limit;
-		}
-
-		if fetch page, config["page"] {
-			let this->_page = page;
-		}
 	}
 
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function paginate() -> <\stdClass>
+	public function getPaginate() -> <RepositoryInterface>
 	{
 		var config, items, page;
 		int show, pageNumber, totalPages, number, previous, next;
@@ -123,16 +115,16 @@ class NativeArray extends Adapter
 			let previous = 1;
 		}
 
-		let page = new \stdClass(),
-			page->items = items,
-			page->first = 1,
-			page->previous = previous,
-			page->current = pageNumber,
-			page->last = totalPages,
-			page->next = next,
-			page->total_items = number,
-			page->limit = this->_limitRows;
-
-		return page;
+		return this->getRepository([
+			RepositoryInterface::PROPERTY_ITEMS 		: items,
+			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
+			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: number,
+			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
+			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : previous,
+			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: pageNumber,
+			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
+			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages
+		]);
 	}
 }

--- a/phalcon/paginator/adapter/nativearray.zep
+++ b/phalcon/paginator/adapter/nativearray.zep
@@ -66,9 +66,9 @@ class NativeArray extends Adapter
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <RepositoryInterface>
+	public function paginate() -> <RepositoryInterface>
 	{
-		var config, items, page;
+		var config, items;
 		int show, pageNumber, totalPages, number, previous, next;
 		double roundedTotal;
 
@@ -117,7 +117,6 @@ class NativeArray extends Adapter
 
 		return this->getRepository([
 			RepositoryInterface::PROPERTY_ITEMS 		: items,
-			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
 			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: number,
 			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
 			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,

--- a/phalcon/paginator/adapter/nativearray.zep
+++ b/phalcon/paginator/adapter/nativearray.zep
@@ -48,21 +48,6 @@ use Phalcon\Paginator\RepositoryInterface;
  */
 class NativeArray extends Adapter
 {
-
-	/**
-	 * Configuration of the paginator
-	 */
-	protected _config = null;
-
-	/**
-	 * Phalcon\Paginator\Adapter\NativeArray constructor
-	 */
-	public function __construct(array! config)
-	{
-		parent::__construct(config);
-		let this->_config = config;
-	}
-
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -69,20 +69,29 @@ class QueryBuilder extends Adapter
 	 */
 	public function __construct(array config)
 	{
-		parent::__construct(config);
+		var builder, limit, page, columns;
+
 		let this->_config = config;
 
-		if !isset config["builder"] {
+		if !fetch builder, config["builder"] {
 			throw new Exception("Parameter 'builder' is required");
 		}
 
-		if !isset config["limit"] {
+		if !fetch limit, config["limit"] {
 			throw new Exception("Parameter 'limit' is required");
 		}
 
-		this->setQueryBuilder(config["builder"]);
-	}
+		if fetch columns, config["columns"] {
+		    let this->_columns = columns;
+		}
 
+		this->setQueryBuilder(builder);
+		this->setLimit(limit);
+
+		if fetch page, config["page"] {
+			this->setCurrentPage(page);
+		}
+	}
 	/**
 	 * Get the current page number
 	 */
@@ -112,10 +121,10 @@ class QueryBuilder extends Adapter
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <RepositoryInterface>
+	public function paginate() -> <RepositoryInterface>
 	{
 		var originalBuilder, builder, totalBuilder, totalPages,
-			limit, numberPage, number, query, page, previous, items, totalQuery,
+			limit, numberPage, number, query, previous, items, totalQuery,
 			result, row, rowcount, next, sql, columns, db, hasHaving, hasGroup,
 			model, modelClass, dbService;
 
@@ -243,7 +252,6 @@ class QueryBuilder extends Adapter
 
 		return this->getRepository([
 			RepositoryInterface::PROPERTY_ITEMS 		: items,
-			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
 			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: rowcount,
 			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
 			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Paginator\Adapter;
 
 use Phalcon\Mvc\Model\Query\Builder;
 use Phalcon\Paginator\Adapter;
+use Phalcon\Paginator\RepositoryInterface;
 use Phalcon\Paginator\Exception;
 use Phalcon\Db;
 
@@ -68,28 +69,18 @@ class QueryBuilder extends Adapter
 	 */
 	public function __construct(array config)
 	{
-		var builder, limit, page, columns;
-
+		parent::__construct(config);
 		let this->_config = config;
 
-		if !fetch builder, config["builder"] {
+		if !isset config["builder"] {
 			throw new Exception("Parameter 'builder' is required");
 		}
 
-		if !fetch limit, config["limit"] {
+		if !isset config["limit"] {
 			throw new Exception("Parameter 'limit' is required");
 		}
 
-		if fetch columns, config["columns"] {
-		    let this->_columns = columns;
-		}
-
-		this->setQueryBuilder(builder);
-		this->setLimit(limit);
-
-		if fetch page, config["page"] {
-			this->setCurrentPage(page);
-		}
+		this->setQueryBuilder(config["builder"]);
 	}
 
 	/**
@@ -121,7 +112,7 @@ class QueryBuilder extends Adapter
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function paginate() -> <\stdClass>
+	public function getPaginate() -> <RepositoryInterface>
 	{
 		var originalBuilder, builder, totalBuilder, totalPages,
 			limit, numberPage, number, query, page, previous, items, totalQuery,
@@ -250,16 +241,16 @@ class QueryBuilder extends Adapter
 			let next = totalPages;
 		}
 
-		let page = new \stdClass(),
-			page->items = items,
-			page->first = 1,
-			page->previous = previous,
-			page->current = numberPage,
-			page->last = totalPages,
-			page->next = next,
-			page->total_items = rowcount,
-			page->limit = this->_limitRows;
-
-		return page;
+		return this->getRepository([
+			RepositoryInterface::PROPERTY_ITEMS 		: items,
+			RepositoryInterface::PROPERTY_TOTAL_PAGES	: totalPages,
+			RepositoryInterface::PROPERTY_TOTAL_ITEMS 	: rowcount,
+			RepositoryInterface::PROPERTY_LIMIT 		: this->_limitRows,
+			RepositoryInterface::PROPERTY_FIRST_PAGE 	: 1,
+			RepositoryInterface::PROPERTY_PREVIOUS_PAGE : previous,
+			RepositoryInterface::PROPERTY_CURRENT_PAGE 	: numberPage,
+			RepositoryInterface::PROPERTY_NEXT_PAGE 	: next,
+			RepositoryInterface::PROPERTY_LAST_PAGE 	: totalPages
+		]);
 	}
 }

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -50,11 +50,6 @@ use Phalcon\Db;
 class QueryBuilder extends Adapter
 {
 	/**
-	 * Configuration of paginator by model
-	 */
-	protected _config;
-
-	/**
 	 * Paginator's data
 	 */
 	protected _builder;
@@ -69,28 +64,23 @@ class QueryBuilder extends Adapter
 	 */
 	public function __construct(array config)
 	{
-		var builder, limit, page, columns;
-
-		let this->_config = config;
+		var builder, columns;
 
 		if !fetch builder, config["builder"] {
 			throw new Exception("Parameter 'builder' is required");
 		}
 
-		if !fetch limit, config["limit"] {
-			throw new Exception("Parameter 'limit' is required");
-		}
-
 		if fetch columns, config["columns"] {
 		    let this->_columns = columns;
 		}
+		
+		if !isset config["limit"] {
+			throw new Exception("Parameter 'limit' is required");
+		}
+
+		parent::__construct(config);
 
 		this->setQueryBuilder(builder);
-		this->setLimit(limit);
-
-		if fetch page, config["page"] {
-			this->setCurrentPage(page);
-		}
 	}
 	/**
 	 * Get the current page number

--- a/phalcon/paginator/adapter/querybuilder.zep
+++ b/phalcon/paginator/adapter/querybuilder.zep
@@ -65,6 +65,10 @@ class QueryBuilder extends Adapter
 	public function __construct(array config)
 	{
 		var builder, columns;
+		
+		if !isset config["limit"] {
+			throw new Exception("Parameter 'limit' is required");
+		}
 
 		if !fetch builder, config["builder"] {
 			throw new Exception("Parameter 'builder' is required");
@@ -72,10 +76,6 @@ class QueryBuilder extends Adapter
 
 		if fetch columns, config["columns"] {
 		    let this->_columns = columns;
-		}
-		
-		if !isset config["limit"] {
-			throw new Exception("Parameter 'limit' is required");
 		}
 
 		parent::__construct(config);

--- a/phalcon/paginator/adapterinterface.zep
+++ b/phalcon/paginator/adapterinterface.zep
@@ -34,7 +34,7 @@ interface AdapterInterface
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function paginate() -> <\stdClass>;
+	public function getPaginate() -> <PaginateInterface>;
 
 	/**
 	 * Set current rows limit

--- a/phalcon/paginator/adapterinterface.zep
+++ b/phalcon/paginator/adapterinterface.zep
@@ -34,7 +34,7 @@ interface AdapterInterface
 	/**
 	 * Returns a slice of the resultset to show in the pagination
 	 */
-	public function getPaginate() -> <PaginateInterface>;
+	public function paginate() -> <PaginateInterface>;
 
 	/**
 	 * Set current rows limit

--- a/phalcon/paginator/repository.zep
+++ b/phalcon/paginator/repository.zep
@@ -59,7 +59,7 @@ class Repository implements RepositoryInterface
 	{
 		return this->getProperty(self::PROPERTY_ITEMS, null);
 	}
-	
+
 	/**
 	 * {@inheritdoc}
 	 */
@@ -153,21 +153,6 @@ class Repository implements RepositoryInterface
 
 		if isset aliases[property] {
 			return aliases[property];
-		}
-
-		/**
-		 * Resolve legacy alias to maintain compatibility with version 2.0.x
-		 */
-		array legacyAliases = [
-			"first" 	: self::PROPERTY_FIRST_PAGE,
-			"before" 	: self::PROPERTY_PREVIOUS_PAGE,
-			"current" 	: self::PROPERTY_CURRENT_PAGE,
-			"next" 		: self::PROPERTY_NEXT_PAGE,
-			"last" 		: self::PROPERTY_LAST_PAGE
-		];
-
-		if isset legacyAliases[property] {
-			return legacyAliases[property];
 		}
 
 		return property;

--- a/phalcon/paginator/repository.zep
+++ b/phalcon/paginator/repository.zep
@@ -1,0 +1,183 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
+ +------------------------------------------------------------------------+
+ */
+namespace Phalcon\Paginator;
+
+/**
+ * Phalcon\Paginator\Repository
+ *
+ * Repository of current state Phalcon\Paginator\AdapterInterface::getPaginate()
+ */
+class Repository implements RepositoryInterface
+{
+	protected _properties = [];
+	protected _aliases = [];
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setProperties(array properties) -> <Repository>
+	{
+		let this->_properties = properties;
+		return this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function setAliases(array aliases) -> <Repository>
+	{
+		let this->_aliases = aliases;
+		return this;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getAliases() -> array
+	{
+		return this->_aliases;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getItems() -> var
+	{
+		return this->getProperty(self::PROPERTY_ITEMS, null);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getTotalPages() -> int
+	{
+		return this->getProperty(self::PROPERTY_TOTAL_PAGES, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getTotalItems() -> int
+	{
+		return this->getProperty(self::PROPERTY_TOTAL_ITEMS, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getLimit() -> int
+	{
+		return this->getProperty(self::PROPERTY_LIMIT, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getFirstPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_FIRST_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getPreviousPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_PREVIOUS_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getCurrentPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_CURRENT_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getNextPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_NEXT_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getLastPage() -> int
+	{
+		return this->getProperty(self::PROPERTY_LAST_PAGE, 0);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function __get(string property)
+	{
+		var method;
+		let method = "get" . camelize(this->getRealNameProperty(property));
+
+		if method_exists(this, method) {
+			return this->{method}();
+		}
+
+		/**
+		 * A notice is shown if the property is not defined
+		 */
+		trigger_error("Access to undefined property " . get_class(this) . "::" . property);
+		return null;
+	}
+
+	/**
+	 * Gets value of property by name
+	 */
+	protected function getProperty(string property, var defaultValue = null) -> var
+	{
+		return isset this->_properties[property] ? this->_properties[property] : defaultValue;
+	}
+
+	/**
+	 * Resolve legacy alias for compatibility with version 2.0.x
+	 */
+	protected function getRealNameProperty(string property) -> string
+	{
+		var aliases;
+		let aliases = this->getAliases();
+
+		if isset aliases[property] {
+			return aliases[property];
+		}
+
+		/**
+		 * Resolve legacy alias to maintain compatibility with version 2.0.x
+		 */
+		array legacyAliases = [
+			"first" 	: self::PROPERTY_FIRST_PAGE,
+			"before" 	: self::PROPERTY_PREVIOUS_PAGE,
+			"current" 	: self::PROPERTY_CURRENT_PAGE,
+			"next" 		: self::PROPERTY_NEXT_PAGE,
+			"last" 		: self::PROPERTY_LAST_PAGE
+		];
+
+		if isset legacyAliases[property] {
+			return legacyAliases[property];
+		}
+
+		return property;
+	}
+}

--- a/phalcon/paginator/repository.zep
+++ b/phalcon/paginator/repository.zep
@@ -59,15 +59,7 @@ class Repository implements RepositoryInterface
 	{
 		return this->getProperty(self::PROPERTY_ITEMS, null);
 	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function getTotalPages() -> int
-	{
-		return this->getProperty(self::PROPERTY_TOTAL_PAGES, 0);
-	}
-
+	
 	/**
 	 * {@inheritdoc}
 	 */
@@ -87,7 +79,7 @@ class Repository implements RepositoryInterface
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getFirstPage() -> int
+	public function getFirst() -> int
 	{
 		return this->getProperty(self::PROPERTY_FIRST_PAGE, 0);
 	}
@@ -95,7 +87,7 @@ class Repository implements RepositoryInterface
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getPreviousPage() -> int
+	public function getPrevious() -> int
 	{
 		return this->getProperty(self::PROPERTY_PREVIOUS_PAGE, 0);
 	}
@@ -103,7 +95,7 @@ class Repository implements RepositoryInterface
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getCurrentPage() -> int
+	public function getCurrent() -> int
 	{
 		return this->getProperty(self::PROPERTY_CURRENT_PAGE, 0);
 	}
@@ -111,7 +103,7 @@ class Repository implements RepositoryInterface
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getNextPage() -> int
+	public function getNext() -> int
 	{
 		return this->getProperty(self::PROPERTY_NEXT_PAGE, 0);
 	}
@@ -119,7 +111,7 @@ class Repository implements RepositoryInterface
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getLastPage() -> int
+	public function getLast() -> int
 	{
 		return this->getProperty(self::PROPERTY_LAST_PAGE, 0);
 	}

--- a/phalcon/paginator/repositoryinterface.zep
+++ b/phalcon/paginator/repositoryinterface.zep
@@ -1,0 +1,95 @@
+/*
+ +------------------------------------------------------------------------+
+ | Phalcon Framework                                                      |
+ +------------------------------------------------------------------------+
+ | Copyright (c) 2011-2015 Phalcon Team (http://www.phalconphp.com)       |
+ +------------------------------------------------------------------------+
+ | This source file is subject to the New BSD License that is bundled     |
+ | with this package in the file docs/LICENSE.txt.                        |
+ |                                                                        |
+ | If you did not receive a copy of the license and are unable to         |
+ | obtain it through the world-wide-web, please send an email             |
+ | to license@phalconphp.com so we can send you a copy immediately.       |
+ +------------------------------------------------------------------------+
+ | Authors: Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
+ +------------------------------------------------------------------------+
+ */
+namespace Phalcon\Paginator;
+
+/**
+ * Phalcon\Paginator\RepositoryInterface
+ *
+ * Interface for the repository of current state Phalcon\Paginator\AdapterInterface::getPaginate()
+ */
+interface RepositoryInterface
+{
+	const PROPERTY_ITEMS            = "items";
+	const PROPERTY_TOTAL_PAGES      = "total_pages";
+	const PROPERTY_TOTAL_ITEMS      = "total_items";
+	const PROPERTY_LIMIT            = "limit";
+	const PROPERTY_FIRST_PAGE       = "first_page";
+	const PROPERTY_PREVIOUS_PAGE    = "previous_page";
+	const PROPERTY_CURRENT_PAGE     = "current_page";
+	const PROPERTY_NEXT_PAGE        = "next_page";
+	const PROPERTY_LAST_PAGE        = "last_page";
+
+	/**
+	 * Sets values for properties of the repository
+	 */
+	public function setProperties(array properties) -> <RepositoryInterface>;
+
+	/**
+	 * Sets the aliases for properties repository
+	 */
+	public function setAliases(array aliases) -> <RepositoryInterface>;
+
+	/**
+	 * Gets the aliases for properties repository
+	 */
+	public function getAliases() -> array;
+
+	/**
+	 * Gets the items on the current page
+	 */
+	public function getItems() -> var;
+
+	/**
+	 * Gets the total number of pages
+	 */
+	public function getTotalPages() -> int;
+
+	/**
+	 * Gets the total number of items
+	 */
+	public function getTotalItems() -> int;
+
+	/**
+	 * Gets current rows limit
+	 */
+	public function getLimit() -> int;
+
+	/**
+	 * Gets number of the first page
+	 */
+	public function getFirstPage() -> int;
+
+	/**
+	 * Gets number of the previous page
+	 */
+	public function getPreviousPage() -> int;
+
+	/**
+	 * Gets number of the current page
+	 */
+	public function getCurrentPage() -> int;
+
+	/**
+		 * Gets number of the next page
+	 */
+	public function getNextPage() -> int;
+
+	/**
+	 * Gets number of the last page
+	 */
+	public function getLastPage() -> int;
+}

--- a/phalcon/paginator/repositoryinterface.zep
+++ b/phalcon/paginator/repositoryinterface.zep
@@ -12,7 +12,8 @@
  | to license@phalconphp.com so we can send you a copy immediately.       |
  +------------------------------------------------------------------------+
  | Authors: Stanislav Kiryukhin <korsar.zn@gmail.com>                     |
- +------------------------------------------------------------------------+
+ | Authors: Cameron Hall <me@chall.id.au>                                 |
+ +------------------------------------------------------------------------+ 
  */
 namespace Phalcon\Paginator;
 
@@ -24,14 +25,13 @@ namespace Phalcon\Paginator;
 interface RepositoryInterface
 {
 	const PROPERTY_ITEMS            = "items";
-	const PROPERTY_TOTAL_PAGES      = "total_pages";
 	const PROPERTY_TOTAL_ITEMS      = "total_items";
 	const PROPERTY_LIMIT            = "limit";
-	const PROPERTY_FIRST_PAGE       = "first_page";
-	const PROPERTY_PREVIOUS_PAGE    = "previous_page";
-	const PROPERTY_CURRENT_PAGE     = "current_page";
-	const PROPERTY_NEXT_PAGE        = "next_page";
-	const PROPERTY_LAST_PAGE        = "last_page";
+	const PROPERTY_FIRST_PAGE       = "first";
+	const PROPERTY_PREVIOUS_PAGE    = "previous";
+	const PROPERTY_CURRENT_PAGE     = "current";
+	const PROPERTY_NEXT_PAGE        = "next";
+	const PROPERTY_LAST_PAGE        = "last";
 
 	/**
 	 * Sets values for properties of the repository
@@ -54,11 +54,6 @@ interface RepositoryInterface
 	public function getItems() -> var;
 
 	/**
-	 * Gets the total number of pages
-	 */
-	public function getTotalPages() -> int;
-
-	/**
 	 * Gets the total number of items
 	 */
 	public function getTotalItems() -> int;
@@ -71,25 +66,25 @@ interface RepositoryInterface
 	/**
 	 * Gets number of the first page
 	 */
-	public function getFirstPage() -> int;
+	public function getFirst() -> int;
 
 	/**
 	 * Gets number of the previous page
 	 */
-	public function getPreviousPage() -> int;
+	public function getPrevious() -> int;
 
 	/**
 	 * Gets number of the current page
 	 */
-	public function getCurrentPage() -> int;
+	public function getCurrent() -> int;
 
 	/**
 		 * Gets number of the next page
 	 */
-	public function getNextPage() -> int;
+	public function getNext() -> int;
 
 	/**
 	 * Gets number of the last page
 	 */
-	public function getLastPage() -> int;
+	public function getLast() -> int;
 }

--- a/tests/integration/Paginator/Adapter/NativeArray/PaginateCest.php
+++ b/tests/integration/Paginator/Adapter/NativeArray/PaginateCest.php
@@ -12,7 +12,7 @@
 namespace Phalcon\Test\Integration\Paginator\Adapter\NativeArray;
 
 use Phalcon\Paginator\Adapter\NativeArray;
-use stdClass;
+use Phalcon\Paginator\Repository;
 use IntegrationTester;
 
 class PaginateCest
@@ -38,15 +38,14 @@ class PaginateCest
 
         $page = $paginator->paginate();
 
-        $expected = stdClass::class;
+        $expected = Repository::class;
         $I->assertInstanceOf($expected, $page);
 
-        $I->assertCount(25, $page->items);
-        $I->assertEquals(1, $page->previous);
-        $I->assertEquals(2, $page->next);
-        $I->assertEquals(2, $page->last);
-        $I->assertEquals(25, $page->limit);
-        $I->assertEquals(1, $page->current);
-        $I->assertEquals(30, $page->total_items);
+        $I->assertCount(25, $page->getItems());
+        $I->assertEquals($page->getPrevious(), 1);
+        $I->assertEquals($page->getNext(), 2);
+        $I->assertEquals($page->getLast(), 2);
+        $I->assertEquals($page->getLimit(), 25);
+        $I->assertEquals($page->getCurrent(), 1);
     }
 }

--- a/tests/integration/Paginator/Adapter/NativeArray/SetCurrentPageCest.php
+++ b/tests/integration/Paginator/Adapter/NativeArray/SetCurrentPageCest.php
@@ -12,7 +12,7 @@
 namespace Phalcon\Test\Integration\Paginator\Adapter\NativeArray;
 
 use Phalcon\Paginator\Adapter\NativeArray;
-use stdClass;
+use Phalcon\Paginator\Repository;
 use IntegrationTester;
 
 class SetCurrentPageCest
@@ -39,7 +39,7 @@ class SetCurrentPageCest
         $paginator->setCurrentPage(2);
         $page = $paginator->paginate();
 
-        $expected = stdClass::class;
+        $expected = Repository::class;
         $I->assertInstanceOf($expected, $page);
 
         $I->assertCount(10, $page->items);

--- a/tests/integration/Paginator/Adapter/RepositoryCest.php
+++ b/tests/integration/Paginator/Adapter/RepositoryCest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Integration\Paginator\Adapter;
+
+use IntegrationTester;
+
+class RepositoryCest
+{
+    /**
+     * Tests Phalcon\Paginator\Repository :: paginate()
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function testRepositoryPaginator(IntegrationTester $I)
+    {
+        $paginatorRepository = new \Phalcon\Paginator\Repository();
+        $paginatorRepository->setAliases([
+            'myFirstPage'   => $paginatorRepository::PROPERTY_FIRST_PAGE,
+            'myLastPage'    => $paginatorRepository::PROPERTY_LAST_PAGE,
+            'myCurrentPage' => $paginatorRepository::PROPERTY_CURRENT_PAGE,
+            'myLimit'       => $paginatorRepository::PROPERTY_LIMIT
+        ]);
+
+        $paginator = new \Phalcon\Paginator\Adapter\NativeArray([
+            'data' => array_fill(0, 30, 'banana'),
+            'limit'=> 25,
+            'page' => 1,
+            'repository' => $paginatorRepository
+        ]);
+
+        $page = $paginator->paginate();
+        $I->assertInstanceOf(\Phalcon\Paginator\Repository::class, $page);
+        // Test getters
+        $I->assertEquals(count($page->getItems()), 25);
+        $I->assertEquals($page->getPrevious(), 1);
+        $I->assertEquals($page->getNext(), 2);
+        $I->assertEquals($page->getLast(), 2);
+        $I->assertEquals($page->getLimit(), 25);
+        $I->assertEquals($page->getCurrent(), 1);
+        // Test aliases
+        $I->assertEquals($page->myLastPage, 2);
+        $I->assertEquals($page->myLimit, 25);
+        $I->assertEquals($page->myCurrentPage, 1);
+        $paginator->setCurrentPage(2);
+        $page = $paginator->paginate();
+        $I->assertInstanceOf(\Phalcon\Paginator\Repository::class, $page);
+        // Test magic getters
+        $I->assertEquals(count($page->items), 5);
+        $I->assertEquals($page->previous, 1);
+        $I->assertEquals($page->next, 2);
+        $I->assertEquals($page->last, 2);
+        $I->assertEquals($page->current, 2);
+        // Test aliases
+        $I->assertEquals($page->myLastPage, 2);
+        $I->assertEquals($page->myLimit, 25);
+        $I->assertEquals($page->myCurrentPage, 2);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/10957, https://github.com/phalcon/cphalcon/issues/13368
* Link to existing PR: https://github.com/phalcon/cphalcon/pull/10985

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: 
- Added `Phalcon\Paginator\RepositoryInterface` for repository the current state of `paginator` and also optional sets the aliases for properties repository. 
- Added bind support to `Phalcon\Mvc\Model\Query\Builder`. The Query Builder has the same methods as `Phalcon\Mvc\Model\Query`; `getBindParams`, `setBindParams`, `getBindTypes` and `setBindTypes`. [#13368](https://github.com/phalcon/cphalcon/issues/13368)

It is worth noting I made a few changes between the original PR https://github.com/phalcon/cphalcon/pull/10985 and this one. I've updated all the property names to what they were changes to in https://github.com/phalcon/cphalcon/issues/13492. I also turfed the `totalPages` property as it was made redundant by the pre-existing property `last`. 

All of the pagination adapter constructors received a spring clean as well.

Thanks 

