### PR TITLE
Show in PHPDoc that Select::addOption is allows strings

### DIFF
--- a/phalcon/Forms/Element/Select.zep
+++ b/phalcon/Forms/Element/Select.zep
@@ -38,7 +38,7 @@ class Select extends AbstractElement
     /**
      * Adds an option to the current options
      *
-     * @param array option
+     * @param array|string option
      */
     public function addOption(var option) -> <Element>
     {


### PR DESCRIPTION
Hello!

* Type: documentation
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
`Select::addOption` allows strings as an argument, but this is not indicated in the PHPDoc
https://github.com/phalcon/cphalcon/blob/45867075476996f5f6e352bf334e381ff0d4608a/phalcon/Forms/Element/Select.zep#L38-L56

Test for this already exists:
https://github.com/phalcon/cphalcon/blob/45867075476996f5f6e352bf334e381ff0d4608a/tests/integration/Forms/Element/Select/AddOptionCest.php#L53-L67

Thanks

