### PR TITLE
Model\Relation::isForeignKey() now returns false if the option is false

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -31,6 +31,7 @@
 - Query Builder's `GROUP BY` field is now always an array. [#13962](https://github.com/phalcon/cphalcon/pull/13962)
 - Renamed `Phalcon\Paginator\Adapter::getPaginate()` to `paginate()` in documentation/tests (originally renamed in 4.0.0-alpha.1). [#13973](https://github.com/phalcon/cphalcon/pull/13973)
 - Fixed the exception message in `Phalcon\Security::computeHmac()` by removing `"%s"` from output.
+- `Phalcon\Mvc\Model\Relation::isForeignKey()` now returns false if the `foreignKey` option is set to `false`.
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Mvc/Model/Relation.zep
+++ b/phalcon/Mvc/Model/Relation.zep
@@ -184,7 +184,13 @@ class Relation implements RelationInterface
      */
     public function isForeignKey() -> bool
     {
-        return isset this->options["foreignKey"];
+        var foreignKey;
+
+        if !fetch foreignKey, this->options["foreignKey"] {
+            return false;
+        }
+
+        return (bool) foreignKey;
     }
 
     /**

--- a/tests/integration/Mvc/Model/Relation/IsForeignKeyCest.php
+++ b/tests/integration/Mvc/Model/Relation/IsForeignKeyCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Relation;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Relation;
 
 /**
  * Class IsForeignKeyCest
@@ -24,12 +25,101 @@ class IsForeignKeyCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-18
      */
     public function mvcModelRelationIsForeignKey(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Relation - isForeignKey()');
-        $I->skipTest('Need implementation');
+
+
+
+        $options = [];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertFalse(
+            $relation->isForeignKey()
+        );
+
+
+
+        $options = [
+            'foreignKey' => false,
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertFalse(
+            $relation->isForeignKey()
+        );
+
+
+
+        $options = [
+            'foreignKey' => [],
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertFalse(
+            $relation->isForeignKey()
+        );
+
+
+
+        $options = [
+            'foreignKey' => true,
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertTrue(
+            $relation->isForeignKey()
+        );
+
+
+
+        $options = [
+            'foreignKey' => [
+                'message' => 'The part_id does not exist on the Parts model',
+            ],
+        ];
+
+        $relation = new Relation(
+            Relation::HAS_MANY,
+            'RobotsParts',
+            'id',
+            'robots_id',
+            $options
+        );
+
+        $I->assertTrue(
+            $relation->isForeignKey()
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Thanks

