### PR TITLE
Added addConnect(), addPurge() and addTrace() to Router Group

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,6 +7,7 @@
 - Added `chunk()`, `first()`, `firstKey()`, `flatten()`, `group()`, `isUnique()`, `last()`, `lastKey()`, `order()`, `pluck()`, `sliceLeft()`, `sliceRight()`, `split()`, `tail()`, `validateAll()`, `validateAny()` to `Phalcon\Helper\Arr` [#13954](https://github.com/phalcon/cphalcon/pull/13954)
 - Added `camelize()`, `concat()`, `countVowels()`, `decapitalize()`, `dynamic()`, `endsWith()`, `firstStringBetween()`, `includes()`, `increment()`, `isAnagram()`, `isLower()`, `isPalindrome()`, `isUpper()`, `lower()`, `random()`, `reduceSlashes()`, `startsWith()`, `uncamelize()`, `underscore()`, `upper()` to `Phalcon\Helper\Str` [#13954](https://github.com/phalcon/cphalcon/pull/13954) 
 - Added `Phalcon\Mvc\Model\Query\BuilderInterface::getModels()` returns the models involved in the query
+- Added `addConnect()`, `addPurge()` and `addTrace()` to `Phalcon\Mvc\Router\Group` and its interface. [#14001](https://github.com/phalcon/cphalcon/pull/14001)
 
 ## Changed
 - Refactored `Phalcon\Events\Manager` to only use `SplPriorityQueue` to store events. [#13924](https://github.com/phalcon/cphalcon/pull/13924)

--- a/phalcon/Annotations/Reflection.zep
+++ b/phalcon/Annotations/Reflection.zep
@@ -90,7 +90,7 @@ class Reflection
      */
     public function getMethodsAnnotations() -> <Collection[]> | bool
     {
-        var reflectionMethods, collections, methodName, reflectionMethod;
+        var reflectionMethods, methodName, reflectionMethod;
 
         if this->methodAnnotations === null {
             if fetch reflectionMethods, this->reflectionData["methods"] {

--- a/phalcon/Mvc/Router/Group.zep
+++ b/phalcon/Mvc/Router/Group.zep
@@ -93,6 +93,16 @@ class Group implements GroupInterface
     }
 
     /**
+     * Adds a route to the router that only match if the HTTP method is CONNECT
+     *
+     * @param string|array paths
+     */
+    public function addConnect(string! pattern, var paths = null) -> <RouteInterface>
+    {
+        return this->addRoute(pattern, paths, "CONNECT");
+    }
+
+    /**
      * Adds a route to the router that only match if the HTTP method is DELETE
      *
      * @param string|array paths
@@ -153,6 +163,16 @@ class Group implements GroupInterface
     }
 
     /**
+     * Adds a route to the router that only match if the HTTP method is PURGE
+     *
+     * @param string|array paths
+     */
+    public function addPurge(string! pattern, var paths = null) -> <RouteInterface>
+    {
+        return this->addRoute(pattern, paths, "PURGE");
+    }
+
+    /**
      * Adds a route to the router that only match if the HTTP method is PUT
      *
      * @param string|array paths
@@ -160,6 +180,16 @@ class Group implements GroupInterface
     public function addPut(string! pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "PUT");
+    }
+
+    /**
+     * Adds a route to the router that only match if the HTTP method is TRACE
+     *
+     * @param string|array paths
+     */
+    public function addTrace(string! pattern, var paths = null) -> <RouteInterface>
+    {
+        return this->addRoute(pattern, paths, "TRACE");
     }
 
     /**

--- a/phalcon/Mvc/Router/GroupInterface.zep
+++ b/phalcon/Mvc/Router/GroupInterface.zep
@@ -71,14 +71,19 @@ interface GroupInterface
     public function add(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>;
 
     /**
-     * Adds a route to the router that only match if the HTTP method is GET
+     * Adds a route to the router that only match if the HTTP method is CONNECT
      */
-    public function addGet(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addConnect(string! pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is DELETE
      */
     public function addDelete(string! pattern, var paths = null) -> <RouteInterface>;
+
+    /**
+     * Adds a route to the router that only match if the HTTP method is GET
+     */
+    public function addGet(string! pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is HEAD
@@ -101,9 +106,19 @@ interface GroupInterface
     public function addPost(string! pattern, var paths = null) -> <RouteInterface>;
 
     /**
+     * Adds a route to the router that only match if the HTTP method is PURGE
+     */
+    public function addPurge(string! pattern, var paths = null) -> <RouteInterface>;
+
+    /**
      * Adds a route to the router that only match if the HTTP method is PUT
      */
     public function addPut(string! pattern, var paths = null) -> <RouteInterface>;
+
+    /**
+     * Adds a route to the router that only match if the HTTP method is TRACE
+     */
+    public function addTrace(string! pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Sets a callback that is called if the route is matched.

--- a/tests/integration/Mvc/Router/Group/AddDeleteCest.php
+++ b/tests/integration/Mvc/Router/Group/AddDeleteCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddDeleteCest
  */
 class AddDeleteCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addDelete()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddDelete(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Router\Group - addDelete()');
-        $I->skipTest('Need implementation');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addDelete(
+            '/docs/index',
+            [
+                'controller' => 'documentation6',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'DELETE';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation6',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/AddGetCest.php
+++ b/tests/integration/Mvc/Router/Group/AddGetCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddGetCest
  */
 class AddGetCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addGet()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddGet(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Router\Group - addGet()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Router - addGet()');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addGet(
+            '/docs/index',
+            [
+                'controller' => 'documentation4',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation4',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/AddHeadCest.php
+++ b/tests/integration/Mvc/Router/Group/AddHeadCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddHeadCest
  */
 class AddHeadCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addHead()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddHead(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Router\Group - addHead()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Router - addHead()');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addHead(
+            '/docs/index',
+            [
+                'controller' => 'documentation8',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'HEAD';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation8',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/AddOptionsCest.php
+++ b/tests/integration/Mvc/Router/Group/AddOptionsCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddOptionsCest
  */
 class AddOptionsCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addOptions()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddOptions(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Router\Group - addOptions()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Router - addOptions()');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addOptions(
+            '/docs/index',
+            [
+                'controller' => 'documentation7',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation7',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/AddPatchCest.php
+++ b/tests/integration/Mvc/Router/Group/AddPatchCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddPatchCest
  */
 class AddPatchCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addPatch()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddPatch(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Router\Group - addPatch()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Router - addPatch()');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addPatch(
+            '/docs/index',
+            [
+                'controller' => 'documentation4',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'PATCH';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation4',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/AddPostCest.php
+++ b/tests/integration/Mvc/Router/Group/AddPostCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddPostCest
  */
 class AddPostCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addPost()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddPost(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Router\Group - addPost()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Router - addPost()');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addPost(
+            '/docs/index',
+            [
+                'controller' => 'documentation3',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation3',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/AddPutCest.php
+++ b/tests/integration/Mvc/Router/Group/AddPutCest.php
@@ -13,23 +13,64 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Group;
+use Phalcon\Test\Fixtures\Traits\RouterTrait;
 
 /**
  * Class AddPutCest
  */
 class AddPutCest
 {
+    use RouterTrait;
+
     /**
      * Tests Phalcon\Mvc\Router\Group :: addPut()
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupAddPut(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Router\Group - addPut()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\Router - addPut()');
+
+        $router = $this->getRouter(false);
+
+        $group = new Group();
+
+        $group->addPut(
+            '/docs/index',
+            [
+                'controller' => 'documentation5',
+                'action'     => 'index',
+            ]
+        );
+
+        $router->mount($group);
+
+
+
+        $_SERVER['REQUEST_METHOD'] = 'PUT';
+
+        $router->handle('/docs/index');
+
+
+
+        $I->assertEquals(
+            'documentation5',
+            $router->getControllerName()
+        );
+
+        $I->assertEquals(
+            'index',
+            $router->getActionName()
+        );
+
+        $I->assertEquals(
+            [],
+            $router->getParams()
+        );
     }
 }

--- a/tests/integration/Mvc/Router/Group/GetPrefixCest.php
+++ b/tests/integration/Mvc/Router/Group/GetPrefixCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Group;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router\Group;
 
 /**
  * Class GetPrefixCest
@@ -24,12 +25,40 @@ class GetPrefixCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
+     */
+    public function mvcRouterGroupGetPrefixEmpty(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Router\Group - empty getPrefix()');
+
+        $group = new Group();
+
+        $I->assertEquals(
+            '',
+            $group->getPrefix()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Router\Group :: getPrefix() when nothing is set
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-17
      */
     public function mvcRouterGroupGetPrefix(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Router\Group - getPrefix()');
-        $I->skipTest('Need implementation');
+
+        $group = new Group();
+
+        $group->setPrefix('/blog');
+
+        $I->assertEquals(
+            '/blog',
+            $group->getPrefix()
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

They exist in the Router so I assume the Router Group was forgotten about.

