### PR TITLE
CLI Routes with bad classnames now throw an exception

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,7 @@
 # [4.0.0-alpha.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.5) (2019-xx-xx)
 ## Changed
 - Refactored `Phalcon\Events\Manager` to only use `SplPriorityQueue` to store events.
+- CLI Routes with bad classnames (eg. `MyApp\\Tasks\\`) now throw an exception instead of suppressing the error.
 
 # [4.0.0-alpha.4](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.4) (2019-03-31)
 ## Added

--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -452,6 +452,10 @@ class Route
                         // Extract the namespace from the namespaced class
                         let namespaceName = get_ns_class(taskName);
 
+                        if namespaceName === null || realClassName === null {
+                            throw new Exception("The route contains invalid paths");
+                        }
+
                         // Update the namespace
                         if namespaceName {
                             let routePaths["namespace"] = namespaceName;

--- a/tests/cli/Cli/RouterCest.php
+++ b/tests/cli/Cli/RouterCest.php
@@ -275,11 +275,6 @@ class RouterCest
             'task' => 'posts',
             'action' => 'show',
         ]);
-        $route = $router->add("route3", "MyApp\\Tasks\\::show");
-        $I->assertEquals($route->getPaths(), [
-            'task' => '',
-            'action' => 'show',
-        ]);
         $route = $router->add("route3", "News::MyApp\\Tasks\\Posts::show");
         $I->assertEquals($route->getPaths(), [
             'module' => 'News',
@@ -292,6 +287,20 @@ class RouterCest
             'task' => 'posts',
             'action' => 'show',
         ]);
+    }
+
+    public function testShortPaths2(CliTester $I)
+    {
+        $I->expectThrowable(
+            new \Phalcon\Cli\Router\Exception("The route contains invalid paths"),
+            function () {
+                Route::reset();
+
+                $router = new Router(false);
+
+                $route = $router->add("route3", "MyApp\\Tasks\\::show");
+            }
+        );
     }
 
     public function testBeforeMatch(CliTester $I)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Routes with bad classnames (such as `MyApp\\Tasks\\`) now throw an exception. Previously, the error was suppressed and left the namespace/task blank. 
