### PR TITLE
T13949 rollback transaction exception

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,7 @@
 - Added `camelize()`, `concat()`, `countVowels()`, `decapitalize()`, `dynamic()`, `endsWith()`, `firstStringBetween()`, `includes()`, `increment()`, `isAnagram()`, `isLower()`, `isPalindrome()`, `isUpper()`, `lower()`, `random()`, `reduceSlashes()`, `startsWith()`, `uncamelize()`, `underscore()`, `upper()` to `Phalcon\Helper\Str` [#13954](https://github.com/phalcon/cphalcon/pull/13954) 
 - Added `Phalcon\Mvc\Model\Query\BuilderInterface::getModels()` returns the models involved in the query
 - Added `addConnect()`, `addPurge()` and `addTrace()` to `Phalcon\Mvc\Router\Group` and its interface. [#14001](https://github.com/phalcon/cphalcon/pull/14001)
+- Added `Phalcon\Mvc\Model\Transaction::throwRollbackException()` which allows a transaction to throw an exception or not on a rollback. [#13949](https://github.com/phalcon/cphalcon/issues/13949)
 
 ## Changed
 - Refactored `Phalcon\Events\Manager` to only use `SplPriorityQueue` to store events. [#13924](https://github.com/phalcon/cphalcon/pull/13924)
@@ -24,6 +25,7 @@
 - Changed `Phalcon\Mvc\Model\Manager::getModelSource()` to use `setModelSource()` internally instead of setting the source manually [#13987](https://github.com/phalcon/cphalcon/pull/13987)
 - The property `options` is always an array in `Phalcon\Mvc\Model\Relation`. [#13989](https://github.com/phalcon/cphalcon/pull/13989)
 - `Phalcon\Logger\Adapter\AbstractAdapter::process()` is now actually abstract. [#14012](https://github.com/phalcon/cphalcon/pull/14012)
+- Changed `Phalcon\Mvc\Model\Transaction::rollback()` to not throw a transaction by default. [#13949](https://github.com/phalcon/cphalcon/issues/13949)
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/Mvc/Model/Transaction.zep
+++ b/phalcon/Mvc/Model/Transaction.zep
@@ -76,6 +76,8 @@ class Transaction implements TransactionInterface
 
     protected rollbackOnAbort = false;
 
+    protected rollbackThrowException = false;
+
     /**
      * Phalcon\Mvc\Model\Transaction constructor
      */
@@ -184,7 +186,9 @@ class Transaction implements TransactionInterface
                 let this->rollbackRecord = rollbackRecord;
             }
 
-            throw new TxFailed(rollbackMessage, this->rollbackRecord);
+            if this->rollbackThrowException {
+                throw new TxFailed(rollbackMessage, this->rollbackRecord);
+            }
         }
 
         return true;
@@ -220,5 +224,15 @@ class Transaction implements TransactionInterface
     public function setTransactionManager(<ManagerInterface> manager) -> void
     {
         let this->manager = manager;
+    }
+
+    /**
+     * Enables throwing exception
+     */
+    public function throwRollbackException(bool status) -> <TransactionInterface>
+    {
+        let this->rollbackThrowException = status;
+
+        return this;
     }
 }

--- a/phalcon/Mvc/Model/TransactionInterface.zep
+++ b/phalcon/Mvc/Model/TransactionInterface.zep
@@ -74,4 +74,9 @@ interface TransactionInterface
      * Sets transaction manager related to the transaction
      */
     public function setTransactionManager(<ManagerInterface> manager) -> void;
+
+    /**
+     * Enables throwing exception
+     */
+    public function throwRollbackException(bool status) -> <TransactionInterface>;
 }

--- a/tests/integration/Mvc/Model/Transaction/Refactor-ManagerCest.php
+++ b/tests/integration/Mvc/Model/Transaction/Refactor-ManagerCest.php
@@ -38,7 +38,6 @@ class ManagerCest
         $this->setDiMysql();
 
         $this->testGetNewExistingTransactionOnce($I);
-        $this->testRollbackNewInserts($I);
         $this->testCommitNewInserts($I);
         $this->testTransactionRemovedOnCommit($I);
         $this->testTransactionRemovedOnRollback($I);
@@ -59,39 +58,6 @@ class ManagerCest
          * @todo - Check why this returns different Ids in db and TM
          */
 //        $I->assertEquals($db->getConnectionId(), $transaction->getConnection()->getConnectionId());
-    }
-
-    private function testRollbackNewInserts(IntegrationTester $I)
-    {
-        $tm = $this->container->getShared('transactionManager');
-
-        $numPersonas = Personas::count();
-        $transaction = $tm->get();
-
-        for ($i = 0; $i < 10; $i++) {
-            $persona = new Personas();
-            $persona->setTransaction($transaction);
-            $persona->cedula            = 'T-Cx' . $i;
-            $persona->tipo_documento_id = 1;
-            $persona->nombres           = 'LOST LOST';
-            $persona->telefono          = '2';
-            $persona->cupo              = 0;
-            $persona->estado            = 'A';
-
-            $I->assertTrue($persona->save());
-        }
-
-        try {
-            $transaction->rollback();
-            $I->assertTrue(
-                false,
-                "The transaction's rollback didn't throw an expected exception. Emergency stop"
-            );
-        } catch (Failed $e) {
-            $I->assertEquals($e->getMessage(), "Transaction aborted");
-        }
-
-        $I->assertEquals($numPersonas, Personas::count());
     }
 
     private function testCommitNewInserts(IntegrationTester $I)
@@ -176,7 +142,6 @@ class ManagerCest
         $this->setDiPostgresql();
 
         $this->testGetNewExistingTransactionOnce($I);
-        $this->testRollbackNewInserts($I);
         $this->testCommitNewInserts($I);
         $this->testTransactionRemovedOnCommit($I);
         $this->testTransactionRemovedOnRollback($I);
@@ -194,7 +159,6 @@ class ManagerCest
         $this->setDiSqlite();
 
         $this->testGetNewExistingTransactionOnce($I);
-        $this->testRollbackNewInserts($I);
         $this->testCommitNewInserts($I);
         $this->testTransactionRemovedOnCommit($I);
         $this->testTransactionRemovedOnRollback($I);

--- a/tests/integration/Mvc/Model/Transaction/RollbackCest.php
+++ b/tests/integration/Mvc/Model/Transaction/RollbackCest.php
@@ -29,7 +29,6 @@ class RollbackCest
     public function _before(IntegrationTester $I)
     {
         $this->setNewFactoryDefault();
-        $this->setDiMysql();
         $this->records = [];
     }
 
@@ -47,14 +46,18 @@ class RollbackCest
     /**
      * Tests Phalcon\Mvc\Model\Transaction :: rollback()
      *
+     * @dataProvider getFunctions
+     *
      * @param IntegrationTester $I
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
      */
-    public function mvcModelTransactionRollback(IntegrationTester $I)
+    public function mvcModelTransactionRollback(IntegrationTester $I, Example $function)
     {
         $I->wantToTest('Mvc\Model\Transaction - rollback()');
+
+        $this->$function();
 
         $tm = $this->container->getShared('transactionManager');
 
@@ -129,5 +132,16 @@ class RollbackCest
         }
 
         $I->assertEquals($count, Personas::count());
+    }
+
+    /**
+     * @return array
+     */
+    private function getFunctions(): array
+    {
+        return [
+            ['setDiMysql']
+            ['setDiPostgresql']
+        ];
     }
 }

--- a/tests/integration/Mvc/Model/Transaction/RollbackCest.php
+++ b/tests/integration/Mvc/Model/Transaction/RollbackCest.php
@@ -38,7 +38,7 @@ class RollbackCest
         $db = $this->container->get('db');
 
         foreach ($this->records as $record) {
-            $db->execute('DELETE FROM personas WHERE cedula = "' . $record . '"');
+            $db->execute("DELETE FROM personas WHERE personas.cedula = '" . $record . "'");
         }
 
         $this->records = [];

--- a/tests/integration/Mvc/Model/Transaction/RollbackCest.php
+++ b/tests/integration/Mvc/Model/Transaction/RollbackCest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Integration\Mvc\Model\Transaction;
 
+use Codeception\Example;
 use IntegrationTester;
 use Phalcon\Mvc\Model\Transaction\Failed;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
@@ -57,7 +58,8 @@ class RollbackCest
     {
         $I->wantToTest('Mvc\Model\Transaction - rollback()');
 
-        $this->$function();
+        $method = $function[0];
+        $this->$method();
 
         $tm = $this->container->getShared('transactionManager');
 
@@ -82,20 +84,24 @@ class RollbackCest
 
         $transaction->rollback();
         $I->assertEquals($count, Personas::count());
-
     }
 
     /**
      * Tests Phalcon\Mvc\Model\Transaction :: rollback() - exception
+     *
+     * @dataProvider getFunctions
      *
      * @param IntegrationTester $I
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  2018-11-13
      */
-    public function mvcModelTransactionRollbackException(IntegrationTester $I)
+    public function mvcModelTransactionRollbackException(IntegrationTester $I, Example $function)
     {
         $I->wantToTest('Mvc\Model\Transaction - rollback() - exception');
+
+        $method = $function[0];
+        $this->$method();
 
         $tm = $this->container->getShared('transactionManager');
 
@@ -140,8 +146,8 @@ class RollbackCest
     private function getFunctions(): array
     {
         return [
-            ['setDiMysql']
-            ['setDiPostgresql']
+            ['setDiMysql'],
+            ['setDiPostgresql'],
         ];
     }
 }

--- a/tests/integration/Mvc/Model/Transaction/RollbackCest.php
+++ b/tests/integration/Mvc/Model/Transaction/RollbackCest.php
@@ -13,12 +13,37 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Transaction;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Transaction\Failed;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Personas;
 
 /**
  * Class RollbackCest
  */
 class RollbackCest
 {
+    use DiTrait;
+
+    private $records = [];
+
+    public function _before(IntegrationTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+        $this->records = [];
+    }
+
+    public function _after(IntegrationTester $I)
+    {
+        $db = $this->container->get('db');
+
+        foreach ($this->records as $record) {
+            $db->execute('DELETE FROM personas WHERE cedula = "' . $record . '"');
+        }
+
+        $this->records = [];
+    }
+
     /**
      * Tests Phalcon\Mvc\Model\Transaction :: rollback()
      *
@@ -30,6 +55,79 @@ class RollbackCest
     public function mvcModelTransactionRollback(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Transaction - rollback()');
-        $I->skipTest('Need implementation');
+
+        $tm = $this->container->getShared('transactionManager');
+
+        $count = Personas::count();
+        $transaction = $tm->get();
+
+        for ($i = 0; $i < 10; $i++) {
+            $persona = new Personas();
+            $persona->setTransaction($transaction);
+            $persona->cedula            = 'T-Cx' . $i;
+            $persona->tipo_documento_id = 1;
+            $persona->nombres           = 'LOST LOST';
+            $persona->telefono          = '2';
+            $persona->cupo              = 0;
+            $persona->estado            = 'A';
+
+            $result = $persona->save();
+
+            $this->records[] = $persona->cedula;
+            $I->assertTrue($result);
+        }
+
+        $transaction->rollback();
+        $I->assertEquals($count, Personas::count());
+
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Transaction :: rollback() - exception
+     *
+     * @param IntegrationTester $I
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function mvcModelTransactionRollbackException(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Transaction - rollback() - exception');
+
+        $tm = $this->container->getShared('transactionManager');
+
+        $count = Personas::count();
+        $transaction = $tm
+            ->get()
+            ->throwRollbackException(true)
+        ;
+
+        for ($i = 0; $i < 10; $i++) {
+            $persona = new Personas();
+            $persona->setTransaction($transaction);
+            $persona->cedula            = 'T-Cx' . $i;
+            $persona->tipo_documento_id = 1;
+            $persona->nombres           = 'LOST LOST';
+            $persona->telefono          = '2';
+            $persona->cupo              = 0;
+            $persona->estado            = 'A';
+
+            $result = $persona->save();
+
+            $this->records[] = $persona->cedula;
+            $I->assertTrue($result);
+        }
+
+        try {
+            $transaction->rollback();
+            $I->assertTrue(
+                false,
+                "The transaction's rollback didn't throw an expected exception. Emergency stop"
+            );
+        } catch (Failed $e) {
+            $I->assertEquals($e->getMessage(), "Transaction aborted");
+        }
+
+        $I->assertEquals($count, Personas::count());
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13949 #13324 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Made rollback not throw an exeption by default. Added `throwRollbackException` on the Transaction object.

Thanks

