### PR TITLE
DI::get shared caching - a more comprehensive solution

### DIFF
--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -225,7 +225,7 @@ class Di implements DiInterface
 		let eventsManager = <ManagerInterface> this->_eventsManager;
 
 		// Allows for custom creation of instances through the "di:beforeServiceResolve" event.
-		if eventsManager !== null {
+		if typeof eventsManager == "object" {
 			let instance = eventsManager->fire(
 				"di:beforeServiceResolve",
 				this,
@@ -273,7 +273,7 @@ class Di implements DiInterface
 		}
 
 		// Allows for post creation instance configuration through the "di:beforeServiceResolve" event.
-		if eventsManager !== null {
+		if typeof eventsManager == "object" {
 			eventsManager->fire(
 				"di:afterServiceResolve",
 				this,

--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -254,7 +254,7 @@ class Di implements DiInterface
 
 				// The DI also acts as builder for any class even if it isn't defined in the DI
 				if !class_exists(name) {
-					throw new Exception("Service '" . name . "' was unable to resolved in the dependency injection container.");
+					throw new Exception("Service '" . name . "' wasn't found in the dependency injection container");
 				}
 
 				if typeof parameters == "array" && count(parameters) {

--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -205,34 +205,56 @@ class Di implements DiInterface
 	 */
 	public function get(string! name, parameters = null) -> var
 	{
-		var service, eventsManager, instance = null;
+		var service, eventsManager, isShared, instance = null;
+
+		// If the service is shared and it already has a cached instance then
+		// immediately return it without triggering events.
+		if fetch service, this->_services[name] {
+			let isShared = service->isShared();
+			if isShared && isset this->_sharedInstances[name] {
+
+				// FIXME: This must be used due to wasFreshInstance()
+				// @see https://github.com/phalcon/cphalcon/pull/13112
+				return this->getShared(name, parameters);
+
+				// This is the desired simple way of returning the shared instance.
+				// return this->_sharedInstances[name];
+			}
+		}
 
 		let eventsManager = <ManagerInterface> this->_eventsManager;
 
-		if typeof eventsManager == "object" {
+		// Allows for custom creation of instances through the "di:beforeServiceResolve" event.
+		if eventsManager !== null {
 			let instance = eventsManager->fire(
 				"di:beforeServiceResolve",
 				this,
-				["name": name, "parameters": parameters]
+				[
+					"name": name,
+					"parameters": parameters
+				]
 			);
 		}
 
 		if typeof instance != "object" {
-			if fetch service, this->_services[name] {
-				/**
-				 * The service is registered in the DI
-				 */
+			if service !== null {
+
+				// The service is registered in the DI.
 				try {
 					let instance = service->resolve(parameters, this);
 				} catch ServiceResolutionException {
 					throw new Exception("Service '" . name . "' cannot be resolved");
 				}
+
+				// If the service is shared then we'll cache the instance.
+				if isShared {
+					let this->_sharedInstances[name] = instance;
+				}
 			} else {
-				/**
-				 * The DI also acts as builder for any class even if it isn't defined in the DI
-				 */
+
+				// The DI also acts as builder for any class even if it isn't defined in the DI
 				if !class_exists(name) {
-					throw new Exception("Service '" . name . "' wasn't found in the dependency injection container");
+					throw new Exception("Service '" . name . "' was unable to resolved in the dependency injection container.");
 				}
 
 				if typeof parameters == "array" && count(parameters) {
@@ -243,16 +265,15 @@ class Di implements DiInterface
 			}
 		}
 
-		/**
-		 * Pass the DI itself if the instance implements \Phalcon\Di\InjectionAwareInterface
-		 */
+		// Pass the DI to the instance if it implements \Phalcon\Di\InjectionAwareInterface
 		if typeof instance == "object" {
 			if instance instanceof InjectionAwareInterface {
 				instance->setDI(this);
 			}
 		}
 
-		if typeof eventsManager == "object" {
+		// Allows for post creation instance configuration through the "di:beforeServiceResolve" event.
+		if eventsManager !== null {
 			eventsManager->fire(
 				"di:afterServiceResolve",
 				this,

--- a/phalcon/di.zep
+++ b/phalcon/di.zep
@@ -272,7 +272,7 @@ class Di implements DiInterface
 			}
 		}
 
-		// Allows for post creation instance configuration through the "di:beforeServiceResolve" event.
+		// Allows for post creation instance configuration through the "di:afterServiceResolve" event.
 		if typeof eventsManager == "object" {
 			eventsManager->fire(
 				"di:afterServiceResolve",


### PR DESCRIPTION
Hello! @virgofx @niden @sergeyklay 

* Type: new feature
* Link to issue: This PR touches on a few other initiatives.

This is designed to help
* [Pull Request 13112](https://github.com/phalcon/cphalcon/pull/13112)
* [Issue 13440](https://github.com/phalcon/cphalcon/issues/13440)

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ] I wrote some tests for this PR.

Last night I read through issue #13440 for improving the DI to deal with process forking.  I realized that the `DI::get` method could be improved to allow for actual shared caching so possible that `DI::get` could be used through Phalcon instead of `DI::getShared` (in as many places as possible).  Next up was the `isFreshInstance` hack around and that lead me to @virgofx 's unmerged PR to fix an architectural flaw in how Phalcon initialized some objects.

I see this PR being a companion to @virgofx 's PR.  Hopefully the entire "isFreshInstance" code can be deleted from the DI class as it is just a hack to fix a design flaw.

My goal with this PR is to allow a service that was set to shared to be treated the same if it was retrieved through `get` and `getShared`.  So I added shared cache short-circuiting in `get`.  In the initial commit there is a commented line for the desired behaviour but to not break things as they are right this moment I'm using the `getShared` method since it contains the fresh instance hacks.

One final thing.  This PR will change the behaviour of `DI::get` so that retrieving cached shared instances will not fire the `"di:beforeServiceResolve"` and `"di:afterServiceResolve"` events.  `getShared` already behaves this way so its really just treating `get` with shared services the same as `getShared`.