### PR TITLE
Add `Dispatcher::toCamelCase()` method

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -67,6 +67,8 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 	protected _activeMethodMap = [];
 
+	protected _camelCaseMap = [];
+
 	protected _previousNamespaceName = null;
 
 	protected _previousHandlerName = null;
@@ -289,7 +291,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 	{
 		var activeMethodName;
 		if !fetch activeMethodName, this->_activeMethodMap[this->_actionName] {
-			let activeMethodName = lcfirst(join("", array_map("ucfirst", preg_split("/[_-]+/", this->_actionName))));
+			let activeMethodName = lcfirst(this->toCamelCase(this->_actionName));
 			let this->_activeMethodMap[this->_actionName] = activeMethodName;
 		}
 		return activeMethodName . this->_actionSuffix;
@@ -835,7 +837,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 		// We don't camelize the classes if they are in namespaces
 		if !memstr(handlerName, "\\") {
-			let camelizedClass = camelize(handlerName);
+			let camelizedClass = this->toCamelCase(handlerName);
 		} else {
 			let camelizedClass = handlerName;
 		}
@@ -904,5 +906,15 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 		if !this->_actionName {
 			let this->_actionName = this->_defaultAction;
 		}
+	}
+
+	protected function toCamelCase(string input) -> string
+	{
+		var camelCaseInput;
+		if !fetch camelCaseInput, this->_camelCaseMap[input] {
+			let camelCaseInput = join("", array_map("ucfirst", preg_split("/[_-]+/", input)));
+			let this->_camelCaseMap[input] = camelCaseInput;
+		}
+		return camelCaseInput;
 	}
 }

--- a/tests/unit/Dispatcher/GetHandlerClassCest.php
+++ b/tests/unit/Dispatcher/GetHandlerClassCest.php
@@ -24,72 +24,47 @@ class GetHandlerClassCest
      * Tests Phalcon\Dispatcher :: getHandlerClass()
      *
      * @param UnitTester $I
+     * @param array $entry
+     * @dataProvider getTestCases
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
      */
-    public function dispatcherGetHandlerClass(UnitTester $I)
+    public function dispatcherGetHandlerClass(UnitTester $I, array $entry)
     {
         $I->wantToTest('Dispatcher - getHandlerClass()');
 
         $dispatcher = new Dispatcher();
 
         // test the handler name
-        $dispatcher->setNamespaceName('');
-        $dispatcher->setHandlerSuffix('');
-
-        $dispatcher->setControllerName('hello');
+        $dispatcher->setNamespaceName($entry[0]);
+        $dispatcher->setControllerName($entry[1]);
+        $dispatcher->setHandlerSuffix($entry[2]);
         $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('Hello', $actualHandler);
+        $I->assertEquals($entry[3], $actualHandler);
+    }
 
-        $dispatcher->setControllerName('hello-phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('HelloPhalcon', $actualHandler);
-
-        $dispatcher->setControllerName('hello_phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('HelloPhalcon', $actualHandler);
-
-        $dispatcher->setControllerName('HelloPhalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('HelloPhalcon', $actualHandler);
-
-        $dispatcher->setControllerName('Hello\\Phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('Hello\\Phalcon', $actualHandler);
-
-        // test the suffix
-        $dispatcher->setHandlerSuffix('Ctrl');
-
-        $dispatcher->setControllerName('hello');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('HelloCtrl', $actualHandler);
-
-        $dispatcher->setControllerName('hello-phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('HelloPhalconCtrl', $actualHandler);
-
-        $dispatcher->setControllerName('hello_phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('HelloPhalconCtrl', $actualHandler);
-
-        $dispatcher->setControllerName('Hello\\Phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('Hello\\PhalconCtrl', $actualHandler);
-
-        $dispatcher->setControllerName('hello_ns\\Phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('hello_ns\\PhalconCtrl', $actualHandler);
-
-        // test the namespace
-        $dispatcher->setNamespaceName('App');
-        $dispatcher->setControllerName('hello');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('App\\HelloCtrl', $actualHandler);
-
-        $dispatcher->setNamespaceName('Ola\\');
-        $dispatcher->setControllerName('phalcon');
-        $actualHandler = $dispatcher->getHandlerClass();
-        $I->assertEquals('Ola\\PhalconCtrl', $actualHandler);
+    private function getTestCases()
+    {
+        return [
+            ['', 'hello', '', 'Hello'],
+            ['', 'hello-phalcon', '', 'HelloPhalcon'],
+            ['', 'hello_phalcon', '', 'HelloPhalcon'],
+            ['', 'HelloPhalcon', '', 'HelloPhalcon'],
+            ['', 'Hello\\Phalcon', '', 'Hello\\Phalcon'],
+            ['', 'non_std\\Phalcon', '', 'non_std\\Phalcon'],
+            // include the suffix
+            ['', 'hello', 'Ctrl', 'HelloCtrl'],
+            ['', 'hello-phalcon', 'Ctrl', 'HelloPhalconCtrl'],
+            ['', 'hello_phalcon', 'Ctrl', 'HelloPhalconCtrl'],
+            ['', 'HelloPhalcon', 'Ctrl', 'HelloPhalconCtrl'],
+            ['', 'Hello\\Phalcon', 'Ctrl', 'Hello\\PhalconCtrl'],
+            // include the namespace
+            ['Ola', 'hello', 'Ctrl', 'Ola\\HelloCtrl'],
+            ['Ola', 'hello-phalcon', 'Ctrl', 'Ola\\HelloPhalconCtrl'],
+            ['ola\\', 'hello_phalcon', 'Ctrl', 'ola\\HelloPhalconCtrl'],
+            ['ola_phalcon\\', 'HelloPhalcon', 'Ctrl', 'ola_phalcon\\HelloPhalconCtrl'],
+            ['Ola\\', 'Hello\\Phalcon', 'Ctrl', 'Ola\\Hello\\PhalconCtrl'],
+        ];
     }
 }

--- a/tests/unit/Dispatcher/GetHandlerClassCest.php
+++ b/tests/unit/Dispatcher/GetHandlerClassCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Dispatcher;
 
 use UnitTester;
+use Phalcon\Mvc\Dispatcher;
 
 /**
  * Class GetHandlerClassCest
@@ -30,6 +31,66 @@ class GetHandlerClassCest
     public function dispatcherGetHandlerClass(UnitTester $I)
     {
         $I->wantToTest('Dispatcher - getHandlerClass()');
-        $I->skipTest('Need implementation');
+
+        $dispatcher = new Dispatcher();
+
+        // test the handler name
+        $dispatcher->setNamespaceName('');
+        $dispatcher->setHandlerSuffix('');
+
+        $dispatcher->setControllerName('hello');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('Hello', $actualHandler);
+
+        $dispatcher->setControllerName('hello-phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('HelloPhalcon', $actualHandler);
+
+        $dispatcher->setControllerName('hello_phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('HelloPhalcon', $actualHandler);
+
+        $dispatcher->setControllerName('HelloPhalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('HelloPhalcon', $actualHandler);
+
+        $dispatcher->setControllerName('Hello\\Phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('Hello\\Phalcon', $actualHandler);
+
+        // test the suffix
+        $dispatcher->setHandlerSuffix('Ctrl');
+
+        $dispatcher->setControllerName('hello');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('HelloCtrl', $actualHandler);
+
+        $dispatcher->setControllerName('hello-phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('HelloPhalconCtrl', $actualHandler);
+
+        $dispatcher->setControllerName('hello_phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('HelloPhalconCtrl', $actualHandler);
+
+        $dispatcher->setControllerName('Hello\\Phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('Hello\\PhalconCtrl', $actualHandler);
+
+        $dispatcher->setControllerName('hello_ns\\Phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('hello_ns\\PhalconCtrl', $actualHandler);
+
+        // test the namespace
+        $dispatcher->setNamespaceName('App');
+        $dispatcher->setControllerName('hello');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('App\\HelloCtrl', $actualHandler);
+
+        $dispatcher->setNamespaceName('Ola\\');
+        $dispatcher->setControllerName('phalcon');
+        $actualHandler = $dispatcher->getHandlerClass();
+        $I->assertEquals('Ola\\PhalconCtrl', $actualHandler);
+
     }
 }

--- a/tests/unit/Dispatcher/GetHandlerClassCest.php
+++ b/tests/unit/Dispatcher/GetHandlerClassCest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Dispatcher;
 
+use Codeception\Example;
 use UnitTester;
 use Phalcon\Mvc\Dispatcher;
 
@@ -30,7 +31,7 @@ class GetHandlerClassCest
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
      */
-    public function dispatcherGetHandlerClass(UnitTester $I, array $entry)
+    public function dispatcherGetHandlerClass(UnitTester $I, Example $entry)
     {
         $I->wantToTest('Dispatcher - getHandlerClass()');
 

--- a/tests/unit/Dispatcher/GetHandlerClassCest.php
+++ b/tests/unit/Dispatcher/GetHandlerClassCest.php
@@ -91,6 +91,5 @@ class GetHandlerClassCest
         $dispatcher->setControllerName('phalcon');
         $actualHandler = $dispatcher->getHandlerClass();
         $I->assertEquals('Ola\\PhalconCtrl', $actualHandler);
-
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #12829 

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Small description of change:

Added `Dispatcher::toCamelCase()` method to use with `::getHandlerClass()` and `::getActiveMethod()`.

Thanks

