### PR TITLE
Fixed $model->countRelated() failing when the relation is reusable

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -35,7 +35,7 @@
 - Fixed `Phalcon\Firewall\Adapter\AdapterInterface::getRoleCallback` and `Phalcon\Firewall\Adapter\AbstractAdapter::setRoleCallback` to correctly accept and return a `Closure` [#14450](https://github.com/phalcon/cphalcon/issues/14450)
 - Fixed `Phalcon\Events\Event::__constructor` to correctly accept an `object` as the `source` parameter [#14449](https://github.com/phalcon/cphalcon/issues/14449)
 - Fixed `Phalcon\Cache::checkKey()` added `.` to key characters pattern [#14457](https://github.com/phalcon/cphalcon/pull/14457)
-- Fixed `Phalcon\Mvc\Model` to store reusable related records correctly. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
+- Fixed `Phalcon\Mvc\Model\Manager` to store reusable related records correctly. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
 - Fixed `Phalcon\Mvc\Model::__call()` not to throw an exception when the return value is `null` for related records. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
 
 ## Removed

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -35,6 +35,8 @@
 - Fixed `Phalcon\Firewall\Adapter\AdapterInterface::getRoleCallback` and `Phalcon\Firewall\Adapter\AbstractAdapter::setRoleCallback` to correctly accept and return a `Closure` [#14450](https://github.com/phalcon/cphalcon/issues/14450)
 - Fixed `Phalcon\Events\Event::__constructor` to correctly accept an `object` as the `source` parameter [#14449](https://github.com/phalcon/cphalcon/issues/14449)
 - Fixed `Phalcon\Cache::checkKey()` added `.` to key characters pattern [#14457](https://github.com/phalcon/cphalcon/pull/14457)
+- Fixed `Phalcon\Mvc\Model` to store reusable related records correctly. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
+- Fixed `Phalcon\Mvc\Model::__call()` not to throw an exception when the return value is `null` for related records. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -199,7 +199,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          */
         let records = this->_getRelatedRecords(modelName, method, arguments);
 
-        if records !== null {
+        if records !== false {
             return records;
         }
 
@@ -4080,7 +4080,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              * Return if the relation was not found because getRelated() throws an exception if the relation is unknown
              */
             if typeof relation != "object" {
-                return null;
+                return false;
             }
 
             return this->getRelated(alias, extraArgs);
@@ -4101,7 +4101,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              * If the relation was found perform the query via the models manager
              */
             if typeof relation != "object" {
-                return null;
+                return false;
             }
 
             return manager->getRelationRecords(
@@ -4112,7 +4112,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             );
         }
 
-        return null;
+        return false;
     }
 
     /**

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4050,12 +4050,16 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     }
 
     /**
-     * Returns related records defined relations depending on the method name
+     * Returns related records defined relations depending on the method name.
+     * Returns false if the relation is non-existent.
      *
-     * @param array arguments
-     * @return mixed
+     * @param string modelName
+     * @param string method
+     * @param array  arguments
+     *
+     * @return ResultsetInterface|ModelInterface|bool|null
      */
-    protected function _getRelatedRecords(string! modelName, string! method, var arguments)
+    protected function _getRelatedRecords(string! modelName, string! method, array! arguments)
     {
         var manager, relation, queryMethod, extraArgs, alias;
 
@@ -4077,7 +4081,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 );
 
             /**
-             * Return if the relation was not found because getRelated() throws an exception if the relation is unknown
+             * Return if the relation was not found because getRelated()
+             * throws an exception if the relation is unknown
              */
             if typeof relation != "object" {
                 return false;

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -188,7 +188,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         let records = self::_invokeFinder(method, arguments);
 
-        if records !== null {
+        if records !== false {
             return records;
         }
 
@@ -4246,7 +4246,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         let modelName = get_called_class();
 
         if !extraMethod {
-            return null;
+            return false;
         }
 
         if unlikely !fetch value, arguments[0] {

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1404,8 +1404,6 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
             let retrieveMethod = method;
         }
 
-        let arguments = [findParams];
-
         /**
          * Find first results could be reusable
          */
@@ -1419,6 +1417,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
                 return records;
             }
         }
+
+        let arguments = [findParams];
 
         /**
          * Load the referenced model

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1412,7 +1412,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         let reusable = (bool) relation->isReusable();
 
         if reusable {
-            let uniqueKey = unique_key(referencedModel, arguments),
+            let uniqueKey = unique_key(referencedModel, [findParams, retrieveMethod]),
                 records = this->getReusableRecords(referencedModel, uniqueKey);
 
             if typeof records == "array" || typeof records == "object" {

--- a/tests/_data/fixtures/models/Robots.php
+++ b/tests/_data/fixtures/models/Robots.php
@@ -26,5 +26,16 @@ class Robots extends Model
                 'foreignKey' => true,
             ]
         );
+
+        $this->hasMany(
+            'id',
+            RobotsParts::class,
+            'robots_id',
+            [
+                'alias' => 'reusableRobotsParts',
+                'foreignKey' => true,
+                'reusable' => true
+            ]
+        );
     }
 }

--- a/tests/_data/fixtures/models/RobotsReusable.php
+++ b/tests/_data/fixtures/models/RobotsReusable.php
@@ -17,6 +17,8 @@ class RobotsReusable extends Model
 {
     public function initialize()
     {
+        $this->setSource('robots');
+
         $this->hasMany(
             'id',
             RobotsParts::class,

--- a/tests/_data/fixtures/models/RobotsReusable.php
+++ b/tests/_data/fixtures/models/RobotsReusable.php
@@ -13,7 +13,7 @@ namespace Phalcon\Test\Models;
 
 use Phalcon\Mvc\Model;
 
-class Robots extends Model
+class RobotsReusable extends Model
 {
     public function initialize()
     {
@@ -24,6 +24,7 @@ class Robots extends Model
             [
                 'alias' => 'robotsParts',
                 'foreignKey' => true,
+                'reusable' => true
             ]
         );
     }

--- a/tests/integration/Mvc/Model/UnderscoreCallCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreCallCest.php
@@ -116,23 +116,23 @@ class UnderscoreCallCest
         /**
          * Reusable has-many relationship
          */
-        $reusableRobot = Models\Robots::findFirst();
+        $reusableRobot = Models\RobotsReusable::findFirst();
 
-        $reusableRobotParts = $reusableRobot->getReusableRobotsParts();
+        $reusableRobotParts = $reusableRobot->getRobotsParts();
 
         $I->assertInstanceOf(
             \Phalcon\Mvc\Model\Resultset\Simple::class,
             $reusableRobotParts
         );
 
-        $countReusableRobotParts = $reusableRobot->countReusableRobotsParts();
+        $countReusableRobotParts = $reusableRobot->countRobotsParts();
 
         $I->assertEquals(
             $reusableRobotParts->count(),
             $countReusableRobotParts
         );
 
-        $nonExistentReusableRobotParts = $reusableRobot->getReusableRobotsParts(
+        $nonExistentReusableRobotParts = $reusableRobot->getRobotsParts(
             [
                 'id < 0',
                 'order' => 'id DESC',

--- a/tests/integration/Mvc/Model/UnderscoreCallCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreCallCest.php
@@ -94,6 +94,13 @@ class UnderscoreCallCest
             $robotParts
         );
 
+        $countRobotParts = $robot->countRobotsParts();
+
+        $I->assertEquals(
+            $robotParts->count(),
+            $countRobotParts
+        );
+
         $nonExistentRobotParts = $robot->getRobotsParts(
             [
                 'id < 0',
@@ -104,6 +111,37 @@ class UnderscoreCallCest
         $I->assertEquals(
             0,
             $nonExistentRobotParts->count()
+        );
+
+        /**
+         * Reusable has-many relationship
+         */
+        $reusableRobot = Models\Robots::findFirst();
+
+        $reusableRobotParts = $reusableRobot->getReusableRobotsParts();
+
+        $I->assertInstanceOf(
+            \Phalcon\Mvc\Model\Resultset\Simple::class,
+            $reusableRobotParts
+        );
+
+        $countReusableRobotParts = $reusableRobot->countReusableRobotsParts();
+
+        $I->assertEquals(
+            $reusableRobotParts->count(),
+            $countReusableRobotParts
+        );
+
+        $nonExistentReusableRobotParts = $reusableRobot->getReusableRobotsParts(
+            [
+                'id < 0',
+                'order' => 'id DESC',
+            ]
+        );
+
+        $I->assertEquals(
+            0,
+            $nonExistentReusableRobotParts->count()
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

The `uniqueKey` used to store reusable related records in `ModelsManager` is currently generated only from the conditions used to lookup the records.

For example:
It uses the same key for `$robot->getParts(["some" = "thing"])` and `$robot->countParts(["some" = "thing"])`. 
If the related records are accessed again using a different method, it will return the result of the first.
In this case, it will be a `Resultset` instead of an `integer`.

I added the `retrieveMethod` variable to the `uniqueKey` generation.
Added some tests for `Model::__call()`

Thanks,
zsilbi
