### PR TITLE
Refactored Html\TagLocatorFactory::getEscaper() method.

### DIFF
--- a/phalcon/Html/TagLocatorFactory.zep
+++ b/phalcon/Html/TagLocatorFactory.zep
@@ -87,16 +87,14 @@ class TagLocatorFactory implements LocatorFactoryInterface
      */
     private function getEscaper() -> <EscaperInterface>
     {
-        var container, escaper;
+        var container;
 
         let container = Di::getDefault();
 
-        if (true !== container->has("escaper")) {
-            let escaper = container->getService("escaper");
-        } else {
-            let escaper = new Escaper();
+        if !container->has("escaper") {
+            return new Escaper();
         }
 
-        return escaper;
+        return container->getService("escaper");
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix | code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I updated the CHANGELOG


This code was previously buggy - it checked if the DI contained the 'escaper' service. If `true`, it made a new instance; if `false`, it attempted to retrieve the non-existent service.
