### PR TITLE
Fixed return type on Phalcon\Mvc\View\Engine\AbstractEngine::partial

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -30,6 +30,7 @@
 - Fixed `Phalcon\Forms\Form` to initialize attributes object if not initialized [#14430](https://github.com/phalcon/cphalcon/issues/14430)
 - Fixed `Phalcon\Http\Message\ServerRequestFactory::load` to correctly detect the protocol passed from `$_SERVER` [#14432](https://github.com/phalcon/cphalcon/issues/14432)
 - Fixed `Phalcon\Cli\Router\Route` added missing `Phalcon\Cli\Router\RouteInterface`
+- Fixed incorrect return types on `Phalcon\Mvc\View\Engine\AbstractEngine::partial` and `Phalcon\Mvc\View\Engine\EngineInterface::partial` [#14429](https://github.com/phalcon/cphalcon/issues/14429)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/phalcon/Mvc/View/Engine/AbstractEngine.zep
+++ b/phalcon/Mvc/View/Engine/AbstractEngine.zep
@@ -52,8 +52,8 @@ abstract class AbstractEngine extends Injectable implements EngineInterface
      *
      * @param array params
      */
-    public function partial(string! partialPath, var params = null) -> string
+    public function partial(string! partialPath, var params = null) -> void
     {
-        return this->view->partial(partialPath, params);
+        this->view->partial(partialPath, params);
     }
 }

--- a/phalcon/Mvc/View/Engine/EngineInterface.zep
+++ b/phalcon/Mvc/View/Engine/EngineInterface.zep
@@ -23,7 +23,7 @@ interface EngineInterface
     /**
      * Renders a partial inside another view
      */
-    public function partial(string! partialPath, var params = null) -> string;
+    public function partial(string! partialPath, var params = null) -> void;
 
     /**
      * Renders a view using the template engine


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14429

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of the change: This issue has only come up now because return types weren't being enforced in Phalcon 3.

Thanks

