### PR TITLE
Fixed #14198: Missing validation value resolution

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -64,6 +64,7 @@
 - Fixed `Phalcon\Mvc\Router` now parses and uses path. [#14087](https://github.com/phalcon/cphalcon/issues/14087)
 - Fixed various areas in `Phalcon\Acl\Adapter` and `Phalcon\Acl\Adapter\Memory` including comments, logic, `denyComponentAccess` and `AdapterInterface`. Added tests. [#13870](https://github.com/phalcon/cphalcon/issues/13870)
 - Fixed `Phalcon\Config::merge()` not merging numeric values properly [#13201](https://github.com/phalcon/cphalcon/issues/13201), [#13768](https://github.com/phalcon/cphalcon/issues/13768)
+- Fixed `Phalcon\Validation\Validator\File\AbstractFile` missing the resolution of the `value` property [#14198](https://github.com/phalcon/cphalcon/issues/14198)
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/phalcon/Validation/Validator/File/FileAbstract.zep
+++ b/phalcon/Validation/Validator/File/FileAbstract.zep
@@ -153,6 +153,8 @@ abstract class FileAbstract extends Validator
     {
         var label, replacePairs, value;
 
+        let value = validation->getValue(field);
+
         if !isset value["error"] || !isset value["tmp_name"] || value["error"] !== UPLOAD_ERR_OK || !is_uploaded_file(value["tmp_name"]) {
             let label = this->prepareLabel(validation, field),
                 replacePairs = [
@@ -184,6 +186,8 @@ abstract class FileAbstract extends Validator
     public function checkUploadIsValid(<Validation> validation, var field) -> bool
     {
         var label, replacePairs, value;
+
+        let value = validation->getValue(field);
 
         if !isset value["name"] || !isset value["type"] || !isset value["size"] {
             let label = this->prepareLabel(validation, field),


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14198 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- -[ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change-

Small description of the change:
```zep
let value = validation->getValue(field);
```

Thanks

