### PR TITLE
[#11926] Changed view engine service closures to no longer receive th…

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 - Added `view:afterCompile` and `view:beforeCompile` events for the Volt compiler [#2182](https://github.com/phalcon/cphalcon/pull/2182)
 - Added array merge support to `Phalcon\Config::merge`
 - Added `setBlacklist` in `Phalcon\Debug` to allow the developer to "blacklist" certain variables from the `$_REQUEST` or `$_SERVER` superglobals being displayed on screen [#13687](https://github.com/phalcon/cphalcon/pull/13687)
+- Changed view engine service closures to no longer receive the dependency injector as the second parameter. Instead use `$this` for the DI. [#11926](https://github.com/phalcon/cphalcon/issues/11926)
 
 ## Fixed
 - Fixed router and controller parameter inconsistencies (camelize etc.) [#13555](https://github.com/phalcon/cphalcon/issues/13555)

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -494,7 +494,7 @@ class View extends Injectable implements ViewInterface
 	 */
 	protected function _loadTemplateEngines() -> array
 	{
-		var engines, dependencyInjector, registeredEngines, engineService, extension;
+		var engines, di, registeredEngines, engineService, extension;
 
 		let engines = this->_engines;
 
@@ -503,7 +503,7 @@ class View extends Injectable implements ViewInterface
 		 */
 		if engines === false {
 
-			let dependencyInjector = <DiInterface> this->_dependencyInjector;
+			let di = <DiInterface> this->_dependencyInjector;
 
 			let engines = [];
 			let registeredEngines = this->_registeredEngines;
@@ -512,10 +512,10 @@ class View extends Injectable implements ViewInterface
 				/**
 				 * We use Phalcon\Mvc\View\Engine\Php as default
 				 */
-				let engines[".phtml"] = new PhpEngine(this, dependencyInjector);
+				let engines[".phtml"] = new PhpEngine(this, di);
 			} else {
 
-				if typeof dependencyInjector != "object" {
+				if typeof di != "object" {
 					throw new Exception("A dependency injector container is required to obtain the application services");
 				}
 
@@ -527,6 +527,7 @@ class View extends Injectable implements ViewInterface
 						 * Engine can be a closure
 						 */
 						if engineService instanceof \Closure {
+							let engineService = \Closure::bind(engineService, di);
 							let engines[extension] = call_user_func(engineService, this);
 						} else {
 							let engines[extension] = engineService;
@@ -541,7 +542,7 @@ class View extends Injectable implements ViewInterface
 							throw new Exception("Invalid template engine registration for extension: " . extension);
 						}
 
-						let engines[extension] = dependencyInjector->getShared(engineService, [this]);
+						let engines[extension] = di->getShared(engineService, [this]);
 					}
 				}
 			}

--- a/phalcon/mvc/view.zep
+++ b/phalcon/mvc/view.zep
@@ -494,8 +494,7 @@ class View extends Injectable implements ViewInterface
 	 */
 	protected function _loadTemplateEngines() -> array
 	{
-		var engines, dependencyInjector, registeredEngines, arguments,
-			engineService, extension;
+		var engines, dependencyInjector, registeredEngines, engineService, extension;
 
 		let engines = this->_engines;
 
@@ -520,7 +519,6 @@ class View extends Injectable implements ViewInterface
 					throw new Exception("A dependency injector container is required to obtain the application services");
 				}
 
-				let arguments = [this, dependencyInjector];
 				for extension, engineService in registeredEngines {
 
 					if typeof engineService == "object" {
@@ -529,7 +527,7 @@ class View extends Injectable implements ViewInterface
 						 * Engine can be a closure
 						 */
 						if engineService instanceof \Closure {
-							let engines[extension] = call_user_func_array(engineService, arguments);
+							let engines[extension] = call_user_func(engineService, this);
 						} else {
 							let engines[extension] = engineService;
 						}
@@ -543,7 +541,7 @@ class View extends Injectable implements ViewInterface
 							throw new Exception("Invalid template engine registration for extension: " . extension);
 						}
 
-						let engines[extension] = dependencyInjector->getShared(engineService, arguments);
+						let engines[extension] = dependencyInjector->getShared(engineService, [this]);
 					}
 				}
 			}

--- a/phalcon/mvc/view/simple.zep
+++ b/phalcon/mvc/view/simple.zep
@@ -155,6 +155,7 @@ class Simple extends Injectable implements ViewBaseInterface
 						 * Engine can be a closure
 						 */
 						if engineService instanceof \Closure {
+							let engineService = \Closure::bind(engineService, di);
 							let engineObject = call_user_func(engineService, this);
 						} else {
 							let engineObject = engineService;

--- a/phalcon/mvc/view/simple.zep
+++ b/phalcon/mvc/view/simple.zep
@@ -120,7 +120,7 @@ class Simple extends Injectable implements ViewBaseInterface
 	 */
 	protected function _loadTemplateEngines() -> array
 	{
-		var engines, dependencyInjector, registeredEngines, arguments, extension,
+		var engines, di, registeredEngines, extension,
 			engineService, engineObject;
 
 		/**
@@ -129,7 +129,7 @@ class Simple extends Injectable implements ViewBaseInterface
 		let engines = this->_engines;
 		if engines === false {
 
-			let dependencyInjector = this->_dependencyInjector;
+			let di = this->_dependencyInjector;
 
 			let engines = [];
 
@@ -140,18 +140,13 @@ class Simple extends Injectable implements ViewBaseInterface
 				 * We use Phalcon\Mvc\View\Engine\Php as default
 				 * Use .phtml as extension for the PHP engine
 				 */
-				let engines[".phtml"] = new PhpEngine(this, dependencyInjector);
+				let engines[".phtml"] = new PhpEngine(this, di);
 
 			} else {
 
-				if typeof dependencyInjector != "object" {
+				if typeof di != "object" {
 					throw new Exception("A dependency injector container is required to obtain the application services");
 				}
-
-				/**
-				 * Arguments for instantiated engines
-				 */
-				let arguments = [this, dependencyInjector];
 
 				for extension, engineService in registeredEngines {
 
@@ -160,7 +155,7 @@ class Simple extends Injectable implements ViewBaseInterface
 						 * Engine can be a closure
 						 */
 						if engineService instanceof \Closure {
-							let engineObject = call_user_func_array(engineService, arguments);
+							let engineObject = call_user_func(engineService, this);
 						} else {
 							let engineObject = engineService;
 						}
@@ -169,7 +164,7 @@ class Simple extends Injectable implements ViewBaseInterface
 						 * Engine can be a string representing a service in the DI
 						 */
 						if typeof engineService == "string" {
-							let engineObject = dependencyInjector->getShared(engineService, arguments);
+							let engineObject = di->getShared(engineService, [this]);
 						} else {
 							throw new Exception("Invalid template engine registration for extension: " . extension);
 						}

--- a/tests/integration/Mvc/View/Engine/Volt/CompilerCest.php
+++ b/tests/integration/Mvc/View/Engine/Volt/CompilerCest.php
@@ -278,8 +278,8 @@ class CompilerCest
         $view->setDI($di);
         $view->setViewsDir(dataFolder('fixtures/views/'));
         $view->registerEngines([
-            '.volt' => function ($view, $di) {
-                return new Volt($view, $di);
+            '.volt' => function ($view) {
+                return new Volt($view, $this);
             },
         ]);
         $object      = new \stdClass();

--- a/tests/integration/Mvc/View/Engine/Volt/CompilerCest.php
+++ b/tests/integration/Mvc/View/Engine/Volt/CompilerCest.php
@@ -62,7 +62,7 @@ class CompilerCest
         $view->setViewsDir(dataFolder('fixtures/views/'));
 
         $view->registerEngines([
-            '.volt' => 'Phalcon\Mvc\View\Engine\Volt',
+            '.volt' => Volt::class,
         ]);
 
         $view->setParamToView('song', 'Rock n roll');
@@ -166,8 +166,8 @@ class CompilerCest
         $view->setViewsDir(dataFolder('fixtures/views/'));
 
         $view->registerEngines([
-            '.volt' => function ($view, $di) {
-                $volt     = new Volt($view, $di);
+            '.volt' => function ($view) {
+                $volt     = new Volt($view, $this);
                 $compiler = $volt->getCompiler();
                 $compiler->addFunction('strtotime', 'strtotime');
                 return $volt;


### PR DESCRIPTION
…e dependency injector as the second parameter.

Hello!

* Type: bug fix
* Link to issue: [#11926](https://github.com/phalcon/cphalcon/issues/11926)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [x] I wrote some tests for this PR.

Back in Phalcon 2.0 the DI was changed to bind service functions to itself.  Before that it was necessary to use `use ($di)` in the function.  This is a minor tweak to remove the DI from being passed as the second argument in the view engine service functions.  Instead use `$this`.

**NOTICE:** I'm trying something different by using a different forked branch for each PR.  If this change is acceptable then I'll make the change log entry to get this all of the way through.  In order to avoid merge conflicts this should be done as late as possible.  I hope to be able to have several of these going at once for higher throughput.