### PR TITLE
Fix/cache key 

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -34,6 +34,7 @@
 - Fixed `Phalcon\Firewall\Adapter\AbstractAdapter::getRoleCallback` and `Phalcon\Firewall\Adapter\AbstractAdapter::setRoleCallback` to correctly accept and return a `Closure` [#14450](https://github.com/phalcon/cphalcon/issues/14450)
 - Fixed `Phalcon\Firewall\Adapter\AdapterInterface::getRoleCallback` and `Phalcon\Firewall\Adapter\AbstractAdapter::setRoleCallback` to correctly accept and return a `Closure` [#14450](https://github.com/phalcon/cphalcon/issues/14450)
 - Fixed `Phalcon\Events\Event::__constructor` to correctly accept an `object` as the `source` parameter [#14449](https://github.com/phalcon/cphalcon/issues/14449)
+- Fixed `Phalcon\Cache::checkKey()` added `.` to key characters pattern [#14457](https://github.com/phalcon/cphalcon/pull/14457)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/phalcon/Cache.zep
+++ b/phalcon/Cache.zep
@@ -205,7 +205,7 @@ class Cache implements CacheInterface
     {
         let key = (string) key;
 
-        if preg_match("/[^A-Za-z0-9-_]/", key) {
+        if preg_match("/[^A-Za-z0-9-_.]/", key) {
             throw new InvalidArgumentException(
                 "The key contains invalid characters"
             );

--- a/tests/unit/Cache/Cache/GetSetCest.php
+++ b/tests/unit/Cache/Cache/GetSetCest.php
@@ -39,6 +39,7 @@ class GetSetCest
 
         $key1 = uniqid();
         $key2 = uniqid();
+        $key3 = 'key.'.uniqid();
 
 
         $adapter->set($key1, 'test');
@@ -54,6 +55,12 @@ class GetSetCest
             $adapter->has($key2)
         );
 
+        $adapter->set($key3, 'test');
+
+        $I->assertTrue(
+            $adapter->has($key3)
+        );
+
         $I->assertEquals(
             'test',
             $adapter->get($key1)
@@ -62,6 +69,11 @@ class GetSetCest
         $I->assertEquals(
             'test',
             $adapter->get($key2)
+        );
+
+        $I->assertEquals(
+            'test',
+            $adapter->get($key3)
         );
     }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change: added missed `.` to key pattern
[see](https://www.php-fig.org/psr/psr-16/#12-definitions)

Thanks
