### PR TITLE
Simplified events.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,3 +1,7 @@
+# [4.0.0-alpha.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.5) (2019-xx-xx)
+## Changed
+- Refactored `Phalcon\Events\Manager` to only use `SplPriorityQueue` to store events.
+
 # [4.0.0-alpha.4](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.4) (2019-03-31)
 ## Added
 - Added `delimiter` and `enclosure` options to *Phalcon\Translate\Adapter\Csv* constructor


### PR DESCRIPTION
Hello!

* Type: code quality

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Previously, the Events Manager was able to store events in two different systems - SplPriorityQueue and arrays. The system depended on whether priorities were enabled or not.

A lof of the code look similar to this:

```zephir
if this->enablePriorities {
    // Handle SplPriorityQueue
} else {
    // Handle array
}
```

It doesn't make sense to duplicate the code functionality for two systems when just one can be used instead.

Now SplPriorityQueue is used regardless. If priorities are disabled, the default priority (new constant DEAULT_PRIORITY) is used instead so that everything has the same priority.
