### PR TITLE
Fixes #13464: httpOnly is no longer initialised with a value

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,7 +8,9 @@
 - Fixed session adapters to properly implement [`SessionHandlerInterface::write`](http://php.net/manual/en/sessionhandlerinterface.write.php)
 - Fixed `Phalcon\Session\Manager` to not interact with `$_SESSION` variable if the session has not been started [#13718](https://github.com/phalcon/cphalcon/issues/13718), [#13520](https://github.com/phalcon/cphalcon/issues/13520)
 - Fixed `Phalcon\Cli\Console` class not found error if handling the same module twice [#13724](https://github.com/phalcon/cphalcon/issues/13724)
-
+- Fixed `Phalcon\Cache\Backend\Libmemcached` returning "empty" values being as `null` when they could be `0`, `false` or empty `string`. [#13497](https://github.com/phalcon/cphalcon/issues/13497)
+- Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` building the incorrect code for the following tags; `select`, and `select_static` [#13459](https://github.com/phalcon/cphalcon/issues/13459)
+- 
 ## Changed
 - Changed the `Phalcon\Tag::renderTitle()` parameters such as `Phalcon\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)
 - Changed the `Phalcon\Html\Tag::renderTitle()` parameters such as `Phalcon\Html\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)
@@ -17,6 +19,7 @@
 - Changed the default action of `Phalcon\Acl\Memory`to be `Acl::DENY` instead of `Acl::ALLOW` [#13758](https://github.com/phalcon/cphalcon/pull/13758)
 - Changed `Phalcon\Mvc\User\Plugin` to `Phalcon\Plugin` [#13749](https://github.com/phalcon/cphalcon/pull/13749)
 - Changed `Phalcon\Exception` to implement `\Throwable` interface.[#13750](https://github.com/phalcon/cphalcon/pull/13758)
+- Changed `Phalcon\Http\Cookie`. The `httpOnly` property is no longer initialised with a value [#13464](https://github.com/phalcon/cphalcon/issues/13464)
 
 ## Removed
 - Removed `Phalcon\Mvc\User\Component`, `Phalcon\Mvc\User\Module` and `Phalcon\Mvc\User\Plugin` [#13749](https://github.com/phalcon/cphalcon/pull/13749)
@@ -142,9 +145,6 @@
 - Changed the `Phalcon\Session` namespace by refactoring the component. `Phalcon\Session\Manager` is now the single component offering session manipulation by using adapters. Each adapter implements PHP's `SessionHandlerInterface`. Available adapters are `Phalcon\Session\Adapter\Files`, `Phalcon\Session\Adapter\Libmemcached`, `Phalcon\Session\Adapter\Noop` and `Phalcon\Session\Adapter\Redis`.  [#12833](https://github.com/phalcon/cphalcon/issues/12833), [#11341](https://github.com/phalcon/cphalcon/issues/11341), [#13535](https://github.com/phalcon/cphalcon/issues/13535)
 - Fixed `Phalcon\Mvc\Models` magic method (setter) is fixed for arrays  [#13661](https://github.com/phalcon/cphalcon/issues/13661)
 - Fixed `Phalcon\Mvc\Model::skipAttributes` and `Phalcon\Mvc\Model::allowEmptyColumns` allowEmptyStrings & skipAttributes repsect the column mapping. [#12975](https://github.com/phalcon/cphalcon/issues/12975), [#13477](https://github.com/phalcon/cphalcon/issues/13477) 
-- Fixed `\Phalcon\Cache\Backend\Libmemcached` returning "empty" values being as `null` when they could be `0`, `false` or empty `string`. [#13497](https://github.com/phalcon/cphalcon/issues/13497)
-- Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` building the incorrect code for the following tags; `select`, and `select_static` [#13459](https://github.com/phalcon/cphalcon/issues/13459)
-
 ## Removed
 - PHP < 7.2 no longer supported
 - Removed `xcache` support from adapters [#13628](https://github.com/phalcon/cphalcon/pull/13628)

--- a/phalcon/http/cookie.zep
+++ b/phalcon/http/cookie.zep
@@ -48,7 +48,7 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 
 	protected _secure;
 
-	protected _httpOnly;
+	protected _httpOnly = false;
 
 	/**
 	 * The cookie's sign key.

--- a/phalcon/http/cookie.zep
+++ b/phalcon/http/cookie.zep
@@ -48,7 +48,7 @@ class Cookie implements CookieInterface, InjectionAwareInterface
 
 	protected _secure;
 
-	protected _httpOnly = true;
+	protected _httpOnly;
 
 	/**
 	 * The cookie's sign key.

--- a/tests/unit/Http/Cookie/CookieCest.php
+++ b/tests/unit/Http/Cookie/CookieCest.php
@@ -153,6 +153,7 @@ class CookieCest extends HttpBase
     public function testIssue13464(UnitTester $I)
     {
         $I->wantToTest("Issue #13464");
+        $I->checkExtensionIsLoaded('xdebug');
         
         $this->setDiCrypt();
         $container = $this->getDi();

--- a/tests/unit/Http/Cookie/CookieCest.php
+++ b/tests/unit/Http/Cookie/CookieCest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Phalcon\Test\Unit\Http;
+namespace Phalcon\Test\Unit\Http\Cookie;
 
 use Phalcon\Http\Cookie;
 use Phalcon\Http\Cookie\Exception;
@@ -148,24 +148,5 @@ class CookieCest extends HttpBase
         $cookies = new Cookies();
         $actual  = $cookies->send();
         $I->assertTrue($actual);
-    }
-
-    public function testIssue13464(UnitTester $I)
-    {
-        $I->wantToTest("Issue #13464");
-        $I->checkExtensionIsLoaded('xdebug');
-        
-        $this->setDiCrypt();
-        $container = $this->getDi();
-        
-        $cookie = new Cookies();
-        $cookie->setDI($container);
-        $cookie->useEncryption(false);
-        $cookie->set(__METHOD__, 'potato', time() + 86400, '/', false, 'localhost', false);
-        $cookie->send();
-
-        $cookie = $this->getCookie(__METHOD__);
-
-        $I->assertNotRegexp('/HttpOnly$/', $cookie);
     }
 }

--- a/tests/unit/Http/Cookie/CookieCest.php
+++ b/tests/unit/Http/Cookie/CookieCest.php
@@ -149,4 +149,22 @@ class CookieCest extends HttpBase
         $actual  = $cookies->send();
         $I->assertTrue($actual);
     }
+
+    public function testIssue13464(UnitTester $I)
+    {
+        $I->wantToTest("Issue #13464");
+        
+        $this->setDiCrypt();
+        $container = $this->getDi();
+        
+        $cookie = new Cookies();
+        $cookie->setDI($container);
+        $cookie->useEncryption(false);
+        $cookie->set(__METHOD__, 'potato', time() + 86400, '/', false, 'localhost', false);
+        $cookie->send();
+
+        $cookie = $this->getCookie(__METHOD__);
+
+        $I->assertNotRegexp('/HttpOnly$/', $cookie);
+    }
 }

--- a/tests/unit/Http/Response/Cookies/SetCest.php
+++ b/tests/unit/Http/Response/Cookies/SetCest.php
@@ -12,13 +12,27 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Http\Response\Cookies;
 
+use Phalcon\Test\Fixtures\Traits\CookieTrait;
+use Phalcon\Test\Unit\Http\Helper\HttpBase;
+use Phalcon\Http\Response\Cookies;
 use UnitTester;
 
 /**
  * Class SetCest
  */
-class SetCest
+class SetCest extends HttpBase
 {
+    use CookieTrait;
+
+    /**
+     * executed before each test
+     */
+    public function _before(UnitTester $I)
+    {
+        parent::_before($I);
+        $this->setDiSessionFiles();
+    }
+
     /**
      * Tests Phalcon\Http\Response\Cookies :: set()
      *
@@ -31,5 +45,39 @@ class SetCest
     {
         $I->wantToTest('Http\Response\Cookies - set()');
         $I->skipTest('Need implementation');
+    }
+
+    /**
+     * Tests Issue #13464
+     *
+     * @param UnitTester $I
+     *
+     * @author Cameron Hall <me@chall.id.au>
+     * @since  2019-01-20
+     * @issue https://github.com/phalcon/cphalcon/issues/13464
+     */
+    public function httpCookieSetHttpOnly(UnitTester $I)
+    {
+        $I->wantToTest("Issue #13464");
+        $I->checkExtensionIsLoaded('xdebug');
+
+        $this->setDiCrypt();
+        $container = $this->getDi();
+        
+        $cookie = new Cookies();
+        $cookie->setDI($container);
+        $cookie->useEncryption(false);
+        $cookie->set('cookie-1', 'potato', time() + 86400, '/', false, 'localhost', true);
+        $cookie->set('cookie-2', 'potato', time() + 86400, '/', false, 'localhost', false);
+        $cookie->set('cookie-3', 'potato', time() + 86400, '/', false, 'localhost');
+        $cookie->send();
+
+        $cookieOne = $this->getCookie('cookie-1');
+        $cookieTwo = $this->getCookie('cookie-2');
+        $cookieThree = $this->getCookie('cookie-3');
+
+        $I->assertRegexp('/HttpOnly$/', $cookieOne);
+        $I->assertNotRegexp('/HttpOnly$/', $cookieTwo);
+        $I->assertNotRegexp('/HttpOnly$/', $cookieThree);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13464

**In raising this pull request, I confirm the following (please check boxes):**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: httpOnly is no longer initialised with a value

Thanks

