### PR TITLE
Use write connection on create to prevent replica lag.

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -36,6 +36,7 @@
 - Fixed `Phalcon/Db/Adapter/PdoFactory` to reference the correct interface [#14381](https://github.com/phalcon/cphalcon/pull/14381)
 - Fixed `Phalcon/Db/Dialect/Mysql` Fixed missing schema in constraint for create table [#14378](https://github.com/phalcon/cphalcon/issues/14378)
 - Fixed `Phalcon\Mvc\Model::hasChanged()` and `getChangedFields()` returning false values when `castOnHydrate` option is on. [#14376](https://github.com/phalcon/cphalcon/issues/14376)
+- Fixed `Phalcon\Mvc\Model::create()` Using write connection to prevent replica lag [#14256](https://github.com/phalcon/cphalcon/issues/14256)
 
 ## Removed
 - Removed `Phalcon\Plugin` - duplicate of `Phalcon\DI\Injectable` [#14359](https://github.com/phalcon/cphalcon/issues/14359)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -955,10 +955,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         let metaData = this->getModelsMetaData();
 
         /**
-         * Get the current connection
+         * Get the current connection use write to prevent replica lag
          * If the record already exists we must throw an exception
          */
-        if this->_exists(metaData, this->getReadConnection()) {
+        if this->_exists(metaData, this->getWriteConnection()) {
             let this->errorMessages = [
                 new Message(
                     "Record cannot be created because it already exists",


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14256

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Used write connection on checking existing record.

