### PR TITLE
T13433 metadata cache exception

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -29,7 +29,7 @@
 - Fixed `Phalcon\Mvc\View::getRender()` to call `view->finish()` instead of `ob_end_clean()`. [#14095](https://github.com/phalcon/cphalcon/issues/14095)
 - Fixed `Phalcon\Cache\Adapter\Libmemcached` failing to set values when `Phalcon\Mvc\Model\MetaData\Libmemcached` was in use. [#14100](https://github.com/phalcon/cphalcon/issues/14100)
 - Fixed `Phalcon\Db\Column` to recognize `tinyint`, `smallint`, `mediumint`, `integer` as valid autoIncrement columns. [#14102](https://github.com/phalcon/cphalcon/issues/14102)
-
+- Fixed `Phalcon\Mvc\Model\MetaData::write()` to throw an exception if `orm.exception_on_failed_metadata_save` is set to true. [#13433](https://github.com/phalcon/cphalcon/issues/13433)
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)
 - Removed `Phalcon\Factory` and `Phalcon\FactoryInterface`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/config.json
+++ b/config.json
@@ -81,6 +81,10 @@
             "type": "bool",
             "default": true
         },
+        "orm.exception_on_failed_metadata_save": {
+            "type": "bool",
+            "default": false
+        },
         "orm.exception_on_failed_save": {
             "type": "bool",
             "default": false

--- a/config.json
+++ b/config.json
@@ -87,7 +87,7 @@
         },
         "orm.exception_on_failed_save": {
             "type": "bool",
-            "default": false
+            "default": true
         },
         "orm.ignore_unknown_columns": {
             "type": "bool",

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -2748,59 +2748,20 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
     public static function setup(array! options) -> void
     {
         var disableEvents, columnRenaming, notNullValidations,
-            exceptionOnFailedSave, phqlLiterals, virtualForeignKeys,
-            lateStateBinding, castOnHydrate, ignoreUnknownColumns,
-            updateSnapshotOnSave, disableAssignSetters,
+            exceptionOnFailedSave, exceptionOnFailedMetaDataSave, phqlLiterals,
+            virtualForeignKeys, lateStateBinding, castOnHydrate,
+            ignoreUnknownColumns, updateSnapshotOnSave, disableAssignSetters,
             caseInsensitiveColumnMap, prefetchRecords, lastInsertId;
 
-        /**
-         * Enables/Disables globally the internal events
-         */
-        if fetch disableEvents, options["events"] {
-            globals_set("orm.events", disableEvents);
+        if fetch caseInsensitiveColumnMap, options["caseInsensitiveColumnMap"] {
+            globals_set(
+                "orm.case_insensitive_column_map",
+                caseInsensitiveColumnMap
+            );
         }
 
-        /**
-         * Enables/Disables virtual foreign keys
-         */
-        if fetch virtualForeignKeys, options["virtualForeignKeys"] {
-            globals_set("orm.virtual_foreign_keys", virtualForeignKeys);
-        }
-
-        /**
-         * Enables/Disables column renaming
-         */
-        if fetch columnRenaming, options["columnRenaming"] {
-            globals_set("orm.column_renaming", columnRenaming);
-        }
-
-        /**
-         * Enables/Disables automatic not null validation
-         */
-        if fetch notNullValidations, options["notNullValidations"] {
-            globals_set("orm.not_null_validations", notNullValidations);
-        }
-
-        /**
-         * Enables/Disables throws an exception if the saving process fails
-         */
-        if fetch exceptionOnFailedSave, options["exceptionOnFailedSave"] {
-            globals_set("orm.exception_on_failed_save", exceptionOnFailedSave);
-        }
-
-        /**
-         * Enables/Disables literals in PHQL this improves the security of
-         * applications
-         */
-        if fetch phqlLiterals, options["phqlLiterals"] {
-            globals_set("orm.enable_literals", phqlLiterals);
-        }
-
-        /**
-         * Enables/Disables late state binding on model hydration
-         */
-        if fetch lateStateBinding, options["lateStateBinding"] {
-            globals_set("orm.late_state_binding", lateStateBinding);
+        if fetch lastInsertId, options["castLastInsertIdToInt"] {
+            globals_set("orm.cast_last_insert_id_to_int", lastInsertId);
         }
 
         /**
@@ -2811,34 +2772,78 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
         }
 
         /**
-         * Allows to ignore unknown columns when hydrating objects
+         * Enables/Disables column renaming
          */
-        if fetch ignoreUnknownColumns, options["ignoreUnknownColumns"] {
-            globals_set("orm.ignore_unknown_columns", ignoreUnknownColumns);
-        }
-
-        if fetch caseInsensitiveColumnMap, options["caseInsensitiveColumnMap"] {
-            globals_set(
-                "orm.case_insensitive_column_map",
-                caseInsensitiveColumnMap
-            );
-        }
-
-        if fetch updateSnapshotOnSave, options["updateSnapshotOnSave"] {
-            globals_set("orm.update_snapshot_on_save", updateSnapshotOnSave);
+        if fetch columnRenaming, options["columnRenaming"] {
+            globals_set("orm.column_renaming", columnRenaming);
         }
 
         if fetch disableAssignSetters, options["disableAssignSetters"] {
             globals_set("orm.disable_assign_setters", disableAssignSetters);
         }
 
+        /**
+         * Enables/Disables globally the internal events
+         */
+        if fetch disableEvents, options["events"] {
+            globals_set("orm.events", disableEvents);
+        }
+
+        /**
+         * Enables/Disables throws an exception if the saving process fails
+         */
+        if fetch exceptionOnFailedSave, options["exceptionOnFailedSave"] {
+            globals_set("orm.exception_on_failed_save", exceptionOnFailedSave);
+        }
+
+        if fetch exceptionOnFailedMetaDataSave, options["exceptionOnFailedMetaDataSave"] {
+            globals_set("orm.exception_on_failed_metadata_save", exceptionOnFailedMetaDataSave);
+        }
+
+        /**
+         * Allows to ignore unknown columns when hydrating objects
+         */
+        if fetch ignoreUnknownColumns, options["ignoreUnknownColumns"] {
+            globals_set("orm.ignore_unknown_columns", ignoreUnknownColumns);
+        }
+
+        /**
+         * Enables/Disables late state binding on model hydration
+         */
+        if fetch lateStateBinding, options["lateStateBinding"] {
+            globals_set("orm.late_state_binding", lateStateBinding);
+        }
+
+        /**
+         * Enables/Disables automatic not null validation
+         */
+        if fetch notNullValidations, options["notNullValidations"] {
+            globals_set("orm.not_null_validations", notNullValidations);
+        }
+
+        /**
+         * Enables/Disables literals in PHQL this improves the security of
+         * applications
+         */
+        if fetch phqlLiterals, options["phqlLiterals"] {
+            globals_set("orm.enable_literals", phqlLiterals);
+        }
+
         if fetch prefetchRecords, options["prefetchRecords"] {
             globals_set("orm.resultset_prefetch_records", prefetchRecords);
         }
-	
-        if fetch lastInsertId, options["castLastInsertIdToInt"] {
-            globals_set("orm.cast_last_insert_id_to_int", lastInsertId);
+
+        if fetch updateSnapshotOnSave, options["updateSnapshotOnSave"] {
+            globals_set("orm.update_snapshot_on_save", updateSnapshotOnSave);
         }
+
+        /**
+         * Enables/Disables virtual foreign keys
+         */
+        if fetch virtualForeignKeys, options["virtualForeignKeys"] {
+            globals_set("orm.virtual_foreign_keys", virtualForeignKeys);
+        }
+
     }
 
     /**

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -711,20 +711,16 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
     {
         var result, option;
 
-        let result = this->adapter->set(key, data),
-            option = globals_get("orm.exception_on_failed_metadata_save");;
+        try {
+            let option = globals_get("orm.exception_on_failed_metadata_save"),
+                result = this->adapter->set(key, data);
 
-        if !result {
-            if option {
-                throw new Exception(
-                    "Failed to store metaData to the cache adapter."
-                );
-            } else {
-                trigger_error(
-                    "Failed to store metaData to the cache adapter.",
-                    E_WARNING
-                );
+            if false === result {
+                this->throwWriteException(option);
             }
+
+        } catch \Exception {
+            this->throwWriteException(option);
         }
     }
 
@@ -873,5 +869,18 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
          * Write the data to the adapter
          */
         this->{"write"}(prefixKey, modelColumnMap);
+    }
+
+    private function throwWriteException(var option) -> void
+    {
+        if option {
+            throw new Exception(
+                "Failed to store metaData to the cache adapter"
+            );
+        } else {
+            trigger_error(
+                "Failed to store metaData to the cache adapter"
+            );
+        }
     }
 }

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -714,10 +714,17 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
         let result = this->adapter->set(key, data),
             option = globals_get("orm.exception_on_failed_metadata_save");;
 
-        if !result && option {
-            throw new Exception(
-                "Failed to store metaData to the cache adapter."
-            );
+        if !result {
+            if option {
+                throw new Exception(
+                    "Failed to store metaData to the cache adapter."
+                );
+            } else {
+                trigger_error(
+                    "Failed to store metaData to the cache adapter.",
+                    E_WARNING
+                );
+            }
         }
     }
 

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -709,11 +709,12 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      */
     public function write(string! key, array data) -> void
     {
-        var result;
+        var result, option;
 
-        let result = this->adapter->set(key, data);
+        let result = this->adapter->set(key, data),
+            option = globals_get("orm.exception_on_failed_metadata_save");;
 
-        if !result {
+        if !result && option {
             throw new Exception(
                 "Failed to store metaData to the cache adapter."
             );

--- a/phalcon/Mvc/Model/MetaData/Stream.zep
+++ b/phalcon/Mvc/Model/MetaData/Stream.zep
@@ -69,18 +69,19 @@ class Stream extends MetaData
     {
         var path, option;
 
-        let path   = this->metaDataDir . prepare_virtual_path(key, "_") . ".php",
-            option = globals_get("orm.exception_on_failed_metadata_save");
+        try {
+            let path   = this->metaDataDir . prepare_virtual_path(key, "_") . ".php",
+                option = globals_get("orm.exception_on_failed_metadata_save");
 
-        if file_put_contents(path, "<?php return " . var_export(data, true) . "; ") === false {
+            file_put_contents(path, "<?php return " . var_export(data, true) . "; ");
+        } catch \Exception {
             if option {
                 throw new Exception(
                     "Meta-Data directory cannot be written"
                 );
             } else {
                 trigger_error(
-                    "Meta-Data directory cannot be written",
-                    E_WARNING
+                    "Meta-Data directory cannot be written"
                 );
             }
         }

--- a/phalcon/Mvc/Model/MetaData/Stream.zep
+++ b/phalcon/Mvc/Model/MetaData/Stream.zep
@@ -72,8 +72,17 @@ class Stream extends MetaData
         let path   = this->metaDataDir . prepare_virtual_path(key, "_") . ".php",
             option = globals_get("orm.exception_on_failed_metadata_save");
 
-        if file_put_contents(path, "<?php return " . var_export(data, true) . "; ") === false && option {
-            throw new Exception("Meta-Data directory cannot be written");
+        if file_put_contents(path, "<?php return " . var_export(data, true) . "; ") === false {
+            if option {
+                throw new Exception(
+                    "Meta-Data directory cannot be written"
+                );
+            } else {
+                trigger_error(
+                    "Meta-Data directory cannot be written",
+                    E_WARNING
+                );
+            }
         }
     }
 }

--- a/phalcon/Mvc/Model/MetaData/Stream.zep
+++ b/phalcon/Mvc/Model/MetaData/Stream.zep
@@ -67,11 +67,12 @@ class Stream extends MetaData
      */
     public function write(string! key, array data) -> void
     {
-        var path;
+        var path, option;
 
-        let path = this->metaDataDir . prepare_virtual_path(key, "_") . ".php";
+        let path   = this->metaDataDir . prepare_virtual_path(key, "_") . ".php",
+            option = globals_get("orm.exception_on_failed_metadata_save");
 
-        if file_put_contents(path, "<?php return " . var_export(data, true) . "; ") === false {
+        if file_put_contents(path, "<?php return " . var_export(data, true) . "; ") === false && option {
             throw new Exception("Meta-Data directory cannot be written");
         }
     }

--- a/tests/integration/Mvc/Model/MetaData/Libmemcached/WriteCest.php
+++ b/tests/integration/Mvc/Model/MetaData/Libmemcached/WriteCest.php
@@ -12,13 +12,27 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Integration\Mvc\Model\MetaData\Libmemcached;
 
+use function file_exists;
+use function file_put_contents;
+use function getOptionsLibmemcached;
 use IntegrationTester;
+use function outputDir;
+use Phalcon\Cache\AdapterFactory;
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Mvc\Model\MetaData\Libmemcached;
+use Phalcon\Mvc\Model\MetaData\Stream;
+use Phalcon\Storage\SerializerFactory;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Robots;
+use function var_dump;
 
 /**
  * Class WriteCest
  */
 class WriteCest
 {
+    use DiTrait;
+
     /**
      * Tests Phalcon\Mvc\Model\MetaData\Libmemcached :: write()
      *
@@ -29,5 +43,59 @@ class WriteCest
     {
         $I->wantToTest('Mvc\Model\MetaData\Libmemcached - write()');
         $I->skipTest('Need implementation');
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\MetaData\Libmemcached :: write() - exception
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function mvcModelMetadataLibmemcachedWriteException(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\MetaData\Libmemcached - write() - exception');
+
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+        $this->container->set(
+            'modelsMetadata',
+            function () {
+                $options = getOptionsLibmemcached();
+                $options['servers'][0]['port'] = 4000;
+
+                $serializer = new SerializerFactory();
+                $factory    = new AdapterFactory($serializer);
+
+                return new Libmemcached($factory, $options);
+            }
+        );
+
+        $I->expectThrowable(
+            new \Exception('Failed to store metaData to the cache adapter'),
+            function () use ($I) {
+
+                Robots::setup(
+                    [
+                        'exceptionOnFailedMetaDataSave' => true,
+                    ]
+                );
+
+                Robots::findFirst(1);
+            }
+        );
+
+        $I->expectThrowable(
+            new \Exception('Failed to store metaData to the cache adapter', 1024),
+            function () use ($I) {
+
+                Robots::setup(
+                    [
+                        'exceptionOnFailedMetaDataSave' => false,
+                    ]
+                );
+
+                Robots::findFirst(1);
+            }
+        );
     }
 }

--- a/tests/integration/Mvc/Model/MetaData/Stream/WriteCest.php
+++ b/tests/integration/Mvc/Model/MetaData/Stream/WriteCest.php
@@ -13,12 +13,19 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\MetaData\Stream;
 
 use IntegrationTester;
+use function outputDir;
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Mvc\Model\MetaData\Stream;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Robots;
 
 /**
  * Class WriteCest
  */
 class WriteCest
 {
+    use DiTrait;
+
     /**
      * Tests Phalcon\Mvc\Model\MetaData\Stream :: write()
      *
@@ -29,5 +36,68 @@ class WriteCest
     {
         $I->wantToTest('Mvc\Model\MetaData\Stream - write()');
         $I->skipTest('Need implementation');
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\MetaData\Stream :: write() - exception
+     *
+     * @author Phalcon Team <team@phalconphp.com>
+     * @since  2018-11-13
+     */
+    public function mvcModelMetadataStreamWriteException(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\MetaData\Stream - write()');
+
+        $directory = outputDir('tests/');
+        $fileName  = $directory . 'metadata';
+
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+        $this->container->set(
+            'modelsMetadata',
+            function () use ($fileName) {
+                return new Stream(['metaDataDir' => $fileName . '/']);
+            }
+        );
+
+        $I->expectThrowable(
+            new Exception('Meta-Data directory cannot be written'),
+            function () use ($I, $fileName) {
+                if (file_exists($fileName)) {
+                    unlink($fileName);
+                }
+
+                $result = file_put_contents($fileName, '');
+                $I->assertNotFalse($result);
+
+                Robots::setup(
+                    [
+                        'exceptionOnFailedMetaDataSave' => true,
+                    ]
+                );
+
+                Robots::findFirst(1);
+            }
+        );
+
+        $I->expectThrowable(
+            new \Exception('Meta-Data directory cannot be written', 1024),
+            function () use ($I, $fileName) {
+                if (file_exists($fileName)) {
+                    unlink($fileName);
+                }
+
+                $result = file_put_contents($fileName, '');
+                $I->assertNotFalse($result);
+
+                Robots::setup(
+                    [
+                        'exceptionOnFailedMetaDataSave' => false,
+                    ]
+                );
+
+                Robots::findFirst(1);
+            }
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #13433 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\MetaData::write()` to throw an exception if `orm.exception_on_failed_metadata_save` is set to true.

Thanks

