### PR TITLE
Add DI presets, a new take on DI factory defaults.

### DIFF
--- a/phalcon/di/presetinterface.zep
+++ b/phalcon/di/presetinterface.zep
@@ -1,0 +1,15 @@
+namespace Phalcon\Di;
+
+use Phalcon\DiInterface;
+
+/**
+ *
+ */
+interface PresetInterface
+{
+
+    /**
+     *
+     */
+    public static function configure(<DiInterface> di, bool clobber = true);
+}

--- a/phalcon/di/presets/cli.zep
+++ b/phalcon/di/presets/cli.zep
@@ -1,0 +1,74 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Di\Presets;
+
+use Phalcon\Di;
+use Phalcon\Di\PresetInterface;
+use Phalcon\Di\Service;
+use Phalcon\DiInterface;
+
+ /**
+ * Phalcon\Di\Presets\Cli
+ *
+ * This is a variant of the standard Phalcon\Di. By default it automatically
+ * registers all the services provided by the framework.
+ * Thanks to this, the developer does not need to register each service individually.
+ * This class is specially suitable for CLI applications
+ */
+class Cli extends Di implements PresetInterface
+{
+
+    /**
+     *
+     */
+	public static function configure(<DiInterface> di, bool clobber = true)
+	{
+		var className, filter, serviceName, services;
+
+		let services = [
+			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
+			"assets":             new Service("Phalcon\\Assets\\Manager", true),
+			"crypt":              new Service("Phalcon\\Crypt", true),
+			"dispatcher":         new Service("Phalcon\\Cli\\Dispatcher", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"eventsManager":      new Service("Phalcon\\Events\\Manager", true),
+			"filter":             new Service("Phalcon\\Filter", true),
+			"flash":              new Service("Phalcon\\Flash\\Direct", true),
+			"flashSession":       new Service("Phalcon\\Flash\\Session", true),
+			"modelsManager":      new Service("Phalcon\\Mvc\\Model\\Manager", true),
+			"modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
+			"router":             new Service("Phalcon\\Cli\\Router", true),
+			"security":           new Service("Phalcon\\Security", true),
+			"tag":                new Service("Phalcon\\Tag", true),
+			"transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
+			"url":                new Service("Phalcon\\Url", true)
+		];
+
+		for serviceName, className in services {
+            if clobber {
+                di->set(serviceName, className, true);
+            } else {
+                di->attempt(serviceName, className, true);
+            }
+        }
+	}
+
+	/**
+	 * Phalcon\Di\Presets\Cli constructor
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+        self::configure(this);
+	}
+}

--- a/phalcon/di/presets/web.zep
+++ b/phalcon/di/presets/web.zep
@@ -1,0 +1,79 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Di;
+
+use Phalcon\Di;
+use Phalcon\Di\PresetInterface;
+use Phalcon\Di\Service;
+use Phalcon\DiInterface;
+use Phalcon\Filter\FilterLocatorFactory;
+
+/**
+ * Phalcon\Di\Presets\Web
+ *
+ * This is a variant of the standard Phalcon\Di. By default it automatically
+ * registers all the services provided by the framework. Thanks to this, the developer does not need
+ * to register each service individually providing a full stack framework
+ */
+class Web extends Di implements PresetInterface
+{
+
+    /**
+     *
+     */
+	public static function configure(<DiInterface> di, bool clobber = true)
+	{
+		var className, filter, serviceName, services;
+
+		let filter = new FilterLocatorFactory();
+
+		let services = [
+			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
+			"assets":             new Service("Phalcon\\Assets\\Manager", true),
+			"crypt":              new Service("Phalcon\\Crypt", true),
+			"cookies":            new Service("Phalcon\\Http\\Response\\Cookies", true),
+			"dispatcher":         new Service("Phalcon\\Mvc\\Dispatcher", true),
+			"escaper":            new Service("Phalcon\\Escaper", true),
+			"eventsManager":      new Service("Phalcon\\Events\\Manager", true),
+			"flash":              new Service("Phalcon\\Flash\\Direct", true),
+			"flashSession":       new Service("Phalcon\\Flash\\Session", true),
+			"filter":             new Service(filter->newInstance(), true),
+//			"filter":             new Service("Phalcon\\Filter", true),
+			"modelsManager":      new Service("Phalcon\\Mvc\\Model\\Manager", true),
+			"modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
+			"request":            new Service("Phalcon\\Http\\Request", true),
+			"response":           new Service("Phalcon\\Http\\Response", true),
+			"router":             new Service("Phalcon\\Mvc\\Router", true),
+			"security":           new Service("Phalcon\\Security", true),
+			"tag":                new Service("Phalcon\\Tag", true),
+			"transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
+			"url":                new Service("Phalcon\\Url", true)
+		];
+
+        for serviceName, className in services {
+            if clobber {
+                di->set(serviceName, className, true);
+            } else {
+                di->attempt(serviceName, className, true);
+            }
+        }
+	}
+
+	/**
+	 * Phalcon\Di\Presets\Web constructor
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+
+		self::configure(this);
+	}
+}

--- a/phalcon/mvc/view/engine/volt/compiler.zep
+++ b/phalcon/mvc/view/engine/volt/compiler.zep
@@ -2504,9 +2504,9 @@ class Compiler implements InjectionAwareInterface
 	 */
 	public function compile(string! templatePath, bool extendsMode = false)
 	{
-		var stat, compileAlways, prefix, compiledPath, compiledSeparator, blocksCode,
-			compiledExtension, compilation, options, realCompiledPath,
-			compiledTemplatePath, templateSepPath;
+		var blocksCode, compilation, compileAlways, compiledExtension, compiledPath,
+			compiledSeparator, compiledTemplatePath, optionKey, options, prefix,
+			realCompiledPath, stat, templateSepPath;
 
 		/**
 		 * Re-initialize some properties already initialized when the object is cloned
@@ -2533,10 +2533,16 @@ class Compiler implements InjectionAwareInterface
 			/**
 			 * This makes that templates will be compiled always
 			 */
-			if isset options["compileAlways"] {
-				let compileAlways = options["compileAlways"];
+			if isset options["always"] || isset options["compileAlways"] {
+				if isset options["always"] {
+					let optionKey = "always";
+				} else {
+					let optionKey = "compileAlways";
+					trigger_error("The 'compileAlways' option is deprecated. Use 'always' instead.", E_USER_DEPRECATED);
+				}
+				let compileAlways = options[optionKey];
 				if typeof compileAlways != "boolean" {
-					throw new Exception("'compileAlways' must be a bool value");
+					throw new Exception("'" . optionKey . "' must be a bool value");
 				}
 			}
 
@@ -2553,11 +2559,17 @@ class Compiler implements InjectionAwareInterface
 			/**
 			 * Compiled path is a directory where the compiled templates will be located
 			 */
-			if isset options["compiledPath"] {
-				let compiledPath = options["compiledPath"];
+			if isset options["path"] || isset options["compiledPath"] {
+				if isset options["path"] {
+					let optionKey = "path";
+				} else {
+					let optionKey = "compiledPath";
+					trigger_error("The 'compiledPath' option is deprecated. Use 'path' instead.", E_USER_DEPRECATED);
+				}
+				let compiledPath = options[optionKey];
 				if typeof compiledPath != "string" {
 					if typeof compiledPath != "object" {
-						throw new Exception("'compiledPath' must be a string or a closure");
+						throw new Exception("'" . optionKey . "' must be a string or a closure");
 					}
 				}
 			}
@@ -2565,20 +2577,32 @@ class Compiler implements InjectionAwareInterface
 			/**
 			 * There is no compiled separator by default
 			 */
-			if isset options["compiledSeparator"] {
-				let compiledSeparator = options["compiledSeparator"];
+			if isset options["separator"] || isset options["compiledSeparator"] {
+				if isset options["separator"] {
+					let optionKey = "separator";
+				} else {
+					let optionKey = "compiledSeparator";
+					trigger_error("The 'compiledSeparator' option is deprecated. Use 'separator' instead.", E_USER_DEPRECATED);
+				}
+				let compiledPath = options[optionKey];
 				if typeof compiledSeparator != "string" {
-					throw new Exception("'compiledSeparator' must be a string");
+					throw new Exception("'" . optionKey . "' must be a string");
 				}
 			}
 
 			/**
 			 * By default the compile extension is .php
 			 */
-			if isset options["compiledExtension"] {
-				let compiledExtension = options["compiledExtension"];
+			if isset options["extension"] || isset options["compiledExtension"] {
+				if isset options["extension"] {
+					let optionKey = "extension";
+				} else {
+					let optionKey = "compiledExtension";
+					trigger_error("The 'compiledExtension' option is deprecated. Use 'extension' instead.", E_USER_DEPRECATED);
+				}
+				let compiledPath = options[optionKey];
 				if typeof compiledExtension != "string" {
-					throw new Exception("'compiledExtension' must be a string");
+					throw new Exception("'" . optionKey . "' must be a string");
 				}
 			}
 


### PR DESCRIPTION
Meh!

* Type: new feature
* Link to issue: [#13593](https://github.com/phalcon/cphalcon/issues/13593)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

DI Presets are a new take on the DI factory defaults.  You can instantiate a DI preset class directly or instead use the `configure` method on an existing DI.  The default for `configure` is to clobber any existing services but if `false` is passed as the second argument then the existing services can be preserved.  This is especially useful to allow third party developers to provide a more complete experience.  For example a plugin provided by composer could then be expected to provide a service which could be provided to the DI through the call `Dschissler\MyPlugin\Di\Preset::configure($di, false)`

The Presets at a glance.

```zephir
namespace Phalcon\Di;

use Phalcon\DiInterface;

interface PresetInterface
{
    public static function configure(<DiInterface> di, bool clobber = true);
}
```

```zephir
class Web extends Di implements PresetInterface
{

	public static function configure(<DiInterface> di, bool clobber = true)
	{
		let services = [
			"annotations":        new Service("Phalcon\\Annotations\\Adapter\\Memory", true),
			"assets":             new Service("Phalcon\\Assets\\Manager", true),
			// and so on
		];

		for serviceName, className in services {
			if clobber {
				di->set(serviceName, className, true);
			} else {
				di->attempt(serviceName, className, true);
			}
		}
	}

	public function __construct()
	{
		parent::__construct();

		self::configure(this);
	}
}
```

There is potential room for optimization by allowing the default `clobber` option to set all of the services directly or at least in one pass without calling an expensive function each time.  Other than potentially negligible performance impact (which can be mitigated) the presets are simply superior.

**NOTICE:** This is the first commit to this tech for seeking comments.  There is no change log entry yet because that would complicate merging and I don't expect this to be a painless change.  The tests are more involved, especially since the CLI factory default inherits from the base FD (which I don't believe is correct).

@niden I'm now PRing from private branches so that I can have several of these going at once.  As it nears completion I'll push in the conflicting bits.  I already have the changelog entry done which I'm keeping separately.

- Added DI Presets, remove DI factory defaults. [#13593](https://github.com/phalcon/cphalcon/issues/13593)