### PR TITLE
Renamed Paginator\Adapter::getPaginate() to paginate()

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -22,6 +22,7 @@
 - Update docblocks to show that we can no longer assign properties via `save()` in models (as per #12317). [#13945](https://github.com/phalcon/cphalcon/pull/13945)
 - Fixed `Mvc\Model` and `Mvc\ModelInterface` `findFirst` to return `ModelInterface` or `bool` [#13947](https://github.com/phalcon/cphalcon/issues/13947)
 - `Phalcon\Acl\Adapter\Memory::dropComponentAccess()` now properly unsets values.
+- Renamed `Phalcon\Paginator\Adapter::getPaginate()` to `paginate()` in documentation/tests (originally renamed in 4.0.0-alpha.1). [#13973](https://github.com/phalcon/cphalcon/pull/13973)
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Paginator/Adapter/Model.zep
+++ b/phalcon/Paginator/Adapter/Model.zep
@@ -31,7 +31,7 @@ use Phalcon\Paginator\RepositoryInterface;
  *     ]
  * );
  *
- * $paginate = $paginator->getPaginate();
+ * $paginate = $paginator->paginate();
  *</code>
  */
 class Model extends Adapter

--- a/phalcon/Paginator/Repository.zep
+++ b/phalcon/Paginator/Repository.zep
@@ -13,7 +13,7 @@ namespace Phalcon\Paginator;
 /**
  * Phalcon\Paginator\Repository
  *
- * Repository of current state Phalcon\Paginator\AdapterInterface::getPaginate()
+ * Repository of current state Phalcon\Paginator\AdapterInterface::paginate()
  */
 class Repository implements RepositoryInterface
 {

--- a/phalcon/Paginator/RepositoryInterface.zep
+++ b/phalcon/Paginator/RepositoryInterface.zep
@@ -14,7 +14,7 @@ namespace Phalcon\Paginator;
  * Phalcon\Paginator\RepositoryInterface
  *
  * Interface for the repository of current state
- * Phalcon\Paginator\AdapterInterface::getPaginate()
+ * Phalcon\Paginator\AdapterInterface::paginate()
  */
 interface RepositoryInterface
 {

--- a/tests/integration/Paginator/Adapter/GetPaginateCest.php
+++ b/tests/integration/Paginator/Adapter/GetPaginateCest.php
@@ -16,16 +16,16 @@ use IntegrationTester;
 class GetPaginateCest
 {
     /**
-     * Tests Phalcon\Paginator\Adapter :: getPaginate()
+     * Tests Phalcon\Paginator\Adapter :: paginate()
      *
      * @param IntegrationTester $I
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
      */
-    public function paginatorAdapterGetPaginate(IntegrationTester $I)
+    public function paginatorAdapterPaginate(IntegrationTester $I)
     {
-        $I->wantToTest("Paginator\Adapter - getPaginate()");
+        $I->wantToTest("Paginator\Adapter - paginate()");
         $I->skipTest("Need implementation");
     }
 }

--- a/tests/integration/Refactor-PaginatorCest.php
+++ b/tests/integration/Refactor-PaginatorCest.php
@@ -42,7 +42,7 @@ class PaginatorCest
         );
 
         //First Page
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
         $I->assertInstanceOf('stdClass', $page);
 
         $I->assertCount(10, $page->items);
@@ -58,7 +58,7 @@ class PaginatorCest
         //Middle Page
         $paginator->setCurrentPage(50);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
         $I->assertInstanceOf('stdClass', $page);
 
         $I->assertCount(10, $page->items);
@@ -73,7 +73,7 @@ class PaginatorCest
         //Last Page
         $paginator->setCurrentPage(218);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
         $I->assertInstanceOf('stdClass', $page);
 
         $I->assertCount(10, $page->items);
@@ -105,7 +105,7 @@ class PaginatorCest
         );
 
         //First Page
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
         $I->assertInstanceOf('stdClass', $page);
 
         $I->assertCount(10, $page->items);
@@ -137,7 +137,7 @@ class PaginatorCest
             ]
         );
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
 
         $I->assertInstanceOf('stdClass', $page);
 
@@ -158,7 +158,7 @@ class PaginatorCest
         //Middle page
         $paginator->setCurrentPage(100);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
 
         $I->assertInstanceOf('stdClass', $page);
 
@@ -177,7 +177,7 @@ class PaginatorCest
         //Last page
         $paginator->setCurrentPage(218);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
 
         $I->assertInstanceOf('stdClass', $page);
 
@@ -301,7 +301,7 @@ class PaginatorCest
             "page"    => 1,
         ]);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
 
         $I->assertInstanceOf('stdClass', $page);
 
@@ -322,7 +322,7 @@ class PaginatorCest
         //Middle page
         $paginator->setCurrentPage(10);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
 
         $I->assertInstanceOf('stdClass', $page);
 
@@ -341,7 +341,7 @@ class PaginatorCest
         //Last page
         $paginator->setCurrentPage(18);
 
-        $page = $paginator->getPaginate();
+        $page = $paginator->paginate();
 
         $I->assertInstanceOf('stdClass', $page);
 


### PR DESCRIPTION
See 4f5381b285fccffdc45fc4263a93db69bca87552

Hello!

* Type: bug fix | documentation
* See also: https://github.com/phalcon/docs/pull/2291

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I updated the CHANGELOG

Small description of change:

Thanks

