### PR TITLE
Update the nanobox config to mongo 4.0

### DIFF
--- a/tests/_ci/nanobox/boxfile.7.2.yml
+++ b/tests/_ci/nanobox/boxfile.7.2.yml
@@ -89,7 +89,7 @@ data.memcached:
   image: nanobox/memcached:1.4
 
 data.mongodb:
-  image: nanobox/mongodb:3.0
+  image: mongo:4.0
 
 data.mysql:
   image: nanobox/mysql:5.7

--- a/tests/_ci/nanobox/boxfile.7.3.yml
+++ b/tests/_ci/nanobox/boxfile.7.3.yml
@@ -89,7 +89,7 @@ data.memcached:
   image: nanobox/memcached:1.4
 
 data.mongodb:
-  image: nanobox/mongodb:3.0
+  image: mongo:4.0
 
 data.mysql:
   image: nanobox/mysql:5.7


### PR DESCRIPTION
Hello!

* Type: code quality

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.

Updating the included nanobox config to use the latest 4.0.x mongodb version (using the offical docker image) under the assumption that we should be testing in environments that include the latest mongo version rather than an out of date version.

Thanks

