### PR TITLE
Phalcon\Translate\InterpolatorInterface now only accepts placeholder arrays

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 
 ## Changed
 - Refactored `Phalcon\Events\Manager` to only use `SplPriorityQueue` to store events.
+- `Phalcon\Translate\InterpolatorInterface` now only accepts placeholder arrays.
 
 
 # [4.0.0-alpha.4](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.4) (2019-03-31)

--- a/phalcon/Translate/Interpolator/AssociativeArray.zep
+++ b/phalcon/Translate/Interpolator/AssociativeArray.zep
@@ -17,14 +17,12 @@ class AssociativeArray implements InterpolatorInterface
     /**
      * Replaces placeholders by the values passed
     */
-    public function replacePlaceholders(string! translation, placeholders = null) -> string
+    public function replacePlaceholders(string! translation, array placeholders = []) -> string
     {
         var key, value;
 
-        if typeof placeholders === "array" && count(placeholders) {
-            for key, value in placeholders {
-                let translation = str_replace("%" . key . "%", value, translation);
-            }
+        for key, value in placeholders {
+            let translation = str_replace("%" . key . "%", value, translation);
         }
 
         return translation;

--- a/phalcon/Translate/Interpolator/IndexedArray.zep
+++ b/phalcon/Translate/Interpolator/IndexedArray.zep
@@ -17,9 +17,9 @@ class IndexedArray implements InterpolatorInterface
     /**
      * Replaces placeholders by the values passed
     */
-    public function replacePlaceholders(string! translation, placeholders = null) -> string
+    public function replacePlaceholders(string! translation, array placeholders = []) -> string
     {
-        if typeof placeholders === "array" && count(placeholders) {
+        if count(placeholders) {
             array_unshift(placeholders, translation);
             return call_user_func_array("sprintf", placeholders);
         }

--- a/phalcon/Translate/InterpolatorInterface.zep
+++ b/phalcon/Translate/InterpolatorInterface.zep
@@ -11,14 +11,14 @@
 namespace Phalcon\Translate;
 
 /**
- * Phalcon\Translate\AdapterInterface
+ * Phalcon\Translate\InterpolatorInterface
  *
- * Interface for Phalcon\Translate adapters
+ * Interface for Phalcon\Translate interpolators
  */
 interface InterpolatorInterface
 {
     /**
      * Replaces placeholders by the values passed
     */
-    public function replacePlaceholders(string! translation, placeholders = null) -> string;
+    public function replacePlaceholders(string! translation, array placeholders = []) -> string;
 }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [X] I updated the CHANGELOG

The parameter typehint was not strong enough. :wink: 
