### PR TITLE
Annotations\Reader::parse() always returns an array.

### DIFF
--- a/phalcon/Annotations/Adapter.zep
+++ b/phalcon/Annotations/Adapter.zep
@@ -65,14 +65,10 @@ abstract class Adapter implements AdapterInterface
             let reader = this->getReader(),
                 parsedAnnotations = reader->parse(realClassName);
 
-            /**
-             * If the reader returns a
-             */
-            if typeof parsedAnnotations == "array" {
-                let classAnnotations = new Reflection(parsedAnnotations),
-                    this->annotations[realClassName] = classAnnotations;
-                    this->{"write"}(realClassName, classAnnotations);
-            }
+
+            let classAnnotations = new Reflection(parsedAnnotations),
+                this->annotations[realClassName] = classAnnotations;
+                this->{"write"}(realClassName, classAnnotations);
         }
 
         return classAnnotations;


### PR DESCRIPTION
Hello!

* Type: code quality

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I updated the CHANGELOG

Small description of change:

[`Annotations\Reader::parse()`](https://github.com/phalcon/cphalcon/blob/4.0.x/phalcon/Annotations/Reader.zep#L26) always returns an array so we don't need to check if it is.




Thanks

