### PR TITLE
T14426 server request segfault

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -27,6 +27,7 @@
 - Fixed `NOT BETWEEN` support in PHQL [#14253](https://github.com/phalcon/cphalcon/issues/14253)
 - Fixed `Phalcon\Storage\Adapter\Stream` to correctly serialize and unserialize data [#14408](https://github.com/phalcon/cphalcon/issues/14408)
 - Fixed `Phalcon\Storage\Serializer\Json` to throw an exception if storing an object [#14408](https://github.com/phalcon/cphalcon/issues/14408)
+- Fixed `Phalcon\Http\Message\ServerRequestFactory::load` to correctly handle superglobals that have not been defined [#14426](https://github.com/phalcon/cphalcon/issues/14426)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/phalcon/Http/Message/ServerRequestFactory.zep
+++ b/phalcon/Http/Message/ServerRequestFactory.zep
@@ -79,27 +79,24 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      * @see fromServer()
      */
     public function load(
-        array server = null,
-        array get = null,
-        array post = null,
-        array cookies = null,
-        array files = null
+        array server = [],
+        array get = [],
+        array post = [],
+        array cookies = [],
+        array files = []
     ) -> <ServerRequest> {
-        var cookies, filesCollection, headers, method, protocol, serverCollection;
+        var cookiesCollection, filesCollection, headers, method, protocol,
+            serverCollection;
 
-        let server           = this->checkNullArray(server, _SERVER),
-            files            = this->checkNullArray(files, _FILES),
-            cookies          = this->checkNullArray(cookies, _COOKIE),
-            get              = this->checkNullArray(get, _GET),
-            post             = this->checkNullArray(post, _POST),
-            serverCollection = this->parseServer(server),
-            method           = serverCollection->get("REQUEST_METHOD", "GET"),
-            protocol         = serverCollection->get("SERVER_PROTOCOL", "1.1"),
-            headers          = this->parseHeaders(serverCollection),
-            filesCollection  = this->parseUploadedFiles(files);
+        let serverCollection  = this->parseServer(server),
+            method            = serverCollection->get("REQUEST_METHOD", "GET"),
+            protocol          = serverCollection->get("SERVER_PROTOCOL", "1.1"),
+            headers           = this->parseHeaders(serverCollection),
+            filesCollection   = this->parseUploadedFiles(files),
+            cookiesCollection = cookies;
 
         if unlikely (empty(cookies) && headers->has("cookie")) {
-            let cookies = this->parseCookieHeader(headers->get("cookie"));
+            let cookiesCollection = this->parseCookieHeader(headers->get("cookie"));
         }
 
         return new ServerRequest(
@@ -108,7 +105,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             serverCollection->toArray(),
             "php://input",
             headers->toArray(),
-            cookies,
+            cookiesCollection,
             get,
             filesCollection->toArray(),
             post,
@@ -262,19 +259,6 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
         }
 
         return scheme;
-    }
-
-    /**
-     * Checks the source if it null and returns the super, otherwise the source
-     * array
-     */
-    private function checkNullArray(var source, array super) -> array
-    {
-        if unlikely null === source {
-            return super;
-        }
-
-        return source;
     }
 
     /**

--- a/phalcon/Storage/Serializer/Igbinary.zep
+++ b/phalcon/Storage/Serializer/Igbinary.zep
@@ -31,18 +31,20 @@ class Igbinary extends AbstractSerializer
 	 */
 	public function unserialize(var data) -> void
 	{
-        let this->warning = false;
-
+	    globals_set("warning.enable", false);
         set_error_handler(
             function (number, message, file, line, context) {
-                if number === E_WARNING {
-                    let this->warning = true;
-                }
-            }
+        	    globals_set("warning.enable", true);
+            },
+            E_WARNING
         );
 
 		let this->data = igbinary_unserialize(data);
 
         restore_error_handler();
+
+        if unlikely globals_get("warning.enable") {
+            let this->data = null;
+        }
     }
 }

--- a/tests/unit/Http/Message/ServerRequestFactory/LoadCest.php
+++ b/tests/unit/Http/Message/ServerRequestFactory/LoadCest.php
@@ -358,7 +358,7 @@ class LoadCest
         ];
 
         $factory = new ServerRequestFactory();
-        $request = $factory->load(null, null, null, null, $files);
+        $request = $factory->load([], [], [], [], $files);
 
         $actual = $request->getUploadedFiles();
 
@@ -407,7 +407,7 @@ class LoadCest
                 ];
 
                 $factory = new ServerRequestFactory();
-                $request = $factory->load(null, null, null, null, $files);
+                $request = $factory->load([], [], [], [], $files);
             }
         );
     }
@@ -441,7 +441,105 @@ class LoadCest
         $I->assertEquals('http', $uri->getScheme());
     }
 
+    /**
+     * Tests Phalcon\Http\Message\ServerRequestFactory :: load() - constructor
+     *
+     * @dataProvider getConstructorExamples
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-09-29
+     */
+    public function httpMessageServerRequestFactoryLoadConstructor(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Http\Message\ServerRequestFactory - load() - constructor ' . $example[0]);
 
+        $factory = new ServerRequestFactory();
+
+        $request = $factory->load($example[1], $example[2], $example[3], $example[4], $example[5]);
+        $I->assertInstanceOf(
+            ServerRequestInterface::class,
+            $request
+        );
+    }
+
+    /**
+     * Tests Phalcon\Http\Message\ServerRequestFactory :: load() - constructor - empty superglobals
+     *
+     * @dataProvider getConstructorExamples
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-09-29
+     */
+    public function httpMessageServerRequestFactoryLoadConstructorEmptySuperglobals(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Http\Message\ServerRequestFactory - load() - constructor - empty superglobals ' . $example[0]);
+
+        $factory = new ServerRequestFactory();
+
+        $request = $factory->load($example[1], $example[2], $example[3], $example[4], $example[5]);
+        $I->assertInstanceOf(
+            ServerRequestInterface::class,
+            $request
+        );
+    }
+
+    private function getConstructorExamples(): array
+    {
+        return [
+            [
+                'empty',
+                [],
+                [],
+                [],
+                [],
+                [],
+            ],
+            [
+                'server',
+                ['one' => 'two'],
+                [],
+                [],
+                [],
+                [],
+            ],
+            [
+                'get',
+                [],
+                ['one' => 'two'],
+                [],
+                [],
+                [],
+            ],
+            [
+                'post',
+                [],
+                [],
+                ['one' => 'two'],
+                [],
+                [],
+            ],
+            [
+                'cookie',
+                [],
+                [],
+                [],
+                ['one' => 'two'],
+                [],
+            ],
+            [
+                'files',
+                [],
+                [],
+                [],
+                [],
+                ['one' => 'two'],
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
     private function getServerNameExamples(): array
     {
         return [

--- a/tests/unit/Http/Message/ServerRequestFactory/LoadCest.php
+++ b/tests/unit/Http/Message/ServerRequestFactory/LoadCest.php
@@ -358,7 +358,7 @@ class LoadCest
         ];
 
         $factory = new ServerRequestFactory();
-        $request = $factory->load([], [], [], [], $files);
+        $request = $factory->load(null, null, null, null, $files);
 
         $actual = $request->getUploadedFiles();
 
@@ -407,7 +407,7 @@ class LoadCest
                 ];
 
                 $factory = new ServerRequestFactory();
-                $request = $factory->load([], [], [], [], $files);
+                $request = $factory->load(null, null, null, null, $files);
             }
         );
     }
@@ -483,55 +483,58 @@ class LoadCest
         );
     }
 
+    /**
+     * @return array
+     */
     private function getConstructorExamples(): array
     {
         return [
             [
                 'empty',
-                [],
-                [],
-                [],
-                [],
-                [],
+                null,
+                null,
+                null,
+                null,
+                null,
             ],
             [
                 'server',
                 ['one' => 'two'],
-                [],
-                [],
-                [],
-                [],
+                null,
+                null,
+                null,
+                null,
             ],
             [
                 'get',
-                [],
+                null,
                 ['one' => 'two'],
-                [],
-                [],
-                [],
+                null,
+                null,
+                null,
             ],
             [
                 'post',
-                [],
-                [],
+                null,
+                null,
                 ['one' => 'two'],
-                [],
-                [],
+                null,
+                null,
             ],
             [
                 'cookie',
-                [],
-                [],
-                [],
+                null,
+                null,
+                null,
                 ['one' => 'two'],
-                [],
+                null,
             ],
             [
                 'files',
-                [],
-                [],
-                [],
-                [],
+                null,
+                null,
+                null,
+                null,
                 ['one' => 'two'],
             ],
         ];

--- a/tests/unit/Http/Message/ServerRequestFactory/LoadCest.php
+++ b/tests/unit/Http/Message/ServerRequestFactory/LoadCest.php
@@ -455,7 +455,27 @@ class LoadCest
 
         $factory = new ServerRequestFactory();
 
+        $server = $_SERVER;
+        $get    = $_GET;
+        $post   = $_POST;
+        $cookie = $_COOKIE;
+        $files  = $_FILES;
+
+        unset($_SERVER);
+        unset($_GET);
+        unset($_POST);
+        unset($_COOKIE);
+        unset($_FILES);
+
         $request = $factory->load($example[1], $example[2], $example[3], $example[4], $example[5]);
+
+        $_SERVER = $server;
+        $_GET    = $get;
+        $_POST   = $post;
+        $_COOKIE = $cookie;
+        $_FILES  = $files;
+
+
         $I->assertInstanceOf(
             ServerRequestInterface::class,
             $request


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14426 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Http\Message\ServerRequestFactory::load` to correctly handle superglobals that have not been defined

Thanks

