### PR TITLE
Added development Zephir to the build matrix [skip appveyor]

### DIFF
--- a/.ci/install-zephir.sh
+++ b/.ci/install-zephir.sh
@@ -33,7 +33,6 @@ then
 else
   git clone -b "$ZEPHIR_VERSION" --depth 1 -q https://github.com/phalcon/zephir
   cd zephir || exit 1
-  echo "composer install ${DEFAULT_COMPOSER_FLAGS[*]}"
-  eval "composer install ${DEFAULT_COMPOSER_FLAGS[*]}"
+  eval "composer install $DEFAULT_COMPOSER_FLAGS"
   ln -s "$(pwd)/zephir" "$HOME/bin/zephir"
 fi

--- a/.ci/install-zephir.sh
+++ b/.ci/install-zephir.sh
@@ -32,7 +32,8 @@ then
   chmod +x "$HOME/bin/zephir"
 else
   git clone -b "$ZEPHIR_VERSION" --depth 1 -q https://github.com/phalcon/zephir
-  cd zephir || exit
-  composer install "$DEFAULT_COMPOSER_FLAGS"
+  cd zephir || exit 1
+  echo "composer install ${DEFAULT_COMPOSER_FLAGS[*]}"
+  eval "composer install ${DEFAULT_COMPOSER_FLAGS[*]}"
   ln -s "$(pwd)/zephir" "$HOME/bin/zephir"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,7 @@ before_script:
   - 'if [ "$(php-config --vernum)" -ge "70400" ]; then export REPORT_COVERAGE=0; fi'
   - .ci/genparsers.sh
   - .ci/build.sh
+  - zephir --version
 
 script:
   - vendor/bin/codecept build --quiet

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ env:
     - REPORT_COVERAGE=1
     - PATH="${HOME}/.composer/vendor/bin:${PATH}"
     - TRAVIS_COMMIT_LOG="$(git log --format=fuller -5)"
+    - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-ansi --no-progress --no-suggest"
 
 before_install:
   - |
@@ -59,12 +60,10 @@ before_install:
     [ -d ~/bin ] || mkdir ~/bin
     export PHP_PEAR_PHP_BIN="$(phpenv which php)"
 
-    DEFAULT_COMPOSER_FLAGS=("--no-interaction" "--no-ansi" "--no-progress" "--no-suggest")
     if [ "$(php-config --vernum)" -ge "70400" ]
     then
-      DEFAULT_COMPOSER_FLAGS+=("--ignore-platform-reqs")
+      export DEFAULT_COMPOSER_FLAGS="$DEFAULT_COMPOSER_FLAGS --ignore-platform-reqs"
     fi
-    export DEFAULT_COMPOSER_FLAGS
 
     # Hide "You are in 'detached HEAD' state" message
     git config --global advice.detachedHead false
@@ -75,7 +74,7 @@ install:
   - .ci/setup-dbs.sh
   - .ci/install-zephir.sh
   - .ci/install-php-extensions.sh
-  - travis_retry composer install ${DEFAULT_COMPOSER_FLAGS[*]}
+  - eval "composer install $DEFAULT_COMPOSER_FLAGS"
 
 before_script:
   - cat .ci/travis.ini >> "$(phpenv prefix)/etc/conf.d/travis.ini"
@@ -103,7 +102,7 @@ jobs:
       env:
         - REPORT_COVERAGE=0
       install:
-        - travis_retry composer install ${DEFAULT_COMPOSER_FLAGS[*]} --ignore-platform-reqs
+        - eval "composer install $DEFAULT_COMPOSER_FLAGS --ignore-platform-reqs"
       before_script:
         - phpenv config-rm xdebug.ini || true
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ matrix:
   fast_finish: true
   allow_failures:
     - php: '7.4snapshot'
+    - env: ZEPHIR_VERSION="development"
 
 cache:
   timeout: 604800
@@ -92,6 +93,10 @@ script:
 
 jobs:
   include:
+    - stage: Development Zephir version
+      php: '7.3'
+      env:
+        - ZEPHIR_VERSION="development"
     - stage: Static Code Analysis
       php: '7.2'
       env:


### PR DESCRIPTION
Add development version of Zephir to the build matrix. This will allow us to know whether we're ready for the latest, development version or not