### PR TITLE
Mvc\Micro now uses getDI() to get the DI/FactoryDefault.

### DIFF
--- a/phalcon/Mvc/Micro.zep
+++ b/phalcon/Mvc/Micro.zep
@@ -13,7 +13,6 @@ namespace Phalcon\Mvc;
 use Phalcon\DiInterface;
 use Phalcon\Di\Injectable;
 use Phalcon\Mvc\Controller;
-use Phalcon\Di\FactoryDefault;
 use Phalcon\Mvc\Micro\Exception;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Mvc\Micro\Collection;
@@ -298,13 +297,7 @@ class Micro extends Injectable implements \ArrayAccess
     {
         var container;
 
-        let container = this->container;
-
-        if typeof container != "object" {
-            let container = new FactoryDefault();
-
-            let this->container = container;
-        }
+        let container = this->getDI();
 
         return container->get(serviceName);
     }
@@ -318,13 +311,7 @@ class Micro extends Injectable implements \ArrayAccess
     {
         var container;
 
-        let container = this->container;
-
-        if typeof container != "object" {
-            let container = new FactoryDefault();
-
-            let this->container = container;
-        }
+        let container = this->getDI();
 
         return container->getShared(serviceName);
     }
@@ -829,13 +816,7 @@ class Micro extends Injectable implements \ArrayAccess
     {
         var container;
 
-        let container = this->container;
-
-        if typeof container != "object" {
-            let container = new FactoryDefault();
-
-            let this->container = container;
-        }
+        let container = this->getDI();
 
         return container->has(serviceName);
     }
@@ -1039,13 +1020,7 @@ class Micro extends Injectable implements \ArrayAccess
     {
         var container;
 
-        let container = this->container;
-
-        if typeof container != "object" {
-            let container = new FactoryDefault();
-
-            let this->container = container;
-        }
+        let container = this->getDI();
 
         container->remove(alias);
     }
@@ -1246,13 +1221,7 @@ class Micro extends Injectable implements \ArrayAccess
     {
         var container;
 
-        let container = this->container;
-
-        if typeof container != "object" {
-            let container = new FactoryDefault();
-
-            let this->container = container;
-        }
+        let container = this->getDI();
 
         return container->set(serviceName, definition, shared);
     }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [-] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

The `offset` and `(get|set)Service` methods create a Factory Default DI if none is given. Should this behaviour extend to `handle()` which will throw an Exception if no DI is previously set? See [line 336](https://github.com/SidRoberts/cphalcon/blob/30e5b475959943c973a9790941f8ad3fccb82e31/phalcon/Mvc/Micro.zep#L336).