### PR TITLE
[NFR] - added description property to Cli\Router\Route

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,4 +1,9 @@
 # [4.0.0-alpha.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.5) (2019-xx-xx)
+## Added
+- Added `Phalcon\Cli\Router\Route::setDescription()` to sets the route's description
+- Added `Phalcon\Cli\Router\Route::getDescription()` returns the route's description
+
+## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended.
 
 ## Changed

--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -79,7 +79,7 @@ class Route
      *
      * @param callback callback
      */
-    public function beforeMatch(var callback) -> <Route>
+    public function beforeMatch(var callback) -> <RouteInterface>
     {
         let this->beforeMatch = callback;
         return this;
@@ -158,7 +158,7 @@ class Route
      *
      * @param callable converter
      */
-    public function convert(string! name, converter) -> <Route>
+    public function convert(string! name, converter) -> <RouteInterface>
     {
         let this->converters[name] = converter;
         return this;
@@ -548,7 +548,7 @@ class Route
     /**
      * Sets the route's description
      */
-    public function setDescription(string! description) -> <Route>
+    public function setDescription(string! description) -> <RouteInterface>
     {
         let this->description = description;
         return this;
@@ -566,7 +566,7 @@ class Route
      * )->setName("about");
      *</code>
      */
-    public function setName(string! name) -> <Route>
+    public function setName(string! name) -> <RouteInterface>
     {
         let this->name = name;
         return this;

--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -29,6 +29,8 @@ class Route
 
     protected static delimiterPath;
 
+    protected description;
+
     protected id;
 
     protected name;
@@ -348,6 +350,14 @@ class Route
     }
 
     /**
+     * Returns the route's description
+     */
+    public function getDescription() -> string
+    {
+        return this->description;
+    }
+
+    /**
      * Returns the route's name
      */
     public function getName() -> string
@@ -529,6 +539,15 @@ class Route
     public static function reset() -> void
     {
         let self::uniqueId = null;
+    }
+
+    /**
+     * Sets the route's description
+     */
+    public function setDescription(string! description) -> <Route>
+    {
+        let this->description = description;
+        return this;
     }
 
     /**

--- a/phalcon/Cli/Router/RouteInterface.zep
+++ b/phalcon/Cli/Router/RouteInterface.zep
@@ -38,6 +38,11 @@ interface RouteInterface
     public static function getDelimiter() -> string;
 
     /**
+     * Returns the route's description
+     */
+    public function getDescription() -> string;
+
+    /**
      * Returns the route's name
      */
     public function getName() -> string;
@@ -73,7 +78,12 @@ interface RouteInterface
     public static function reset() -> void;
 
     /**
+     * Sets the route's description
+     */
+    public function setDescription(string! description) -> <Route>;
+
+    /**
      * Sets the route's name
      */
-    public function setName(string name) -> void;
+    public function setName(string name) -> <Route>;
 }

--- a/phalcon/Cli/Router/RouteInterface.zep
+++ b/phalcon/Cli/Router/RouteInterface.zep
@@ -80,10 +80,10 @@ interface RouteInterface
     /**
      * Sets the route's description
      */
-    public function setDescription(string! description) -> <Route>;
+    public function setDescription(string! description) -> <RouteInterface>;
 
     /**
      * Sets the route's name
      */
-    public function setName(string name) -> <Route>;
+    public function setName(string name) -> <RouteInterface>;
 }

--- a/tests/cli/Cli/Router/Route/GetDescriptionCest.php
+++ b/tests/cli/Cli/Router/Route/GetDescriptionCest.php
@@ -40,6 +40,5 @@ class GetDescriptionCest
         foreach ($router->getRoutes() as $route) {
             $I->assertEquals($routes[$route->getPattern()], $route->getDescription());
         }
-
     }
 }

--- a/tests/cli/Cli/Router/Route/GetDescriptionCest.php
+++ b/tests/cli/Cli/Router/Route/GetDescriptionCest.php
@@ -26,11 +26,7 @@ class GetDescriptionCest
     {
         $I->wantToTest('Phalcon\Cli\Router\Route - getDescription()');
 
-        $routes = [
-            'test' => 'test description',
-            'test1' => 'test description1',
-            'test2' => 'test description2',
-        ];
+        $routes = $this->getExampleRoutes();
 
         $router = new \Phalcon\Cli\Router(false);
         foreach ($routes as $pattern => $description) {
@@ -40,5 +36,14 @@ class GetDescriptionCest
         foreach ($router->getRoutes() as $route) {
             $I->assertEquals($routes[$route->getPattern()], $route->getDescription());
         }
+    }
+
+    private function getExampleRoutes(): array
+    {
+        return [
+            'test'  => 'test description',
+            'test1' => 'test description1',
+            'test2' => 'test description2',
+        ];
     }
 }

--- a/tests/cli/Cli/Router/Route/GetDescriptionCest.php
+++ b/tests/cli/Cli/Router/Route/GetDescriptionCest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Cli\Cli\Router\Route;
+
+use CliTester;
+
+class GetDescriptionCest
+{
+    /**
+     * Tests Phalcon\Cli\Router\Route :: getDescription()
+     *
+     * @param CliTester $I
+     *
+     * @since 2019-04-02
+     */
+    public function cliRouterRouteGetDescription(CliTester $I)
+    {
+        $I->wantToTest('Phalcon\Cli\Router\Route - getDescription()');
+
+        $routes = [
+            'test' => 'test description',
+            'test1' => 'test description1',
+            'test2' => 'test description2',
+        ];
+
+        $router = new \Phalcon\Cli\Router(false);
+        foreach ($routes as $pattern => $description) {
+            $router->add($pattern)->setDescription($description);
+        }
+
+        foreach ($router->getRoutes() as $route) {
+            $I->assertEquals($routes[$route->getPattern()], $route->getDescription());
+        }
+
+    }
+}

--- a/tests/cli/Cli/Router/Route/SetDescriptionCest.php
+++ b/tests/cli/Cli/Router/Route/SetDescriptionCest.php
@@ -26,11 +26,7 @@ class SetDescriptionCest
     {
         $I->wantToTest('Phalcon\Cli\Router\Route - setDescription()');
 
-        $routes = [
-            'test' => 'test description',
-            'test1' => 'test description1',
-            'test2' => 'test description2',
-        ];
+        $routes = $this->getExampleRoutes();
 
         $router = new \Phalcon\Cli\Router(false);
         foreach ($routes as $pattern => $description) {
@@ -40,5 +36,14 @@ class SetDescriptionCest
         foreach ($router->getRoutes() as $route) {
             $I->assertEquals($routes[$route->getPattern()], $route->getDescription());
         }
+    }
+
+    private function getExampleRoutes(): array
+    {
+        return [
+            'test'  => 'test description',
+            'test1' => 'test description1',
+            'test2' => 'test description2',
+        ];
     }
 }

--- a/tests/cli/Cli/Router/Route/SetDescriptionCest.php
+++ b/tests/cli/Cli/Router/Route/SetDescriptionCest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Cli\Cli\Router\Route;
+
+use CliTester;
+
+class SetDescriptionCest
+{
+    /**
+     * Tests Phalcon\Cli\Router\Route :: setDescription()
+     *
+     * @param CliTester $I
+     *
+     * @since 2019-04-02
+     */
+    public function cliRouterRouteSetDescription(CliTester $I)
+    {
+        $I->wantToTest('Phalcon\Cli\Router\Route - setDescription()');
+
+        $routes = [
+            'test' => 'test description',
+            'test1' => 'test description1',
+            'test2' => 'test description2',
+        ];
+
+        $router = new \Phalcon\Cli\Router(false);
+        foreach ($routes as $pattern => $description) {
+            $router->add($pattern)->setDescription($description);
+        }
+
+        foreach ($router->getRoutes() as $route) {
+            $I->assertEquals($routes[$route->getPattern()], $route->getDescription());
+        }
+
+    }
+}

--- a/tests/cli/Cli/Router/Route/SetDescriptionCest.php
+++ b/tests/cli/Cli/Router/Route/SetDescriptionCest.php
@@ -40,6 +40,5 @@ class SetDescriptionCest
         foreach ($router->getRoutes() as $route) {
             $I->assertEquals($routes[$route->getPattern()], $route->getDescription());
         }
-
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change: added description property to Cli\Router\Route

## Usage: 
```php
$router = new \Phalcon\Cli\Router(false);
$router->add('test')->setName('testName')->setDescription('testDescription');
$router->add('test1')->setName('testName1')->setDescription('testDescription1');
$router->add('test2')->setName('testName2')->setDescription('testDescription2');

foreach ($router->getRoutes() as $route) {
    printf("%s    %s\n", $route->getName(), $route->getDescription());
}
```

```
$./phalconcli
Available command or tasks:
   testName      testDescription
   testName1     testDescription1
   testName2     testDescription2
```
Thanks

