### PR TITLE
Fix argument types for Builder::groupBy/getGroupBy

### DIFF
--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -4528,7 +4528,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	 *
 	 * @param string property
 	 * @param mixed value
-	 * @return string
+	 * @return boolean
 	 */
 	protected final function _possibleSetter(string property, value)
 	{

--- a/phalcon/mvc/model/query/builder.zep
+++ b/phalcon/mvc/model/query/builder.zep
@@ -1025,7 +1025,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
 	/**
 	 * Returns the GROUP BY clause
 	 *
-	 * @return string
+	 * @return string|array
 	 */
 	public function getGroupBy()
 	{

--- a/phalcon/mvc/model/query/builderinterface.zep
+++ b/phalcon/mvc/model/query/builderinterface.zep
@@ -233,7 +233,7 @@ interface BuilderInterface
 	/**
 	 * Sets a LIMIT clause
 	 *
-	 * @param string group
+	 * @param string|array group
 	 * @return \Phalcon\Mvc\Model\Query\BuilderInterface
 	 */
 	public function groupBy(group);
@@ -241,7 +241,7 @@ interface BuilderInterface
 	/**
 	 * Returns the GROUP BY clause
 	 *
-	 * @return string
+	 * @return string|array
 	 */
 	public function getGroupBy();
 


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

According to the code `groupBy` may be `string` AND `array`, but PHPDoc in `BuilderInterface` and `getGroupBy` says that the argument type must be a `string`.

https://github.com/phalcon/cphalcon/blob/1341f1df3982712b5e168de9ba2159dfbd08a096/phalcon/mvc/model/query/builder.zep#L1005-L1018

https://github.com/phalcon/cphalcon/blob/1341f1df3982712b5e168de9ba2159dfbd08a096/phalcon/mvc/model/query/builder.zep#L1270-L1285

Thanks

