### PR TITLE
Route::getReversedPaths() now uses `array_flip()`.

### DIFF
--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -391,16 +391,9 @@ class Route
      */
     public function getReversedPaths() -> array
     {
-        var path, position;
-        array reversed;
-
-        let reversed = [];
-
-        for path, position in this->paths {
-            let reversed[position] = path;
-        }
-
-        return reversed;
+        return array_flip(
+            this->paths
+        );
     }
 
     /**

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -382,16 +382,9 @@ class Route implements RouteInterface
      */
     public function getReversedPaths() -> array
     {
-        var path, position;
-        array reversed;
-
-        let reversed = [];
-
-        for path, position in this->paths {
-            let reversed[position] = path;
-        }
-
-        return reversed;
+        return array_flip(
+            this->paths
+        );
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

https://www.php.net/manual/en/function.array-flip.php