### PR TITLE
Fixed compatibility issue.

### DIFF
--- a/phalcon/image/adapter/imagick.zep
+++ b/phalcon/image/adapter/imagick.zep
@@ -346,20 +346,10 @@ class Imagick extends Adapter
 		var watermark, ret, version, method;
 
 		let opacity = opacity / 100,
-			watermark = new \Imagick(),
-			method = "setImageOpacity";
-
-		// Imagick >= 2.0.0
-		if likely method_exists(watermark, "getVersion") {
-			let version = watermark->getVersion();
-
-			if version["versionNumber"] >= 0x700 {
-				let method = "setImageAlpha";
-			}
-		}
+			watermark = new \Imagick();
 
 		watermark->readImageBlob(image->render());
-		watermark->{method}(opacity);
+		watermark->evaluateImage(constant("Imagick::EVALUATE_MULTIPLY"), opacity, constant("Imagick::CHANNEL_ALPHA"));
 
 		this->_image->setIteratorIndex(0);
 


### PR DESCRIPTION
Hello!

* Type: improvement
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

setImageAlpha () - fills the alpha channel with black before execution.
evaluateImage () is the best compatibility.

Thanks

