### PR TITLE
Setting the views directory no longer requires a trailing slash when using Simple View

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -16,6 +16,7 @@
 - Refactored `Phalcon\Mvc\Collection\Behavior\SoftDelete` and `Phalcon\Mvc\Model\Behavior\SoftDelete`. [#13930](https://github.com/phalcon/cphalcon/pull/13930)
 - Model methods that extend Model Manager functionality are now `final`. [#13950](https://github.com/phalcon/cphalcon/pull/13950)
 - Changed `Phalcon\Text` to call methods from `Phalcon\Helper\Str` [#13954](https://github.com/phalcon/cphalcon/pull/13954)
+- Setting the views directory no longer requires a trailing slash when using Simple View.
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/Mvc/View/Simple.zep
+++ b/phalcon/Mvc/View/Simple.zep
@@ -458,11 +458,14 @@ class Simple extends Injectable implements ViewBaseInterface
     }
 
     /**
-     * Sets views directory. Depending of your platform, always add a trailing
-     * slash or backslash
+     * Sets views directory
      */
     public function setViewsDir(string! viewsDir)
     {
+        if substr(viewsDir, -1) != DIRECTORY_SEPARATOR {
+            let viewsDir = viewsDir . DIRECTORY_SEPARATOR;
+        }
+
         let this->viewsDir = viewsDir;
     }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* See also: https://github.com/phalcon/cphalcon/pull/10028

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Thanks

