### PR TITLE
Fix Phalcon\Mvc\Micro\LazyLoader::callMethod() segfault

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -97,6 +97,7 @@
 - `Phalcon\Form\Form::clear()` now correctly clears single fields. [#14217](https://github.com/phalcon/cphalcon/issues/14217)
 - Fixed `Phalcon\Form\Form::getValue()` not to call `getAttributes()` when an element is named "attributes" [#14226](https://github.com/phalcon/cphalcon/issues/14226)
 - Fixed `Phalcon\Model::delete()` array to string conversion [#14080](https://github.com/phalcon/cphalcon/issues/14080)
+- Fixed segfault in `Phalcon\Mvc\Micro\LazyLoader::callMethod()` when handler contains syntax error.
 
 ## Removed
 - Removed `Phalcon\Session\Factory`. [#13672](https://github.com/phalcon/cphalcon/issues/13672)

--- a/phalcon/Mvc/Micro/LazyLoader.zep
+++ b/phalcon/Mvc/Micro/LazyLoader.zep
@@ -45,7 +45,11 @@ class LazyLoader
             definition = this->definition;
 
         if typeof handler != "object" {
-            let handler = new {definition}();
+            if !class_exists(definition) {
+                throw new Exception("Handler '" . definition ."' doesn't exist");
+            }
+
+            let handler = create_instance(definition);
 
             let this->handler = handler;
         }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/pull/14238

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
This patch fixes a segfault when a `Phalcon\Mvc\Micro\LazyLoader` handler contains a syntax error. Same as patch https://github.com/phalcon/cphalcon/pull/14238 but for v4.0.x

Thanks

