### PR TITLE
Fix: assets manager hard reference to phalcon\tag. Use DI

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -24,6 +24,9 @@ The implementation offers PSR-7/PSR-17 compatible components in a different name
 [#13889](https://github.com/phalcon/cphalcon/pull/13889)
 - Added `Phalcon\Collection`, an object implementing `ArrayAccess`, `Countable`, `IteratorAggregate`, `JsonSerializable`, `Serializable`, offering an easy way to handle collections of data such as arrays, superglobals etc. [#13886](https://github.com/phalcon/cphalcon/issues/13886)
 
+## Fixed
+- Fixed Assets Manager hard reference to \Phalcon\Tag, should use DI [#12261](https://github.com/phalcon/cphalcon/issues/12261)
+
 
 # [4.0.0-alpha.3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.3) (2019-02-31)
 ## Added

--- a/phalcon/assets/manager.zep
+++ b/phalcon/assets/manager.zep
@@ -18,14 +18,18 @@ use Phalcon\Assets\Asset\Js as AssetJs;
 use Phalcon\Assets\Asset\Css as AssetCss;
 use Phalcon\Assets\Inline\Css as InlineCss;
 use Phalcon\Assets\Inline\Js as InlineJs;
+use Phalcon\DiInterface;
+use Phalcon\Di\InjectionAwareInterface;
 
 /**
  * Phalcon\Assets\Manager
  *
  * Manages collections of CSS/Javascript assets
  */
-class Manager
+class Manager implements InjectionAwareInterface
 {
+
+	protected _dependencyInjector;
 
 	/**
 	 * Options configure
@@ -36,7 +40,7 @@ class Manager
 	protected collections;
 
 	/**
-	 * @var bool 
+	 * @var bool
 	 */
 	protected implicitOutput = true;
 
@@ -46,6 +50,22 @@ class Manager
 	public function __construct(array options = [])
 	{
 		let this->options = options;
+	}
+
+	/**
+	 * Sets the dependency injector
+	 */
+	public function setDI(<DiInterface> dependencyInjector)
+	{
+		let this->_dependencyInjector = dependencyInjector;
+	}
+
+	/**
+	 * Returns the internal dependency injector
+	 */
+	public function getDI() -> <DiInterface>
+	{
+		return this->_dependencyInjector;
 	}
 
 	/**
@@ -763,7 +783,7 @@ class Manager
 	 */
 	public function outputCss(string collectionName = null) -> string
 	{
-		var collection;
+		var collection, dependencyInjector, tag, callback;
 
 		if !collectionName {
 			let collection = this->getCss();
@@ -771,7 +791,15 @@ class Manager
 			let collection = this->get(collectionName);
 		}
 
-		return this->output(collection, ["Phalcon\\Tag", "stylesheetLink"], "css");
+		let callback = ["Phalcon\\Tag", "stylesheetLink"];
+
+		let dependencyInjector = this->_dependencyInjector;
+		if typeof dependencyInjector == "object" && dependencyInjector->has("tag") {
+			let tag = dependencyInjector->getShared("tag");
+			let callback = [tag, "stylesheetLink"];
+		}
+
+		return this->output(collection, callback, "css");
 	}
 
 	/**
@@ -795,7 +823,7 @@ class Manager
 	 */
 	public function outputJs(string collectionName = null) -> string
 	{
-		var collection;
+		var collection, dependencyInjector, tag, callback;
 
 		if !collectionName {
 			let collection = this->getJs();
@@ -803,7 +831,15 @@ class Manager
 			let collection = this->get(collectionName);
 		}
 
-		return this->output(collection, ["Phalcon\\Tag", "javascriptInclude"], "js");
+		let callback = ["Phalcon\\Tag", "javascriptInclude"];
+
+		let dependencyInjector = this->_dependencyInjector;
+		if typeof dependencyInjector == "object" && dependencyInjector->has("tag") {
+			let tag = dependencyInjector->getShared("tag");
+			let callback = [tag, "javascriptInclude"];
+		}
+
+		return this->output(collection, callback, "js");
 	}
 
 	/**

--- a/tests/_data/fixtures/Assets/CustomTag.php
+++ b/tests/_data/fixtures/Assets/CustomTag.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Fixtures\Assets;
+
+class CustomTag extends \Phalcon\Tag
+{
+    public static function stylesheetLink($parameters = null, bool $local = true): string
+    {
+        return sprintf("<link href=\"%s\">\n", $parameters[0]);
+    }
+
+    public static function javascriptInclude($parameters = null, bool $local = true): string
+    {
+        return sprintf("<script src=\"%s\" type=\"application/javascript\"></script>\n", $parameters[0]);
+    }
+}

--- a/tests/unit/Assets/Manager/OutputCssCest.php
+++ b/tests/unit/Assets/Manager/OutputCssCest.php
@@ -17,6 +17,7 @@ use Phalcon\Assets\Manager;
 use Phalcon\Test\Fixtures\Assets\TrimFilter;
 use Phalcon\Test\Fixtures\Assets\UppercaseFilter;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Fixtures\Assets\CustomTag;
 use UnitTester;
 
 /**
@@ -129,6 +130,34 @@ class OutputCssCest
 
         $I->safeDeleteFile(cacheFolder($fileName));
 
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Assets\Manager :: outputCss() - custom tag component
+     *
+     * @param UnitTester $I
+     */
+    public function assetsManagerOutputCssCustomTag(UnitTester $I)
+    {
+        $I->wantToTest('Assets\Manager - outputCss() - custom tag component');
+
+        $di = $this->getDi();
+        $di->setShared('tag', CustomTag::class);
+
+        $assets = new Manager();
+        $assets->setDI($di);
+
+        $assets->addCss('css/style1.css');
+        $assets->addCss('/css/style2.css');
+        $assets->addAsset(new Css('/css/style.css'));
+
+        $expected = '<link href="css/style1.css">' . PHP_EOL
+            . '<link href="/css/style2.css">' . PHP_EOL
+            . '<link href="/css/style.css">' . PHP_EOL;
+
+        $assets->useImplicitOutput(false);
+        $actual = $assets->outputCss();
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Assets/Manager/OutputJsCest.php
+++ b/tests/unit/Assets/Manager/OutputJsCest.php
@@ -15,12 +15,34 @@ namespace Phalcon\Test\Unit\Assets\Manager;
 use Phalcon\Assets\Asset\Js;
 use Phalcon\Assets\Manager;
 use UnitTester;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Fixtures\Assets\CustomTag;
 
 /**
  * Class OutputJsCest
  */
 class OutputJsCest
 {
+    use DiTrait;
+
+    /**
+     * @param UnitTester $I
+     */
+    public function _after(UnitTester $I)
+    {
+        $this->resetDi();
+    }
+
+    /**
+     * @param UnitTester $I
+     */
+    public function _before(UnitTester $I)
+    {
+        $this->newDi();
+        $this->setDiEscaper();
+        $this->setDiUrl();
+    }
+
     /**
      * Tests Phalcon\Assets\Manager :: outputJs() - implicit
      *
@@ -67,6 +89,35 @@ class OutputJsCest
         $expected = '<script src="/js/script1.js"></script>' . PHP_EOL
             . '<script src="/js/script2.js"></script>' . PHP_EOL
             . '<script src="/js/script3.js"></script>' . PHP_EOL;
+
+        ob_start();
+        $assets->outputJs();
+        $actual = ob_get_clean();
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Assets\Manager :: outputJs - custom tag component
+     *
+     * @param UnitTester $I
+     */
+    public function assetsManagerOutputJsCustomTag(UnitTester $I)
+    {
+        $I->wantToTest('Asset/Manager - outputJs() - custom tag component');
+
+        $di = $this->getDi();
+        $di->setShared('tag', CustomTag::class);
+
+        $assets = new Manager();
+        $assets->setDI($di);
+
+        $assets->addJs('js/script1.js');
+        $assets->addJs('/js/script2.js');
+        $assets->addAsset(new Js('/js/script3.js'));
+
+        $expected = '<script src="js/script1.js" type="application/javascript"></script>' . PHP_EOL
+            . '<script src="/js/script2.js" type="application/javascript"></script>' . PHP_EOL
+            . '<script src="/js/script3.js" type="application/javascript"></script>' . PHP_EOL;
 
         ob_start();
         $assets->outputJs();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12261

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Thanks
