### PR TITLE
4.0.x: adding missing method isSent to interface ResponseInterface

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -9,6 +9,7 @@
 - Fixed storing related model data in `Phalcon\Messages\Message`. The method is now `setMetadata` and can be used to store any metadata from any component that emits messages [#13811](https://github.com/phalcon/cphalcon/issues/13811)
 - Fixed Dispatcher calling camelize twice and producing incorrect results [#12829](https://github.com/phalcon/cphalcon/issues/12829)
 - Fixed `Phalcon\Mvc\Model:findFirst` to throw an exception when the passed parameter for a primary key is not an array, string or numeric [#13336](https://github.com/phalcon/cphalcon/issues/13336)
+- Added `Phalcon\Http\ResponseInterface::isSent`, that was already used. [#13836](https://github.com/phalcon/cphalcon/pull/13836)
 
 ## Changed
 - Renamed `Phalcon\Acl\Subject` to `Phalcon\Acl\Component` [#13808](https://github.com/phalcon/cphalcon/issues/13808)

--- a/phalcon/http/responseinterface.zep
+++ b/phalcon/http/responseinterface.zep
@@ -45,6 +45,11 @@ interface ResponseInterface
 	public function hasHeader(string name) -> bool;
 
 	/**
+	 * Checks if the response was already sent
+	 */
+	public function isSent() -> bool;
+
+	/**
 	 * Redirect by HTTP to another action or URL
 	 */
 	public function redirect(location = null, bool externalRedirect = false, int statusCode = 302) -> <ResponseInterface>;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following (please check boxes):**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [X] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

This is a followup to #13821, adding the missing method to the interface. Compare https://github.com/phalcon/cphalcon/pull/13821#issuecomment-464663406

