### PR TITLE
Changed the Phalcon\Version::get() to follow semantic versioning

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,8 @@
-# [4.1.x](https://github.com/phalcon/cphalcon/releases/tag/v4.1.x) (2019-XX-XX)
-
+# [4.0.0-alpha.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.2) (2019-XX-XX)
+## Changed
+- Changed the `Phalcon\Tag::renderTitle()` parameters such as `Phalcon\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)
+- Changed the `Phalcon\Html\Tag::renderTitle()` parameters such as `Phalcon\Html\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)
+- Changed the `Phalcon\Version::get()` to follow [semantic versioning](https://semver.org/) [#13720](https://github.com/phalcon/cphalcon/pull/13720)
 
 # [4.0.0-alpha1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha1) (2018-12-25)
 ## Added
@@ -119,11 +122,9 @@
     - the `Phalcon\Session\Adapter\Files` using the name `session` 
     - the `Phalcon\Session\Bag` using the name `sessionBag` [#12921](https://github.com/phalcon/cphalcon/issues/12921)
   [#12921](https://github.com/phalcon/cphalcon/issues/12921)
-- Changed the `Phalcon\Session` namespace by refactoring the component. `Phalcon\Session\Manager` is now the single component offering session manipulation by using adapters. Each adapter implements PHP's `SessionHandlerInterface`. Available adapters are `Phalcon\Session\Files`, `Phalcon\Session\Libmemcached`, `Phalcon\Session\Noop` and `Phalcon\Session\Redis`.  [#12921](https://github.com/phalcon/cphalcon/issues/12833), (https://github.com/phalcon/cphalcon/issues/11341), (https://github.com/phalcon/cphalcon/issues/13535)
+- Changed the `Phalcon\Session` namespace by refactoring the component. `Phalcon\Session\Manager` is now the single component offering session manipulation by using adapters. Each adapter implements PHP's `SessionHandlerInterface`. Available adapters are `Phalcon\Session\Files`, `Phalcon\Session\Libmemcached`, `Phalcon\Session\Noop` and `Phalcon\Session\Redis`.  [#12833](https://github.com/phalcon/cphalcon/issues/12833), [#11341](https://github.com/phalcon/cphalcon/issues/11341), [#13535](https://github.com/phalcon/cphalcon/issues/13535)
 - Fixed `Phalcon\Mvc\Models` magic method (setter) is fixed for arrays  [#13661](https://github.com/phalcon/cphalcon/issues/13661)
 - Fixed `Phalcon\Mvc\Model::skipAttributes` and `Phalcon\Mvc\Model::allowEmptyColumns` allowEmptyStrings & skipAttributes repsect the column mapping. [#12975](https://github.com/phalcon/cphalcon/issues/12975), [#13477](https://github.com/phalcon/cphalcon/issues/13477) 
-- Changed the `Phalcon\Tag::renderTitle()` parameters such as `Phalcon\Tag::getTitle()`
-- Changed the `Phalcon\Html\Tag::renderTitle()` parameters such as `Phalcon\Html\Tag::getTitle()`
 
 ## Removed
 - PHP < 7.2 no longer supported

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.0.0-{build}
+version: 4.0.0-alpha.2+{build}
 
 environment:
     matrix:

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "name": "phalcon",
     "description": "Web framework delivered as a C-extension for PHP",
     "author": "Phalcon Team and contributors",
-    "version": "4.0.0-alpha1",
+    "version": "4.0.0-alpha.2",
     "verbose": false,
     "optimizer-dirs": [
         "optimizers"

--- a/phalcon/version.zep
+++ b/phalcon/version.zep
@@ -80,7 +80,7 @@ class Version
 	 * A - Major version
 	 * B - Med version (two digits)
 	 * C - Min version (two digits)
-	 * D - Special release: 1 = Alpha, 2 = Beta, 3 = RC, 4 = Stable
+	 * D - Special release: 1 = alpha, 2 = beta, 3 = RC, 4 = stable
 	 * E - Special release version i.e. RC1, Beta2 etc.
 	 */
 	protected static function _getVersion() -> array
@@ -138,10 +138,13 @@ class Version
 			 * A pre-release version should be denoted by appending a hyphen and a series
 			 * of dot separated identifiers immediately following the patch version.
 			 */
-			let result .= "-". suffix . "." .specialNumber;
+			let result .= "-". suffix;
+			if specialNumber != 0 {
+				let result .= "." . specialNumber;
+			}
 		}
 
-		return trim(result);
+		return result;
 	}
 
 	/**
@@ -184,7 +187,6 @@ class Version
 		let version = static::_getVersion();
 
 		switch part {
-
 			case self::VERSION_MAJOR:
 			case self::VERSION_MEDIUM:
 			case self::VERSION_MINOR:

--- a/phalcon/version.zep
+++ b/phalcon/version.zep
@@ -85,13 +85,11 @@ class Version
 	 */
 	protected static function _getVersion() -> array
 	{
-		return [4, 0, 0, 1, 0];
+		return [4, 0, 0, 1, 2];
 	}
 
 	/**
-	 * Translates a number to a special release
-	 *
-	 * If Special release = 1 this function will return ALPHA
+	 * Translates a number to a special release.
 	 */
 	protected final static function _getSpecial(int special) -> string
 	{
@@ -99,10 +97,10 @@ class Version
 
 		switch special {
 			case 1:
-				let suffix = "ALPHA";
+				let suffix = "alpha";
 				break;
 			case 2:
-				let suffix = "BETA";
+				let suffix = "beta";
 				break;
 			case 3:
 				let suffix = "RC";
@@ -132,11 +130,15 @@ class Version
 			special       = version[self::VERSION_SPECIAL],
 			specialNumber = version[self::VERSION_SPECIAL_NUMBER];
 
-		let result  = major . "." . medium . "." . minor . " ";
+		let result  = major . "." . medium . "." . minor;
 		let suffix  = static::_getSpecial(special);
 
 		if suffix != "" {
-			let result .= suffix . " " . specialNumber;
+			/**
+			 * A pre-release version should be denoted by appending a hyphen and a series
+			 * of dot separated identifiers immediately following the patch version.
+			 */
+			let result .= "-". suffix . "." .specialNumber;
 		}
 
 		return trim(result);

--- a/tests/_data/fixtures/Traits/VersionTrait.php
+++ b/tests/_data/fixtures/Traits/VersionTrait.php
@@ -20,7 +20,7 @@ namespace Phalcon\Test\Fixtures\Traits;
 trait VersionTrait
 {
     /**
-     * Translates a number to a special version string (ALPHA, BETA, RC)
+     * Translates a number to a special version string (alpha, beta, RC)
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
@@ -35,10 +35,10 @@ trait VersionTrait
 
         switch ($number) {
             case '1':
-                $special = 'ALPHA';
+                $special = 'alpha';
                 break;
             case '2':
-                $special = 'BETA';
+                $special = 'beta';
                 break;
             case '3':
                 $special = 'RC';
@@ -49,7 +49,7 @@ trait VersionTrait
     }
 
     /**
-     * Translates a special version (ALPHA, BETA, RC) to a version number
+     * Translates a special version (alpha, beta, RC) to a version number
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
@@ -61,10 +61,10 @@ trait VersionTrait
     protected function specialToNumber($input): string
     {
         switch ($input) {
-            case 'ALPHA':
+            case 'alpha':
                 $special = '1';
                 break;
-            case 'BETA':
+            case 'beta':
                 $special = '2';
                 break;
             case 'RC':

--- a/tests/unit/Version/GetCest.php
+++ b/tests/unit/Version/GetCest.php
@@ -54,7 +54,7 @@ class GetCest
         $special   = $this->numberToSpecial($id[5]);
         $specialNo = ($special) ? $id[6] : '';
 
-        $expected = trim("{$major}.{$med}.{$min} {$special} {$specialNo}");
+        $expected = trim("{$major}.{$med}.{$min}-{$special}.{$specialNo}");
         $actual   = Version::get();
         $I->assertEquals($expected, $actual);
     }

--- a/tests/unit/Version/GetIdCest.php
+++ b/tests/unit/Version/GetIdCest.php
@@ -48,15 +48,19 @@ class GetIdCest
     {
         $I->wantToTest('Version - get() to getId()');
         $version = Version::get();
-        $chunks  = explode(' ', $version);
+        $chunks  = explode('-', $version);
 
         $special   = '4';
         $specialNo = '0';
 
-        // There are special versions
+        // There are pre-release version parts (eg. 4.0.0-alpha.2)
         if (count($chunks) > 1) {
-            $specialNo = $chunks[2];
-            $special   = $this->specialToNumber($chunks[1]);
+            if (false === strpos($chunks[1], '.')) { // 4.0.0-alpha
+                $special = $this->specialToNumber($chunks[1]);
+            } else { // 4.0.0-alpha.2
+                $specialNo = substr($chunks[1], strpos($chunks[1], '.') + 1);
+                $special = $this->specialToNumber(substr($chunks[1], 0, strpos($chunks[1], '.')));
+            }
         }
 
         // Now the version itself


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md).
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Changed the `Phalcon\Version::get()` to follow [semantic versioning](https://semver.org/)

Thanks

