### PR TITLE
fix redis 'delete' and 'getKeys' deprecated warning

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,7 @@
 ## Fixed
 - Fixed missing imports in `Phalcon\Db\Adapter\AbstractAdapter`, `Phalcon\Db\Adapter\AdapterInterface`, `Phalcon\Db\Result\Pdo`, `Phalcon\Html\Tag` and `Phalcon\Tag\Select`. [#14249](https://github.com/phalcon/cphalcon/issues/14249)
 - Fixed `isSerializable` in `Phalcon\Storage\Serializer\AbstractSerializer` to return true when the data is seriazable and false when it's not.
+- Fixed `Phalcon\Storage\Adapter\Redis::delete()` and `Phalcon\Storage\Adapter\Redis::getKeys()` deprecated warning from php-redis [#14281](https://github.com/phalcon/cphalcon/issues/14281)
 
 ## Removed
 - Removed dead libsodium-related code. It was never called in PHP >= 7.0.

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -81,7 +81,7 @@ class Redis extends AbstractAdapter
      */
     public function delete(string! key) -> bool
     {
-        return (bool) this->getAdapter()->delete(key);
+        return (bool) this->getAdapter()->del(key);
     }
 
     /**
@@ -156,7 +156,7 @@ class Redis extends AbstractAdapter
      */
     public function getKeys() -> array
     {
-        return this->getAdapter()->getKeys("*");
+        return this->getAdapter()->keys("*");
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [#14281](https://github.com/phalcon/cphalcon/issues/14281)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

`setTimeout` command was removed from phalcon-v4.0.x. but `delete` and `getKeys` still exists deprecated warning

Thanks

