### PR TITLE
Form::clear() now correctly clears single fields

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -66,6 +66,7 @@
 - Fixed `Phalcon\Config::merge()` not merging numeric values properly [#13201](https://github.com/phalcon/cphalcon/issues/13201), [#13768](https://github.com/phalcon/cphalcon/issues/13768)
 - Fixed `Phalcon\Validation\Validator\File\AbstractFile` missing the resolution of the `value` property [#14198](https://github.com/phalcon/cphalcon/issues/14198)
 - Fixed `Phalcon\Storage\Adapter\Stream` [#14190](https://github.com/phalcon/cphalcon/issues/14190)
+- `Phalcon\Form\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -223,13 +223,11 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         if fields === null {
             let data = [];
         } else {
-            if typeof fields == "array" {
-                for field in fields {
-                    if isset data[field] {
-                        unset data[field];
-                    }
-                }
-            } else {
+            if typeof fields != "array" {
+                let fields = [fields];
+            }
+
+            for field in fields {
                 if isset data[field] {
                     unset data[field];
                 }

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -218,10 +218,23 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     {
         var elements, element, data, field;
 
-        let data = this->data;
+        let data = this->data,
+            elements = this->elements;
 
+        /**
+         * If fields is string, clear just that field.
+         * If it's array, clear only fields in array.
+         * If null, clear all
+         */
         if fields === null {
             let data = [];
+
+            for element in elements {
+                Tag::setDefault(
+                    element->getName(),
+                    element->getDefault()
+                );
+            }
         } else {
             if typeof fields != "array" {
                 let fields = [fields];
@@ -231,45 +244,17 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
                 if isset data[field] {
                     unset data[field];
                 }
-            }
-        }
 
-        let this->data = data,
-            elements = this->elements;
-
-        /**
-        * If fields is string, clear just that field.
-        * If it's array, clear only fields in array.
-        * If null, clear all
-        */
-        if typeof elements == "array" {
-            if fields === null {
-                for element in elements {
+                if fetch element, elements[field] {
                     Tag::setDefault(
                         element->getName(),
                         element->getDefault()
                     );
                 }
-            } else {
-                if typeof fields == "array" {
-                    for element in elements {
-                        if in_array(element->getName(), fields) {
-                            Tag::setDefault(
-                                element->getName(),
-                                element->getDefault()
-                            );
-                        }
-                    }
-                } else {
-                    if fetch element, elements[fields] {
-                        Tag::setDefault(
-                            element->getName(),
-                            element->getDefault()
-                        );
-                    }
-                }
             }
         }
+
+        let this->data = data;
 
         return this;
     }

--- a/tests/integration/Forms/Form/ClearCest.php
+++ b/tests/integration/Forms/Form/ClearCest.php
@@ -40,16 +40,155 @@ class ClearCest
     }
 
     /**
-     * Tests Phalcon\Forms\Form :: clear()
+     * Tests Phalcon\Forms\Form :: clear() - all
      *
-     * @author Phalcon Team <team@phalconphp.com>
-     * @since  2018-11-13
+     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @since  2019-06-28
      */
-    public function formsFormClear(IntegrationTester $I)
+    public function formsFormClearAll(IntegrationTester $I)
     {
-        $I->wantToTest('Forms\Form - clear()');
+        $I->wantToTest('Forms\Form - clear() - all');
 
-        $I->skipTest('Need implementation');
+        $name     = new Text('name');
+        $email    = new Email('email');
+        $password = new Password('password');
+
+        $form = new Form();
+
+        $form
+            ->add($name)
+            ->add($email)
+            ->add($password)
+        ;
+
+        $entity = new \stdClass();
+
+        $form->bind(
+            [
+                'name'     => 'Sid Roberts',
+                'email'    => 'team@phalconphp.com',
+                'password' => 'hunter2',
+            ],
+            $entity
+        );
+
+        $form->clear();
+
+        $I->assertNull(
+            $form->get('name')->getValue()
+        );
+
+        $I->assertNull(
+            $form->get('email')->getValue()
+        );
+
+        $I->assertNull(
+            $form->get('password')->getValue()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Forms\Form :: clear() - fields array
+     *
+     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @since  2019-06-28
+     */
+    public function formsFormClearFieldsArray(IntegrationTester $I)
+    {
+        $I->wantToTest('Forms\Form - clear() - fields array');
+
+        $name     = new Text('name');
+        $email    = new Email('email');
+        $password = new Password('password');
+
+        $form = new Form();
+
+        $form
+            ->add($name)
+            ->add($email)
+            ->add($password)
+        ;
+
+        $entity = new \stdClass();
+
+        $form->bind(
+            [
+                'name'     => 'Sid Roberts',
+                'email'    => 'team@phalconphp.com',
+                'password' => 'hunter2',
+            ],
+            $entity
+        );
+
+        $form->clear(
+            [
+                'email',
+                'password',
+            ]
+        );
+
+        $I->assertEquals(
+            'Sid Roberts',
+            $form->get('name')->getValue()
+        );
+
+        $I->assertNull(
+            $form->get('email')->getValue()
+        );
+
+        $I->assertNull(
+            $form->get('password')->getValue()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Forms\Form :: clear() - field string
+     *
+     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @since  2019-06-28
+     */
+    public function formsFormClearFieldString(IntegrationTester $I)
+    {
+        $I->wantToTest('Forms\Form - clear() - field string');
+
+        $name     = new Text('name');
+        $email    = new Email('email');
+        $password = new Password('password');
+
+        $form = new Form();
+
+        $form
+            ->add($name)
+            ->add($email)
+            ->add($password)
+        ;
+
+        $entity = new \stdClass();
+
+        $form->bind(
+            [
+                'name'     => 'Sid Roberts',
+                'email'    => 'team@phalconphp.com',
+                'password' => 'hunter2',
+            ],
+            $entity
+        );
+
+        $form->clear('password');
+
+        $I->assertEquals(
+            'Sid Roberts',
+            $form->get('name')->getValue()
+        );
+
+        $I->assertEquals(
+            'team@phalconphp.com',
+            $form->get('email')->getValue()
+        );
+
+        $I->assertNull(
+            $form->get('password')->getValue()
+        );
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix | code quality
* Link to issue: #14217

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

