### PR TITLE
preventing call to undefined method isSent

### DIFF
--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -1024,8 +1024,8 @@ class Micro extends Injectable implements \ArrayAccess
 			/**
 			 * Automatically send the response
 			 */
-			 if !returnedValue->isSent() {
-				returnedValue->send();
+			 if !response->isSent() {
+				response->send();
 			 }
 		}
 	}

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -24,6 +24,7 @@ use Phalcon\Mvc\Micro\Exception;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Mvc\Micro\Collection;
 use Phalcon\Mvc\Micro\LazyLoader;
+use Phalcon\Http\Response;
 use Phalcon\Http\ResponseInterface;
 use Phalcon\Mvc\Model\BinderInterface;
 use Phalcon\Mvc\Router\RouteInterface;
@@ -1007,7 +1008,7 @@ class Micro extends Injectable implements \ArrayAccess
 		 * Check if the returned object is already a response
 		 */
 		if typeof returnedValue == "object" {
-			if returnedValue instanceof ResponseInterface {
+			if returnedValue instanceof Response {
 				/**
 				 * Automatically send the response
 				 */

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -997,9 +997,9 @@ class Micro extends Injectable implements \ArrayAccess
 		 */
 		if typeof returnedValue == "string" {
 			let response = <ResponseInterface> dependencyInjector->getShared("response");
-			if !response->isSent() {
+			if this->isSendable(response) {
 				response->setContent(returnedValue);
-				this->sendIfUnsent(response);
+				response->send();
 			}
 		}
 
@@ -1007,27 +1007,24 @@ class Micro extends Injectable implements \ArrayAccess
 		 * Check if the returned object is already a response
 		 */
 		if typeof returnedValue == "object" {
-			if returnedValue instanceof ResponseInterface {
-				this->sendIfUnsent(returnedValue);
+			/**
+			 * Automatically send the response
+			 */
+			if this->isSendable(returnedValue) {
+				returnedValue->send();
 			}
 		}
 
 		return returnedValue;
 	}
-	
+
 	/**
-	 * Prevents isSent from being called on implementations that don't have it
+	 * @param object response
+	 * @return bool
 	 **/
-	private function sendIfUnsent(<ResponseInterface> response)
+	private function isSendable(response) -> boolean
 	{
-		if method_exists(response, "isSent") {
-			/**
-			 * Automatically send the response
-			 */
-			 if !response->isSent() {
-				response->send();
-			 }
-		}
+		return response instanceof ResponseInterface && method_exists(response, "isSent") && !response->isSent();
 	}
 
 	/**

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -1020,7 +1020,7 @@ class Micro extends Injectable implements \ArrayAccess
 	 **/
 	private function sendIfUnsent(<ResponseInterface> response)
 	{
-		if method_exists(response, "isSent) {
+		if method_exists(response, "isSent") {
 			/**
 			 * Automatically send the response
 			 */

--- a/phalcon/mvc/micro.zep
+++ b/phalcon/mvc/micro.zep
@@ -24,7 +24,6 @@ use Phalcon\Mvc\Micro\Exception;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Mvc\Micro\Collection;
 use Phalcon\Mvc\Micro\LazyLoader;
-use Phalcon\Http\Response;
 use Phalcon\Http\ResponseInterface;
 use Phalcon\Mvc\Model\BinderInterface;
 use Phalcon\Mvc\Router\RouteInterface;
@@ -1000,7 +999,7 @@ class Micro extends Injectable implements \ArrayAccess
 			let response = <ResponseInterface> dependencyInjector->getShared("response");
 			if !response->isSent() {
 				response->setContent(returnedValue);
-				response->send();
+				this->sendIfUnsent(response);
 			}
 		}
 
@@ -1008,17 +1007,27 @@ class Micro extends Injectable implements \ArrayAccess
 		 * Check if the returned object is already a response
 		 */
 		if typeof returnedValue == "object" {
-			if returnedValue instanceof Response {
-				/**
-				 * Automatically send the response
-				 */
-				 if !returnedValue->isSent() {
-				 	returnedValue->send();
-				 }
+			if returnedValue instanceof ResponseInterface {
+				this->sendIfUnsent(returnedValue);
 			}
 		}
 
 		return returnedValue;
+	}
+	
+	/**
+	 * Prevents isSent from being called on implementations that don't have it
+	 **/
+	private function sendIfUnsent(<ResponseInterface> response)
+	{
+		if method_exists(response, "isSent) {
+			/**
+			 * Automatically send the response
+			 */
+			 if !returnedValue->isSent() {
+				returnedValue->send();
+			 }
+		}
 	}
 
 	/**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

Currently isSent is only implemented by `Response` and not part of the `ResponseInterface`. Therefore calling it on instances of the interfaces is not a reasonable solution.
Adjusting the interface would break backwards compatibility, so adding the check seems like the more sensible option.

