### PR TITLE
Fix Phalcon\Mvc\Micro\LazyLoader segfault

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,9 +1,11 @@
+# [3.4.5](https://github.com/phalcon/cphalcon/releases/tag/v3.4.5) (2019-XX-XX)
+- Fixed segfault in `Phalcon\Mvc\Micro\LazyLoader::__call()` when the handler has a syntax error. [#12396](https://github.com/phalcon/cphalcon/issues/12396)
+
 # [3.4.4](https://github.com/phalcon/cphalcon/releases/tag/v3.4.4) (2019-06-30)
 - Generated Dialect Class referring to a PHP class can't be found [#13867](https://github.com/phalcon/cphalcon/pull/13867)
 - Changed default gcc's CFLAGS so that, the extension should be properly generated for most hosts, including Docker [#13143](https://github.com/phalcon/cphalcon/issues/13143)
 - `Phalcon\Forms\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
 - Used latest stable Zephir from 0.10.x branch to prevent segfaults with PHP 7.3.6 [#14160](https://github.com/phalcon/cphalcon/issues/14160)
-- Fixed segfault in `Phalcon\Mvc\Micro\LazyLoader::__call()` when the handler has a syntax error. [#12396](https://github.com/phalcon/cphalcon/issues/12396)
 
 # [3.4.3](https://github.com/phalcon/cphalcon/releases/tag/v3.4.3) (2019-02-24)
 - Provided PHP 7.3 support [#13847](https://github.com/phalcon/cphalcon/issues/13847)

--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -3,6 +3,7 @@
 - Changed default gcc's CFLAGS so that, the extension should be properly generated for most hosts, including Docker [#13143](https://github.com/phalcon/cphalcon/issues/13143)
 - `Phalcon\Forms\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
 - Used latest stable Zephir from 0.10.x branch to prevent segfaults with PHP 7.3.6 [#14160](https://github.com/phalcon/cphalcon/issues/14160)
+- Fixed segfault in `Phalcon\Mvc\Micro\LazyLoader::__call()` when the handler has a syntax error. [#12396](https://github.com/phalcon/cphalcon/issues/12396)
 
 # [3.4.3](https://github.com/phalcon/cphalcon/releases/tag/v3.4.3) (2019-02-24)
 - Provided PHP 7.3 support [#13847](https://github.com/phalcon/cphalcon/issues/13847)

--- a/phalcon/mvc/micro/lazyloader.zep
+++ b/phalcon/mvc/micro/lazyloader.zep
@@ -60,7 +60,11 @@ class LazyLoader
 		let definition = this->_definition;
 
 		if typeof handler != "object" {
-			let handler = new {definition}();
+			if(!class_exists(definition)) {
+				throw new Exception("Handler '" . definition . "' doesn't exist");
+			}
+
+			let handler = create_instance(definition);
 			let this->_handler = handler;
 		}
 

--- a/phalcon/mvc/micro/lazyloader.zep
+++ b/phalcon/mvc/micro/lazyloader.zep
@@ -60,7 +60,7 @@ class LazyLoader
 		let definition = this->_definition;
 
 		if typeof handler != "object" {
-			if(!class_exists(definition)) {
+			if !class_exists(definition) {
 				throw new Exception("Handler '" . definition . "' doesn't exist");
 			}
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12396

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Fixes a segfault when using Micro with Collections. The segfault happens when you lazy load a handler that has a syntax error.

Sample Application:
This sample application with `index.php` and `controllers/BadController.php`. The controller is missing a semi-colon on purpose when assigning the array to a variable.

```
<?php

try {
	$collection = new Phalcon\Mvc\Micro\Collection();
	$collection->setPrefix("");
	$collection->setHandler("Controller\\BadController");
	$collection->setLazy(true);
	$collection->head("/", "bugAction");
	$collection->get("/", "bugAction");

	$loader = new Phalcon\Loader();
	$loader->registerNamespaces([
		"Controller" => __DIR__ . "/controllers/"
	]);

	$loader->register();

	$app = new Phalcon\Mvc\Micro();
	$app->mount($collection);
	$app->handle();
} catch(Throwable $t) {
	print_r($t);
}
```
```
<?php

namespace Controller;

class BadController {

	public function bugAction($slug) {
		$a = []
	}

}
```

Thank you.