### PR TITLE
Fixes #12975, #13477, #2374: allowEmptyStrings & skipAttributes repsect column mapping

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -148,3 +148,4 @@
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Models` magic method (setter) is fixed for arrays  [#13661](https://github.com/phalcon/cphalcon/issues/13661)
+- Fixed `Phalcon\Mvc\Model::skipAttributes` and `Phalcon\Mvc\Model::allowEmptyColumns` allowEmptyStrings & skipAttributes repsect the column mapping. [#12975](https://github.com/phalcon/cphalcon/issues/12975), [#13477](https://github.com/phalcon/cphalcon/issues/13477) 

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -3075,18 +3075,18 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 		 */
 		for field in attributes {
 
-			if !isset automaticAttributes[field] {
-
-				/**
-				 * Check if the model has a column map
-				 */
-				if typeof columnMap == "array" {
-					if !fetch attributeField, columnMap[field] {
-						throw new Exception("Column '" . field . "' isn't part of the column map");
-					}
-				} else {
-					let attributeField = field;
+			/**
+			 * Check if the model has a column map
+			 */
+			if typeof columnMap == "array" {
+				if !fetch attributeField, columnMap[field] {
+					throw new Exception("Column '" . field . "' isn't part of the column map");
 				}
+			} else {
+				let attributeField = field;
+			}
+
+			if !isset automaticAttributes[attributeField] {
 
 				/**
 				 * Check every attribute in the model except identity field
@@ -3274,7 +3274,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  		}
 
  		let dataTypes = metaData->getDataTypes(this),
-			 bindDataTypes = metaData->getBindTypes(this),
+			bindDataTypes = metaData->getBindTypes(this),
  			nonPrimary = metaData->getNonPrimaryKeyAttributes(this),
  			automaticAttributes = metaData->getAutomaticUpdateAttributes(this);
 
@@ -3289,7 +3289,18 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  		 */
  		for field in nonPrimary {
 
- 			if !isset automaticAttributes[field] {
+			/**
+			 * Check if the model has a column map
+			 */
+			if typeof columnMap == "array" {
+				if !fetch attributeField, columnMap[field] {
+					throw new Exception("Column '" . field . "' isn't part of the column map");
+				}
+			} else {
+				let attributeField = field;
+			}
+
+ 			if !isset automaticAttributes[attributeField] {
 
  				/**
  				 * Check a bind type for field to update
@@ -3298,16 +3309,6 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
  					throw new Exception("Column '" . field . "' have not defined a bind data type");
  				}
 
- 				/**
- 				 * Check if the model has a column map
- 				 */
- 				if typeof columnMap == "array" {
- 					if !fetch attributeField, columnMap[field] {
- 						throw new Exception("Column '" . field . "' isn't part of the column map");
- 					}
- 				} else {
- 					let attributeField = field;
- 				}
 
  				/**
  				 * Get the field's value
@@ -3939,20 +3940,21 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 				let error = false;
 				for field in notNull {
 
+					if typeof columnMap == "array" {
+						if !fetch attributeField, columnMap[field] {
+							throw new Exception("Column '" . field . "' isn't part of the column map");
+						}
+					} else {
+						let attributeField = field;
+					}
+
 					/**
 					 * We don't check fields that must be omitted
 					 */
-					if !isset automaticAttributes[field] {
+					if !isset automaticAttributes[attributeField] {
 
 						let isNull = false;
 
-						if typeof columnMap == "array" {
-							if !fetch attributeField, columnMap[field] {
-								throw new Exception("Column '" . field . "' isn't part of the column map");
-							}
-						} else {
-							let attributeField = field;
-						}
 
 						/**
 						 * Field is null when: 1) is not set, 2) is numeric but


### PR DESCRIPTION
allowEmptyStrings and skipAttributes will follow the column mapping from now on.

Hello!

* Type: bug fix
* Link to issue: #12975, #13477, #2374

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change: Moved the column mapping decision to before the field existence check.

Thanks

