### PR TITLE
Fixed PHPDoc code example in session/adapter/files

### DIFF
--- a/phalcon/session/adapter/files.zep
+++ b/phalcon/session/adapter/files.zep
@@ -29,7 +29,7 @@ use Phalcon\Session\Exception;
  *         'savePath' => '/tmp',
  *     ]
  * );
- * $session->setHandler(new Files());
+ * $session->setHandler($files);
  * </code>
  */
 class Files extends Noop


### PR DESCRIPTION
Hello!

* Type: documentation
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I updated the CHANGELOG

Thanks

