### PR TITLE
Query Builder's GROUP BY field is now always an array

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -22,6 +22,7 @@
 - Update docblocks to show that we can no longer assign properties via `save()` in models (as per #12317). [#13945](https://github.com/phalcon/cphalcon/pull/13945)
 - Fixed `Mvc\Model` and `Mvc\ModelInterface` `findFirst` to return `ModelInterface` or `bool` [#13947](https://github.com/phalcon/cphalcon/issues/13947)
 - `Phalcon\Acl\Adapter\Memory::dropComponentAccess()` now properly unsets values.
+- Query Builder's `GROUP BY` field is now always an array. [#13962](https://github.com/phalcon/cphalcon/pull/13962)
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -62,7 +62,12 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     protected container;
     protected distinct;
     protected forUpdate;
+
+    /**
+     * @var array
+     */
     protected group;
+
     protected having;
     protected hiddenParamNumber = 0;
     protected joins;
@@ -178,7 +183,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
              * Assign GROUP clause
              */
             if fetch groupClause, params["group"] {
-                let this->group = groupClause;
+                this->groupBy(groupClause);
             }
 
             /**
@@ -524,7 +529,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Returns the GROUP BY clause
      */
-    public function getGroupBy() -> string
+    public function getGroupBy() -> array
     {
         return this->group;
     }
@@ -833,14 +838,6 @@ class Builder implements BuilderInterface, InjectionAwareInterface
          */
         let group = this->group;
         if group !== null {
-            if typeof group == "string" {
-                if memstr(group, ",") {
-                    let group = str_replace(" ", "", group);
-                }
-
-                let group = explode(",", group);
-            }
-
             let groupItems = [];
             for groupItem in group {
                 let groupItems[] = this->autoescape(groupItem);
@@ -1015,7 +1012,16 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      */
     public function groupBy(var group) -> <BuilderInterface>
     {
+        if typeof group == "string" {
+            if memstr(group, ",") {
+                let group = str_replace(" ", "", group);
+            }
+
+            let group = explode(",", group);
+        }
+
         let this->group = group;
+
         return this;
     }
 

--- a/phalcon/Mvc/Model/Query/BuilderInterface.zep
+++ b/phalcon/Mvc/Model/Query/BuilderInterface.zep
@@ -105,7 +105,7 @@ interface BuilderInterface
     /**
      * Returns the GROUP BY clause
      */
-    public function getGroupBy() -> string;
+    public function getGroupBy() -> array;
 
     /**
      * Returns the HAVING condition clause
@@ -154,9 +154,11 @@ interface BuilderInterface
     public function getWhere();
 
     /**
-     * Sets a LIMIT clause
+     * Sets a GROUP BY clause
+     *
+     * @param string|array group
      */
-    public function groupBy(string group) -> <BuilderInterface>;
+    public function groupBy(var group) -> <BuilderInterface>;
 
     /**
      * Sets a HAVING condition clause


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #11690

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

[Line 828](https://github.com/SidRoberts/cphalcon/blob/query-builder-groupby/phalcon/Mvc/Model/Query/Builder.zep#L828) also blindly assumes that `this->_group` is an array.