### PR TITLE
Mvc\Model\Criteria::limit() now corrects negative offsets.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -45,6 +45,7 @@
 - Fixed `Phalcon\Db\Dialect\Postgresql::truncateTable()` to now escape table names. [#14125](https://github.com/phalcon/cphalcon/pull/14125)
 - Fixed `Phalcon\Mvc\Model\MetaData::write()` to throw an exception if `orm.exception_on_failed_metadata_save` is set to true. [#13433](https://github.com/phalcon/cphalcon/issues/13433)
 - Fixed `Phalcon\Image\Adapter\Gd` to throw an error with `imagecolorat`. [#14139](https://github.com/phalcon/cphalcon/issues/14139)
+- `Phalcon\Mvc\Model\Criteria::limit()` now corrects negative offsets.
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/phalcon/Mvc/Model/Criteria.zep
+++ b/phalcon/Mvc/Model/Criteria.zep
@@ -550,7 +550,8 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      */
     public function limit(int limit, int offset = 0) -> <CriteriaInterface>
     {
-        let limit = abs(limit);
+        let limit  = abs(limit);
+        let offset = abs(offset);
 
         if unlikely limit == 0 {
             return this;

--- a/tests/integration/Mvc/Model/Refactor-CriteriaCest.php
+++ b/tests/integration/Mvc/Model/Refactor-CriteriaCest.php
@@ -55,35 +55,82 @@ class CriteriaCest
      * @issue  https://github.com/phalcon/cphalcon/issues/12419
      * @author Serghei Iakovelv <serghei@phalconphp.com>
      * @since  2016-12-18
+     *
+     * @dataProvider getLimitOffset
      */
-    public function shouldCorrectHandleLimitAndOffset(IntegrationTester $I)
+    public function shouldCorrectHandleLimitAndOffset(IntegrationTester $I, Example $example)
     {
-        $I->skipTest('TODO - Check the test data');
-        $examples = $this->getLimitOffset();
-        foreach ($examples as $item) {
-            $limit    = $item[0];
-            $offset   = $item[1];
-            $expected = $item[2];
-            /** @var Criteria $query */
-            $query = Users::query();
-            $query->limit($limit, $offset);
+        $limit    = $example[0];
+        $offset   = $example[1];
+        $expected = $example[2];
 
-            $actual = $query->getLimit();
-            $I->assertEquals($expected, $actual);
-        }
+        /** @var Criteria $query */
+        $query = Users::query();
+
+        $query->limit($limit, $offset);
+
+        $I->assertEquals(
+            $expected,
+            $query->getLimit()
+        );
     }
 
     private function getLimitOffset(): array
     {
         return [
-            [-7, null, 7],
-            ['-7234', null, 7234],
-            ['18', null, 18],
-            ['18', 2, ['number' => 18, 'offset' => 2]],
-            ['-1000', -200, ['number' => 1000, 'offset' => 200]],
-            ['1000', '-200', ['number' => 1000, 'offset' => 200]],
-            ['0', '-200', null],
-            ['%3CMETA%20HTTP-EQUIV%3D%22refresh%22%20CONT ENT%3D%220%3Burl%3Djavascript%3Aqss%3D7%22%3E', 50, null],
+            [
+                -7,
+                0,
+                [
+                    'number' => 7,
+                    'offset' => 0,
+                ],
+            ],
+            [
+                '-7234',
+                0,
+                [
+                    'number' => 7234,
+                    'offset' => 0,
+                ],
+            ],
+            [
+                '18',
+                0,
+                [
+                    'number' => 18,
+                    'offset' => 0,
+                ],
+            ],
+            [
+                '18',
+                2,
+                [
+                    'number' => 18,
+                    'offset' => 2,
+                ],
+            ],
+            [
+                '-1000',
+                -200,
+                [
+                    'number' => 1000,
+                    'offset' => 200,
+                ],
+            ],
+            [
+                '1000',
+                '-200',
+                [
+                    'number' => 1000,
+                    'offset' => 200,
+                ],
+            ],
+            [
+                '0',
+                '-200',
+                null,
+            ],
         ];
     }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

