### PR TITLE
Criteria::limit() now takes 'offset' as an integer.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -17,6 +17,7 @@
 - Model methods that extend Model Manager functionality are now `final`. [#13950](https://github.com/phalcon/cphalcon/pull/13950)
 - Changed `Phalcon\Text` to call methods from `Phalcon\Helper\Str` [#13954](https://github.com/phalcon/cphalcon/pull/13954)
 - Setting the views directory no longer requires a trailing slash when using Simple View.
+- `Phalcon\Mvc\Model\CriteriaInterface::filter()` now takes `offset` as an integer. [#13977](https://github.com/phalcon/cphalcon/pull/13977)
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/Mvc/Model/Criteria.zep
+++ b/phalcon/Mvc/Model/Criteria.zep
@@ -507,7 +507,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * $criteria->limit("100", "200");
      * </code>
      */
-    public function limit(int limit, var offset = null) -> <CriteriaInterface>
+    public function limit(int limit, int offset = null) -> <CriteriaInterface>
     {
         let limit = abs(limit);
 
@@ -516,7 +516,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
         }
 
         if is_numeric(offset) {
-            let offset = abs((int) offset);
+            let offset = abs(offset);
 
             let this->params["limit"] = [
                 "number": limit,

--- a/phalcon/Mvc/Model/CriteriaInterface.zep
+++ b/phalcon/Mvc/Model/CriteriaInterface.zep
@@ -167,10 +167,8 @@ interface CriteriaInterface
 
     /**
      * Sets the limit parameter to the criteria
-     *
-     * @param int offset
      */
-    public function limit(int limit, offset = null) -> <CriteriaInterface>;
+    public function limit(int limit, int offset = null) -> <CriteriaInterface>;
 
     /**
      * Appends a NOT BETWEEN condition to the current conditions


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Thanks

