### PR TITLE
Exceptions in Phalcon should extend Phalcon\Exception

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,6 +3,9 @@
 - Fixed `Phalcon\Helper\Str::includes` to return correct result [#14301](https://github.com/phalcon/cphalcon/issues/14301)
 - Fixed `Phalcon\Logger` moved to correct namespace [#14263](https://github.com/phalcon/cphalcon/issues/14263)
 - Fixed `Phalcon\Session\Adapter\AbstractAdapter::read()` to return ""(empty string) when `Session/Adapter/*::get()` returns null [#14314](https://github.com/phalcon/cphalcon/issues/14314)
+- Fixed `Phalcon\Cache\Exception` to extend Phalcon\Exception
+- Fixed `Phalcon\Cache\InvalidArgumentException` to extend Phalcon\Exception
+- Fixed `Phalcon\Collection\Exception` to extend Phalcon\Exception
 
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (2019-08-18)
 

--- a/phalcon/Cache/Exception/Exception.zep
+++ b/phalcon/Cache/Exception/Exception.zep
@@ -13,7 +13,7 @@ namespace Phalcon\Cache\Exception;
 /**
  * Exceptions thrown in Phalcon\Cache will use this class
  */
-class Exception extends \Exception implements \Psr\SimpleCache\CacheException
+class Exception extends \Phalcon\Exception implements \Psr\SimpleCache\CacheException
 {
 
 }

--- a/phalcon/Cache/Exception/InvalidArgumentException.zep
+++ b/phalcon/Cache/Exception/InvalidArgumentException.zep
@@ -13,7 +13,7 @@ namespace Phalcon\Cache\Exception;
 /**
  * Exceptions thrown in Phalcon\Cache will use this class
  */
-class InvalidArgumentException extends \Exception implements \Psr\SimpleCache\InvalidArgumentException
+class InvalidArgumentException extends \Phalcon\Exception implements \Psr\SimpleCache\InvalidArgumentException
 {
 
 }

--- a/phalcon/Collection/Exception.zep
+++ b/phalcon/Collection/Exception.zep
@@ -15,6 +15,6 @@ use Throwable;
 /**
  * Exceptions for the Collection object
  */
-class Exception extends \Exception implements Throwable
+class Exception extends \Phalcon\Exception implements Throwable
 {
 }


### PR DESCRIPTION
Exceptions in Phalcon should extend Phalcon\Exception
Fixed
- Phalcon\Cache\Exception
- Phalcon\Cache\InvalidArgumentException
- Phalcon\Collection\Exception

* Type: code quality 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change
