### PR TITLE
The property 'options' is always an array in Model Relations.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -21,6 +21,7 @@
 - `Phalcon\Mvc\View\Simple::render()` `params` property is now always an array.
 - `Phalcon\Mvc\Model\CriteriaInterface::limit()` now takes `offset` as an integer. [#13977](https://github.com/phalcon/cphalcon/pull/13977)
 - Changed `Phalcon\Mvc\Model\Manager::getModelSource()` to use `setModelSource()` internally instead of setting the source manually [#13987](https://github.com/phalcon/cphalcon/pull/13987)
+- The property `options` is always an array in `Phalcon\Mvc\Model\Relation`. [#13989](https://github.com/phalcon/cphalcon/pull/13989)
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/Mvc/Model/Relation.zep
+++ b/phalcon/Mvc/Model/Relation.zep
@@ -40,12 +40,10 @@ class Relation implements RelationInterface
     /**
      * Phalcon\Mvc\Model\Relation constructor
      *
-     * @param int type
      * @param string|array fields
      * @param string|array referencedFields
-     * @param array options
      */
-    public function __construct(int type, string! referencedModel, var fields, var referencedFields, var options = null) -> void
+    public function __construct(int type, string! referencedModel, var fields, var referencedFields, array options = []) -> void
     {
         let this->type = type,
             this->referencedModel = referencedModel,
@@ -72,14 +70,15 @@ class Relation implements RelationInterface
     public function getForeignKey()
     {
         var options, foreignKey;
+
         let options = this->options;
-        if typeof options == "array" {
-            if fetch foreignKey, options["foreignKey"] {
-                if foreignKey {
-                    return foreignKey;
-                }
+
+        if fetch foreignKey, options["foreignKey"] {
+            if foreignKey {
+                return foreignKey;
             }
         }
+
         return false;
     }
 
@@ -118,18 +117,18 @@ class Relation implements RelationInterface
     public function getOption(string! name)
     {
         var option;
-        if fetch option, this->options[name] {
-            return option;
+
+        if !fetch option, this->options[name] {
+            return null;
         }
-        return null;
+
+        return option;
     }
 
     /**
      * Returns the options
-     *
-     * @return string|array
      */
-    public function getOptions()
+    public function getOptions() -> array
     {
         return this->options;
     }
@@ -142,14 +141,15 @@ class Relation implements RelationInterface
     public function getParams()
     {
         var options, params;
+
         let options = this->options;
-        if typeof options == "array" {
-            if fetch params, options["params"] {
-                if params {
-                    return params;
-                }
+
+        if fetch params, options["params"] {
+            if params {
+                return params;
             }
         }
+
         return false;
     }
 
@@ -199,7 +199,9 @@ class Relation implements RelationInterface
     public function isThrough() -> bool
     {
         var type;
+
         let type = this->type;
+
         return type == self::HAS_ONE_THROUGH || type == self::HAS_MANY_THROUGH;
     }
 
@@ -209,13 +211,14 @@ class Relation implements RelationInterface
     public function isReusable() -> bool
     {
         var options, reusable;
+
         let options = this->options;
-        if typeof options == "array" {
-            if fetch reusable, options["reusable"] {
-                return reusable;
-            }
+
+        if !fetch reusable, options["reusable"] {
+            return false;
         }
-        return false;
+
+        return reusable;
     }
 
     /**

--- a/phalcon/Mvc/Model/RelationInterface.zep
+++ b/phalcon/Mvc/Model/RelationInterface.zep
@@ -58,10 +58,8 @@ interface RelationInterface
 
     /**
      * Returns the options
-     *
-     * @return string|array
      */
-    public function getOptions();
+    public function getOptions() -> array;
 
     /**
      * Returns parameters that must be always used when the related records are obtained

--- a/tests/integration/Mvc/Model/Relation/GetFieldsCest.php
+++ b/tests/integration/Mvc/Model/Relation/GetFieldsCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class GetFieldsCest
@@ -24,12 +25,62 @@ class GetFieldsCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
-    public function mvcModelRelationGetFields(IntegrationTester $I)
+    public function mvcModelRelationGetFieldsString(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Model\Relation - getFields()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Model\Relation - getFields() - string');
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            [
+                'reusable' => true, // cache related data
+                'alias'    => 'mechanicalParts',
+            ]
+        );
+
+        $I->assertEquals(
+            'id',
+            $relation->getFields()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Relation :: getFields()
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
+     */
+    public function mvcModelRelationGetFieldsArray(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Relation - getFields() - array');
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            [
+                'type',
+                'name',
+            ],
+            'robots_id',
+            [
+                'reusable' => true, // cache related data
+                'alias'    => 'mechanicalParts',
+            ]
+        );
+
+        $I->assertEquals(
+            [
+                'type',
+                'name',
+            ],
+            $relation->getFields()
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Relation/GetOptionCest.php
+++ b/tests/integration/Mvc/Model/Relation/GetOptionCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class GetOptionCest
@@ -24,12 +25,36 @@ class GetOptionCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
     public function mvcModelRelationGetOption(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Relation - getOption()');
-        $I->skipTest('Need implementation');
+
+        $options = [
+            'reusable' => true, // cache related data
+            'alias'    => 'mechanicalParts',
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+
+
+        $I->assertEquals(
+            $options['reusable'],
+            $relation->getOption('reusable')
+        );
+
+        $I->assertEquals(
+            $options['alias'],
+            $relation->getOption('alias')
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Relation/GetOptionsCest.php
+++ b/tests/integration/Mvc/Model/Relation/GetOptionsCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class GetOptionsCest
@@ -24,12 +25,29 @@ class GetOptionsCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
     public function mvcModelRelationGetOptions(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Relation - getOptions()');
-        $I->skipTest('Need implementation');
+
+        $options = [
+            'reusable' => true, // cache related data
+            'alias'    => 'mechanicalParts',
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertEquals(
+            $options,
+            $relation->getOptions()
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Relation/GetParamsCest.php
+++ b/tests/integration/Mvc/Model/Relation/GetParamsCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class GetParamsCest
@@ -24,12 +25,65 @@ class GetParamsCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
     public function mvcModelRelationGetParams(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Relation - getParams()');
-        $I->skipTest('Need implementation');
+
+        $options = [
+            'reusable' => true, // cache related data
+            'alias'    => 'mechanicalParts',
+            'params'   => [
+                'conditions' => 'robotTypeId = :type:',
+                'bind'       => [
+                    'type' => 4,
+                ],
+            ],
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertEquals(
+            $options['params'],
+            $relation->getParams()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Relation :: getParams() when none are set
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
+     */
+    public function mvcModelRelationGetParamsWhenNoneSet(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Relation - getParams() when none are set');
+
+        $options = [
+            'reusable' => true, // cache related data
+            'alias'    => 'mechanicalParts',
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertFalse(
+            $relation->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Relation/GetReferencedModelCest.php
+++ b/tests/integration/Mvc/Model/Relation/GetReferencedModelCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class GetReferencedModelCest
@@ -24,12 +25,27 @@ class GetReferencedModelCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
     public function mvcModelRelationGetReferencedModel(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Relation - getReferencedModel()');
-        $I->skipTest('Need implementation');
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            [
+                'reusable' => true, // cache related data
+                'alias'    => 'mechanicalParts',
+            ]
+        );
+
+        $I->assertEquals(
+            'RobotsParts',
+            $relation->getReferencedModel()
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Relation/GetTypeCest.php
+++ b/tests/integration/Mvc/Model/Relation/GetTypeCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class GetTypeCest
@@ -24,12 +25,29 @@ class GetTypeCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
     public function mvcModelRelationGetType(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Relation - getType()');
-        $I->skipTest('Need implementation');
+
+        $options = [
+            'reusable' => true, // cache related data
+            'alias'    => 'mechanicalParts',
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertEquals(
+            Relation::HAS_MANY,
+            $relation->getType()
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Thanks

