### PR TITLE
PHP extension installer fails on error.

### DIFF
--- a/.ci/install-php-extensions.sh
+++ b/.ci/install-php-extensions.sh
@@ -7,6 +7,8 @@
 # For the full copyright and license information, please view the
 # LICENSE.txt file that was distributed with this source code.
 
+set -e
+
 PHP_INI="$(phpenv root)/versions/$(phpenv version-name)/etc/php.ini"
 
 # Install latest APC(u)

--- a/.ci/install-php-extensions.sh
+++ b/.ci/install-php-extensions.sh
@@ -33,7 +33,7 @@ then
   echo 'zend_extension="xdebug.so"' > "$(phpenv root)/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini"
 fi
 
-# Install latest memcached, msgpack, igbinary, imagick, psr, libsodium and yaml
+# Install latest memcached, msgpack, igbinary, imagick, psr and yaml
 printf "\\n" | pecl install --force memcached 1> /dev/null
 printf "\\n" | pecl install --force msgpack 1> /dev/null
 printf "\\n" | pecl install --force igbinary 1> /dev/null
@@ -41,7 +41,6 @@ printf "\\n" | pecl install --force imagick 1> /dev/null
 printf "\\n" | pecl install --force psr 1> /dev/null
 printf "\\n" | pecl install --force yaml 1> /dev/null
 printf "\\n" | pecl install --force mongodb 1> /dev/null
-printf "\\n" | pecl install --force libosodium 1> /dev/null
 
 # Install redis
 redis_ext=$($(phpenv which php-config) --extension-dir)/redis.so


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [-] I wrote some tests for this PR
- [-] I have updated the relevant CHANGELOG
- [-] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

I had an issue where one of my private Travis builds failed because a PHP extension didn't install properly and the install script didn't stop and report the error.