### PR TITLE
Update form.zep

### DIFF
--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -240,7 +240,9 @@ class Form extends Injectable implements \Countable, \Iterator
 			/**
 			 * Use the public property if it doesn't have a setter
 			 */
-			let entity->{key} = filteredValue;
+			 if property_exists(entity, key) {
+			 	let entity->{key} = filteredValue;
+			 }
 		}
 
 		let this->_data = data;


### PR DESCRIPTION
Form shouldn't create object variables, it should write to entity only if the property exists

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

