### PR TITLE
Adding Environment Handler And PhpDotEnv Adapter & Testing

### DIFF
--- a/phalcon/Di/FactoryDefault.zep
+++ b/phalcon/Di/FactoryDefault.zep
@@ -50,7 +50,8 @@ class FactoryDefault extends \Phalcon\Di
             "security":           new Service("Phalcon\\Security", true),
             "tag":                new Service("Phalcon\\Tag", true),
             "transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
-            "url":                new Service("Phalcon\\Url", true)
+            "url":                new Service("Phalcon\\Url", true),
+            "environment":        new Service("Phalcon\\Environment", true)
         ];
     }
 }

--- a/phalcon/Di/FactoryDefault/Cli.zep
+++ b/phalcon/Di/FactoryDefault/Cli.zep
@@ -45,7 +45,8 @@ class Cli extends FactoryDefault
             "modelsMetadata":     new Service("Phalcon\\Mvc\\Model\\MetaData\\Memory", true),
             "router":             new Service("Phalcon\\Cli\\Router", true),
             "security":           new Service("Phalcon\\Security", true),
-            "transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true)
+            "transactionManager": new Service("Phalcon\\Mvc\\Model\\Transaction\\Manager", true),
+            "environment":        new Service("Phalcon\\Environment", true)
         ];
     }
 }

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -41,6 +41,7 @@ use Phalcon\Session\BagInterface;
  * @property \Phalcon\Di|\Phalcon\Di\DiInterface $di
  * @property \Phalcon\Session\Bag|\Phalcon\Session\BagInterface $persistent
  * @property \Phalcon\Mvc\View|\Phalcon\Mvc\ViewInterface $view
+ * @property \Phalcon\Environment $environment
  */
 abstract class Injectable implements InjectionAwareInterface
 {

--- a/phalcon/Environment.zep
+++ b/phalcon/Environment.zep
@@ -1,0 +1,141 @@
+namespace Phalcon;
+
+use Exception;
+use Phalcon\Di\Injectable;
+use RuntimeException;
+
+/**
+ * Environment Class To Retrieve Environment Variables (IE: getenv).
+ *
+ */
+class Environment extends Injectable
+{
+    /** @var array */
+    private envVars = [];
+
+    /** @var bool */
+    private _isLoaded = false;
+
+    /**
+    * Has environment been loaded?
+    */
+    protected function isLoaded() -> bool
+    {
+        return this->_isLoaded;
+    }
+
+    /**
+     * Disables Debug Info
+     */
+    public function __debugInfo()
+    {
+        return [];
+    }
+
+    /**
+     * Set Environment Variable Override
+     *
+     * @param string envName Environment Variable To Set
+     * @param string envValue Environment Variable Value
+     */
+    public function setValue(string envName, var envValue) -> <Environment>
+    {
+        let this->envVars[envName] = envValue;
+
+        return this;
+    }
+
+    /**
+     * Retrive Environemnt Variable
+     *
+     * @param string envName ENV To Retrieve
+     * @param mixed defaultValue Default Value If ENV Does Not Exist
+     */
+    public function getValue(string envName, var defaultValue = null) -> var
+    {
+        //Lazy Load Environment
+        if (!this->isLoaded()) {
+            this->loadEnvironment();
+        }
+
+        var value = this->retrieveValue(envName);
+        if unlikely value === null {
+            return defaultValue;
+        }
+
+        return this->parseValue(value);
+    }
+
+    /**
+     * Retrieve Value.
+     *
+     * @param string envName ENV To Retrieve
+     * @private
+     * @return mixed
+     */
+    protected function retrieveValue(string envName) -> var
+    {
+        var value = getenv(envName);
+        if value !== false {
+            return value;
+        } elseif isset this->envVars[envName] {
+            return this->envVars[envName];
+        }
+
+        let value = null;
+
+        return value;
+    }
+
+    /**
+     * Parses ENV To Scalar Type If Possible
+     *
+     * @param string Value To Parse
+     * @return mixed
+     */
+    private function parseValue(var value)
+    {
+        //Strip Off Wrapping Quotes
+        if unlikely strlen(value) > 1 && substr(value, 0, 1) === "\"" && substr(value, -1) === "\"" {
+            let value = substr(value, 1, -1);
+        }
+
+        //Return Literal Numbers
+        if is_numeric(value) {
+            //Cannot Do Strict Comparison
+            if value != (int) value || strpos(value, '.') !== false {
+                return (float) value;
+            }
+
+            return (int) value;
+        }
+
+        //Convert Specific Types
+        switch strtolower(value) {
+            case "true":
+            case "(true)":
+                return true;
+            case "false":
+            case "(false)":
+                return false;
+            case "empty":
+            case "(empty)":
+                return "";
+            case "null":
+            case "(null)":
+                return;
+        }
+
+        return value;
+    }
+
+    /**
+     * Loads Project Overrides
+     */
+    protected function loadEnvironment() -> <Environment>
+    {
+        let this->_isLoaded = true;
+
+        return this;
+    }
+}

--- a/phalcon/Environment.zep
+++ b/phalcon/Environment.zep
@@ -43,15 +43,7 @@ class Environment extends Injectable
     private envVars = [];
 
     /** @var bool */
-    private _isLoaded = false;
-
-    /**
-    * Has environment been loaded?
-    */
-    protected function isLoaded() -> bool
-    {
-        return this->_isLoaded;
-    }
+    private wasLoaded = false;
 
     /**
      * Disables Debug Info
@@ -59,19 +51,6 @@ class Environment extends Injectable
     public function __debugInfo()
     {
         return [];
-    }
-
-    /**
-     * Set Environment Variable Override
-     *
-     * @param string envName Environment Variable To Set
-     * @param string envValue Environment Variable Value
-     */
-    public function setValue(string envName, var envValue) -> <Environment>
-    {
-        let this->envVars[envName] = envValue;
-
-        return this;
     }
 
     /**
@@ -96,13 +75,44 @@ class Environment extends Injectable
     }
 
     /**
+     * Set Environment Variable Override
+     *
+     * @param string envName Environment Variable To Set
+     * @param string envValue Environment Variable Value
+     */
+    public function setValue(string envName, var envValue) -> <Environment>
+    {
+        let this->envVars[envName] = envValue;
+
+        return this;
+    }
+
+    /**
+    * Has environment been loaded?
+    */
+    protected function isLoaded() -> bool
+    {
+        return this->wasLoaded;
+    }
+
+    /**
+     * Loads Project Overrides
+     */
+    protected function loadEnvironment() -> <Environment>
+    {
+        let this->wasLoaded = true;
+
+        return this;
+    }
+
+    /**
      * Retrieve Value.
      *
      * @param string envName ENV To Retrieve
      * @private
      * @return mixed
      */
-    protected function retrieveValue(string envName) -> var
+    protected function retrieveValue(string envName) -> var | null
     {
         var value = getenv(envName);
         if value !== false {
@@ -111,18 +121,16 @@ class Environment extends Injectable
             return this->envVars[envName];
         }
 
-        let value = null;
-
-        return value;
+        return null;
     }
 
     /**
      * Parses ENV To Scalar Type If Possible
      *
      * @param string Value To Parse
-     * @return mixed
+     * @return float|int|string|bool|null
      */
-    private function parseValue(var value)
+    private function parseValue(var value) -> float | int | string | bool | null
     {
         //Strip Off Wrapping Quotes
         if unlikely strlen(value) > 1 && substr(value, 0, 1) === "\"" && substr(value, -1) === "\"" {
@@ -152,19 +160,9 @@ class Environment extends Injectable
                 return "";
             case "null":
             case "(null)":
-                return;
+                return null;
         }
 
         return value;
-    }
-
-    /**
-     * Loads Project Overrides
-     */
-    protected function loadEnvironment() -> <Environment>
-    {
-        let this->_isLoaded = true;
-
-        return this;
     }
 }

--- a/phalcon/Environment.zep
+++ b/phalcon/Environment.zep
@@ -5,8 +5,37 @@ use Phalcon\Di\Injectable;
 use RuntimeException;
 
 /**
- * Environment Class To Retrieve Environment Variables (IE: getenv).
+ * Phalcon\Environment is a component that allows for easy access to environment variables.
  *
+ * Typically, getenv is used to get environment variables. This component leverages getenv, but also gives the
+ * ability to specify the default value. Additionally, it will automatically convert all envs to the proper type:
+ *
+ * A=true => bool (true)
+ * A=(false) => bool (false)
+ * A=1 => int (1)
+ * A=2.0 => float (2.0)
+ * A=empty => string ("")
+ * A=(empty) => string ("")
+ * A=null => null
+ * A=(null) => null
+ * A="something" => string ("something")
+ * A=else => string ("else")
+ *
+ *
+ *```php
+ * use Phalcon\Environment;
+ *
+ * $env = new Environment();
+ *
+ * $var = $env->getValue("ABC", "blah"); //$var === "blah"
+ *
+ * $env->setValue("SOMETHING", "else");
+ * $var = $nv->getValue("SOMETHING"); //$var === "else"
+ *
+ * putenv('SOMETHING=BLAH')
+ * $var = $nv->getValue("SOMETHING", "else"); //$var === "BLAH"
+ *
+ *```
  */
 class Environment extends Injectable
 {

--- a/phalcon/Environment/Adapter/PhpDotEnv.zep
+++ b/phalcon/Environment/Adapter/PhpDotEnv.zep
@@ -36,15 +36,6 @@ class PhpDotEnv extends Environment
         }
     }
 
-    private function getService() -> <DotEnv>
-    {
-        if unlikely !this->getDi()->has("DotEnv\\DotEnv") {
-            throw new RuntimeException("Missing Required Service DotEnv\\DotEnv");
-        }
-
-        return this->getDi()->get("DotEnv\\DotEnv");
-    }
-
     protected function retrieveValue(string envName) -> var
     {
         var value;
@@ -56,5 +47,14 @@ class PhpDotEnv extends Environment
         }
 
         return value;
+    }
+
+    private function getService() -> <DotEnv>
+    {
+        if unlikely !this->getDi()->has("DotEnv\\DotEnv") {
+            throw new RuntimeException("Missing Required Service DotEnv\\DotEnv");
+        }
+
+        return this->getDi()->get("DotEnv\\DotEnv");
     }
 }

--- a/phalcon/Environment/Adapter/PhpDotEnv.zep
+++ b/phalcon/Environment/Adapter/PhpDotEnv.zep
@@ -1,0 +1,38 @@
+namespace Phalcon\Environment\Adapter;
+
+use DotEnv\DotEnv;
+use Phalcon\Di\DiInterface;
+use Phalcon\Environment;
+use RuntimeException;
+
+class PhpDotEnv extends Environment
+{
+    public function __construct()
+    {
+        if unlikely !class_exists("DotEnv\\DotEnv") {
+            throw new RuntimeException("Missing Required Composer Plugin vlucas/phpdotenv");
+        }
+    }
+
+    private function getService() -> <DotEnv>
+    {
+        if unlikely !this->getDi()->has("DotEnv\\DotEnv") {
+            throw new RuntimeException("Missing Required Service DotEnv\\DotEnv");
+        }
+
+        return this->getDi()->get("DotEnv\\DotEnv");
+    }
+
+    protected function retrieveValue(string envName) -> var
+    {
+        var value;
+
+        let value = parent::retrieveValue(envName);
+
+        if likely value === null {
+            let value = this->getService()->getEnvironmentVariable(envName);
+        }
+
+        return value;
+    }
+}

--- a/phalcon/Environment/Adapter/PhpDotEnv.zep
+++ b/phalcon/Environment/Adapter/PhpDotEnv.zep
@@ -5,6 +5,28 @@ use Phalcon\Di\DiInterface;
 use Phalcon\Environment;
 use RuntimeException;
 
+/**
+ * Phalcon\Environment\Adapter\PhpDotEnv is a component that leverages the vlucas/phpdotenv package to load
+ * environment configs from a .env file.
+ *
+ * A service of "DotEnv\DotEnv" must be registered in the DIC for this component to work.
+ *
+ *```php
+ * use DotEnv\DotEnv
+ * use Phalcon\Di
+ * use Phalcon\Environment\Adapter\PhpDotEnv;
+ *
+ * $di = new Di();
+ * $di->set(DotEnv::class, function () {
+ *    return DotEnv::create(__DIR__);
+ * });
+ *
+ * $env = new Environment();
+ * $env->setDi($di);
+ *
+ * $var = $env->getValue("ABC", "blah");
+ *```
+ */
 class PhpDotEnv extends Environment
 {
     public function __construct()

--- a/tests/cli/Di/FactoryDefault/Cli/ConstructCest.php
+++ b/tests/cli/Di/FactoryDefault/Cli/ConstructCest.php
@@ -18,6 +18,7 @@ use Codeception\Example;
 use Phalcon\Cli\Dispatcher;
 use Phalcon\Cli\Router;
 use Phalcon\Di\FactoryDefault\Cli;
+use Phalcon\Environment;
 use Phalcon\Escaper;
 use Phalcon\Filter;
 use Phalcon\Mvc\Model\MetaData\Memory;
@@ -96,6 +97,11 @@ class ConstructCest
             [
                 'service' => 'transactionManager',
                 'class'   => Manager::class,
+            ],
+
+            [
+                'service' => 'environment',
+                'class'   => Environment::class
             ],
         ];
     }

--- a/tests/unit/Di/FactoryDefault/ConstructCest.php
+++ b/tests/unit/Di/FactoryDefault/ConstructCest.php
@@ -18,6 +18,7 @@ use Phalcon\Annotations\Adapter\Memory as MemoryAnnotations;
 use Phalcon\Assets\Manager as ManagerAssets;
 use Phalcon\Crypt;
 use Phalcon\Di\FactoryDefault;
+use Phalcon\Environment;
 use Phalcon\Escaper;
 use Phalcon\Events\Manager as ManagerEvents;
 use Phalcon\Filter;
@@ -153,6 +154,11 @@ class ConstructCest
             [
                 'service' => 'url',
                 'class'   => Url::class,
+            ],
+
+            [
+                'service' => 'environment',
+                'class'   => Environment::class
             ],
         ];
     }

--- a/tests/unit/Environment/Adapter/PhpDotEnvTest.php
+++ b/tests/unit/Environment/Adapter/PhpDotEnvTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Phalcon\Test;
 
-
 use Codeception\Test\Unit;
 use DotEnv\DotEnv;
 use Phalcon\Di;

--- a/tests/unit/Environment/Adapter/PhpDotEnvTest.php
+++ b/tests/unit/Environment/Adapter/PhpDotEnvTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test;
+
+
+use Codeception\Test\Unit;
+use DotEnv\DotEnv;
+use Phalcon\Di;
+use Phalcon\Environment\Adapter\PhpDotEnv;
+use UnitTester;
+
+class EnvironmentTest extends Unit
+{
+    /** @var Environment  */
+    private $testSubject = null;
+
+    /** @var UnitTester */
+    protected $tester;
+
+    public function _before()
+    {
+        $this->testSubject = new PhpDotEnv();
+
+        $di = new Di();
+
+        $mockLoader = $this->getMockBuilder(DotEnv::class)
+                           ->disableOriginalConstructor()
+                           ->setMethods(['getEnvironmentVariable'])
+                           ->getMock();
+
+        $di->set(DotEnv::class, $mockLoader);
+
+        $this->testSubject->setDi($di);
+    }
+
+    public function _after()
+    {
+        putenv('SOME_RANDOM_VALUE');
+    }
+
+
+    public function testFallback()
+    {
+        putenv('SOME_RANDOM_VALUE=blah');
+
+        $this->assertEquals('blah', $this->testSubject->getValue('SOME_RANDOM_VALUE'));
+    }
+
+    public function testLoader()
+    {
+        $this->testSubject->getDi()->get(DotEnv::class)->expects($this->once())->method('getEnvironmentVariable')->with('SOME_RANDOM_VALUE')->willReturn('blah');
+        $this->assertEquals('blah', $this->testSubject->getValue('SOME_RANDOM_VALUE'));
+    }
+}

--- a/tests/unit/Environment/Adapter/PhpDotEnvTest.php
+++ b/tests/unit/Environment/Adapter/PhpDotEnvTest.php
@@ -19,7 +19,7 @@ use Phalcon\Di;
 use Phalcon\Environment\Adapter\PhpDotEnv;
 use UnitTester;
 
-class EnvironmentTest extends Unit
+class PhpDotEnvTest extends Unit
 {
     /** @var Environment  */
     private $testSubject = null;

--- a/tests/unit/Environment/Adapter/PhpDotEnvTest.php
+++ b/tests/unit/Environment/Adapter/PhpDotEnvTest.php
@@ -21,7 +21,7 @@ use UnitTester;
 
 class PhpDotEnvTest extends Unit
 {
-    /** @var Environment  */
+    /** @var PhpDotEnv  */
     private $testSubject = null;
 
     /** @var UnitTester */

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Phalcon\Test;
 
-
 use Codeception\Test\Unit;
 use Phalcon\Environment;
 use UnitTester;

--- a/tests/unit/EnvironmentTest.php
+++ b/tests/unit/EnvironmentTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test;
+
+
+use Codeception\Test\Unit;
+use Phalcon\Environment;
+use UnitTester;
+
+class EnvironmentTest extends Unit
+{
+    /** @var Environment  */
+    private $testSubject = null;
+
+    /** @var UnitTester */
+    protected $tester;
+
+    public function _before()
+    {
+        $this->testSubject = new Environment();
+    }
+
+    public function _after()
+    {
+        putenv('SOME_RANDOM_VALUE');
+    }
+
+    public function testDefaultValue()
+    {
+        $this->assertEquals(
+            'blah',
+            $this->testSubject->getValue('SOME_RANDOM_VALUE', 'blah')
+        );
+    }
+
+    /**
+     * @param $envValue
+     * @param $expectedValue
+     * @dataProvider _dpTestParseValues
+     */
+    public function testParseValues($envValue, $expectedValue)
+    {
+        putenv('SOME_RANDOM_VALUE=' . $envValue);
+
+        $this->assertSame(
+            $expectedValue,
+            $this->testSubject->getValue('SOME_RANDOM_VALUE')
+        );
+    }
+
+    public function _dpTestParseValues(): \Generator
+    {
+        yield 'Test Boolean - True - A' => [
+            "true",
+            true
+        ];
+
+        yield 'Test Boolean - True - B' => [
+            "(true)",
+            true
+        ];
+
+        yield 'Test Boolean - False - A' => [
+            "false",
+            false
+        ];
+
+        yield 'Test Boolean - False - B' => [
+            "(false)",
+            false
+        ];
+
+        yield 'Test Empty - A' => [
+            "empty",
+            ""
+        ];
+
+        yield 'Test Empty - B' => [
+            "(empty)",
+            ""
+        ];
+
+        yield 'Test Null - A' => [
+            "null",
+            null
+        ];
+
+        yield 'Test Null - B' => [
+            "(null)",
+            null
+        ];
+
+        yield 'Test Float' => [
+            '1.2',
+            1.2
+        ];
+
+        yield 'Test Alt Float' => [
+            '1.0',
+            1.0
+        ];
+
+        yield 'Test Integer' => [
+            '1',
+            1
+        ];
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

I will openly admit that I do not like Laravel for many different reasons. However, I must admit that there are certain 'features' of it that are typically handy. This PR is to add one such feature to Phalcon. Laravel has a general function called `env` that is used to retrieve env vars via getenv,  with defaults, and format them appropriately. Phalcon doesn't have an equivalent. 

This PR adds two new classes. The first is a base Environment class. The second is an Adapter for the ever popular PhpDotEnv from vlucas. It also updates the Factories to include the base environment by default.

Thanks

