### PR TITLE
Updated Stale to stop closing NFR and Enhancements

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -14,6 +14,8 @@ exemptLabels:
   - "Bug - High"
   - WIP
   - Locked
+  - "Feature - NFR"
+  - "Enhancement"
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Hello,

I'd like to stop stale marking NFR or Enhancements as stale... I don't think we should be relying upon ticket activity to identify whether an NFR is worthwhile.