### PR TITLE
Updated Model\Manager relations getter functions

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -25,19 +25,19 @@
 - Renamed `Phalcon\Translate\Adapter` to `Phalcon\Translate\Adapter\AbstractAdapter`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)
 - Renamed `Phalcon\Translate\AdapterInterface` to `Phalcon\Translate\Adapter\AdapterInterface`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)
 - `Phalcon\Plugin` is now abstract.
-- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getRelationRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
-- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getBelongsToRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
-- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getHasOneRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
-- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getHasManyRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)  
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getRelationRecords()` to the last position. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getBelongsToRecords()` to the last position. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getHasOneRecords()` to the last position. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getHasManyRecords()` to the last position. [#14115](https://github.com/phalcon/cphalcon/issues/14115)  
 
 ## Fixed
 - Fixed `Phalcon\Mvc\View::getRender()` to call `view->finish()` instead of `ob_end_clean()`. [#14095](https://github.com/phalcon/cphalcon/issues/14095)
 - Fixed `Phalcon\Cache\Adapter\Libmemcached` failing to set values when `Phalcon\Mvc\Model\MetaData\Libmemcached` was in use. [#14100](https://github.com/phalcon/cphalcon/issues/14100)
 - Fixed `Phalcon\Db\Column` to recognize `tinyint`, `smallint`, `mediumint`, `integer` as valid autoIncrement columns. [#14102](https://github.com/phalcon/cphalcon/issues/14102)
-- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getRelationRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
-- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getBelongsToRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
-- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getHasOneRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
-- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getHasManyRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getRelationRecords()`, it's not always a string, null by default. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getBelongsToRecords()`, it's not always a string, null by default. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getHasOneRecords()`, it's not always a string, null by default. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getHasManyRecords()`, it's not always a string, null by default. [#14115](https://github.com/phalcon/cphalcon/issues/14115)
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -25,11 +25,19 @@
 - Renamed `Phalcon\Translate\Adapter` to `Phalcon\Translate\Adapter\AbstractAdapter`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)
 - Renamed `Phalcon\Translate\AdapterInterface` to `Phalcon\Translate\Adapter\AdapterInterface`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)
 - `Phalcon\Plugin` is now abstract.
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getRelationRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getBelongsToRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getHasOneRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Moved `method` parameter in `Phalcon\Mvc\Model\Manager::getHasManyRecords()` to the last position. [#14114](https://github.com/phalcon/cphalcon/issues/14114)  
 
 ## Fixed
 - Fixed `Phalcon\Mvc\View::getRender()` to call `view->finish()` instead of `ob_end_clean()`. [#14095](https://github.com/phalcon/cphalcon/issues/14095)
 - Fixed `Phalcon\Cache\Adapter\Libmemcached` failing to set values when `Phalcon\Mvc\Model\MetaData\Libmemcached` was in use. [#14100](https://github.com/phalcon/cphalcon/issues/14100)
 - Fixed `Phalcon\Db\Column` to recognize `tinyint`, `smallint`, `mediumint`, `integer` as valid autoIncrement columns. [#14102](https://github.com/phalcon/cphalcon/issues/14102)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getRelationRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getBelongsToRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getHasOneRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
+- Fixed `method` parameter in `Phalcon\Mvc\Model\Manager::getHasManyRecords()`, it's not always a string, null by default. [#14114](https://github.com/phalcon/cphalcon/issues/14114)
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1771,7 +1771,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
                 /**
                  * Call the 'getRelationRecords' in the models manager.
                  */
-                let result = manager->getRelationRecords(relation, null, this, arguments);
+                let result = manager->getRelationRecords(relation, this, arguments);
 
                 /**
                  * We store relationship objects in the related cache if there were no arguments.
@@ -1783,7 +1783,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
              * Individually queried related records are handled by Manager.
              * The Manager also checks and stores reusable records.
              */
-            let result = manager->getRelationRecords(relation, null, this, arguments);
+            let result = manager->getRelationRecords(relation, this, arguments);
         }
 
         return result;
@@ -4113,9 +4113,9 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
             return manager->getRelationRecords(
                 relation,
-                queryMethod,
                 this,
-                extraArgs
+                extraArgs,
+                queryMethod
             );
         }
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1375,15 +1375,15 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          */
         let fields = relation->getFields();
 
+        /**
+         * Compound relation
+         */
+        let referencedFields = relation->getReferencedFields();
+
         if typeof fields != "array" {
-            let conditions[] = "[". relation->getReferencedFields() . "] = :APR0:",
+            let conditions[] = "[". referencedFields . "] = :APR0:",
                 placeholders["APR0"] = record->readAttribute(fields);
         } else {
-            /**
-             * Compound relation
-             */
-            let referencedFields = relation->getReferencedFields();
-
             for refPosition, field in relation->getFields() {
                 let conditions[] = "[". referencedFields[refPosition] . "] = :APR" . refPosition . ":",
                     placeholders["APR" . refPosition] = record->readAttribute(field);
@@ -1503,7 +1503,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Gets belongsTo related records from a model
      */
-    public function getBelongsToRecords(string! method, string! modelName, var modelRelation, <ModelInterface> record, parameters = null)
+    public function getBelongsToRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
         -> <ResultsetInterface> | bool
     {
         var relations;
@@ -1524,9 +1524,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          */
         return this->getRelationRecords(
             relations[0],
-            method,
             record,
-            parameters
+            parameters,
+            method
         );
     }
 
@@ -1554,9 +1554,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          */
         return this->getRelationRecords(
             relations[0],
-            method,
             record,
-            parameters
+            parameters,
+            method
         );
     }
 
@@ -1584,9 +1584,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          */
         return this->getRelationRecords(
             relations[0],
-            method,
             record,
-            parameters
+            parameters,
+            method
         );
     }
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1533,7 +1533,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Gets hasMany related records from a model
      */
-    public function getHasManyRecords(string! method, string! modelName, var modelRelation, <ModelInterface> record, parameters = null)
+    public function getHasManyRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
         -> <ResultsetInterface> | bool
     {
         var relations;
@@ -1563,7 +1563,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Gets belongsTo related records from a model
      */
-    public function getHasOneRecords(string! method, string! modelName, var modelRelation, <ModelInterface> record, parameters = null)
+    public function getHasOneRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
         -> <ModelInterface> | bool
     {
         var relations;

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1270,7 +1270,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return \Phalcon\Mvc\Model\Resultset\Simple|Phalcon\Mvc\Model\Resultset\Simple|int|false
      */
-    public function getRelationRecords(<RelationInterface> relation, string! method, <ModelInterface> record, var parameters = null)
+    public function getRelationRecords(<RelationInterface> relation, <ModelInterface> record, var parameters = null, string method = null)
     {
         var referencedModel, intermediateModel, intermediateFields, fields,
             builder, extraParameters, refPosition, field, referencedFields,

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -195,7 +195,7 @@ interface ManagerInterface
      *
      * @return \Phalcon\Mvc\Model\Resultset\Simple|Phalcon\Mvc\Model\Resultset\Simple|int|false
      */
-    public function getRelationRecords(<RelationInterface> relation, string! method, <ModelInterface> record, var parameters = null);
+    public function getRelationRecords(<RelationInterface> relation, <ModelInterface> record, var parameters = null, string method = null);
 
     /**
      * Query all the relationships defined on a model

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -114,10 +114,13 @@ interface ManagerInterface
     /**
      * Gets belongsTo related records from a model
      *
-     * @param string modelRelation
-     * @param array  parameters
+     * @param string            $modelName
+     * @param string            $modelRelation
+     * @param array|string|null $parameters
+     * @param ModelInterface    $record
+     * @param string|null       $method
      */
-    public function getBelongsToRecords(string! method, string! modelName, var modelRelation, <ModelInterface> record, parameters = null) -> <ResultsetInterface> | bool;
+    public function getBelongsToRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null) -> <ResultsetInterface> | bool;
 
     /**
      * Gets hasMany relations defined on a model
@@ -127,10 +130,13 @@ interface ManagerInterface
     /**
      * Gets hasMany related records from a model
      *
-     * @param string modelRelation
-     * @param array  parameters
+     * @param string            $modelName
+     * @param string            $modelRelation
+     * @param array|string|null $parameters
+     * @param ModelInterface    $record
+     * @param string|null       $method
      */
-    public function getHasManyRecords(string! method, string! modelName, var modelRelation, <ModelInterface> record, parameters = null) -> <ResultsetInterface> | bool;
+    public function getHasManyRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null) -> <ResultsetInterface> | bool;
 
     /**
      * Gets hasManyToMany relations defined on a model
@@ -150,10 +156,13 @@ interface ManagerInterface
     /**
      * Gets belongsTo related records from a model
      *
-     * @param string modelRelation
-     * @param array  parameters
+     * @param string            $modelName
+     * @param string            $modelRelation
+     * @param array|string|null $parameters
+     * @param ModelInterface    $record
+     * @param string|null       $method
      */
-    public function getHasOneRecords(string! method, string! modelName, var modelRelation, <ModelInterface> record, parameters = null) -> <ModelInterface> | bool;
+    public function getHasOneRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null) -> <ModelInterface> | bool;
 
     /**
      * Get last initialized model

--- a/tests/_data/fixtures/models/AlbumORama/Albums.php
+++ b/tests/_data/fixtures/models/AlbumORama/Albums.php
@@ -34,5 +34,20 @@ class Albums extends Model
                 'alias' => 'songs',
             ]
         );
+
+        $this->hasMany(
+            [
+                'id',
+                'name'
+            ],
+            Songs::class,
+            [
+                'albums_id',
+                'name'
+            ],
+            [
+                'alias' => 'singles',
+            ]
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Manager/GetRelationRecordsCest.php
+++ b/tests/integration/Mvc/Model/Manager/GetRelationRecordsCest.php
@@ -13,21 +13,156 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model\Manager;
 
 use IntegrationTester;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Mvc\Model\Manager;
+use Phalcon\Mvc\Model\Resultset;
+use Phalcon\Test\Models\AlbumORama\Albums;
+use Phalcon\Test\Models\AlbumORama\Artists;
+use Phalcon\Test\Models\AlbumORama\Songs;
 
 /**
  * Class GetRelationRecordsCest
  */
 class GetRelationRecordsCest
 {
+    use DiTrait;
+
+    public function _before(IntegrationTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+    }
+
     /**
      * Tests Phalcon\Mvc\Model\Manager :: getRelationRecords()
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-05-22
      */
     public function mvcModelManagerGetRelationRecords(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Model\Manager - getRelationRecords()');
-        $I->skipTest('Need implementation');
+
+        /**
+         * @var Albums $album
+         */
+        $album = Albums::findFirst(1);
+
+        /**
+         * @var Manager $modelsManager
+         */
+        $modelsManager = $album->getModelsManager();
+
+
+        /**
+         * Relation: belongsTo artist
+         */
+        $artistRelation = $modelsManager->getRelationByAlias(
+            Albums::class,
+            'artist'
+        );
+
+        $artistRelationRecord = $modelsManager->getRelationRecords(
+            $artistRelation,
+            null,
+            $album
+        );
+
+        $I->assertInstanceOf(
+            Artists::class,
+            $artistRelationRecord
+        );
+
+        $I->assertEquals(
+            [
+                'id'   => 1,
+                'name' => 'Lana del Rey'
+            ],
+            $artistRelationRecord->toArray()
+        );
+
+
+        /**
+         * Relation: hasMany songs
+         */
+        $songsRelation = $modelsManager->getRelationByAlias(
+            Albums::class,
+            'songs'
+        );
+
+        $songsRelationRecordsCount = $modelsManager->getRelationRecords(
+            $songsRelation,
+            'count',
+            $album,
+            []
+        );
+
+        $I->assertEquals(
+            7,
+            $songsRelationRecordsCount
+        );
+
+        $songsRelationRecords = $modelsManager->getRelationRecords(
+            $songsRelation,
+            null,
+            $album,
+            [
+                'id <= 5'
+            ]
+        );
+
+        $I->assertInstanceOf(
+            Resultset\Simple::class,
+            $songsRelationRecords
+        );
+
+        $I->assertInstanceOf(
+            Songs::class,
+            $songsRelationRecords->getFirst()
+        );
+
+        $I->assertEquals(
+            5,
+            $songsRelationRecords->count()
+        );
+
+
+        /**
+         * Relation: hasMany singles (with multiple referenced fields)
+         */
+        $singlesRelation = $modelsManager->getRelationByAlias(
+            Albums::class,
+            'singles'
+        );
+
+        $singlesRelationRecords = $modelsManager->getRelationRecords(
+            $singlesRelation,
+            null,
+            $album
+        );
+
+        $I->assertInstanceOf(
+            Resultset\Simple::class,
+            $singlesRelationRecords
+        );
+
+        $I->assertInstanceOf(
+            Songs::class,
+            $singlesRelationRecords->getFirst()
+        );
+
+        $I->assertEquals(
+            1,
+            $singlesRelationRecords->count()
+        );
+
+        $I->assertEquals(
+            [
+                'id'        => 1,
+                'albums_id' => $album->id,
+                'name'      => 'Born to Die'
+            ],
+            $singlesRelationRecords->getFirst()->toArray()
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Manager/GetRelationRecordsCest.php
+++ b/tests/integration/Mvc/Model/Manager/GetRelationRecordsCest.php
@@ -64,7 +64,6 @@ class GetRelationRecordsCest
 
         $artistRelationRecord = $modelsManager->getRelationRecords(
             $artistRelation,
-            null,
             $album
         );
 
@@ -92,9 +91,9 @@ class GetRelationRecordsCest
 
         $songsRelationRecordsCount = $modelsManager->getRelationRecords(
             $songsRelation,
-            'count',
             $album,
-            []
+            [],
+            'count'
         );
 
         $I->assertEquals(
@@ -104,7 +103,6 @@ class GetRelationRecordsCest
 
         $songsRelationRecords = $modelsManager->getRelationRecords(
             $songsRelation,
-            null,
             $album,
             [
                 'id <= 5'
@@ -137,7 +135,6 @@ class GetRelationRecordsCest
 
         $singlesRelationRecords = $modelsManager->getRelationRecords(
             $singlesRelation,
-            null,
             $album
         );
 


### PR DESCRIPTION
Hello!

* Type: bug fix and code quality
* Link to issue: https://github.com/phalcon/cphalcon/issues/11504

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

In `Phalcon\Mvc\Model\Manager::getRelationRecords()` function, `$method` parameter is not always `string`. (most of the time it's `null`)
It's optional and rarely ever used so I think it should be the last parameter. (This **Breaks BC**)

Same applies to:
 - `Phalcon\Mvc\Model\Manager::getBelongsToRecords()`
 - `Phalcon\Mvc\Model\Manager::getHasOneRecords()`
 - `Phalcon\Mvc\Model\Manager::getHasManyRecords()`

Modified the interfaces and usage everywhere accordingly.

Made some minor changes inside `Phalcon\Mvc\Model\Manager::getRelationRecords()`.
Added tests for `Phalcon\Mvc\Model\Manager::getRelationRecords()`, also for issue: https://github.com/phalcon/cphalcon/issues/11504

Thanks,
zsilbi

