### PR TITLE
[Translate] more options to csv adapter

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,6 @@
 # [4.0.0-alpha.4](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.4) (2019-XX-XX)
-
+## Added
+- Added `delimiter` and `enclosure` options to *Phalcon\Translate\Adapter\Csv* constructor
 # [4.0.0-alpha.3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.3) (2019-02-31)
 ## Added
 - Added `view:afterCompile` and `view:beforeCompile` events for the Volt compiler [#2182](https://github.com/phalcon/cphalcon/pull/2182)

--- a/phalcon/translate/adapter/csv.zep
+++ b/phalcon/translate/adapter/csv.zep
@@ -28,13 +28,27 @@ class Csv extends Adapter implements \ArrayAccess
 	 */
 	public function __construct(array! options)
 	{
+		var delimiter, enclosure;
+
 		parent::__construct(options);
 
 		if !isset options["content"] {
 			throw new Exception("Parameter 'content' is required");
 		}
 
-		this->_load(options["content"], 0, ";", "\"");
+		if !isset options["delimiter"] {
+			let delimiter = options["delimiter"];
+		} else {
+			let delimiter = ";";
+		}
+
+		if !isset options["enclosure"] {
+			let enclosure = options["enclosure"];
+		} else {
+			let enclosure = "\"";
+		}
+
+		this->_load(options["content"], 0, delimiter, enclosure);
 	}
 
 	/**

--- a/phalcon/translate/adapter/csv.zep
+++ b/phalcon/translate/adapter/csv.zep
@@ -36,13 +36,13 @@ class Csv extends Adapter implements \ArrayAccess
 			throw new Exception("Parameter 'content' is required");
 		}
 
-		if !isset options["delimiter"] {
+		if isset options["delimiter"] {
 			let delimiter = options["delimiter"];
 		} else {
 			let delimiter = ";";
 		}
 
-		if !isset options["enclosure"] {
+		if isset options["enclosure"] {
 			let enclosure = options["enclosure"];
 		} else {
 			let enclosure = "\"";

--- a/tests/_data/assets/translation/csv/fr_FR_options.csv
+++ b/tests/_data/assets/translation/csv/fr_FR_options.csv
@@ -1,3 +1,3 @@
 # Commented string
 'Hello!'	'Bonjour!'
-'Hello %fname% %mname% %lname%!'	'Привет, %fname% %mname% %lname%!'
+'Hello %fname% %mname% %lname%!'	'Bonjour, %fname% %mname% %lname%!'

--- a/tests/_data/assets/translation/csv/fr_FR_options.csv
+++ b/tests/_data/assets/translation/csv/fr_FR_options.csv
@@ -1,0 +1,3 @@
+# Commented string
+'Hello!'	'Bonjour!'
+'Hello %fname% %mname% %lname%!'	'Привет, %fname% %mname% %lname%!'

--- a/tests/unit/Translate/Adapter/CsvCest.php
+++ b/tests/unit/Translate/Adapter/CsvCest.php
@@ -27,7 +27,7 @@ class CsvCest
         $this->config = [
             'ru' => ['content' => dataFolder('assets/translation/csv/ru_RU.csv')],
             // the next delimiter is a tab character
-            'options' => ['content' => dataFolder('assets/translation/csv/fr_FR.csv'), 'delimiter' => "	", 'enclosure' => "'"]
+            'options' => ['content' => dataFolder('assets/translation/csv/fr_FR_options.csv'), 'delimiter' => "	", 'enclosure' => "'"]
         ];
     }
 

--- a/tests/unit/Translate/Adapter/CsvCest.php
+++ b/tests/unit/Translate/Adapter/CsvCest.php
@@ -24,7 +24,11 @@ class CsvCest
      */
     public function _before(UnitTester $I)
     {
-        $this->config = ['ru' => ['content' => dataFolder('assets/translation/csv/ru_RU.csv')]];
+        $this->config = [
+            'ru' => ['content' => dataFolder('assets/translation/csv/ru_RU.csv')],
+            // the next delimiter is a tab character
+            'options' => ['content' => dataFolder('assets/translation/csv/fr_FR.csv'), 'delimiter' => "	", 'enclosure' => "'"]
+        ];
     }
 
 
@@ -50,4 +54,25 @@ class CsvCest
         );
         $I->assertEquals($expect, $actual);
     }
+    
+    /**
+     * Translate into french with a csv using non standard delimiter and enclosure
+     */
+    public function testCsvOptions(UnitTester $I)
+    {
+        $params     = $this->config['options'];
+        $translator = new Csv($params);
+
+        $expect = 'Bonjour!';
+        $actual = $translator->query('Hello!');
+        $I->assertEquals($expect, $actual);
+
+        $expect = 'Bonjour, TestFname TestMname TestLname!';
+        $actual = $translator->query(
+            'Hello %fname% %mname% %lname%!',
+            ["fname" => "TestFname", "mname" => "TestMname", "lname" => "TestLname"]
+        );
+        $I->assertEquals($expect, $actual);
+    }
+    
 }

--- a/tests/unit/Translate/Adapter/CsvCest.php
+++ b/tests/unit/Translate/Adapter/CsvCest.php
@@ -74,5 +74,4 @@ class CsvCest
         );
         $I->assertEquals($expect, $actual);
     }
-    
 }


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Added `delimiter` and `enclosure` options to *Phalcon\Translate\Adapter\Csv* constructor. In order to support non-standard formats, for instance with a *tab* delimiter.