### PR TITLE
Saving model fails after fetching its related records via __get()

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -270,8 +270,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
 				/**
 				 * We store relationship objects in the related bag
+				 *
+				 * Removed temporarily.
+				 * See https://github.com/phalcon/cphalcon/issues/13964
 				 */
-				let this->_related[lowerProperty] = result;
+				// let this->_related[lowerProperty] = result;
 			}
 
 			return result;

--- a/tests/integration/Mvc/Model/Refactor-ModelsRelationsCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsRelationsCest.php
@@ -28,7 +28,6 @@ class ModelsRelationsCest
         $this->executeTestsRenamed($I);
         $this->testIssue938($I);
         $this->testIssue11042($I);
-        $this->testIssue13964($I);
     }
 
     private function executeTestsNormal(IntegrationTester $I)
@@ -298,21 +297,6 @@ class ModelsRelationsCest
 //        $I->assertInstanceOf('RelationsRobotsParts', $robotsParts->getFirst());
     }
 
-    protected function testIssue13964(IntegrationTester $I)
-    {
-        $robot = RelationsRobots::findFirst();
-        $I->assertNotEquals($robot, false);
-        $I->assertEquals($robot->getDirtyState(), $robot::DIRTY_STATE_PERSISTENT);
-
-        $robot->getRelationsRobotsParts();
-
-        $I->assertTrue($robot->save());
-
-        $robot->relationsRobotsParts;
-
-        $I->assertTrue($robot->save());
-    }
-
     public function testModelsPostgresql(IntegrationTester $I)
     {
         $this->setDiPostgresql();
@@ -320,7 +304,6 @@ class ModelsRelationsCest
         $this->executeTestsNormal($I);
         $this->executeTestsRenamed($I);
         $this->testIssue11042($I);
-        $this->testIssue13964($I);
     }
 
     public function testModelsSqlite(IntegrationTester $I)
@@ -331,6 +314,5 @@ class ModelsRelationsCest
         $this->executeTestsRenamed($I);
         $this->testIssue938($I);
         $this->testIssue11042($I);
-        $this->testIssue13964($I);
     }
 }

--- a/tests/integration/Mvc/Model/Refactor-ModelsRelationsCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsRelationsCest.php
@@ -304,11 +304,11 @@ class ModelsRelationsCest
         $I->assertNotEquals($robot, false);
         $I->assertEquals($robot->getDirtyState(), $robot::DIRTY_STATE_PERSISTENT);
 
-        $robot->getRobotsParts();
+        $robot->getRelationsRobotsParts();
 
         $I->assertTrue($robot->save());
 
-        $robot->robotsParts;
+        $robot->relationsRobotsParts;
 
         $I->assertTrue($robot->save());
     }

--- a/tests/integration/Mvc/Model/Refactor-ModelsRelationsCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsRelationsCest.php
@@ -28,6 +28,7 @@ class ModelsRelationsCest
         $this->executeTestsRenamed($I);
         $this->testIssue938($I);
         $this->testIssue11042($I);
+        $this->testIssue13964($I);
     }
 
     private function executeTestsNormal(IntegrationTester $I)
@@ -297,6 +298,21 @@ class ModelsRelationsCest
 //        $I->assertInstanceOf('RelationsRobotsParts', $robotsParts->getFirst());
     }
 
+    protected function testIssue13964(IntegrationTester $I)
+    {
+        $robot = RelationsRobots::findFirst();
+        $I->assertNotEquals($robot, false);
+        $I->assertEquals($robot->getDirtyState(), $robot::DIRTY_STATE_PERSISTENT);
+
+        $robot->getRobotsParts();
+
+        $I->assertTrue($robot->save());
+
+        $robot->robotsParts;
+
+        $I->assertTrue($robot->save());
+    }
+
     public function testModelsPostgresql(IntegrationTester $I)
     {
         $this->setDiPostgresql();
@@ -304,6 +320,7 @@ class ModelsRelationsCest
         $this->executeTestsNormal($I);
         $this->executeTestsRenamed($I);
         $this->testIssue11042($I);
+        $this->testIssue13964($I);
     }
 
     public function testModelsSqlite(IntegrationTester $I)
@@ -314,5 +331,6 @@ class ModelsRelationsCest
         $this->executeTestsRenamed($I);
         $this->testIssue938($I);
         $this->testIssue11042($I);
+        $this->testIssue13964($I);
     }
 }

--- a/tests/integration/Mvc/Model/Refactor-ModelsRelationsMagicCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsRelationsMagicCest.php
@@ -23,6 +23,7 @@ class ModelsRelationsMagicCest
         $this->setDiMysql();
 
         $this->executeQueryRelated($I);
+        $this->executeSaveAfterQueryRelated($I);
         $this->executeSaveRelatedBelongsTo($I);
     }
 
@@ -76,6 +77,28 @@ class ModelsRelationsMagicCest
 
         $originalAlbum = $album->artist->albums[0];
         $I->assertEquals($originalAlbum->id, $album->id);
+    }
+
+    /**
+     * Test for issue: #13964
+     * See: https://github.com/phalcon/cphalcon/issues/13964
+     *
+     * @param IntegrationTester $I
+     */
+    private function executeSaveAfterQueryRelated(IntegrationTester $I) {
+        $album = Albums::findFirst();
+
+        $artist = $album->artist;
+
+        $I->assertTrue($album->save());
+
+        $artist->albums;
+
+        $I->assertTrue($artist->save());
+
+        $album->songs;
+
+        $I->assertTrue($album->save());
     }
 
     private function executeSaveRelatedBelongsTo(IntegrationTester $I)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13964

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Small description of change: 

I've added a test to check if this issue exists at all.
The CI tests are supposed to fail, I'll add the fixes later if it's confirmed.

Thanks