### PR TITLE
Generate integration tests using command parameters

### DIFF
--- a/tests/_ci/generate-test-stubs.php
+++ b/tests/_ci/generate-test-stubs.php
@@ -22,19 +22,19 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Phalcon\Test\Unit\%n%;
+namespace Phalcon\Test\%type%\%n%;
 
-use UnitTester;
+use %type%Tester;
 
 class %m%Cest
 {
     /**
-     * Tests %ns% :: %sm%()
+     * %type% Tests %ns% :: %sm%()
      *
      * @author Phalcon Team <team@phalconphp.com>
      * @since  %d%
      */
-    public function %nn%%m%(UnitTester $I)
+    public function %nn%%m%(%type%Tester $I)
     {
         $I->wantToTest(\'%n% - %sm%()\');
 
@@ -52,13 +52,22 @@ foreach ($allClasses as $class) {
     }
 }
 
+// Argument 1: could be "unit" or "integration" shortcut "u" or "i"
+$type = ucfirst($argv[1] ?? 'unit');
+
+// Normalize shortcut I = Integration or U = Unit
+if (strlen($type) === 1) {
+    $type = $type === 'I' ? 'Integration' : 'Unit';
+}
+
 $placeholders = [
-    '%ns%' => '',
-    '%nn%' => '',
-    '%n%'  => '',
-    '%m%'  => '',
-    '%sm%' => '',
-    '%d%'  => date('Y-m-d'),
+    '%type%' => $type,
+    '%ns%'   => '',
+    '%nn%'   => '',
+    '%n%'    => '',
+    '%m%'    => '',
+    '%sm%'   => '',
+    '%d%'    => date('Y-m-d'),
 ];
 
 $outputDir = dirname(__DIR__) . '/nikos/';


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
It's a simple change to generate `unit` or `integration` tests passing a simple parameter from CLI
`php generate-test-stup.php` works like always. Even you can use `unit` or `u`
`php generate-test-stup.php i` generate integration tests. Even you can use `integration`
Thanks

