### PR TITLE
Form\Elements::attributes is always an array

### DIFF
--- a/phalcon/Forms/Element.zep
+++ b/phalcon/Forms/Element.zep
@@ -170,10 +170,6 @@ abstract class Element implements ElementInterface
 
         let attributes = this->attributes;
 
-        if typeof attributes != "array" {
-            return [];
-        }
-
         return attributes;
     }
 
@@ -316,12 +312,8 @@ abstract class Element implements ElementInterface
             let name = this->name;
         }
 
-        if typeof attributes == "array" {
-            if !isset attributes["for"] {
-                let attributes["for"] = name;
-            }
-        } else {
-            let attributes = ["for": name];
+        if !isset attributes["for"] {
+            let attributes["for"] = name;
         }
 
         let code = Tag::renderAttributes("<label", attributes);
@@ -330,6 +322,7 @@ abstract class Element implements ElementInterface
          * Use the default label or leave the same name as label
          */
         let label = this->label;
+
         if label || is_numeric(label) {
             let code .= ">" . label . "</label>";
         } else {
@@ -343,36 +336,23 @@ abstract class Element implements ElementInterface
      * Returns an array of prepared attributes for Phalcon\Tag helpers
      * according to the element parameters
      */
-    public function prepareAttributes(array attributes = null, bool useChecked = false) -> array
+    public function prepareAttributes(array attributes = [], bool useChecked = false) -> array
     {
-        var value, name, widgetAttributes, mergedAttributes,
-            defaultAttributes, currentValue;
+        var value, name, mergedAttributes, defaultAttributes, currentValue;
 
         let name = this->name;
 
-        /**
-         * Create an array of parameters
-         */
-        if typeof attributes != "array" {
-            let widgetAttributes = [];
-        } else {
-            let widgetAttributes = attributes;
-        }
-
-        let widgetAttributes[0] = name;
+        let attributes[0] = name;
 
         /**
          * Merge passed parameters with default ones
          */
         let defaultAttributes = this->attributes;
-        if typeof defaultAttributes == "array" {
-            let mergedAttributes = array_merge(
-                defaultAttributes,
-                widgetAttributes
-            );
-        } else {
-            let mergedAttributes = widgetAttributes;
-        }
+
+        let mergedAttributes = array_merge(
+            defaultAttributes,
+            attributes
+        );
 
         /**
          * Get the current element value

--- a/phalcon/Forms/ElementInterface.zep
+++ b/phalcon/Forms/ElementInterface.zep
@@ -126,7 +126,7 @@ interface ElementInterface
      * Returns an array of prepared attributes for Phalcon\Tag helpers
      * according to the element's parameters
      */
-    public function prepareAttributes(array attributes = null, bool useChecked = false) -> array;
+    public function prepareAttributes(array attributes = [], bool useChecked = false) -> array;
 
     /**
      * Renders the element widget

--- a/tests/integration/Forms/Element/GetFormCest.php
+++ b/tests/integration/Forms/Element/GetFormCest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Forms\Element;
 
 use IntegrationTester;
+use Phalcon\Forms\Element\Text;
+use Phalcon\Forms\Form;
 
 /**
  * Class GetFormCest
@@ -24,12 +26,46 @@ class GetFormCest
      *
      * @param IntegrationTester $I
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-25
      */
     public function formsElementGetForm(IntegrationTester $I)
     {
         $I->wantToTest('Forms\Element - getForm()');
-        $I->skipTest('Need implementation');
+
+        $address = new Text('address');
+
+        $form = new Form();
+
+        $address->setForm($form);
+
+        $I->assertSame(
+            $form,
+            $address->getForm()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Forms\Element :: getForm()
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Sid Roberts <sid@sidroberts.co.uk>
+     * @since  2019-04-25
+     */
+    public function formsElementGetFormViaForm(IntegrationTester $I)
+    {
+        $I->wantToTest('Forms\Element - getForm()');
+
+        $address = new Text('address');
+
+        $form = new Form();
+
+        $form->add($address);
+
+        $I->assertSame(
+            $form,
+            $address->getForm()
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [-] I updated the CHANGELOG

Small description of change:

Thanks

