### PR TITLE
Fixed missing Interface imports

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,8 @@
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (xxxx-xx-xx)
 
+## Fixed
+- Fixed missing import `DialectInterface` in `Phalcon\Db\Adapter\AbstractAdapter` and `Phalcon\Db\Adapter\AdapterInterface`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
+
 # [4.0.0-beta.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.1) (2019-07-14)
 
 ## Added

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,7 +1,7 @@
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (xxxx-xx-xx)
 
 ## Fixed
-- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter` and `Phalcon\Db\Adapter\AdapterInterface`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
+- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface` and `Phalcon\Db\Result\Pdo`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
 
 # [4.0.0-beta.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.1) (2019-07-14)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,7 +1,7 @@
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (xxxx-xx-xx)
 
 ## Fixed
-- Fixed missing import `DialectInterface` in `Phalcon\Db\Adapter\AbstractAdapter` and `Phalcon\Db\Adapter\AdapterInterface`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
+- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter` and `Phalcon\Db\Adapter\AdapterInterface`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
 
 # [4.0.0-beta.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.1) (2019-07-14)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,7 +1,7 @@
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (xxxx-xx-xx)
 
 ## Fixed
-- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface`, `Phalcon\Db\Result\Pdo` and `Phalcon\Html\Tag`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
+- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface`, `Phalcon\Db\Result\Pdo`, `Phalcon\Html\Tag` and `Phalcon\Tag\Select`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
 
 # [4.0.0-beta.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.1) (2019-07-14)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,7 +1,7 @@
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (xxxx-xx-xx)
 
 ## Fixed
-- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface` and `Phalcon\Db\Result\Pdo`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
+- Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface`, `Phalcon\Db\Result\Pdo` and `Phalcon\Html\Tag`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
 
 # [4.0.0-beta.1](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.1) (2019-07-14)
 

--- a/phalcon/Db/Adapter/AbstractAdapter.zep
+++ b/phalcon/Db/Adapter/AbstractAdapter.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Db\Adapter;
 
+use Phalcon\Db\DialectInterface;
 use Phalcon\Db\Adapter\AdapterInterface;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\Enum;

--- a/phalcon/Db/Adapter/AdapterInterface.zep
+++ b/phalcon/Db/Adapter/AdapterInterface.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Db\Adapter;
 
 use Phalcon\Db\DialectInterface;
+use Phalcon\Db\ResultInterface;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\IndexInterface;
 use Phalcon\Db\RawValue;

--- a/phalcon/Db/Adapter/AdapterInterface.zep
+++ b/phalcon/Db/Adapter/AdapterInterface.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Db\Adapter;
 
+use Phalcon\Db\DialectInterface;
 use Phalcon\Db\ColumnInterface;
 use Phalcon\Db\IndexInterface;
 use Phalcon\Db\RawValue;

--- a/phalcon/Db/Result/Pdo.zep
+++ b/phalcon/Db/Result/Pdo.zep
@@ -12,6 +12,7 @@ namespace Phalcon\Db\Result;
 
 use Phalcon\Db\Enum;
 use Phalcon\Db\ResultInterface;
+use Phalcon\Db\Adapter\AdapterInterface;
 
 %{
 #include <ext/pdo/php_pdo_driver.h>
@@ -61,7 +62,7 @@ class Pdo implements ResultInterface
     /**
      * Phalcon\Db\Result\Pdo constructor
      */
-    public function __construct(<Db\AdapterInterface> connection, <\PDOStatement> result,
+    public function __construct(<AdapterInterface> connection, <\PDOStatement> result,
         sqlStatement = null, bindParams = null, bindTypes = null) -> void
     {
         let this->connection = connection,

--- a/phalcon/Html/Tag.zep
+++ b/phalcon/Html/Tag.zep
@@ -17,6 +17,7 @@ use Phalcon\Escaper\EscaperInterface;
 use Phalcon\Helper\Arr;
 use Phalcon\Html\Exception;
 use Phalcon\Url\UrlInterface;
+use Phalcon\Mvc\Model\ResulsetInterface;
 
 /**
  * Phalcon\Html\Tag

--- a/phalcon/Html/Tag.zep
+++ b/phalcon/Html/Tag.zep
@@ -17,7 +17,7 @@ use Phalcon\Escaper\EscaperInterface;
 use Phalcon\Helper\Arr;
 use Phalcon\Html\Exception;
 use Phalcon\Url\UrlInterface;
-use Phalcon\Mvc\Model\ResulsetInterface;
+use Phalcon\Mvc\Model\ResultsetInterface;
 
 /**
  * Phalcon\Html\Tag
@@ -1739,7 +1739,7 @@ class Tag implements InjectionAwareInterface
     /**
      * Generates the option values from a resultset
      */
-    private function renderSelectResultset(<ResulsetInterface> resultset, using, var value, string closeOption) -> string
+    private function renderSelectResultset(<ResultsetInterface> resultset, using, var value, string closeOption) -> string
     {
         var escaper, option, output, optionValue, optionText, parameters,
             strOptionValue, strValue;

--- a/phalcon/Tag/Select.zep
+++ b/phalcon/Tag/Select.zep
@@ -13,7 +13,7 @@ namespace Phalcon\Tag;
 use Phalcon\Tag\Exception;
 use Phalcon\Tag as BaseTag;
 use Phalcon\Escaper\EscaperInterface;
-use Phalcon\Mvc\Model\ResulsetInterface;
+use Phalcon\Mvc\Model\ResultsetInterface;
 
 /**
  * Phalcon\Tag\Select
@@ -186,7 +186,7 @@ abstract class Select
      * @param array using
      */
     private static function optionsFromResultset(
-        <ResulsetInterface> resultset,
+        <ResultsetInterface> resultset,
         var using,
         var value,
         string closeOption


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I have updated the relevant CHANGELOG

Small description of change:
Some interfaces were not imported properly after refactoring.
Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface`, `Phalcon\Db\Result\Pdo`, `Phalcon\Html\Tag` and `Phalcon\Tag\Select`.

Thanks,
zsilbi

