### PR TITLE
[Db] Generated DialectClass referring to a raw PHP class won't be found

### DIFF
--- a/phalcon/db/adapter.zep
+++ b/phalcon/db/adapter.zep
@@ -116,7 +116,7 @@ abstract class Adapter implements AdapterInterface, EventsAwareInterface
 		 * Dialect class can override the default dialect
 		 */
 		if !fetch dialectClass, descriptor["dialectClass"] {
-			let dialectClass = "phalcon\\db\\dialect\\" . this->_dialectType;
+			let dialectClass = "Phalcon\\Db\\Dialect\\" . ucfirst(this->_dialectType);
 		}
 
 		/**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/incubator/issues/663

**In raising this pull request, I confirm the following (please check boxes):**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)?
- [x] I have checked that another pull request for this purpose does not exist.
https://github.com/phalcon/cphalcon/pull/12686 exists, but closed and messed up (indeed it was myself on another github account years ago)
- [ ] I wrote some tests for this PR.

## Description
On Instantiating a Db-Instance, the DialectClass is generated by Zephir if not given as a property. The generated Class is always lowercase which does only work for internal zephir classes, but not for PHP-Classes for example the Oracle adapter given by the incubator.

### This won't work...
... because the dialectClass Property is not given and phalcon tries to guess it on its own.
As zephir works case insensitive the generated class `phalcon\db\dialect\oracle` won't be found, because it's not inside Phalcon since 3.0, but available via incubator only
```
$test = new \Phalcon\Db\Adapter\Pdo\Oracle([
            'username'    => '',
            'password'    => '',
            'dbname'      => ''
        ]);
```
#### Result
Fatal error: Class 'phalcon\db\dialect\oracle' not found in ....

### Workaround 
If the dialectClass is given as property, then it works
```
$test = new \Phalcon\Db\Adapter\Pdo\Oracle([
            'username'    => '',
            'password'    => '',
            'dbname'      => '',
            'dialectClass' => \Phalcon\Db\Dialect\Oracle::class
        ]);
```

## Closes
https://github.com/phalcon/incubator/issues/663
More Info: https://github.com/phalcon/incubator/issues/663#issuecomment-285032030


