### PR TITLE
Fixed saving a model after fetching its related records

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -31,6 +31,7 @@
 - Query Builder's `GROUP BY` field is now always an array. [#13962](https://github.com/phalcon/cphalcon/pull/13962)
 - Renamed `Phalcon\Paginator\Adapter::getPaginate()` to `paginate()` in documentation/tests (originally renamed in 4.0.0-alpha.1). [#13973](https://github.com/phalcon/cphalcon/pull/13973)
 - Fixed the exception message in `Phalcon\Security::computeHmac()` by removing `"%s"` from output.
+- Fixed `Mvc\Model::save()` throwing an exception after fetching its related records (many/many-to-many) via `__get()` [#13985](https://github.com/phalcon/cphalcon/pull/13985)
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -288,8 +288,11 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
                 /**
                  * We store relationship objects in the related bag
+                 *
+                 * Removed temporarily.
+                 * See https://github.com/phalcon/cphalcon/issues/13964
                  */
-                let this->related[lowerProperty] = result;
+                // let this->related[lowerProperty] = result;
             }
 
             return result;

--- a/tests/integration/Mvc/Model/Refactor-ModelsRelationsMagicCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsRelationsMagicCest.php
@@ -85,7 +85,8 @@ class ModelsRelationsMagicCest
         $I->assertEquals($originalAlbum->id, $album->id);
     }
 
-    private function executeSaveAfterQueryRelated(IntegrationTester $I) {
+    private function executeSaveAfterQueryRelated(IntegrationTester $I)
+    {
         $album = Albums::findFirst();
         $artist = $album->artist;
 

--- a/tests/integration/Mvc/Model/Refactor-ModelsRelationsMagicCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsRelationsMagicCest.php
@@ -23,6 +23,7 @@ class ModelsRelationsMagicCest
         $this->setDiMysql();
 
         $this->executeQueryRelated($I);
+        $this->executeSaveAfterQueryRelated($I);
         $this->executeSaveRelatedBelongsTo($I);
     }
 
@@ -54,6 +55,12 @@ class ModelsRelationsMagicCest
         $this->_executeSaveRelatedBelongsTo($connection);
     }*/
 
+    /**
+     * Test for issue: #13964
+     * See: https://github.com/phalcon/cphalcon/issues/13964
+     *
+     * @param IntegrationTester $I
+     */
     private function executeQueryRelated(IntegrationTester $I)
     {
 
@@ -76,6 +83,21 @@ class ModelsRelationsMagicCest
 
         $originalAlbum = $album->artist->albums[0];
         $I->assertEquals($originalAlbum->id, $album->id);
+    }
+
+    private function executeSaveAfterQueryRelated(IntegrationTester $I) {
+        $album = Albums::findFirst();
+        $artist = $album->artist;
+
+        $I->assertTrue($album->save());
+
+        $artist->albums;
+
+        $I->assertTrue($artist->save());
+
+        $album->songs;
+
+        $I->assertTrue($album->save());
     }
 
     private function executeSaveRelatedBelongsTo(IntegrationTester $I)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13964

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

I've added some tests to check if this issue exists at all.
The tests failed, so added a fix in a previous PR (https://github.com/phalcon/cphalcon/pull/13970) but ran into a conflict so I made a new PR.

The problem is, that the related models are stored in the `_related` storage inside Model after accessing via `__get()`. It is not stored when accessing related records via `__call()`.

When the model is saved,` _postSaveRelatedRecords` is being called and it iterates through `_related` and tries to save the previously fetched related records.

For now, I just removed adding these records to the `_related` as it's not mandatory when you are only reading them.

Thanks