### PR TITLE
Mvc\Model::snapshot data cast

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -35,6 +35,7 @@
 - Fixed `Phalcon\Mvc\Model\Query\Builder` Empty table alias in query [#14366](https://github.com/phalcon/cphalcon/issues/14366)
 - Fixed `Phalcon/Db/Adapter/PdoFactory` to reference the correct interface [#14381](https://github.com/phalcon/cphalcon/pull/14381)
 - Fixed `Phalcon/Db/Dialect/Mysql` Fixed missing schema in constraint for create table [#14378](https://github.com/phalcon/cphalcon/issues/14378)
+- Fixed `Phalcon\Mvc\Model::hasChanged()` and `getChangedFields()` returning false values when `castOnHydrate` option is on. [#14376](https://github.com/phalcon/cphalcon/issues/14376)
 
 ## Removed
 - Removed `Phalcon\Plugin` - duplicate of `Phalcon\DI\Injectable` [#14359](https://github.com/phalcon/cphalcon/issues/14359)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1511,6 +1511,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     public function getChangedFields() -> array
     {
         var metaData, name, snapshot, columnMap, allAttributes, value;
+        bool hasChanged;
         array changed;
 
         let snapshot = this->snapshot;
@@ -1564,6 +1565,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 let changed[] = name;
 
                 continue;
+            }
+
+            if globals_get("orm.cast_on_hydrate") {
+                let hasChanged = value != snapshot[name];
+            } else {
+                let hasChanged = value !== snapshot[name];
             }
 
             /**

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1511,7 +1511,6 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     public function getChangedFields() -> array
     {
         var metaData, name, snapshot, columnMap, allAttributes, value;
-        bool hasChanged;
         array changed;
 
         let snapshot = this->snapshot;
@@ -1567,16 +1566,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 continue;
             }
 
-            if globals_get("orm.cast_on_hydrate") {
-                let hasChanged = value != snapshot[name];
-            } else {
-                let hasChanged = value !== snapshot[name];
-            }
-
             /**
              * Check if the field has changed
              */
-            if hasChanged {
+            if value !== snapshot[name] {
                 let changed[] = name;
 
                 continue;

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -793,7 +793,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
 
             let attributeName = attribute[0],
-                instance->{attributeName} = castValue;
+                instance->{attributeName} = castValue,
+                data[key] = castValue;
         }
 
         /**
@@ -1568,7 +1569,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             /**
              * Check if the field has changed
              */
-            if value !== snapshot[name] {
+            if hasChanged {
                 let changed[] = name;
 
                 continue;

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1568,9 +1568,9 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
 
             if globals_get("orm.cast_on_hydrate") {
-                let hasChanged = value != snapshot[name];
-            } else {
                 let hasChanged = value !== snapshot[name];
+            } else {
+                let hasChanged = value != snapshot[name];
             }
 
             /**

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1568,9 +1568,9 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
 
             if globals_get("orm.cast_on_hydrate") {
-                let hasChanged = value !== snapshot[name];
-            } else {
                 let hasChanged = value != snapshot[name];
+            } else {
+                let hasChanged = value !== snapshot[name];
             }
 
             /**

--- a/tests/integration/Mvc/Model/HasChangedCest.php
+++ b/tests/integration/Mvc/Model/HasChangedCest.php
@@ -74,16 +74,6 @@ class HasChangedCest
             $robot->hasChanged('year')
         );
 
-        $robot->year = 1900;
-
-        /**
-         * Testing that default value is unchanged when
-         * an integer is set
-         */
-        $I->assertFalse(
-            $robot->hasChanged('year')
-        );
-
         /**
          * Any of multiple fields
          */

--- a/tests/integration/Mvc/Model/HasChangedCest.php
+++ b/tests/integration/Mvc/Model/HasChangedCest.php
@@ -74,6 +74,16 @@ class HasChangedCest
             $robot->hasChanged('year')
         );
 
+        $robot->year = 1900;
+
+        /**
+         * Testing that default value is unchanged when
+         * an integer is set
+         */
+        $I->assertFalse(
+            $robot->hasChanged('year')
+        );
+
         /**
          * Any of multiple fields
          */


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14376

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

When `orm.cast_on_hydrate` is on, I think `Model::cloneResultMap()` should save the casted values to the snapshot data.
If it's off, then `Model::getChangedFields()` should not use `===` to check if the field has changed.

Thanks,
zsilbi