### PR TITLE
Fixed session adapters to properly implement SessionHandlerInterface::write

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -2,6 +2,9 @@
 ## Added
 - Added `notFound()` method in `Phalcon\Translate\Adapter\NativeArray` which returns the key requested if not found. The method can be overriden when extending the class, returning what the developer needs [#13007](https://github.com/phalcon/cphalcon/pull/13007)
 
+## Fixed
+- Fixed session adapters to properly implement [`SessionHandlerInterface::write`](http://php.net/manual/en/sessionhandlerinterface.write.php)
+
 ## Changed
 - Changed the `Phalcon\Tag::renderTitle()` parameters such as `Phalcon\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)
 - Changed the `Phalcon\Html\Tag::renderTitle()` parameters such as `Phalcon\Html\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)

--- a/phalcon/session/adapter/files.zep
+++ b/phalcon/session/adapter/files.zep
@@ -121,12 +121,12 @@ class Files extends Noop
 		return data;
 	}
 
-	public function write(var id, var data) -> void
+	public function write(var id, var data) -> bool
 	{
 		var name;
 
 		let name = this->path . this->getPrefixedName(id);
 
-		file_put_contents(name, data);
+		return false !== file_put_contents(name, data);
 	}
 }

--- a/phalcon/session/adapter/libmemcached.zep
+++ b/phalcon/session/adapter/libmemcached.zep
@@ -105,10 +105,10 @@ class Libmemcached extends Noop
 		return data;
 	}
 
-	public function write(var id, var data) -> void
+	public function write(var id, var data) -> bool
 	{
 		var name = this->getPrefixedName(id);
 
-		this->connection->save(name, data, this->ttl);
+		return this->connection->save(name, data, this->ttl);
 	}
 }

--- a/phalcon/session/adapter/noop.zep
+++ b/phalcon/session/adapter/noop.zep
@@ -115,8 +115,9 @@ class Noop extends Utility implements SessionHandlerInterface
 	/**
 	 * Write
 	 */
-	public function write(var id, var data) -> void
+	public function write(var id, var data) -> bool
 	{
+		return true;
 	}
 
 	/**

--- a/phalcon/session/adapter/redis.zep
+++ b/phalcon/session/adapter/redis.zep
@@ -83,10 +83,10 @@ use Phalcon\Cache\Frontend\None as FrontendNone;
 		return data;
 	}
 
-	public function write(var id, var data) -> void
+	public function write(var id, var data) -> bool
 	{
 		var name = this->getPrefixedName(id);
 
-		this->connection->save(name, data, this->ttl);
+		return this->connection->save(name, data, this->ttl);
 	}
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13718

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR

Small description of change:

Fixed session adapters to properly implement [`SessionHandlerInterface::write`](http://php.net/manual/en/sessionhandlerinterface.write.php).
```
session_write_close(): Session callback expects true/false return value
```

Thanks

