### PR TITLE
Dispatcher handlercache

### DIFF
--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -495,14 +495,6 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 			let handler = dependencyInjector->getShared(handlerClass);
 
-			let handlerHash = spl_object_hash(handler);
-
-			// Ensure that the handler is new.
-			let wasFresh = isset this->_handlerHashes[handlerHash] ? false : true;
-			if wasFresh {
-				let this->_handlerHashes[handlerHash] = true;
-			}
-
 			// Handlers must be only objects
 			if typeof handler !== "object" {
 				let status = this->{"_throwDispatchException"}("Invalid handler returned from the services container", self::EXCEPTION_INVALID_HANDLER);
@@ -510,6 +502,13 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 					continue;
 				}
 				break;
+			}
+
+			// Check if the handler is new (hasn't been initialized).
+			let handlerHash = spl_object_hash(handler);
+			let wasFresh = isset this->_handlerHashes[handlerHash] ? false : true;
+			if wasFresh {
+				let this->_handlerHashes[handlerHash] = true;
 			}
 
 			let this->_activeHandler = handler;

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -81,6 +81,8 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 
 	protected _isControllerInitialize = false;
 
+	protected _handlerHashes = [];
+
 	const EXCEPTION_NO_DI = 0;
 
 	const EXCEPTION_CYCLIC_ROUTING = 1;
@@ -394,7 +396,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			actionName, params, eventsManager,
 			actionSuffix, handlerClass, status, actionMethod,
 			modelBinder, bindCacheKey,
-			wasFresh, e;
+			wasFresh, handlerHash, e;
 
 		let dependencyInjector = <DiInterface> this->_dependencyInjector;
 		if typeof dependencyInjector != "object" {
@@ -492,7 +494,14 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			}
 
 			let handler = dependencyInjector->getShared(handlerClass);
-			let wasFresh = dependencyInjector->wasFreshInstance();
+
+			let handlerHash = spl_object_hash(handler);
+
+			// Ensure that the handler is new.
+			let wasFresh = isset this->_handlerHashes[handlerHash] ? false : true;
+			if wasFresh {
+				this->_handlerHashes[handlerHash] = true;
+			}
 
 			// Handlers must be only objects
 			if typeof handler !== "object" {

--- a/phalcon/dispatcher.zep
+++ b/phalcon/dispatcher.zep
@@ -500,7 +500,7 @@ abstract class Dispatcher implements DispatcherInterface, InjectionAwareInterfac
 			// Ensure that the handler is new.
 			let wasFresh = isset this->_handlerHashes[handlerHash] ? false : true;
 			if wasFresh {
-				this->_handlerHashes[handlerHash] = true;
+				let this->_handlerHashes[handlerHash] = true;
 			}
 
 			// Handlers must be only objects


### PR DESCRIPTION
…a handler hash cache.

Hello!  This is another proof of concept PR

* Type: code quality
* Link to issue: #13853

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
- [ ]  I did not write tests for this because a large refactor of the Dispatcher is needed.  This is only to remove one small wart.  Creating tests at this time would be premature.

This PR is attempting to solve the use of `DI::wasFreshInstance` in `Phalcon\Dispatcher`.  I think that `DI::wasFreshInstance` should be completely removed in 4.0.x since it is only used in this one place for this hack.  I'm attempting to see if a hash hit map of all handlers seen could be used instead of the use of `wasFreshInstance`.

I'm attempting to understand everything that would need to be changed to get the Dispatcher to run initialize first every time as first began by @virgofx but wow is it some involved code.  I'm not sure that I'm setup to change something so large at this point.  So I'm starting small.  This PR may never be merged or I could also grow it to be more encompassing.