### PR TITLE
Removed assigning properties via save() in models (as per #12317)

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -12,6 +12,7 @@
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended.
+- Update docblocks to show that we can no longer assign properties via `save()` in models (as per #12317). [#13945](https://github.com/phalcon/cphalcon/pull/13945)
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1218,16 +1218,19 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
      *
      * $myTransaction = new Transaction(\Phalcon\Di::getDefault());
      * $myTransaction->begin();
+     *
      * $newRobot = new Robot();
      * $newRobot->setTransaction($myTransaction);
      *
-     * $newRobot->save(
+     * $newRobot->assign(
      *     [
      *         'name' => 'test',
      *         'type' => 'mechanical',
      *         'year' => 1944,
      *     ]
      * );
+     *
+     * $newRobot->save();
      *
      * $resultInsideTransaction = Robot::find(
      *     [
@@ -1258,11 +1261,25 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
      *  // add a new robots
      * $firstNewRobot = new Robot();
      * $firstNewRobot->setTransaction($myTransaction1);
-     * $firstNewRobot->save(['name' => 'first-transaction-robot', 'type' => 'mechanical', 'year' => 1944]);
+     * $firstNewRobot->assign(
+     *     [
+     *         'name' => 'first-transaction-robot',
+     *         'type' => 'mechanical',
+     *         'year' => 1944,
+     *     ]
+     * );
+     * $firstNewRobot->save();
      *
      * $secondNewRobot = new Robot();
      * $secondNewRobot->setTransaction($myTransaction2);
-     * $secondNewRobot->save(['name' => 'second-transaction-robot', 'type' => 'fictional', 'year' => 1984]);
+     * $secondNewRobot->assign(
+     *     [
+     *         'name' => 'second-transaction-robot',
+     *         'type' => 'fictional',
+     *         'year' => 1984,
+     *     ]
+     * );
+     * $secondNewRobot->save();
      *
      * // this transaction will find the robot.
      * $resultInFirstTransaction = Robot::find(['name' => 'first-transaction-robot', Model::TRANSACTION_INDEX => $myTransaction1]);
@@ -1345,7 +1362,14 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
      * $myTransaction->begin();
      * $newRobot = new Robot();
      * $newRobot->setTransaction($myTransaction);
-     * $newRobot->save(['name' => 'test', 'type' => 'mechanical', 'year' => 1944]);
+     * $newRobot->assign(
+     *     [
+     *         'name' => 'test',
+     *         'type' => 'mechanical',
+     *         'year' => 1944,
+     *     ]
+     * );
+     * $newRobot->save();
      *
      * $findsARobot = Robot::findFirst(['name' => 'test', Model::TRANSACTION_INDEX => $myTransaction]);
      * $doesNotFindARobot = Robot::findFirst(['name' => 'test']);

--- a/phalcon/Mvc/Model/Resultset.zep
+++ b/phalcon/Mvc/Model/Resultset.zep
@@ -576,10 +576,12 @@ abstract class Resultset
                 }
             }
 
+            record->assign(data);
+
             /**
              * Try to update the record
              */
-            if !record->save(data) {
+            if !record->save() {
 
                 /**
                  * Get the messages from the record that produce the error


### PR DESCRIPTION
Hello!

* Type: bug fix | documentation

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Forgot to update some of the docblocks with the changes made in #12317 and I missed one code reference in Mvc\Model\Resultset that still tried to assign data whilst saving. I can only assume that it's in a method that isn't used very much as no one has complained since the original PR merged 2 years ago. :open_mouth: 