### PR TITLE
Logger\Adapter\AbstractAdapter::process() is now actually abstract.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -23,6 +23,7 @@
 - `Phalcon\Mvc\Model\CriteriaInterface::limit()` now takes `offset` as an integer. [#13977](https://github.com/phalcon/cphalcon/pull/13977)
 - Changed `Phalcon\Mvc\Model\Manager::getModelSource()` to use `setModelSource()` internally instead of setting the source manually [#13987](https://github.com/phalcon/cphalcon/pull/13987)
 - The property `options` is always an array in `Phalcon\Mvc\Model\Relation`. [#13989](https://github.com/phalcon/cphalcon/pull/13989)
+- `Phalcon\Logger\Adapter\AbstractAdapter::process()` is now actually abstract. [#14012](https://github.com/phalcon/cphalcon/pull/14012)
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/Logger/Adapter/AbstractAdapter.zep
+++ b/phalcon/Logger/Adapter/AbstractAdapter.zep
@@ -130,10 +130,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
       * Processes the message in the adapter
       */
-    public function process(<Item> item) -> void
-    {
-        throw new Exception("This method cannot be called directly in the adapter");
-    }
+    abstract public function process(<Item> item) -> void;
 
     /**
       * Rollbacks the internal transaction


### PR DESCRIPTION
Hello!

* Type: bug fix | code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Small description of change:

Thanks

