### PR TITLE
Removed -march

### DIFF
--- a/build/install
+++ b/build/install
@@ -24,7 +24,7 @@
 
 # Check best compilation flags for GCC
 export CC="gcc"
-export CFLAGS="-march=native -mtune=native -O2 -fomit-frame-pointer"
+export CFLAGS="-mtune=native -O2 -fomit-frame-pointer"
 export CPPFLAGS="-DPHALCON_RELEASE"
 
 # Set defaults


### PR DESCRIPTION
Removed march to be cross cpu compatible. Mtune isn't used because of -march
Solves #13143

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Thanks

