### PR TITLE
Removed unused parameter from Model::_exists()

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -2171,7 +2171,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
             /**
              * We need to check if the record exists
              */
-            if unlikely !this->_exists(metaData, readConnection, table) {
+            if unlikely !this->_exists(metaData, readConnection) {
                 throw new Exception(
                     "The record cannot be refreshed because it does not exist or is deleted"
                 );
@@ -2309,7 +2309,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
         /**
          * We need to check if the record exists
          */
-        let exists = this->_exists(metaData, readConnection, table);
+        let exists = this->_exists(metaData, readConnection);
 
         if exists {
             let this->operationMade = self::OP_UPDATE;
@@ -3907,15 +3907,13 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 
     /**
      * Checks whether the current record already exists
-     *
-     * @param string|array table
      */
-    protected function _exists(<MetaDataInterface> metaData, <AdapterInterface> connection, var table = null) -> bool
+    protected function _exists(<MetaDataInterface> metaData, <AdapterInterface> connection) -> bool
     {
         int numberEmpty, numberPrimary;
         var uniqueParams, uniqueTypes, uniqueKey, columnMap, primaryKeys,
             wherePk, field, attributeField, value, bindDataTypes, joinWhere,
-            num, type, schema, source;
+            num, type, schema, source, table;
 
         let uniqueParams = null,
             uniqueTypes = null;


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

`table` is overwritten here: https://github.com/phalcon/cphalcon/blob/37d07a1558f2d929d7c4f35548eaee612e639d3e/phalcon/Mvc/Model.zep#L4036-L4040