### PR TITLE
Removed Travis branch restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ php:
 git:
   depth: 1
 
-branches:
-  only:
-    - master
-    - /^(4|5)\.\d+\.(\d+|x)$/
-    - /^T\d+-[a-zA-Z-]+/
-
 addons:
   apt:
     packages:


### PR DESCRIPTION
Hello!

* Type: testing
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Previously, Travis only ran builds for specific branches which isn't particularly helpful for developers running their own Travis builds. All branches should be tested anyway. :wink: 