### PR TITLE
T14102 int autoincrement

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,7 +1,8 @@
 # [4.0.0-beta.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.1) (2019-xx-xx)
 
 ## Fixed
-- Fixed `Phalcon\Mvc\View::getRender()` to call `view->finish()` instead of `ob_end_clean()`. [#14095](https://github.com/phalcon/cphalcon/pull/14095)
+- Fixed `Phalcon\Mvc\View::getRender()` to call `view->finish()` instead of `ob_end_clean()`. [#14095](https://github.com/phalcon/cphalcon/issues/14095)
+- Fixed `Phalcon\Db\Column` to recognize `tinyint`, `smallint`, `mediumint` as valid autoIncrement columns. [#14102](https://github.com/phalcon/cphalcon/issues/14102)
 
 # [4.0.0-alpha.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-alpha.5) (2019-05-18)
 

--- a/phalcon/Db/Column.zep
+++ b/phalcon/Db/Column.zep
@@ -410,9 +410,11 @@ class Column implements ColumnInterface
                 let this->autoIncrement = false;
             } else {
                 switch type {
-
-                    case self::TYPE_INTEGER:
-                    case self::TYPE_BIGINTEGER:
+                    const self::TYPE_BIGINTEGER:
+                    const self::TYPE_INTEGER:
+                    const self::TYPE_MEDIUMINTEGER:
+                    const self::TYPE_SMALLINTEGER:
+                    const self::TYPE_TINYINTEGER:
                         let this->autoIncrement = true;
                         break;
 


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14102 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Db\Column` to recognize `tinyint`, `smallint`, `mediumint` as valid autoIncrement columns. 

Thanks

