### PR TITLE
T13869 crypt aes 256 gcm

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -71,6 +71,7 @@
 - `Phalcon\Logger\Formatter\Json::__construct()` service parameters must be a string or omitted.
 - Removed deprecated code from `Phalcon\Forms\Form::getMessages()`.
 - Loading a Module (either MVC or CLI) now throws an exception if the path does not exists regardless of whether the class is already loaded.
+- Changed `Phalcon\Crypt` to accept auth tag, tag length and data for "gcm" and "ccm" modes. Removed insecure algorithms with modes: `des*`, `rc2*`, `rc4*`, `des*`, `*ecb` [#13869](https://github.com/phalcon/cphalcon/pull/13869)
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/CryptInterface.zep
+++ b/phalcon/CryptInterface.zep
@@ -43,6 +43,21 @@ interface CryptInterface
     public function getAvailableCiphers() -> array;
 
     /**
+     * Returns the authentication tag
+     */
+    public function getAuthTag() -> string;
+
+    /**
+     * Returns authentication data
+     */
+    public function getAuthData() -> string;
+
+    /**
+     * Returns the authentication tag length
+     */
+    public function getAuthTagLength() -> int;
+
+    /**
      * Returns the current cipher
      */
     public function getCipher() -> string;
@@ -51,6 +66,21 @@ interface CryptInterface
      * Returns the encryption key
      */
     public function getKey() -> string;
+
+    /**
+     * Sets the authentication tag
+     */
+    public function setAuthTag(string! tag) -> <CryptInterface>;
+
+    /**
+     * Sets authentication data
+     */
+    public function setAuthData(string! data) -> <CryptInterface>;
+
+    /**
+     * Sets the authentication tag length
+     */
+    public function setAuthTagLength(int! length) -> <CryptInterface>;
 
     /**
      * Sets the cipher algorithm

--- a/tests/unit/Crypt/EncryptBase64Cest.php
+++ b/tests/unit/Crypt/EncryptBase64Cest.php
@@ -34,7 +34,6 @@ class EncryptBase64Cest
         ];
 
         $ciphers = [
-            'AES-128-ECB',
             'AES-128-CBC',
             'AES-128-CFB',
             'AES-128-OFB',

--- a/tests/unit/Crypt/EncryptCest.php
+++ b/tests/unit/Crypt/EncryptCest.php
@@ -12,7 +12,10 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Crypt;
 
+use function hash_hmac_algos;
 use Phalcon\Crypt;
+use Phalcon\Crypt\Exception;
+use function substr;
 use UnitTester;
 
 class EncryptCest
@@ -34,7 +37,6 @@ class EncryptCest
         ];
 
         $ciphers = [
-            'AES-128-ECB',
             'AES-128-CBC',
             'AES-128-CFB',
             'AES-128-OFB',
@@ -77,6 +79,58 @@ class EncryptCest
 
                 $I->assertEquals($test, $actual);
             }
+        }
+    }
+
+    /**
+     * Tests Phalcon\Crypt :: encrypt() - unsupported algo
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function cryptEncryptException(UnitTester $I)
+    {
+        $I->wantToTest('Crypt - encrypt() - exception');
+
+        $I->expectThrowable(
+            new Exception(
+                'The cipher algorithm "AES-128-ECB" is not supported on this system.'
+            ),
+            function () {
+                $crypt = new Crypt();
+                $crypt->setCipher('AES-128-ECB');
+            }
+        );
+    }
+
+    /**
+     * Tests Phalcon\Crypt :: encrypt() - gcm
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2019-05-15
+     */
+    public function cryptEncryptGcm(UnitTester $I)
+    {
+        $I->wantToTest('Crypt - encrypt()');
+
+        $ciphers = [
+            'aes-128-gcm',
+            'aes-128-ccm',
+        ];
+
+        $crypt = new Crypt();
+
+        foreach ($ciphers as $cipher) {
+            $crypt
+                ->setCipher($cipher)
+                ->setAuthTag('1234')
+                ->setAuthData('abcd')
+                ->setKey('123456')
+            ;
+
+            $encryption = $crypt->encrypt('phalcon');
+            $actual     = $crypt->decrypt($encryption);
+            $I->assertEquals('phalcon', $actual);
         }
     }
 }

--- a/tests/unit/Crypt/SetPaddingCest.php
+++ b/tests/unit/Crypt/SetPaddingCest.php
@@ -34,7 +34,6 @@ class SetPaddingCest
         $key = '0123456789ABCDEF0123456789ABCDEF';
 
         $ciphers = [
-            'AES-256-ECB',
             'AES-256-CBC',
             'AES-256-CFB',
         ];


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13869 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

- Changed `Phalcon\Crypt` to accept auth tag, tag length and data for "gcm" and "ccm" modes. Removed insecure algorithms with modes: `des*`, `rc2*`, `rc4*`, `des*`, `*ecb` 


Thanks

