### PR TITLE
Adding Passback To DIC

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,7 @@
 - Changed `Phalcon\Flash\Direct` to allow `escaper` in the constructor [#14349](https://github.com/phalcon/cphalcon/issues/14349)
 - Changed `Phalcon\Flash\Session` to allow `escaper` in the constructor [#14349](https://github.com/phalcon/cphalcon/issues/14349)
 - Changed `Phalcon\Di\AbstractDIAware` to `Phalcon\Di\AbstractInjectionAware` [#14359](https://github.com/phalcon/cphalcon/issues/14359)
+- Changed `Phalcon\Di\Service` to use DI to initialize `string` based services when possible [#14342](https://github.com/phalcon/cphalcon/pull/14342)
 
 ## Fixed
 - Fixed `Phalcon\Helper\Str::includes` to return correct result [#14301](https://github.com/phalcon/cphalcon/issues/14301)

--- a/phalcon/Di/Service.zep
+++ b/phalcon/Di/Service.zep
@@ -134,11 +134,12 @@ class Service implements ServiceInterface
 
         let definition = this->definition;
         if typeof definition == "string" {
-
             /**
              * String definitions can be class names without implicit parameters
              */
-            if class_exists(definition) {
+            if container !== null {
+                let instance = container->get(definition, parameters);
+            } elseif class_exists(definition) {
                 if typeof parameters == "array" && count(parameters) {
                     let instance = create_instance_params(
                         definition,

--- a/tests/unit/Di/ServiceCest.php
+++ b/tests/unit/Di/ServiceCest.php
@@ -61,4 +61,23 @@ class ServiceCest
             $di->getService('notResolved')->isResolved()
         );
     }
+
+    public function testAlias(UnitTester $I)
+    {
+        $escaper = new Escaper();
+
+        $di = new Di();
+
+        $di->set(
+            'resolved',
+            Escaper::class
+        );
+
+        $di->set(Escaper::class, $escaper);
+
+        $I->assertSame(
+            $escaper,
+            $di->get('resolved')
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

I often find myself having to do the following:

```php
use Phalcon\Di;
use Other;
use Another;

$di = new Di();

$di->set('name', function () {
   return $this->get(Other::class);
});

if (true) {
     $di->set(Other::class, Another::class);
}

```

This PR eliminates the extra steps by letting the service class instantiate through the DIC. I can now right the code as:

```php

use Phalcon\Di;
use Other;
use Another;

$di = new Di();

$di->set('name', Other::class);
if (true) {
     $di->set(Other::class, Another::class);
}

```

Thanks

