### PR TITLE
`Phalcon\Acl\Adapter\Memory::dropComponentAccess()` now properly unsets values

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -21,6 +21,7 @@
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)
 - Update docblocks to show that we can no longer assign properties via `save()` in models (as per #12317). [#13945](https://github.com/phalcon/cphalcon/pull/13945)
 - Fixed `Mvc\Model` and `Mvc\ModelInterface` `findFirst` to return `ModelInterface` or `bool` [#13947](https://github.com/phalcon/cphalcon/issues/13947)
+- `Phalcon\Acl\Adapter\Memory::dropComponentAccess()` now properly unsets values.
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -516,16 +516,13 @@ class Memory extends Adapter
     {
         var accessName, accessKey;
 
+        if typeof accessList == "string" {
+            let accessList = [accessList];
+        }
+
         if typeof accessList == "array" {
             for accessName in accessList {
                 let accessKey = componentName . "!" . accessName;
-                if isset this->accessList[accessKey] {
-                    unset this->accessList[accessKey];
-                }
-            }
-        } else {
-            if typeof accessList == "string" {
-                let accessKey = componentName . "!" . accessList;
                 if isset this->accessList[accessKey] {
                     unset this->accessList[accessKey];
                 }

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -525,7 +525,7 @@ class Memory extends Adapter
             }
         } else {
             if typeof accessList == "string" {
-                let accessKey = componentName . "!" . accessName;
+                let accessKey = componentName . "!" . accessList;
                 if isset this->accessList[accessKey] {
                     unset this->accessList[accessKey];
                 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG