### PR TITLE
Update Phalcon\Url::get

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,6 @@
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-xx-xx)
 ## Changed
+- Changed `Phalcon\Url::get` to use implementation behind `Phalcon\Helper\Str::reduceSlashes` to reduce slashes [#14331](https://github.com/phalcon/cphalcon/issues/14331)
 - Changed `Phalcon\Http\Headers\set()` to return self for a more fluent interface
 
 ## Fixed

--- a/phalcon/Url.zep
+++ b/phalcon/Url.zep
@@ -16,6 +16,7 @@ use Phalcon\Url\Exception;
 use Phalcon\Mvc\RouterInterface;
 use Phalcon\Mvc\Router\RouteInterface;
 use Phalcon\Di\InjectionAwareInterface;
+use Phalcon\Helper\Str;
 
 /**
  * This components helps in the generation of: URIs, URLs and Paths
@@ -162,16 +163,7 @@ class Url implements UrlInterface, InjectionAwareInterface
 
         if local {
             let strUri = (string) uri;
-
-            if substr(baseUri, -1) == "/" && strlen(strUri) > 2 && strUri[0] == '/' && strUri[1] != '/' {
-                let uri = baseUri . substr(strUri, 1);
-            } else {
-                if baseUri == "/" && strlen(strUri) == 1 && strUri[0] == '/' {
-                    let uri = baseUri;
-                } else {
-                    let uri = baseUri . strUri;
-                }
-            }
+            let uri = preg_replace("#(?<!:)//+#", "/", baseUri . strUri);
         }
 
         if args {

--- a/phalcon/Url.zep
+++ b/phalcon/Url.zep
@@ -16,7 +16,6 @@ use Phalcon\Url\Exception;
 use Phalcon\Mvc\RouterInterface;
 use Phalcon\Mvc\Router\RouteInterface;
 use Phalcon\Di\InjectionAwareInterface;
-use Phalcon\Helper\Str;
 
 /**
  * This components helps in the generation of: URIs, URLs and Paths


### PR DESCRIPTION
Hey guys.

* Type: bug fix && new feature
* Link to the issue: #14331 

Why do we complicate things? Let's utilize `Phalcon\Helper\Str::reduceSlashes` method instead of
```zephir
if substr(baseUri, -1) == "/" && strlen(strUri) > 2 && strUri[0] == '/' && strUri[1] != '/' {
    let uri = baseUri . substr(strUri, 1);
} else {
    if baseUri == "/" && strlen(strUri) == 1 && strUri[0] == '/' {
        let uri = baseUri;
    } else {
        let uri = baseUri . strUri;
    }
}
```

`Phalcon\Helper\Str::concat('/', baseUri, strUri)` would've worked as well.

