### PR TITLE
Get URL path only from the REQUEST_URI

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,5 +1,6 @@
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-xx-xx)
 ## Changed
+- `Phalcon\Http\Request::getURI()` now accepts optional boolean parameter which indicates whether or not the method should return only the path without the query string
 - Changed `Phalcon\Url::get` to use implementation behind `Phalcon\Helper\Str::reduceSlashes` to reduce slashes [#14331](https://github.com/phalcon/cphalcon/issues/14331)
 - Changed `Phalcon\Http\Headers\set()` to return self for a more fluent interface
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,6 @@
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-xx-xx)
 ## Changed
-- `Phalcon\Http\Request::getURI()` now accepts optional boolean parameter which indicates whether or not the method should return only the path without the query string
+- Added optional boolean parameter to `Phalcon\Http\Request::getURI()` which indicates whether or not the method should return only the path without the query string
 - Changed `Phalcon\Url::get` to use implementation behind `Phalcon\Helper\Str::reduceSlashes` to reduce slashes [#14331](https://github.com/phalcon/cphalcon/issues/14331)
 - Changed `Phalcon\Http\Headers\set()` to return self for a more fluent interface
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,9 @@
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-xx-xx)
+
+## Added
+- Added optional boolean parameter to `Phalcon\Http\Request::getURI()` (as well as its interface) which indicates whether or not the method should return only the path without the query string
+
 ## Changed
-- Added optional boolean parameter to `Phalcon\Http\Request::getURI()` which indicates whether or not the method should return only the path without the query string
 - Changed `Phalcon\Url::get` to use implementation behind `Phalcon\Helper\Str::reduceSlashes` to reduce slashes [#14331](https://github.com/phalcon/cphalcon/issues/14331)
 - Changed `Phalcon\Http\Headers\set()` to return self for a more fluent interface
 

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -845,7 +845,7 @@ class Request implements RequestInterface, InjectionAwareInterface
     }
 
     /**
-     * Gets HTTP URI which request has been made
+     * Gets HTTP URI which request has been made to
      *
      *```php
      * // Returns /some/path?with=queryParams

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -846,14 +846,29 @@ class Request implements RequestInterface, InjectionAwareInterface
 
     /**
      * Gets HTTP URI which request has been made
+     *
+     *```php
+     * // Returns /some/path?with=queryParams
+     * $uri = $request->getURI();
+     *
+     * // Returns /some/path
+     * $uri = $request->getURI(true);
+     *```
+     *
+     * @param bool onlyPath If true, query part will be omitted
+	 * @return string
      */
-    final public function getURI() -> string
+    final public function getURI(bool onlyPath = false) -> string
     {
         var requestURI;
 
         let requestURI = this->getServer("REQUEST_URI");
         if null === requestURI {
             return "";
+        }
+        
+        if onlyPath {
+            let requestURI = explode('?', requestURI)[0];
         }
 
         return requestURI;

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -856,7 +856,7 @@ class Request implements RequestInterface, InjectionAwareInterface
      *```
      *
      * @param bool onlyPath If true, query part will be omitted
-	 * @return string
+     * @return string
      */
     final public function getURI(bool onlyPath = false) -> string
     {

--- a/phalcon/Http/RequestInterface.zep
+++ b/phalcon/Http/RequestInterface.zep
@@ -189,7 +189,7 @@ interface RequestInterface
      *```
      *
      * @param bool onlyPath If true, query part will be omitted
-	 * @return string
+     * @return string
      */
     final public function getURI(bool onlyPath = false) -> string;
 

--- a/phalcon/Http/RequestInterface.zep
+++ b/phalcon/Http/RequestInterface.zep
@@ -178,7 +178,7 @@ interface RequestInterface
     public function getPort() -> int;
 
     /**
-     * Gets HTTP URI which request has been made with
+     * Gets HTTP URI which request has been made to
      *
      *```php
      * // Returns /some/path?with=queryParams

--- a/phalcon/Http/RequestInterface.zep
+++ b/phalcon/Http/RequestInterface.zep
@@ -178,9 +178,20 @@ interface RequestInterface
     public function getPort() -> int;
 
     /**
-     * Gets HTTP URI which request has been made
+     * Gets HTTP URI which request has been made with
+     *
+     *```php
+     * // Returns /some/path?with=queryParams
+     * $uri = $request->getURI();
+     *
+     * // Returns /some/path
+     * $uri = $request->getURI(true);
+     *```
+     *
+     * @param bool onlyPath If true, query part will be omitted
+	 * @return string
      */
-    final public function getURI() -> string;
+    final public function getURI(bool onlyPath = false) -> string;
 
     /**
      * Gets a variable from the $_POST superglobal applying filters if needed


### PR DESCRIPTION
Hi

* Type: new feature | code quality | documentation

Small description of change:

I added boolean flag to `Phalcon\Http\Request::getURI()` which if true, would have the query part omitted from the response. Flag is optional and set to false by default for backward compatibility.

Thanks

