### PR TITLE
[4.0.x] - Renamed the arrayToObject to toObject

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -16,7 +16,7 @@
 - Changed `Phalcon\Mvc\Router\Annotations` to be able to handle patterns az prefixes [#14259](https://github.com/phalcon/cphalcon/pull/14259)
 - Changed `Phalcon\Mvc\Router\Group::routes` to an array as default [#14259](https://github.com/phalcon/cphalcon/pull/14259)
 - Changed `Phalcon\Mvc\Model::assign` changed order of parameters to $data, $whiteList, $dataColumnMap [#14386](https://github.com/phalcon/cphalcon/pull/14386)
-
+- Changed `Phalcon\Helper\Arr::arrayToObject` to `toObject` [#14389](https://github.com/phalcon/cphalcon/pull/14389)
 
 ## Fixed
 - Fixed `Phalcon\Helper\Str::includes` to return correct result [#14301](https://github.com/phalcon/cphalcon/issues/14301)

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -342,7 +342,7 @@ class Arr
      */
     final public static function toObject(array! collection)
     {
-        return (object) returnObject;
+        return (object) collection;
     }
 
     /**

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -18,19 +18,6 @@ use stdClass;
  */
 class Arr
 {
-    final public static function arrayToObject(array! collection)
-    {
-        var returnObject, key, value;
-
-        let returnObject = new stdClass();
-
-        for key, value in collection {
-            let returnObject->{key} = value;
-        }
-
-        return returnObject;
-    }
-
     /**
      * Chunks an array into smaller arrays of a specified size.
      *
@@ -348,6 +335,14 @@ class Arr
             array_keys(collection),
             array_values(collection)
         ];
+    }
+
+    /**
+     * Returns the passed array as an object
+     */
+    final public static function toObject(array! collection)
+    {
+        return (object) returnObject;
     }
 
     /**

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -881,7 +881,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         }
 
         if hydrationMode != Resultset::HYDRATE_ARRAYS {
-            return Arr::arrayToObject(hydrateArray);
+            return Arr::toObject(hydrateArray);
         }
 
         return hydrateArray;

--- a/tests/unit/Helper/Arr/PluckCest.php
+++ b/tests/unit/Helper/Arr/PluckCest.php
@@ -46,8 +46,8 @@ class PluckCest
     {
         $I->wantToTest('Helper\Arr - pluck()');
         $collection = [
-            Arr::arrayToObject(['product_id' => 'prod-100', 'name' => 'Desk']),
-            Arr::arrayToObject(['product_id' => 'prod-200', 'name' => 'Chair']),
+            Arr::toObject(['product_id' => 'prod-100', 'name' => 'Desk']),
+            Arr::toObject(['product_id' => 'prod-200', 'name' => 'Chair']),
         ];
 
         $expected = ['Desk', 'Chair'];

--- a/tests/unit/Helper/Arr/ToObjectCest.php
+++ b/tests/unit/Helper/Arr/ToObjectCest.php
@@ -16,24 +16,24 @@ use Phalcon\Helper\Arr;
 use stdClass;
 use UnitTester;
 
-class ArrayToObjectCest
+class ToObjectCest
 {
     /**
-     * Unit Tests Phalcon\Helper\Arr :: arrayToObject()
+     * Unit Tests Phalcon\Helper\Arr :: toObject()
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-05-25
      */
     public function helperArrArrayToObject(UnitTester $I)
     {
-        $I->wantToTest('Helper\Arr - arrayToObject()');
+        $I->wantToTest('Helper\Arr - toObject()');
 
         $source = [
             'one'   => 'two',
             'three' => 'four',
         ];
 
-        $actual = Arr::arrayToObject($source);
+        $actual = Arr::toObject($source);
 
         $expected        = new stdClass();
         $expected->one   = 'two';


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Renamed the `arrayToObject` to `toObject` from the `Arr` helper

Thanks

