### PR TITLE
[3.4.x] `Phalcon\Forms\Form::clear()` now correctly clears single fields

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,6 +1,7 @@
 # [3.4.4](https://github.com/phalcon/cphalcon/releases/tag/v3.4.4) (2019-XX-XX)
 - Generated Dialect Class referring to a PHP class can't be found [#13867](https://github.com/phalcon/cphalcon/pull/13867)
 - Changed default gcc's CFLAGS so that, the extension should be properly generated for most hosts, including Docker [#13143](https://github.com/phalcon/cphalcon/issues/13143)
+- `Phalcon\Forms\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
 
 # [3.4.3](https://github.com/phalcon/cphalcon/releases/tag/v3.4.3) (2019-02-24)
 - Provided PHP 7.3 support [#13847](https://github.com/phalcon/cphalcon/issues/13847)

--- a/phalcon/forms/form.zep
+++ b/phalcon/forms/form.zep
@@ -684,13 +684,11 @@ class Form extends Injectable implements \Countable, \Iterator
 		if is_null(fields) {
 			let data = [];
 		} else {
-			if typeof fields == "array" {
-				for field in fields {
-					if isset data[field] {
-						unset data[field];
-					}
-				}
-			} else {
+			if typeof fields != "array" {
+                let fields = [fields];
+            }
+
+			for field in fields {
 				if isset data[field] {
 					unset data[field];
 				}

--- a/tests/unit/Forms/FormTest.php
+++ b/tests/unit/Forms/FormTest.php
@@ -3,6 +3,8 @@
 namespace Phalcon\Test\Unit\Forms;
 
 use Phalcon\Forms\Form;
+use Phalcon\Forms\Element\Email;
+use Phalcon\Forms\Element\Password;
 use Phalcon\Forms\Element\Radio;
 use Phalcon\Forms\Element\Select;
 use Phalcon\Forms\Element\Text;
@@ -597,5 +599,152 @@ class FormTest extends UnitTest
                 ]
             ]);
         });
+    }
+
+
+    /**
+     * Tests Phalcon\Forms\Form :: clear() - all
+     *
+     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @since  2019-06-28
+     */
+    public function formsFormClearAll()
+    {
+        $name     = new Text('name');
+        $email    = new Email('email');
+        $password = new Password('password');
+
+        $form = new Form();
+
+        $form
+            ->add($name)
+            ->add($email)
+            ->add($password)
+        ;
+
+        $entity = new \stdClass();
+
+        $form->bind(
+            [
+                'name'     => 'Sid Roberts',
+                'email'    => 'team@phalconphp.com',
+                'password' => 'hunter2',
+            ],
+            $entity
+        );
+
+        $form->clear();
+
+        $this->assertNull(
+            $form->get('name')->getValue()
+        );
+
+        $this->assertNull(
+            $form->get('email')->getValue()
+        );
+
+        $this->assertNull(
+            $form->get('password')->getValue()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Forms\Form :: clear() - fields array
+     *
+     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @since  2019-06-28
+     */
+    public function formsFormClearFieldsArray(IntegrationTester $I)
+    {
+        $name     = new Text('name');
+        $email    = new Email('email');
+        $password = new Password('password');
+
+        $form = new Form();
+
+        $form
+            ->add($name)
+            ->add($email)
+            ->add($password)
+        ;
+
+        $entity = new \stdClass();
+
+        $form->bind(
+            [
+                'name'     => 'Sid Roberts',
+                'email'    => 'team@phalconphp.com',
+                'password' => 'hunter2',
+            ],
+            $entity
+        );
+
+        $form->clear(
+            [
+                'email',
+                'password',
+            ]
+        );
+
+        $this->assertEquals(
+            'Sid Roberts',
+            $form->get('name')->getValue()
+        );
+
+        $this->assertNull(
+            $form->get('email')->getValue()
+        );
+
+        $this->assertNull(
+            $form->get('password')->getValue()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Forms\Form :: clear() - field string
+     *
+     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @since  2019-06-28
+     */
+    public function formsFormClearFieldString(IntegrationTester $I)
+    {
+        $name     = new Text('name');
+        $email    = new Email('email');
+        $password = new Password('password');
+
+        $form = new Form();
+
+        $form
+            ->add($name)
+            ->add($email)
+            ->add($password)
+        ;
+
+        $entity = new \stdClass();
+
+        $form->bind(
+            [
+                'name'     => 'Sid Roberts',
+                'email'    => 'team@phalconphp.com',
+                'password' => 'hunter2',
+            ],
+            $entity
+        );
+
+        $form->clear('password');
+
+        $this->assertEquals(
+            'Sid Roberts',
+            $form->get('name')->getValue()
+        );
+
+        $this->assertEquals(
+            'team@phalconphp.com',
+            $form->get('email')->getValue()
+        );
+
+        $this->assertNull(
+            $form->get('password')->getValue()
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14217

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

