### PR TITLE
T14044 model findfirst null

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -74,8 +74,9 @@
 - `Phalcon\Logger\Formatter\Json::__construct()` service parameters must be a string or omitted.
 - Removed deprecated code from `Phalcon\Forms\Form::getMessages()`.
 - Loading a Module (either MVC or CLI) now throws an exception if the path does not exists regardless of whether the class is already loaded.
-- Changed `Phalcon\Crypt` to accept auth tag, tag length and data for "gcm" and "ccm" modes. Removed insecure algorithms with modes: `des*`, `rc2*`, `rc4*`, `des*`, `*ecb` [#13869](https://github.com/phalcon/cphalcon/pull/13869)
+- Changed `Phalcon\Crypt` to accept auth tag, tag length and data for "gcm" and "ccm" modes. Removed insecure algorithms with modes: `des*`, `rc2*`, `rc4*`, `des*`, `*ecb` [#13869](https://github.com/phalcon/cphalcon/issues/13869)
 - Changed `Phalcon\Mvc\Model` to copy the unset default values from the `MetaData` to the `Model` after a successful insert. [#13781](https://github.com/phalcon/cphalcon/issues/13781)
+- Changed `Phalcon\Mvc\Model::findFirst()` now returns `null`. `Phalcon\Mvc\Model::getRelated()` for one to one relationships returns `null` [#14044](https://github.com/phalcon/cphalcon/issues/14044)
 
 ## Fixed
 - Fixed `Mvc\Collection::isInitialized()` now works as intended. [#13931](https://github.com/phalcon/cphalcon/pull/13931)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -228,17 +228,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
      */
     public static function __callStatic(string method, array arguments)
     {
-        var records;
-
-        let records = self::_invokeFinder(method, arguments);
-
-        if unlikely records === null {
-            throw new Exception(
-                "The static method '" . method . "' doesn't exist"
-            );
-        }
-
-        return records;
+        return self::_invokeFinder(method, arguments);
     }
 
 

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -3071,7 +3071,7 @@ class Query implements QueryInterface, InjectionAwareInterface
         if result instanceof ResultInterface {
             let resultData = result;
         } else {
-            let resultData = false;
+            let resultData = null;
         }
 
         /**

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -3061,7 +3061,6 @@ class Query implements QueryInterface, InjectionAwareInterface
          * Execute the query
          */
         let result = connection->query(sqlSelect, processed, processedTypes);
-
         /**
          * Check if the query has data
          *

--- a/phalcon/Mvc/Model/Resultset.zep
+++ b/phalcon/Mvc/Model/Resultset.zep
@@ -304,10 +304,10 @@ abstract class Resultset
     /**
      * Get first row in the resultset
      */
-    public function getFirst() -> <ModelInterface> | bool
+    public function getFirst() -> <ModelInterface> | null
     {
         if this->count == 0 {
-            return false;
+            return null;
         }
 
         this->seek(0);
@@ -326,14 +326,14 @@ abstract class Resultset
     /**
      * Get last row in the resultset
      */
-    public function getLast() -> <ModelInterface> | bool
+    public function getLast() -> <ModelInterface> | null
     {
         var count;
 
         let count = this->count;
 
         if count == 0 {
-            return false;
+            return null;
         }
 
         this->seek(count - 1);

--- a/phalcon/Mvc/Model/Resultset/Simple.zep
+++ b/phalcon/Mvc/Model/Resultset/Simple.zep
@@ -48,7 +48,6 @@ class Simple extends Resultset
     ) -> void {
         let this->model = model,
             this->columnMap = columnMap;
-
         /**
          * Set if the returned resultset must keep the record snapshots
          */
@@ -60,7 +59,7 @@ class Simple extends Resultset
     /**
      * Returns current row in the resultset
      */
-    final public function current() -> <ModelInterface> | bool
+    final public function current() -> <ModelInterface> | null
     {
         var row, hydrateMode, columnMap, activeRow, modelName;
 
@@ -81,7 +80,7 @@ class Simple extends Resultset
         if typeof row != "array" {
             let this->activeRow = false;
 
-            return false;
+            return null;
         }
 
         /**

--- a/phalcon/Mvc/Model/ResultsetInterface.zep
+++ b/phalcon/Mvc/Model/ResultsetInterface.zep
@@ -49,7 +49,7 @@ interface ResultsetInterface
     /**
      * Get first row in the resultset
      */
-    public function getFirst() -> <ModelInterface> | bool;
+    public function getFirst() -> <ModelInterface> | null;
 
     /**
      * Returns the current hydration mode
@@ -59,7 +59,7 @@ interface ResultsetInterface
     /**
      * Get last row in the resultset
      */
-    public function getLast() -> <ModelInterface> | bool;
+    public function getLast() -> <ModelInterface> | null;
 
     /**
      * Returns the error messages produced by a batch operation

--- a/tests/integration/Mvc/Model/FindFirstCest.php
+++ b/tests/integration/Mvc/Model/FindFirstCest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Test\Integration\Mvc\Model;
 use IntegrationTester;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Customers;
 use Phalcon\Test\Models\Robots;
 use Phalcon\Test\Models\RobotsExtended;
 
@@ -68,6 +69,22 @@ class FindFirstCest
                 'conditions' => 'id < 0',
             ]
         );
+        $I->assertNull($robot);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: findFirstBy() - not found
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function mvcModelFindFirstByNotFound(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model - findFirstBy() - not found');
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+
+        $robot = Customers::findFirstByEmail('unknown');
         $I->assertNull($robot);
     }
 

--- a/tests/integration/Mvc/Model/FindFirstCest.php
+++ b/tests/integration/Mvc/Model/FindFirstCest.php
@@ -52,6 +52,26 @@ class FindFirstCest
     }
 
     /**
+     * Tests Phalcon\Mvc\Model :: findFirst() - not found
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function mvcModelFindFirstNotFound(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model - findFirst() - not found');
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+
+        $robot = Robots::findFirst(
+            [
+                'conditions' => 'id < 0',
+            ]
+        );
+        $I->assertNull($robot);
+    }
+
+    /**
      * Tests Phalcon\Mvc\Model :: findFirst() - extended
      *
      * @author Phalcon Team <team@phalconphp.com>
@@ -69,7 +89,7 @@ class FindFirstCest
         $I->assertEquals(1, $robot->id);
 
         $robot = RobotsExtended::findFirst(0);
-        $I->assertFalse($robot);
+        $I->assertNull($robot);
     }
 
     /**

--- a/tests/integration/Mvc/Model/GetRelatedCest.php
+++ b/tests/integration/Mvc/Model/GetRelatedCest.php
@@ -60,7 +60,7 @@ class GetRelatedCest
             ]
         );
 
-        $I->assertFalse($nonExistentPart);
+        $I->assertNull($nonExistentPart);
 
         /**
          * Testing has-one relationship
@@ -82,7 +82,7 @@ class GetRelatedCest
             ]
         );
 
-        $I->assertFalse($nonExistentUser);
+        $I->assertNull($nonExistentUser);
 
         /**
          * Has-many relationship

--- a/tests/integration/Mvc/Model/Refactor-ModelsResultsetCest.php
+++ b/tests/integration/Mvc/Model/Refactor-ModelsResultsetCest.php
@@ -361,13 +361,13 @@ class ModelsResultsetCest
         $robots->seek(1);
         $robots->valid();
         $robot = $robots->current();
-        $I->assertFalse($robot);
+        $I->assertNull($robot);
 
         $robot = $robots->getFirst();
-        $I->assertFalse($robot);
+        $I->assertNull($robot);
 
         $robot = $robots->getLast();
-        $I->assertFalse($robot);
+        $I->assertNull($robot);
 
         /**
          * @todo Check the code below
@@ -466,7 +466,7 @@ class ModelsResultsetCest
         // invalid element
         $personas->seek(33);
         $I->assertFalse($personas->valid());
-        $I->assertFalse($personas->current());
+        $I->assertNull($personas->current());
 
         /**
          * @todo Check the code below


### PR DESCRIPTION
Hello!

* Type: enhancement
* Link to issue: #14044 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I updated the CHANGELOG

 Changed `Phalcon\Mvc\Model::findFirst()` now returns `null`. `Phalcon\Mvc\Model::getRelated()` for one to one relationships returns `null` 

Thanks

