### PR TITLE
#13352: Select elements can now render without any options

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -10,6 +10,7 @@
 - Fixed `Phalcon\Cli\Console` class not found error if handling the same module twice [#13724](https://github.com/phalcon/cphalcon/issues/13724)
 - Fixed `Phalcon\Cache\Backend\Libmemcached` returning "empty" values being as `null` when they could be `0`, `false` or empty `string`. [#13497](https://github.com/phalcon/cphalcon/issues/13497)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall` building the incorrect code for the following tags; `select`, and `select_static` [#13459](https://github.com/phalcon/cphalcon/issues/13459)
+- Fixed `Phalcon\Tag\Select` not rendering without any options.
 - 
 ## Changed
 - Changed the `Phalcon\Tag::renderTitle()` parameters such as `Phalcon\Tag::getTitle()` [#13706](https://github.com/phalcon/cphalcon/pull/13706)

--- a/phalcon/tag/select.zep
+++ b/phalcon/tag/select.zep
@@ -127,8 +127,6 @@ abstract class Select
 				 * Create the SELECT's option from an array
 				 */
 				let code .= self::_optionsFromArray(options, value, "</option>" . PHP_EOL);
-			} else {
-				throw new Exception("Invalid data provided to SELECT helper");
 			}
 		}
 

--- a/tests/unit/Tag/SelectCest.php
+++ b/tests/unit/Tag/SelectCest.php
@@ -12,24 +12,56 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Tag;
 
+use Phalcon\Test\Fixtures\Helpers\TagSetup;
 use UnitTester;
 
 /**
  * Class SelectCest
  */
-class SelectCest
+class SelectCest extends TagSetup
 {
     /**
      * Tests Phalcon\Tag :: select()
      *
      * @param UnitTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Cameron Hall <me@chall.id.au>
+     * @since  2019-01-27
      */
     public function tagSelect(UnitTester $I)
     {
         $I->wantToTest('Tag - select()');
-        $I->skipTest('Need implementation');
+        
+        $this->testFieldParameter(
+            $I,
+            'select',
+            [
+                'potato',
+                [
+                    'Phalcon',
+                    'PHP'
+                ]
+            ],
+            "<select id=\"potato\" name=\"potato\">\n\t<option value=\"0\">Phalcon</option>\n\t<option value=\"1\">PHP</option>\n</select"
+        );
+    }
+
+    /**
+     * Tests Phalcon\Tag :: select() with no options
+     *
+     * @param UnitTester $I
+     *
+     * @author Cameron Hall <me@chall.id.au>
+     * @since  2019-01-27
+     *
+     * @issue https://github.com/phalcon/cphalcon/issues/13352
+     */
+    public function tagSelectWithNoOptions(UnitTester $I)
+    {
+        $I->wantToTest('Tag - select() with no options');
+
+        $this->testFieldParameter($I, 'select', [
+            'potato',
+        ], "<select id=\"potato\" name=\"potato\">\n</select");
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13352:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: Select tags can now render without any options

Thanks