### PR TITLE
Annotations Router to use patterns as prefix

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -12,6 +12,8 @@
 - Changed `Phalcon\Flash\Direct` to allow `escaper` in the constructor [#14349](https://github.com/phalcon/cphalcon/issues/14349)
 - Changed `Phalcon\Flash\Session` to allow `escaper` in the constructor [#14349](https://github.com/phalcon/cphalcon/issues/14349)
 - Changed `Phalcon\Di\AbstractDIAware` to `Phalcon\Di\AbstractInjectionAware` [#14359](https://github.com/phalcon/cphalcon/issues/14359)
+- Changed `Phalcon\Mvc\Router\Annotations` to be able to handle patterns az prefixes [#14259](https://github.com/phalcon/cphalcon/pull/14259)
+- Changed `Phalcon\Mvc\Router\Group::routes` to an array as default [#14259](https://github.com/phalcon/cphalcon/pull/14259)
 
 ## Fixed
 - Fixed `Phalcon\Helper\Str::includes` to return correct result [#14301](https://github.com/phalcon/cphalcon/issues/14301)

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -114,31 +114,31 @@ class Annotations extends Router
              */
             let prefix = scope[0];
 
-            if empty prefix {
-                continue;
-            }
+            if !empty prefix {
+                /**
+                 * Route object is used to compile patterns
+                 */
+                let route = new Route(prefix);
 
-            /**
-             * Route object is used to compile patterns
-             */
-            let route = new Route(prefix);
+                /**
+                 * Compiled patterns can be valid regular expressions.
+                 * In that case We only need to theck if it starts with
+                 * the pattern so we remove to "$" from the end.
+                 */
+                let compiledPattern = str_replace(
+                    "$#", "#", route->getCompiledPattern()
+                );
 
-            /**
-             * Compiled patterns can be valid regular expressions.
-             * In that case We only need to theck if it starts with
-             * the pattern so we remove to "$" from the end.
-             */
-            let compiledPattern = str_replace(
-                "$#", "#", route->getCompiledPattern()
-            );
-
-            /**
-             * If it's a regular expression, it will contain the "^"
-            */
-            if memstr(compiledPattern, "^") && !preg_match(compiledPattern, uri) {
-                continue;
-            } elseif !starts_with(uri, prefix) {
-                continue;
+                if memstr(compiledPattern, "^") {
+                    /**
+                     * If it's a regular expression, it will contain the "^"
+                     */
+                    if !preg_match(compiledPattern, uri) {
+                        continue;
+                    }
+                } elseif !starts_with(uri, prefix) {
+                    continue;
+                }
             }
 
             /**

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -84,9 +84,10 @@ class Annotations extends Router
     public function handle(string! uri)
     {
         var annotationsService, handlers, controllerSuffix, scope, prefix,
-            container, handler, controllerName, lowerControllerName,
-            namespaceName, moduleName, handlerAnnotations, classAnnotations,
-            annotations, annotation, methodAnnotations, method, collection;
+            route, compiledPattern, container, handler, controllerName,
+            lowerControllerName, namespaceName, moduleName, handlerAnnotations,
+            classAnnotations, annotations, annotation, methodAnnotations, method,
+            collection;
         string sufixed;
 
         let container = <DiInterface> this->container;
@@ -113,7 +114,30 @@ class Annotations extends Router
              */
             let prefix = scope[0];
 
-            if !empty prefix && !starts_with(uri, prefix) {
+            if empty prefix {
+                continue;
+            }
+
+            /**
+             * Route object is used to compile patterns
+             */
+            let route = new Route(prefix);
+
+            /**
+             * Compiled patterns can be valid regular expressions.
+             * In that case We only need to theck if it starts with
+             * the pattern so we remove to "$" from the end.
+             */
+            let compiledPattern = str_replace(
+                "$#", "#", route->getCompiledPattern()
+            );
+
+            /**
+             * If it's a regular expression, it will contain the "^"
+            */
+            if memstr(compiledPattern, "^") && !preg_match(compiledPattern, uri) {
+                continue;
+            } elseif !starts_with(uri, prefix) {
                 continue;
             }
 

--- a/phalcon/Mvc/Router/Group.zep
+++ b/phalcon/Mvc/Router/Group.zep
@@ -64,7 +64,7 @@ class Group implements GroupInterface
     protected hostname;
     protected paths;
     protected prefix;
-    protected routes;
+    protected routes = [];
 
     /**
      * Phalcon\Mvc\Router\Group constructor


### PR DESCRIPTION
Hello!

* Type: performance tuning

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

To use `Mvc\Router\Annotations`, you have to add the resources that you want it to parse. 
You can assign a prefix for every resource for faster handling.

```php
$di->setShared(
     "router",
     function() {
         // Use the annotations router
         $router = new Annotations(false);

         // This will do the same as above but only if the handled uri starts with /robots
         $router->addResource("Robots", "/robots");

        return $router;
     }
);
```

Adding controllers with distinct prefixes will work great, even in a huge a project.

If you don't use prefixes, it will basicly need to check and parse every resource that you added. It will be a bit slow but will work good enough for small projects.

However, if you have a lot of controllers with prefixes that have parameters or placeholders in the beginning, you won't be able to use them. 

For example if you have 75 controllers with prefixes like this: 
 - /clients/{clientId:[0-9]+}/
 - /clients/{clientId:[0-9]+}/robots
 - /clients/{clientId:[0-9]+}/parts
 - ...

In this case, only the `/clients` prefix can be used for all the 75 controllers.

In my test runs, I used a total of 150 resources, 75 with the same prefix and the average route handling time was over 50ms. Without using any prefixes, it was around 90ms.

**My idea would be to compile the prefixes as standard route patterns, so you could pass any type of pattern as a prefix along with your resource to the `Router`.**

I repeated the same tests using this code, and my average route handling time was around 3ms which I find somewhat acceptable. 

Thanks,
zsilbi
