### PR TITLE
[13647] - Allow default PDO DSN values.

### DIFF
--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -52,7 +52,7 @@ abstract class Pdo extends Adapter
 	protected _pdo;
 
 	/**
-	 *
+	 * Returns PDO adapter DSN defaults as a key-value map.
 	 */
 	abstract protected function getDsnDefaults() -> array;
 

--- a/phalcon/db/adapter/pdo.zep
+++ b/phalcon/db/adapter/pdo.zep
@@ -52,6 +52,11 @@ abstract class Pdo extends Adapter
 	protected _pdo;
 
 	/**
+	 *
+	 */
+	abstract protected function getDsnDefaults() -> array;
+
+	/**
 	 * Constructor for Phalcon\Db\Adapter\Pdo
 	 */
 	public function __construct(array! descriptor)
@@ -75,7 +80,6 @@ abstract class Pdo extends Adapter
 	{
 		return this->_affectedRows;
 	}
-
 
 	/**
 	 * Starts a transaction in the connection
@@ -246,8 +250,8 @@ abstract class Pdo extends Adapter
 	 */
 	public function connect(array descriptor = null) -> bool
 	{
-		var username, password, dsnParts, dsnAttributes,
-			persistent, options, key, value;
+		var username, password, dsnDefaults, dsnDefaultValue, dsnParts,
+			dsnAttributes, persistent, options, key, value, pdoKey;
 
 		if empty descriptor {
 			let descriptor = (array) this->_descriptor;
@@ -283,12 +287,15 @@ abstract class Pdo extends Adapter
 		/**
 		 * Check for \PDO::XXX class constant aliases
 		 */
-        for key, value in options {
-            if typeof key == "string" && defined("\PDO::" . key->upper()) {
-                let options[constant("\PDO::" . key->upper())] = value;
-                unset options[key];
-            }
-        }
+		for key, value in options {
+			if typeof key == "string" {
+				let pdoKey = "\PDO::" . key->upper();
+				if defined(pdoKey) {
+					let options[constant(pdoKey)] = value;
+					unset options[key];
+				}
+			}
+		}
 
 		/**
 		 * Check if the connection must be persistent
@@ -310,9 +317,13 @@ abstract class Pdo extends Adapter
 		/**
 		 * Check if the user has defined a custom dsn
 		 */
-		 if !fetch dsnAttributes, descriptor["dsn"] {
+		if !fetch dsnAttributes, descriptor["dsn"] {
+			let dsnDefaults = this->getDsnDefaults();
 			let dsnParts = [];
 			for key, value in descriptor {
+				if fetch dsnDefaultValue, dsnDefaults[key] {
+					let value = dsnDefaultValue;
+				}
 				let dsnParts[] = key . "=" . value;
 			}
 			let dsnAttributes = join(";", dsnParts);

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -47,6 +47,16 @@ class Mysql extends PdoAdapter
 	protected _type = "mysql";
 
 	/**
+	 *
+	 */
+	protected function getDsnDefaults() -> array
+	{
+		return [
+			"charset" : "utf8mb4"
+		];
+	}
+
+	/**
 	 * Adds a foreign key to a table
 	 */
 	public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> bool

--- a/phalcon/db/adapter/pdo/mysql.zep
+++ b/phalcon/db/adapter/pdo/mysql.zep
@@ -47,10 +47,11 @@ class Mysql extends PdoAdapter
 	protected _type = "mysql";
 
 	/**
-	 *
+	 * Returns PDO adapter DSN defaults as a key-value map.
 	 */
 	protected function getDsnDefaults() -> array
 	{
+		// In modern MySQL the "utf8mb4" charset is more ideal than just "uf8".
 		return [
 			"charset" : "utf8mb4"
 		];

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -45,6 +45,23 @@ class Postgresql extends PdoAdapter
 
 	protected _type = "pgsql";
 
+	protected function getDsnDefaults() -> array
+	{
+		return [];
+	}
+
+	/**
+	 * Constructor for Phalcon\Db\Adapter\Pdo\Postgresql
+	 */
+	public function __construct(array! descriptor)
+	{
+		if isset descriptor["charset"] {
+			trigger_error("Postgres does not allow the charset to be changed in the DSN.");
+		}
+
+		parent::__construct(descriptor);
+	}
+
 	/**
 	 * This method is automatically called in Phalcon\Db\Adapter\Pdo constructor.
 	 * Call it when you need to restore a database connection.

--- a/phalcon/db/adapter/pdo/postgresql.zep
+++ b/phalcon/db/adapter/pdo/postgresql.zep
@@ -45,6 +45,9 @@ class Postgresql extends PdoAdapter
 
 	protected _type = "pgsql";
 
+	/**
+	 * Returns PDO adapter DSN defaults as a key-value map.
+	 */
 	protected function getDsnDefaults() -> array
 	{
 		return [];

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -44,6 +44,26 @@ class Sqlite extends PdoAdapter
 	protected _type = "sqlite";
 
 	/**
+	 *
+	 */
+	protected function getDsnDefaults() -> array
+	{
+		return [];
+	}
+
+	/**
+	 * Constructor for Phalcon\Db\Adapter\Pdo\Sqlite
+	 */
+	public function __construct(array! descriptor)
+	{
+		if isset descriptor["charset"] {
+			trigger_error("Postgres does not allow the charset to be changed in the DSN.");
+		}
+
+		parent::__construct(descriptor);
+	}
+
+	/**
 	 * This method is automatically called in Phalcon\Db\Adapter\Pdo constructor.
 	 * Call it when you need to restore a database connection.
 	 */

--- a/phalcon/db/adapter/pdo/sqlite.zep
+++ b/phalcon/db/adapter/pdo/sqlite.zep
@@ -44,7 +44,7 @@ class Sqlite extends PdoAdapter
 	protected _type = "sqlite";
 
 	/**
-	 *
+	 * Returns PDO adapter DSN defaults as a key-value map.
 	 */
 	protected function getDsnDefaults() -> array
 	{
@@ -57,7 +57,7 @@ class Sqlite extends PdoAdapter
 	public function __construct(array! descriptor)
 	{
 		if isset descriptor["charset"] {
-			trigger_error("Postgres does not allow the charset to be changed in the DSN.");
+			trigger_error("Sqlite does not allow the charset to be changed in the DSN.");
 		}
 
 		parent::__construct(descriptor);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: [#13647](https://github.com/phalcon/cphalcon/issues/13647)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Small description of change:

This initial commit is an early proof-of-concept for providing automatic DSN values for each PDO adapter.  At the moment only the MySQL adapter is providing anything with `charset=utf8mb4`.  As far as the other included adapters postgres and sqlite don't seem to support that option.  The goal is to remove the need to specify the charset in PHP code for 99% of the users.  This will ease the learning curve as well as allow frameworks and skeletons to have an easier time.

**NOTICE:** I'm trying something different by using a different forked branch for each PR.  If this change is acceptable then I'll make the change log entry to get this all of the way through.  In order to avoid merge conflicts this should be done as late as possible.  I hope to be able to have several of these going at once for higher throughput.