### PR TITLE
redis adapter update: add persistent id for `pconnect()` method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ build/gccarch
 tests/_cache
 
 .php_cs.cache
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,3 @@ build/gccarch
 tests/_cache
 
 .php_cs.cache
-.idea

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -11,10 +11,7 @@
 - Fixed `Phalcon\Cache\InvalidArgumentException` to extend Phalcon\Exception
 - Fixed `Phalcon\Collection\Exception` to extend Phalcon\Exception
 - Fixed `Phalcon\Storage\Adapter\AbstractAdapter::initSerializer` to throw exception if `null === $this->serializerFactory && null === $this->serializer` [#14324](https://github.com/phalcon/cphalcon/issues/14324)
-
-## Fixed
 - Fixed `Phalcon\Storage\Adapter\Redis::getAdapter()` to provide a persistent id for redis persistent connection [#14334](https://github.com/phalcon/cphalcon/issues/14334)
-
 
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (2019-08-18)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -12,6 +12,10 @@
 - Fixed `Phalcon\Collection\Exception` to extend Phalcon\Exception
 - Fixed `Phalcon\Storage\Adapter\AbstractAdapter::initSerializer` to throw exception if `null === $this->serializerFactory && null === $this->serializer` [#14324](https://github.com/phalcon/cphalcon/issues/14324)
 
+## Fixed
+- Fixed `Phalcon\Storage\Adapter\Redis::getAdapter()` to provide a persistent id for redis persistent connection [#14334](https://github.com/phalcon/cphalcon/issues/14334)
+
+
 # [4.0.0-beta.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-beta.2) (2019-08-18)
 
 ## Fixed

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -110,20 +110,24 @@ class Redis extends AbstractAdapter
      */
     public function getAdapter() -> var
     {
-        var auth, connection, host, index, method, options,
-            persistent, port, result;
+        var auth, connection, host, index, options, port, result,
+            persistent, persistentid;
 
         if null === this->adapter {
             let options    = this->options,
                 connection = new \Redis(),
                 auth       = options["auth"],
                 host       = options["host"],
-                index      = options["index"],
-                persistent = options["persistent"],
                 port       = options["port"],
-                method     = persistent ? "pconnect" : "connect";
+                index      = options["index"],
+                persistent = options["persistent"];
 
-            let result = connection->{method}(host, port, this->lifetime);
+            if !persistent {
+                let result = connection->connect(host, port, this->lifetime);
+            } else {
+                let persistentid = "persistentid_" . index;
+                let result = connection->pconnect(host, port, this->lifetime, persistentid);
+            }
 
             if !result {
                 throw new Exception(


### PR DESCRIPTION
### Explain
Another old pull request https://github.com/phalcon/cphalcon/pull/14335 based on a wrong branch, so I close it and open the new one.
sorry, it's my first time to create a pull request.

### Description
we'd better have a persistent id for Redis pconnect() method.
cause without it we can't switch between multiple databases at in the same PHP process.
the data will always be saved to the last database without it.
as I know all Phalcon versions have this bug.

### Issue
* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14334