### PR TITLE
ServerRequest Trying to call method gethost on a non-object

### DIFF
--- a/phalcon/Http/Message/ServerRequest.zep
+++ b/phalcon/Http/Message/ServerRequest.zep
@@ -207,8 +207,8 @@ class ServerRequest implements ServerRequestInterface
 
         let this->protocolVersion = this->processProtocol(protocol),
             this->method          = this->processMethod(method),
-            this->headers         = this->processHeaders(headers),
             this->uri             = this->processUri(uri),
+            this->headers         = this->processHeaders(headers),
             this->body            = this->processBody(body, "w+b"),
             this->uploadedFiles   = uploadFiles,
             this->parsedBody      = parsedBody,

--- a/tests/unit/Http/Message/ServerRequest/ConstructCest.php
+++ b/tests/unit/Http/Message/ServerRequest/ConstructCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Http\Message\ServerRequest;
 
 use Phalcon\Http\Message\ServerRequest;
+use Phalcon\Http\Message\Uri;
 use Psr\Http\Message\ServerRequestInterface;
 use UnitTester;
 
@@ -30,5 +31,20 @@ class ConstructCest
         $request = new ServerRequest();
         $class   = ServerRequestInterface::class;
         $I->assertInstanceOf($class, $request);
+    }
+
+    /**
+     * Tests Phalcon\Http\Message\ServerRequest :: __construct()
+     *
+     * @author cq-z <64899484@qq.com>
+     * @since  2019-06-02
+     */
+    public function httpMessageServerRequestConstructIssues14151(UnitTester $I)
+    {
+        $I->wantToTest('Http\Message\ServerRequest - __construct()');
+        $request = new ServerRequest("GET",new Uri(),[],'php://input',['host'=>['127.0.0.1']]);
+        $expected = ['127.0.0.1'];
+        $actual   = $request->getHeader('host');
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Http/Message/ServerRequest/ConstructCest.php
+++ b/tests/unit/Http/Message/ServerRequest/ConstructCest.php
@@ -42,9 +42,9 @@ class ConstructCest
     public function httpMessageServerRequestConstructIssues14151(UnitTester $I)
     {
         $I->wantToTest('Http\Message\ServerRequest - __construct()');
-        $request = new ServerRequest("GET",new Uri(),[],'php://input',['host'=>['127.0.0.1']]);
+        $request = new ServerRequest("GET", new Uri(), [], 'php://input', ['host' => ['127.0.0.1']]);
         $expected = ['127.0.0.1'];
-        $actual   = $request->getHeader('host');
+        $actual = $request->getHeader('host');
         $I->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
Trying to call method gethost on a non-object
Stack trace:
#0 [internal function]: Phalcon\Http\Message\ServerRequest->processHeaders(Array)
#1 xxx: Phalcon\Http\Message\ServerRequest->__construct('GET', Object(Phalcon\Http\Message\Uri), Array, '', Array, Array, Array, Array, Array, '1.1')