### PR TITLE
Bugfix: access to a protected property model builder

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Added
 - Added `Phalcon\Cli\Router\Route::setDescription()` to sets the route's description [#13936](https://github.com/phalcon/cphalcon/pull/13936)
 - Added `Phalcon\Cli\Router\Route::getDescription()` returns the route's description [#13936](https://github.com/phalcon/cphalcon/pull/13936)
+- Added `Phalcon\Mvc\Model\Query\BuilderInterface::getModels()` returns the models involved in the query
 
 ## Changed
 - Refactored `Phalcon\Events\Manager` to only use `SplPriorityQueue` to store events. [#13924](https://github.com/phalcon/cphalcon/pull/13924)

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -556,6 +556,20 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     }
 
     /**
+     * Returns the models involved in the query
+     */
+    public function getModels() -> string | array | null
+    {
+        var models = this->_models;
+
+        if typeof models == "array" && count(models) == 1 {
+            return array_values(models)[0];
+        }
+
+        return models;
+    }
+
+    /**
      * Returns the current OFFSET clause
      */
     public function getOffset() -> int

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -13,6 +13,7 @@ namespace Phalcon\Mvc\Model\Query;
 use Phalcon\Di;
 use Phalcon\Db\Column;
 use Phalcon\DiInterface;
+use Phalcon\Helper\Arr;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Mvc\Model\QueryInterface;
@@ -563,7 +564,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
         var models = this->_models;
 
         if typeof models == "array" && count(models) == 1 {
-            return array_values(models)[0];
+            return Arr::first(models);
         }
 
         return models;

--- a/phalcon/Mvc/Model/Query/BuilderInterface.zep
+++ b/phalcon/Mvc/Model/Query/BuilderInterface.zep
@@ -197,6 +197,11 @@ interface BuilderInterface
     public function limit(int limit, offset = null) -> <BuilderInterface>;
 
     /**
+     * Returns the models involved in the query
+     */
+    public function getModels() -> string | array | null;
+
+    /**
      * Appends a NOT BETWEEN condition to the current conditions
      *
      * @param mixed minimum

--- a/phalcon/Paginator/Adapter/QueryBuilder.zep
+++ b/phalcon/Paginator/Adapter/QueryBuilder.zep
@@ -202,7 +202,11 @@ class QueryBuilder extends Adapter
          */
         if hasHaving {
             let sql = totalQuery->getSql(),
-              modelClass = builder->_models;
+             modelClass = builder->getModels();
+
+            if typeof modelClass == "null" {
+                throw new Exception("Model not defined in builder");
+            }
 
             if typeof modelClass == "array" {
                 let modelClass = array_values(modelClass)[0];

--- a/tests/integration/Mvc/Model/Query/Builder/GetModelsCest.php
+++ b/tests/integration/Mvc/Model/Query/Builder/GetModelsCest.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Integration\Mvc\Model\Query\Builder;
+
+use IntegrationTester;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Robots;
+use Phalcon\Test\Models\RobotsParts;
+use Phalcon\Test\Models\Stock;
+
+/**
+ * Class GetModelsCest
+ */
+class GetModelsCest
+{
+    use DiTrait;
+
+    public function _before(IntegrationTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Query\Builder :: getModels()
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-04-8
+     */
+    public function mvcModelQueryBuilderGetModelsNull(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Query\Builder - getModels() - null');
+        $manager = $this->getService('modelsManager');
+        $builder = $manager->createBuilder();
+
+        $expected = null;
+        $actual   = $builder->getModels();
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Query\Builder :: getModels()
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-04-8
+     */
+    public function mvcModelQueryBuilderGetModelsString(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Query\Builder - getModels() - string');
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->from(['Stock' => Stock::class]);
+
+        $expected = 'Phalcon\\Test\\Models\\Stock';
+        $actual   = $builder->getModels();
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Query\Builder :: getModels()
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-04-8
+     */
+    public function mvcModelQueryBuilderGetModelsArray(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Query\Builder - getModels() - array');
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->from(['Robots' => Robots::class])
+            ->addFrom(RobotsParts::class, 'RobotsParts');
+
+        $expected = [
+            'Robots'      => 'Phalcon\Test\Models\Robots',
+            'RobotsParts' => 'Phalcon\Test\Models\RobotsParts',
+        ];
+        $actual   = $builder->getModels();
+        $I->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature
* Link to PR: https://github.com/phalcon/cphalcon/pull/13952

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change: Added `Phalcon\Mvc\Model\Query\BuilderInterface::getModels()` 

Thanks
