### PR TITLE
Form attributes fixed

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -17,8 +17,9 @@
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setCurrentPage()` 
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setLimit()` 
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setRepository()` to return `AdapterInterface` instead of non existing `Adapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
-- Fixed `Phalcon\Translate\TranslateFactory::set()` to return `AdapterInterface` instead of non existing `AbstractAdapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
+- Fixed `Phalcon\Translate\TranslateFactory::set()` to return `AdapterInterface` instead of non existing `Abstractdapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
 - Fixed `Phalcon\Filter` to properly work with closures [#14417](https://github.com/phalcon/cphalcon/issues/14417)
+- Fixed `Phalcon\Form::setAction()` throwing error when called in `Form::initialize()` [#14421](https://github.com/phalcon/cphalcon/pull/14421)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -17,7 +17,7 @@
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setCurrentPage()` 
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setLimit()` 
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setRepository()` to return `AdapterInterface` instead of non existing `Adapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
-- Fixed `Phalcon\Translate\TranslateFactory::set()` to return `AdapterInterface` instead of non existing `Abstractdapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
+- Fixed `Phalcon\Translate\TranslateFactory::set()` to return `AdapterInterface` instead of non existing `AbstractAdapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
 - Fixed `Phalcon\Filter` to properly work with closures [#14417](https://github.com/phalcon/cphalcon/issues/14417)
 - Fixed `Phalcon\Form::setAction()` throwing error when called in `Form::initialize()` [#14421](https://github.com/phalcon/cphalcon/pull/14421)
 

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -64,16 +64,16 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         let this->options = userOptions;
 
         /**
+        * Set form attributes
+        */
+        this->setAttributes(new Attributes());
+
+        /**
          * Check for an 'initialize' method and call it
          */
         if method_exists(this, "initialize") {
             this->{"initialize"}(entity, userOptions);
         }
-
-        /**
-        * Set form attributes
-        */
-        this->setAttributes(new Attributes());
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

`Form::setAction()` fails when called in `Form::initialize()` because the default attributes are only set, after the `initialize()` had finished.

Thanks,
zsilbi

