### PR TITLE
Fixed Form::getValue() calling getAttributes() when an element is named "attributes"

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -67,7 +67,7 @@
 - Fixed `Phalcon\Validation\Validator\File\AbstractFile` missing the resolution of the `value` property [#14198](https://github.com/phalcon/cphalcon/issues/14198)
 - Fixed `Phalcon\Storage\Adapter\Stream` [#14190](https://github.com/phalcon/cphalcon/issues/14190)
 - `Phalcon\Form\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
-- Fixed `Phalcon\Form\Form::getValue()` not to return call `getAttributes()` when an element is named "attributes" [#14226](https://github.com/phalcon/cphalcon/issues/14226)
+- Fixed `Phalcon\Form\Form::getValue()` not to call `getAttributes()` when an element is named "attributes" [#14226](https://github.com/phalcon/cphalcon/issues/14226)
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -67,6 +67,7 @@
 - Fixed `Phalcon\Validation\Validator\File\AbstractFile` missing the resolution of the `value` property [#14198](https://github.com/phalcon/cphalcon/issues/14198)
 - Fixed `Phalcon\Storage\Adapter\Stream` [#14190](https://github.com/phalcon/cphalcon/issues/14190)
 - `Phalcon\Form\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
+- Fixed `Phalcon\Form\Form::getValue()` not to return call `getAttributes()` when an element is named "attributes" [#14226](https://github.com/phalcon/cphalcon/issues/14226)
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -454,6 +454,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         }
 
         let forbidden = [
+            "attributes":    true,
             "validation":    true,
             "action":        true,
             "useroption":    true,


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/13646

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I have updated the relevant CHANGELOG

Small description of change:

The `getAttributes()` method was added to `Phalcon\Form\Form`, but it wasn't added to the internal methods array.
`Phalcon\Form\Form::getValue('attributes')` returns the attributes from `Phalcon\Form\Form::getAttributes()` instead of the value of the `Element`, named `attributes`.

Thanks,
zsilbi

