### PR TITLE
Phalcon\Message MetaData

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Contributor Covenant Code of Conduct
 
-## TDLR
+## TL;DR
 
 Common sense rules. Treat people the same way you want to be treated. 
 

--- a/phalcon/messages/message.zep
+++ b/phalcon/messages/message.zep
@@ -40,14 +40,20 @@ class Message implements MessageInterface, \JsonSerializable
 	protected type;
 
 	/**
+	 * @var array
+	 */
+	protected metaData = [];
+
+	/**
 	 * Phalcon\Messages\Message constructor
 	 */
-	public function __construct(string! message, var field = "", string type = "", int code = 0)
+	public function __construct(string! message, var field = "", string type = "", int code = 0, array metaData = [])
 	{
-		let this->message = message,
-			this->field   = field,
-			this->type    = type,
-			this->code    = code;
+		let this->message  = message,
+			this->field    = field,
+			this->type     = type,
+			this->code     = code,
+			this->metaData = metaData;
 	}
 
 	/**
@@ -84,16 +90,25 @@ class Message implements MessageInterface, \JsonSerializable
 		return this->type;
 	}
 
+	/**
+	 * Returns message metadata
+	 */
+	public function getMetaData() -> array
+	{
+		return this->metaData;
+	}
+
     /**
     * Serializes the object for json_encode
     */
 	public function jsonSerialize() -> array
 	{
 		return [
-			"field"   : this->field,
-			"message" : this->message,
-			"type"    : this->type,
-			"code"    : this->code
+		   	"field"    : this->field,
+			"message"  : this->message,
+			"type"     : this->type,
+			"code"     : this->code,
+			"metaData" : this->metaData
 		];
 	}
 
@@ -134,6 +149,15 @@ class Message implements MessageInterface, \JsonSerializable
 	}
 
 	/**
+	 * Sets message metadata
+	 */
+	public function setMetaData(array! metaData) -> <MessageInterface>
+	{
+		let this->metaData = metaData;
+		return this;
+	}
+
+	/**
 	 * Magic __toString method returns verbose message
 	 */
 	public function __toString() -> string
@@ -146,6 +170,6 @@ class Message implements MessageInterface, \JsonSerializable
 	 */
 	public static function __set_state(array! message) -> <MessageInterface>
 	{
-		return new self(message["_message"], message["_field"], message["_type"], message["_code"]);
+		return new self(message["_message"], message["_field"], message["_type"], message["_code"], message["_metaData"]);
 	}
 }

--- a/phalcon/messages/messageinterface.zep
+++ b/phalcon/messages/messageinterface.zep
@@ -44,6 +44,11 @@ interface MessageInterface
 	public function getType() -> string;
 
 	/**
+	 * Returns message metadata
+	 */
+	public function getMetaData() -> array;
+
+	/**
 	 * Sets code for the message
 	 */
 	public function setCode(int code) -> <MessageInterface>;
@@ -62,6 +67,11 @@ interface MessageInterface
 	 * Sets message type
 	 */
 	public function setType(string! type) -> <MessageInterface>;
+
+	/**
+	 * Sets message metadata
+	 */
+	public function setMetaData(array! metaData) -> <MessageInterface>;
 
 	/**
 	 * Magic __toString method returns verbose message

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4157,7 +4157,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 							 * Set the related model
 							 */
 							if typeof message == "object" {
-								message->setModel(record);
+                                message->setMetaData([
+                                    "model" : record
+                                ]);
 							}
 
 							/**
@@ -4303,7 +4305,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 							 * Set the related model
 							 */
 							if typeof message == "object" {
-								message->setModel(record);
+								message->setMetaData([
+                                    "model" : record
+                                ]);
 							}
 
 							/**
@@ -4355,7 +4359,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 								 * Set the related model
 								 */
 								if typeof message == "object" {
-									message->setModel(record);
+                                    message->setMetaData([
+                                        "model" : record
+                                    ]);
 								}
 
 								/**

--- a/tests/integration/Mvc/Model/Refactor-ModelsForeignKeysCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsForeignKeysCest.php
@@ -39,10 +39,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'Value of field "parts_id" does not exist on referenced table',
-                '_field'   => 'parts_id',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'Value of field "parts_id" does not exist on referenced table',
+                '_field'    => 'parts_id',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -54,10 +55,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'The robot code does not exist',
-                '_field'   => 'robots_id',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'The robot code does not exist',
+                '_field'    => 'robots_id',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -72,10 +74,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'Record is referenced by model Phalcon\Test\Models\RobotsParts',
-                '_field'   => 'id',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'Record is referenced by model Phalcon\Test\Models\RobotsParts',
+                '_field'    => 'id',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -88,10 +91,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'Parts cannot be deleted because is referenced by a Robot',
-                '_field'   => 'id',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'Parts cannot be deleted because is referenced by a Robot',
+                '_field'    => 'id',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -109,10 +113,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'Value of field "delesCode" does not exist on referenced table',
-                '_field'   => 'delesCode',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'Value of field "delesCode" does not exist on referenced table',
+                '_field'    => 'delesCode',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -124,10 +129,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'The robotters code does not exist',
-                '_field'   => 'robottersCode',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'The robotters code does not exist',
+                '_field'    => 'robottersCode',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -141,10 +147,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'Record is referenced by model Phalcon\Test\Models\RobottersDeles',
-                '_field'   => 'code',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'Record is referenced by model Phalcon\Test\Models\RobottersDeles',
+                '_field'    => 'code',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 
@@ -157,10 +164,11 @@ class ModelsForeignKeysCest
 
         $messages = [
             0 => Message::__set_state([
-                '_type'    => 'ConstraintViolation',
-                '_message' => 'Deles cannot be deleted because is referenced by a Robotter',
-                '_field'   => 'code',
-                '_code'    => 0,
+                '_type'     => 'ConstraintViolation',
+                '_message'  => 'Deles cannot be deleted because is referenced by a Robotter',
+                '_field'    => 'code',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
 

--- a/tests/integration/Mvc/Model/Refactor-ModelsQueryExecuteCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsQueryExecuteCest.php
@@ -668,10 +668,11 @@ class ModelsQueryExecuteCest
         $I->assertFalse($status->success());
         $I->assertEquals($status->getMessages(), [
             0 => Message::__set_state([
-                '_type'    => null,
-                '_message' => 'Sorry Marina, but you are not allowed here',
-                '_field'   => null,
-                '_code'    => 0,
+                '_type'     => null,
+                '_message'  => 'Sorry Marina, but you are not allowed here',
+                '_field'    => null,
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ]);
 
@@ -681,10 +682,11 @@ class ModelsQueryExecuteCest
         $I->assertFalse($status->success());
         $I->assertEquals($status->getMessages(), [
             0 => Message::__set_state([
-                '_type'    => 'Email',
-                '_message' => "Field email must be an email address",
-                '_field'   => 'email',
-                '_code'    => 0,
+                '_type'     => 'Email',
+                '_message'  => "Field email must be an email address",
+                '_field'    => 'email',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ]);
 
@@ -731,10 +733,11 @@ class ModelsQueryExecuteCest
         $I->assertFalse($status->success());
         $I->assertEquals($status->getMessages(), [
             0 => Message::__set_state([
-                '_type'    => null,
-                '_message' => 'Désolé Marina, mais vous n\'êtes pas autorisé ici',
-                '_field'   => null,
-                '_code'    => 0,
+                '_type'     => null,
+                '_message'  => 'Désolé Marina, mais vous n\'êtes pas autorisé ici',
+                '_field'    => null,
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ]);
 
@@ -747,10 +750,11 @@ class ModelsQueryExecuteCest
         $I->assertFalse($status->success());
         $I->assertEquals($status->getMessages(), [
             0 => Message::__set_state([
-                '_type'    => 'Email',
-                '_message' => "Le courrier électronique est invalide",
-                '_field'   => 'courrierElectronique',
-                '_code'    => 0,
+                '_type'     => 'Email',
+                '_message'  => "Le courrier électronique est invalide",
+                '_field'    => 'courrierElectronique',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ]);
 

--- a/tests/integration/Mvc/Refactor-ModelsCest.php
+++ b/tests/integration/Mvc/Refactor-ModelsCest.php
@@ -168,22 +168,25 @@ class ModelsCest
 
         $messages = [
             0 => ModelMessage::__set_state([
-                '_type'    => 'PresenceOf',
-                '_message' => 'tipo_documento_id is required',
-                '_field'   => 'tipo_documento_id',
-                '_code'    => 0,
+                '_type'     => 'PresenceOf',
+                '_message'  => 'tipo_documento_id is required',
+                '_field'    => 'tipo_documento_id',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
             1 => ModelMessage::__set_state([
-                '_type'    => 'PresenceOf',
-                '_message' => 'cupo is required',
-                '_field'   => 'cupo',
-                '_code'    => 0,
+                '_type'     => 'PresenceOf',
+                '_message'  => 'cupo is required',
+                '_field'    => 'cupo',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
             2 => ModelMessage::__set_state([
-                '_type'    => 'PresenceOf',
-                '_message' => 'estado is required',
-                '_field'   => 'estado',
-                '_code'    => 0,
+                '_type'     => 'PresenceOf',
+                '_message'  => 'estado is required',
+                '_field'    => 'estado',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
         $I->assertEquals($persona->getMessages(), $messages);
@@ -472,22 +475,25 @@ class ModelsCest
 
         $messages = [
             0 => ModelMessage::__set_state([
-                '_type'    => 'PresenceOf',
-                '_message' => 'slagBorgerId is required',
-                '_field'   => 'slagBorgerId',
-                '_code'    => 0,
+                '_type'     => 'PresenceOf',
+                '_message'  => 'slagBorgerId is required',
+                '_field'    => 'slagBorgerId',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
             1 => ModelMessage::__set_state([
-                '_type'    => 'PresenceOf',
-                '_message' => 'kredit is required',
-                '_field'   => 'kredit',
-                '_code'    => 0,
+                '_type'     => 'PresenceOf',
+                '_message'  => 'kredit is required',
+                '_field'    => 'kredit',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
             2 => ModelMessage::__set_state([
-                '_type'    => 'PresenceOf',
-                '_message' => 'status is required',
-                '_field'   => 'status',
-                '_code'    => 0,
+                '_type'     => 'PresenceOf',
+                '_message'  => 'status is required',
+                '_field'    => 'status',
+                '_code'     => 0,
+                '_metaData' => []
             ]),
         ];
         $I->assertEquals($personer->getMessages(), $messages);

--- a/tests/unit/Messages/Message/GetSetMetaDataCest.php
+++ b/tests/unit/Messages/Message/GetSetMetaDataCest.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Unit\Messages\Message;
+
+use Phalcon\Messages\Message;
+use UnitTester;
+
+/**
+ * Class GetSetMetaDataCest
+ */
+class GetSetMetaDataCest
+{
+    /**
+     * Tests Phalcon\Messages\Message :: getMetaData()/setMetaData()
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2019-02-10
+     */
+    public function messagesMessageGetSetMetaData(UnitTester $I)
+    {
+        $I->wantToTest('Messages\Message - getMetaData()/setMetaData()');
+        $message = new Message(
+            'This is a message #1',
+            'MyField',
+            'MyType',
+            111,
+            ['My1' => 'Metadata1']
+        );
+
+        $expected = ['My1' => 'Metadata1'];
+        $actual   = $message->getMetaData();
+        $I->assertEquals($expected, $actual);
+
+        $expected = ['My2' => 'Metadata2'];
+        $message->setMetaData($expected);
+        $actual   = $message->getMetaData();
+        $I->assertEquals($expected, $actual);
+    }
+}

--- a/tests/unit/Messages/Message/JsonSerializeCest.php
+++ b/tests/unit/Messages/Message/JsonSerializeCest.php
@@ -31,17 +31,18 @@ class JsonSerializeCest
     public function messagesMessageJsonSerialize(UnitTester $I)
     {
         $I->wantToTest('Messages\Message - jsonSerialize()');
-        $message = new Message('This is a message #1', 'MyField', 'MyType', 111);
+        $message = new Message('This is a message #1', 'MyField', 'MyType', 111, ['My1' => 'Metadata1']);
 
         $expected = '\JsonSerializable';
         $actual   = $message;
         $I->assertInstanceOf($expected, $actual);
 
         $expected = [
-            'field'   => 'MyField',
-            'message' => 'This is a message #1',
-            'type'    => 'MyType',
-            'code'    => 111,
+            'field'    => 'MyField',
+            'message'  => 'This is a message #1',
+            'type'     => 'MyType',
+            'code'     => 111,
+            'metaData' => ['My1' => 'Metadata1']
         ];
         $actual   = $message->jsonSerialize();
         $I->assertEquals($expected, $actual);

--- a/tests/unit/Messages/Messages/CurrentCest.php
+++ b/tests/unit/Messages/Messages/CurrentCest.php
@@ -34,8 +34,8 @@ class CurrentCest
         $I->wantToTest('Messages\Messages - current()');
         $messages = new Messages(
             [
-                new Message('This is a message #1', 'MyField1', 'MyType1', 111),
-                new Message('This is a message #2', 'MyField2', 'MyType2', 222),
+                new Message('This is a message #1', 'MyField1', 'MyType1', 111, ['My1' => 'Metadata1']),
+                new Message('This is a message #2', 'MyField2', 'MyType2', 222, ['My2' => 'Metadata2']),
             ]
         );
 
@@ -45,10 +45,11 @@ class CurrentCest
 
         $expected = Message::__set_state(
             [
-                '_message' => 'This is a message #1',
-                '_field'   => 'MyField1',
-                '_type'    => 'MyType1',
-                '_code'    => 111,
+                '_message'  => 'This is a message #1',
+                '_field'    => 'MyField1',
+                '_type'     => 'MyType1',
+                '_code'     => 111,
+                '_metaData' => ['My1' => 'Metadata1']
             ]
         );
         $I->assertEquals($expected, $actual);

--- a/tests/unit/Messages/Messages/FilterCest.php
+++ b/tests/unit/Messages/Messages/FilterCest.php
@@ -34,9 +34,9 @@ class FilterCest
         $I->wantToTest('Messages\Messages - filter()');
         $messages = new Messages(
             [
-                new Message('Password: no number present', 'Password', 'MyType1', 111),
-                new Message('Password: no uppercase letter present', 'Password', 'MyType2', 222),
-                new Message('Email: not valid', 'Email', 'MyType3', 333),
+                new Message('Password: no number present', 'Password', 'MyType1', 111, ['My1' => 'Metadata1']),
+                new Message('Password: no uppercase letter present', 'Password', 'MyType2', 222, ['My2' => 'Metadata2']),
+                new Message('Email: not valid', 'Email', 'MyType3', 333, ['My3' => 'Metadata3']),
             ]
         );
 
@@ -50,18 +50,20 @@ class FilterCest
         $expected = [
             0 => Message::__set_state(
                 [
-                    '_message' => 'Password: no number present',
-                    '_field'   => 'Password',
-                    '_type'    => 'MyType1',
-                    '_code'    => 111,
+                    '_message'  => 'Password: no number present',
+                    '_field'    => 'Password',
+                    '_type'     => 'MyType1',
+                    '_code'     => 111,
+                    '_metaData' => ['My1' => 'Metadata1']
                 ]
             ),
             1 => Message::__set_state(
                 [
-                    '_message' => 'Password: no uppercase letter present',
-                    '_field'   => 'Password',
-                    '_type'    => 'MyType2',
-                    '_code'    => 222,
+                    '_message'  => 'Password: no uppercase letter present',
+                    '_field'    => 'Password',
+                    '_type'     => 'MyType2',
+                    '_code'     => 222,
+                    '_metaData' => ['My2' => 'Metadata2']
                 ]
             ),
         ];

--- a/tests/unit/Messages/Messages/JsonSerializeCest.php
+++ b/tests/unit/Messages/Messages/JsonSerializeCest.php
@@ -34,8 +34,8 @@ class JsonSerializeCest
         $I->wantToTest('Messages\Messages - jsonSerialize()');
         $messages = new Messages(
             [
-                new Message('This is a message #1', 'MyField1', 'MyType1', 111),
-                new Message('This is a message #2', 'MyField2', 'MyType2', 222),
+                new Message('This is a message #1', 'MyField1', 'MyType1', 111, ['My1' => 'Metadata1']),
+                new Message('This is a message #2', 'MyField2', 'MyType2', 222, ['My2' => 'Metadata2']),
             ]
         );
         $expected = '\JsonSerializable';

--- a/tests/unit/Messages/Messages/NextCest.php
+++ b/tests/unit/Messages/Messages/NextCest.php
@@ -34,8 +34,8 @@ class NextCest
         $I->wantToTest('Messages\Messages - next()');
         $messages = new Messages(
             [
-                new Message('This is a message #1', 'MyField1', 'MyType1', 111),
-                new Message('This is a message #2', 'MyField2', 'MyType2', 222),
+                new Message('This is a message #1', 'MyField1', 'MyType1', 111, ['My1' => 'Metadata1']),
+                new Message('This is a message #2', 'MyField2', 'MyType2', 222, ['My2' => 'Metadata2']),
             ]
         );
 
@@ -47,10 +47,11 @@ class NextCest
 
         $expected = Message::__set_state(
             [
-                '_message' => 'This is a message #2',
-                '_field'   => 'MyField2',
-                '_type'    => 'MyType2',
-                '_code'    => 222,
+                '_message'  => 'This is a message #2',
+                '_field'    => 'MyField2',
+                '_type'     => 'MyType2',
+                '_code'     => 222,
+                '_metaData' => ['My2' => 'Metadata2']
             ]
         );
         $I->assertEquals($expected, $actual);

--- a/tests/unit/Messages/Messages/OffsetGetSetCest.php
+++ b/tests/unit/Messages/Messages/OffsetGetSetCest.php
@@ -34,14 +34,14 @@ class OffsetGetSetCest
         $I->wantToTest('Messages\Messages - offsetGet()/offsetSet()');
         $messages = new Messages(
             [
-                0 => new Message('This is a message #1', 'MyField1', 'MyType1', 111),
-                1 => new Message('This is a message #2', 'MyField2', 'MyType2', 222),
+                0 => new Message('This is a message #1', 'MyField1', 'MyType1', 111, ['My1' => 'Metadata1']),
+                1 => new Message('This is a message #2', 'MyField2', 'MyType2', 222, ['My2' => 'Metadata2']),
             ]
         );
 
         $messages->offsetSet(
             2,
-            new Message('This is a message #3', 'MyField3', 'MyType3', 777)
+            new Message('This is a message #3', 'MyField3', 'MyType3', 777, ['My3' => 'Metadata3'])
         );
 
         $expected = 3;
@@ -54,10 +54,11 @@ class OffsetGetSetCest
 
         $expected = Message::__set_state(
             [
-                '_message' => 'This is a message #3',
-                '_field'   => 'MyField3',
-                '_type'    => 'MyType3',
-                '_code'    => 777,
+                '_message'  => 'This is a message #3',
+                '_field'    => 'MyField3',
+                '_type'     => 'MyType3',
+                '_code'     => 777,
+                '_metaData' => ['My3' => 'Metadata3']
             ]
         );
         $actual   = $message;

--- a/tests/unit/Messages/Messages/OffsetUnsetCest.php
+++ b/tests/unit/Messages/Messages/OffsetUnsetCest.php
@@ -34,8 +34,8 @@ class OffsetUnsetCest
         $I->wantToTest('Messages\Messages - offsetUnset()');
         $messages = new Messages(
             [
-                0 => new Message('This is a message #1', 'MyField1', 'MyType1', 111),
-                1 => new Message('This is a message #2', 'MyField2', 'MyType2', 222),
+                0 => new Message('This is a message #1', 'MyField1', 'MyType1', 111, ['My1' => 'Metadata1']),
+                1 => new Message('This is a message #2', 'MyField2', 'MyType2', 222, ['My2' => 'Metadata2']),
             ]
         );
 
@@ -56,10 +56,11 @@ class OffsetUnsetCest
 
         $expected = Message::__set_state(
             [
-                '_message' => 'This is a message #2',
-                '_field'   => 'MyField2',
-                '_type'    => 'MyType2',
-                '_code'    => 222,
+                '_message'  => 'This is a message #2',
+                '_field'    => 'MyField2',
+                '_type'     => 'MyType2',
+                '_code'     => 222,
+                '_metaData' => ['My2' => 'Metadata2']
             ]
         );
         $actual   = $message;

--- a/tests/unit/Messages/Messages/RewindCest.php
+++ b/tests/unit/Messages/Messages/RewindCest.php
@@ -34,8 +34,8 @@ class RewindCest
         $I->wantToTest('Messages\Messages - rewind()');
         $messages = new Messages(
             [
-                new Message('This is a message #1', 'MyField1', 'MyType1', 111),
-                new Message('This is a message #2', 'MyField2', 'MyType2', 222),
+                new Message('This is a message #1', 'MyField1', 'MyType1', 111, ['My1' => 'Metadata1']),
+                new Message('This is a message #2', 'MyField2', 'MyType2', 222, ['My2' => 'Metadata2']),
             ]
         );
 
@@ -57,10 +57,11 @@ class RewindCest
 
         $expected = Message::__set_state(
             [
-                '_message' => 'This is a message #1',
-                '_field'   => 'MyField1',
-                '_type'    => 'MyType1',
-                '_code'    => 111,
+                '_message'  => 'This is a message #1',
+                '_field'    => 'MyField1',
+                '_type'     => 'MyType1',
+                '_code'     => 111,
+                '_metaData' => ['My1' => 'Metadata1']
             ]
         );
         $I->assertEquals($expected, $actual);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13811

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change: 
Added metadata to the `Phalcon\Message` object and extended its interface.
Fixed `Phalcon\Mvc\Model` to use this new method instead of the old `setModel` function.
Modifed the tests accordingly

Thanks

