### PR TITLE
T13149 cancel on fail

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -91,6 +91,7 @@
 - `Phalcon\Mvc\Model::isRelationshipLoaded()` is now working for every type of relations. [#14035](https://github.com/phalcon/cphalcon/pull/14035)
 - Fixed `Phalcon\Mvc\Model::writeAttribute()` to handle associative arrays correctly. [#14021](https://github.com/phalcon/cphalcon/issues/14021)
 - Fixed `Phalcon\Html\Tag::appendTitle()` and `Phalcon\Html\Tag::prependTitle()`to mirror `Phalcon\Tag`. [#14039](https://github.com/phalcon/cphalcon/issues/14039)
+- Fixed `Phalcon\Validation::validate()` with `cancelOnFail`. The validator will validate all elements and will stop processing validators on a per element basis if `cancelOnFail` is present. [#13149](https://github.com/phalcon/cphalcon/issues/13149)
 
 ## Removed
 - Removed `arrayHelpers` property from the Volt compiler. [#13925](https://github.com/phalcon/cphalcon/pull/13925)

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -432,7 +432,7 @@ class Form extends Injectable implements \Countable, \Iterator, AttributesInterf
      */
     public function getValue(string! name) -> var | null
     {
-        var entity, value, data, $internal, element;
+        var entity, value, data, internalEntity, element;
         array forbidden;
         string method;
 
@@ -490,8 +490,8 @@ class Form extends Injectable implements \Countable, \Iterator, AttributesInterf
         /**
          * Check if the method is internal
          */
-        let $internal = strtolower(name);
-        if isset forbidden[$internal] {
+        let internalEntity = strtolower(name);
+        if isset forbidden[internalEntity] {
             return null;
         }
 

--- a/phalcon/Validation.zep
+++ b/phalcon/Validation.zep
@@ -440,7 +440,7 @@ class Validation extends Injectable implements ValidationInterface
      */
     public function validate(var data = null, var entity = null) -> <Messages>
     {
-        var combinedFieldsValidators, field, messages, status, validator,
+        var combinedFieldsValidators, field, messages, scope, status, validator,
             validatorData, validators;
 
         let validatorData            = this->validators,
@@ -486,12 +486,6 @@ class Validation extends Injectable implements ValidationInterface
         }
 
         for field, validators in validatorData {
-//            if unlikely typeof scope != "array" {
-//                throw new Exception("The validator scope is not valid");
-//            }
-//
-//            let field = scope[0],
-//                validator = scope[1];
             for validator in validators {
                 if unlikely typeof validator != "object" {
                     throw new Exception("One of the validators is not valid");
@@ -516,33 +510,32 @@ class Validation extends Injectable implements ValidationInterface
             }
         }
 
-        for validator in combinedFieldsValidators {
-//            if unlikely typeof scope != "array" {
-//                throw new Exception("The validator scope is not valid");
-//            }
-//
-//            let field = scope[0],
-//                validator = scope[1];
-            for validator in validators {
-                if unlikely typeof validator != "object" {
-                    throw new Exception("One of the validators is not valid");
-                }
+        for scope in combinedFieldsValidators {
+            if unlikely typeof scope != "array" {
+                throw new Exception("The validator scope is not valid");
+            }
 
-                /**
-                 * Call internal validations, if it returns true, then skip the
-                 * current validator
-                 */
-                if this->preChecking(field, validator) {
-                    continue;
-                }
+            let field     = scope[0],
+                validator = scope[1];
 
-                /**
-                 * Check if the validation must be canceled if this validator fails
-                 */
-                if validator->validate(this, field) === false {
-                    if validator->getOption("cancelOnFail") {
-                        break;
-                    }
+            if unlikely typeof validator != "object" {
+                throw new Exception("One of the validators is not valid");
+            }
+
+            /**
+             * Call internal validations, if it returns true, then skip the
+             * current validator
+             */
+            if this->preChecking(field, validator) {
+                continue;
+            }
+
+            /**
+             * Check if the validation must be canceled if this validator fails
+             */
+            if validator->validate(this, field) === false {
+                if validator->getOption("cancelOnFail") {
+                    break;
                 }
             }
         }

--- a/tests/_data/fixtures/Forms/ValidationForm.php
+++ b/tests/_data/fixtures/Forms/ValidationForm.php
@@ -1,0 +1,112 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalconphp.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Fixtures\Forms;
+
+use Phalcon\Forms\Element\Email;
+use Phalcon\Forms\Element\Text;
+use Phalcon\Forms\Element\TextArea;
+use Phalcon\Forms\Form;
+use Phalcon\Validation\Validator\PresenceOf;
+use Phalcon\Validation\Validator\StringLength;
+
+class ValidationForm extends Form
+{
+    public function initialize($entity = null, $options = null)
+    {
+        // Full Name
+        $validators = [
+            new PresenceOf(
+                [
+                    'message'      => 'your :field is required',
+                    'cancelOnFail' => true,
+                ]
+            ),
+            new StringLength(
+                [
+                    'max'            => 20,
+                    'messageMaximum' => ':field too long',
+                    'min'            => 2,
+                    'messageMinimum' => ':field too short',
+                ]
+            ),
+        ];
+        $field      = new Text(
+            'fullname',
+            [
+                'placeholder' => 'First & Last Name',
+            ]
+        );
+
+        $field->addValidators($validators);
+
+        $this->add($field);
+
+        // Email
+        $field = new Email(
+            'email',
+            []
+        );
+
+        $validators = [
+            new PresenceOf(
+                [
+                    'message'      => 'valid :field is required',
+                    'cancelOnFail' => true,
+                ]
+            ),
+        ];
+
+        $field->addValidators($validators);
+
+        $this->add($field);
+
+        // Subject
+        $field      = new Text('subject');
+        $validators = [
+            new PresenceOf(
+                [
+                    'message'      => 'your :field is required',
+                    'cancelOnFail' => true,
+                ]
+            ),
+        ];
+
+        $field->addValidators($validators);
+
+        $this->add($field);
+
+        // Message
+        $field      = new TextArea('message');
+        $validators = [
+            new PresenceOf(
+                [
+                    'message'      => 'Your message is required',
+                    'cancelOnFail' => true,
+                ]
+            ),
+            new StringLength(
+                [
+                    'max'            => 300,
+                    'messageMaximum' => "your message can't be longer than 300 characters",
+                    'min'            => 4,
+                    'messageMinimum' => 'Tell us what we can do for you',
+                    'cancelOnFail'   => true,
+                ]
+            ),
+        ];
+
+        $field->addValidators($validators);
+
+        $this->add($field);
+    }
+}

--- a/tests/_data/fixtures/Forms/ValidationForm.php
+++ b/tests/_data/fixtures/Forms/ValidationForm.php
@@ -40,12 +40,7 @@ class ValidationForm extends Form
                 ]
             ),
         ];
-        $field      = new Text(
-            'fullname',
-            [
-                'placeholder' => 'First & Last Name',
-            ]
-        );
+        $field      = new Text('fullname');
 
         $field->addValidators($validators);
 
@@ -61,7 +56,6 @@ class ValidationForm extends Form
             new PresenceOf(
                 [
                     'message'      => 'valid :field is required',
-                    'cancelOnFail' => true,
                 ]
             ),
         ];
@@ -76,7 +70,6 @@ class ValidationForm extends Form
             new PresenceOf(
                 [
                     'message'      => 'your :field is required',
-                    'cancelOnFail' => true,
                 ]
             ),
         ];
@@ -100,7 +93,6 @@ class ValidationForm extends Form
                     'messageMaximum' => "your message can't be longer than 300 characters",
                     'min'            => 4,
                     'messageMinimum' => 'Tell us what we can do for you',
-                    'cancelOnFail'   => true,
                 ]
             ),
         ];

--- a/tests/integration/Forms/Form/IsValidCest.php
+++ b/tests/integration/Forms/Form/IsValidCest.php
@@ -18,6 +18,7 @@ use Phalcon\Forms\Form;
 use Phalcon\Messages\Message;
 use Phalcon\Messages\Messages;
 use Phalcon\Tag;
+use Phalcon\Test\Fixtures\Forms\ValidationForm;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use Phalcon\Validation;
 use Phalcon\Validation\Validator\PresenceOf;
@@ -140,5 +141,30 @@ class IsValidCest
             $expected,
             $form->get('address')->getMessages()
         );
+    }
+
+    /**
+     * Tests Form::isValid()
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/13149
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function formsFormRemoveIsValidCancelOnFail(IntegrationTester $I)
+    {
+        $form = new ValidationForm();
+
+        $data = [
+            'fullname' => '',
+            'email'    => '',
+            'subject'  => '',
+            'message'  => '',
+        ];
+
+        $actual = $form->isValid($data);
+        $I->assertFalse($actual);
+
+        $messages = $form->getMessages();
+        $I->assertCount(6, $messages);
     }
 }

--- a/tests/integration/Forms/Form/IsValidCest.php
+++ b/tests/integration/Forms/Form/IsValidCest.php
@@ -164,7 +164,35 @@ class IsValidCest
         $actual = $form->isValid($data);
         $I->assertFalse($actual);
 
+        /**
+         * 6 validators in total
+         */
         $messages = $form->getMessages();
-        $I->assertCount(6, $messages);
+        $I->assertCount(4, $messages);
+
+        $data = [
+            'fullname' => '',
+            'email'    => 'team@phalconphp.com',
+            'subject'  => 'Some subject',
+            'message'  => 'Some message',
+        ];
+
+        $actual = $form->isValid($data);
+        $I->assertFalse($actual);
+
+        $messages = $form->getMessages();
+        $I->assertCount(1, $messages);
+
+        $expected = new Messages(
+            [
+                new Message(
+                    'your fullname is required',
+                    'fullname',
+                    'PresenceOf'
+                )
+            ]
+        );
+
+        $I->assertEquals($expected, $messages);
     }
 }

--- a/tests/integration/Forms/FormElementsCest.php
+++ b/tests/integration/Forms/FormElementsCest.php
@@ -133,8 +133,12 @@ class FormElementsCest
                 new Message(
                     'user.lastName.presenceOf',
                     'lastName',
-                    'PresenceOf',
-                    0
+                    'PresenceOf'
+                ),
+                new Message(
+                    'user.firstName.presenceOf',
+                    'firstName',
+                    'PresenceOf'
                 ),
             ]
         );

--- a/tests/integration/Validation/Validator/PresenceOfCest.php
+++ b/tests/integration/Validation/Validator/PresenceOfCest.php
@@ -231,14 +231,17 @@ class PresenceOfCest
                 new Message(
                     'The name is required',
                     'name',
-                    'PresenceOf',
-                    0
+                    'PresenceOf'
                 ),
                 new Message(
                     'The email is required',
                     'email',
-                    'PresenceOf',
-                    0
+                    'PresenceOf'
+                ),
+                new Message(
+                    'The login is required',
+                    'login',
+                    'PresenceOf'
                 ),
             ]
         );


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13149 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

Fixed `Phalcon\Validation::validate()` with `cancelOnFail`. The validator will validate all elements and will stop processing validators on a per element basis if `cancelOnFail` is present.

Thanks

