### PR TITLE
#13610 Allow Config::merge to accept array.

### DIFF
--- a/phalcon/config.zep
+++ b/phalcon/config.zep
@@ -201,8 +201,13 @@ class Config implements \ArrayAccess, \Countable
 	 * $globalConfig->merge($appConfig);
 	 *</code>
 	 */
-	public function merge(<Config> config) -> <Config>
+	public function merge(var configParam) -> <Config>
 	{
+		var config;
+
+		// Allow merge to accept array.
+		let config = is_array(configParam) ? new Config(configParam) : configParam;
+
 		return this->_merge(config);
 	}
 


### PR DESCRIPTION
new feature
Issue #13610

If this code is acceptable then I will create a change log entry as well as possibly a test.

I modified the Config::merge method to allow arrays.  I first tried the following but I decided to go with a ternary:

```zephir
let config = is_array(config) ? new Config(configParam);
```

Another way of doing it but it seems too much:

```zephir
	public function merge(var configParam) -> <Config>
	{
		var config;

		switch typeof configParam {
			case "array":
				let config = new Config(configParam);
				break;
			case "object":
				let config = configParam;
				break;
			default:
				throw new \Exception("Invalid data type for merge.");
		}

		return this->_merge(config);
	}
```

