### PR TITLE
Fixed Collection::isInitialized()

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,5 @@
 # [4.0.0-alpha.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.5) (2019-xx-xx)
-## Fixed `Mvc\Collection::isInitialized()` now works as intended.
+- Fixed `Mvc\Collection::isInitialized()` now works as intended.
 
 
 # [4.0.0-alpha.4](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.4) (2019-03-31)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,3 +1,7 @@
+# [4.0.0-alpha.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.5) (2019-xx-xx)
+## Fixed `Mvc\Collection::isInitialized()` now works as intended.
+
+
 # [4.0.0-alpha.4](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.4) (2019-03-31)
 ## Added
 - Added `delimiter` and `enclosure` options to *Phalcon\Translate\Adapter\Csv* constructor

--- a/phalcon/Mvc/Collection/Manager.zep
+++ b/phalcon/Mvc/Collection/Manager.zep
@@ -201,9 +201,9 @@ class Manager implements InjectionAwareInterface, EventsAwareInterface
     /**
      * Check whether a model is already initialized
      */
-    public function isInitialized(string! modelName) -> bool
+    public function isInitialized(string! className) -> bool
     {
-        return isset this->initialized[strtolower(modelName)];
+        return isset this->initialized[strtolower(className)];
     }
 
     /**
@@ -213,24 +213,23 @@ class Manager implements InjectionAwareInterface, EventsAwareInterface
     {
         var className, initialized, eventsManager;
 
-        let className = get_class(model);
+        let className = get_class_lower(model);
         let initialized = this->initialized;
 
         /**
-        * Models are just initialized once per request
-        */
+         * Models are just initialized once per request
+         */
         if !isset initialized[className] {
-
             /**
-            * Call the 'initialize' method if it's implemented
-            */
+             * Call the 'initialize' method if it's implemented
+             */
             if method_exists(model, "initialize") {
                 model->{"initialize"}();
             }
 
             /**
-            * If an EventsManager is available we pass to it every initialized model
-            */
+             * If an EventsManager is available we pass to it every initialized model
+             */
             let eventsManager = this->eventsManager;
             if typeof eventsManager == "object" {
                 eventsManager->fire("collectionManager:afterInitialize", model);

--- a/phalcon/Mvc/Collection/ManagerInterface.zep
+++ b/phalcon/Mvc/Collection/ManagerInterface.zep
@@ -66,7 +66,7 @@ interface ManagerInterface
     /**
      * Check whether a model is already initialized
      */
-    public function isInitialized(string! modelName) -> bool;
+    public function isInitialized(string! className) -> bool;
 
     /**
      * Checks if a model is using implicit object ids

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -250,9 +250,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Check whether a model is already initialized
      */
-    public function isInitialized(string! modelName) -> bool
+    public function isInitialized(string! className) -> bool
     {
-        return isset this->_initialized[strtolower(modelName)];
+        return isset this->_initialized[strtolower(className)];
     }
 
     /**

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -235,7 +235,7 @@ interface ManagerInterface
     /**
      * Check of a model is already initialized
      */
-    public function isInitialized(string! modelName) -> bool;
+    public function isInitialized(string! className) -> bool;
 
     /**
      * Checks if a model is keeping snapshots for the queried records


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Previously, `initialize()` would store a list of the initialized collections in the `this->initialized` array. It stored the class name as is; `Models\Users` would be stored as "Models\Users". However, `isInitialized()` would check for an all lowercase version ("models\users").

I've also edited the method signature of `isInitialized()` by renaming `modelName` to `className` as it is a better description of what the variable is.



