### PR TITLE
 Cli\Route::delimiterPath now has a default value

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -61,7 +61,7 @@ The implementation offers PSR-7/PSR-17 compatible components in a different name
 ## Changed
 - Refactored `Phalcon\Registry` to use the `Phalcon\Collection` class [#13893](https://github.com/phalcon/cphalcon/issues/13893)
 - Refactored `Phalcon\Session\Bag` to use the `Phalcon\Collection` class [#13893](https://github.com/phalcon/cphalcon/issues/13893)
-- Refactored almost all files of the project to abide by the new coding standard for Phalcon. Certain files have been intentionally left untouched because they will be relaced later on. [#13915](https://github.com/phalcon/cphalcon/issues/13915)
+- Refactored almost all files of the project to abide by the new coding standard for Phalcon. Certain files have been intentionally left untouched because they will be replaced later on. [#13915](https://github.com/phalcon/cphalcon/issues/13915)
 
 ## Removed
 - Removed `Phalcon\Session\BagInterface` [#13893](https://github.com/phalcon/cphalcon/issues/13893)
@@ -120,9 +120,9 @@ The implementation offers PSR-7/PSR-17 compatible components in a different name
 
 # [4.0.0-alpha.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.2) (2019-02-02)
 ## Added
-- Added `notFound()` method in `Phalcon\Translate\Adapter\NativeArray` which returns the key requested if not found. The method can be overriden when extending the class, returning what the developer needs [#13007](https://github.com/phalcon/cphalcon/pull/13007)
+- Added `notFound()` method in `Phalcon\Translate\Adapter\NativeArray` which returns the key requested if not found. The method can be overridden when extending the class, returning what the developer needs [#13007](https://github.com/phalcon/cphalcon/pull/13007)
 - Added `Phalcon\Service\Locator`, `Phalcon\Service\LocatorInterface` and `Phalcon\Service\LocatorFactoryInterface` to allow for the creation of service locators and factories throughout the application [#13771](https://github.com/phalcon/cphalcon/pull/13771)
-- Added `Phalcon\Http\Request::setParameterFilters`. It allows you to preset filters for specific input (i.e. `id`, `name` etc.). You can then retrieve the automatcally sanitized values using `Phalcon\Http\Request::getFilteredQuery`, `Phalcon\Http\Request::getFilteredPost` and `Phalcon\Http\Request::getFilteredPut` [#13488](https://github.com/phalcon/cphalcon/issue/13488)
+- Added `Phalcon\Http\Request::setParameterFilters`. It allows you to preset filters for specific input (i.e. `id`, `name` etc.). You can then retrieve the automatically sanitized values using `Phalcon\Http\Request::getFilteredQuery`, `Phalcon\Http\Request::getFilteredPost` and `Phalcon\Http\Request::getFilteredPut` [#13488](https://github.com/phalcon/cphalcon/issue/13488)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Micro::handle` to properly return a response object [#13712](https://github.com/phalcon/cphalcon/issues/13712)

--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -44,7 +44,7 @@ class Route
     /**
      * Phalcon\Cli\Router\Route constructor
      *
-     * @param array paths
+     * @param array|string paths
      */
     public function __construct(string! pattern, paths = null) -> void
     {
@@ -191,8 +191,6 @@ class Route
 
     /**
      * Extracts parameters from a string
-     *
-     * @return array|bool
      */
     public function extractNamedParams(string! pattern) -> array | bool
     {
@@ -421,7 +419,7 @@ class Route
     /**
      * Reconfigure the route adding a new pattern and a set of paths
      *
-     * @param array paths
+     * @param array|string paths
      */
     public function reConfigure(string! pattern, paths = null) -> void
     {

--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -27,7 +27,7 @@ class Route
 
     protected delimiter;
 
-    protected static delimiterPath;
+    protected static delimiterPath = self::DEFAULT_DELIMITER;
 
     protected description;
 
@@ -48,14 +48,10 @@ class Route
      */
     public function __construct(string! pattern, paths = null) -> void
     {
-        var routeId, uniqueId, delimiter;
+        var routeId, uniqueId;
 
         // Get the delimiter from the static member delimiterPath
-        let delimiter = self::delimiterPath;
-        if !delimiter {
-            let delimiter = self::DEFAULT_DELIMITER;
-        }
-        let this->delimiter = delimiter;
+        let this->delimiter = self::delimiterPath;
 
         // Configure the route (extract parameters, paths, etc)
         this->reConfigure(pattern, paths);
@@ -352,14 +348,7 @@ class Route
      */
     public static function getDelimiter() -> string
     {
-        var delimiter;
-
-        let delimiter = self::delimiterPath;
-        if !delimiter {
-            let delimiter = self::DEFAULT_DELIMITER;
-        }
-
-        return delimiter;
+        return self::delimiterPath;
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I updated the CHANGELOG

Small description of change:

Thanks

