### PR TITLE
WIP: Update params for deep assoc completion plugin

### DIFF
--- a/phalcon/Annotations/Adapter/Apcu.zep
+++ b/phalcon/Annotations/Adapter/Apcu.zep
@@ -35,6 +35,11 @@ class Apcu extends AbstractAdapter
     protected ttl = 172800;
 
     /**
+     * @param array options = [
+     *     'prefix' => 'phalcon'
+     *     'lifetime' => 3600
+     * ]
+     *
      * Phalcon\Annotations\Adapter\Apcu constructor
      */
     public function __construct(array options = [])

--- a/phalcon/Annotations/Adapter/Stream.zep
+++ b/phalcon/Annotations/Adapter/Stream.zep
@@ -35,6 +35,10 @@ class Stream extends AbstractAdapter
     protected annotationsDir = "./";
 
     /**
+     * @param array options = [
+     *     'annotationsDir' => 'phalconDir'
+     * ]
+     *
      * Phalcon\Annotations\Adapter\Stream constructor
      */
     public function __construct(array options = [])

--- a/phalcon/Annotations/AnnotationsFactory.zep
+++ b/phalcon/Annotations/AnnotationsFactory.zep
@@ -28,6 +28,15 @@ class AnnotationsFactory extends AbstractFactory
     }
 
     /**
+     * @param array|\Phalcon\Config config = [
+     *     'adapter' => 'apcu',
+     *     'options' => [
+     *         'prefix' => 'phalcon',
+     *         'lifetime' => 3600,
+     *         'annotationsDir' => 'phalconDir'
+     *     ]
+     * ]
+     *
      * Factory to create an instace from a Config object
      */
     public function load(var config) -> var

--- a/phalcon/Annotations/AnnotationsFactory.zep
+++ b/phalcon/Annotations/AnnotationsFactory.zep
@@ -55,6 +55,12 @@ class AnnotationsFactory extends AbstractFactory
 
     /**
      * Create a new instance of the adapter
+     *
+     * @param array options = [
+     *     'prefix' => 'phalcon',
+     *     'lifetime' => 3600,
+     *     'annotationsDir' => 'phalconDir'
+     * ]
      */
     public function newInstance(string! name, array! options = []) -> <AbstractAdapter>
     {

--- a/phalcon/Cache/AdapterFactory.zep
+++ b/phalcon/Cache/AdapterFactory.zep
@@ -37,6 +37,27 @@ class AdapterFactory extends AbstractFactory
 
     /**
      * Create a new instance of the adapter
+     *
+     * @param array options = [
+     *     'servers' => [
+     *         [
+     *             'host' => 'localhost',
+     *             'port' => 11211,
+     *             'weight' => 1,
+     *         ]
+     *     ],
+     *     'host' => '127.0.0.1',
+     *     'port' => 6379,
+     *     'index' => 0,
+     *     'persistent' => false,
+     *     'auth' => '',
+     *     'socket' => '',
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => 'phalcon',
+     *     'storageDir' => ''
+     * ]
      */
     public function newInstance(string! name, array! options = []) -> <AdapterInterface>
     {

--- a/phalcon/Cache/CacheFactory.zep
+++ b/phalcon/Cache/CacheFactory.zep
@@ -40,13 +40,28 @@ class CacheFactory
      * Factory to create an instace from a Config object
      *
      * @param array|\Phalcon\Config config = [
-     *      'adapter' => 'apcu',
-     *      'options' => [
-     *          'defaultSerializer' => 'Php',
-     *          'lifetime' => 3600,
-     *          'serializer' => null,
-     *          'prefix' => 'phalcon'
-     *      ]
+     *     'adapter' => 'apcu',
+     *     'options' => [
+     *         'servers' => [
+     *             [
+     *                 'host' => 'localhost',
+     *                 'port' => 11211,
+     *                 'weight' => 1,
+     *
+     *             ]
+     *         ],
+     *         'host' => '127.0.0.1',
+     *         'port' => 6379,
+     *         'index' => 0,
+     *         'persistent' => false,
+     *         'auth' => '',
+     *         'socket' => '',
+     *         'defaultSerializer' => 'Php',
+     *         'lifetime' => 3600,
+     *         'serializer' => null,
+     *         'prefix' => 'phalcon',
+     *         'storageDir' => ''
+     *     ]
      * ]
      */
     public function load(var config) -> var
@@ -77,6 +92,28 @@ class CacheFactory
 
     /**
      * Constructs a new Cache instance.
+     *
+     * @param array options = [
+     *     'servers' => [
+     *         [
+     *             'host' => 'localhost',
+     *             'port' => 11211,
+     *             'weight' => 1,
+
+     *         ]
+     *     ],
+     *     'host' => '127.0.0.1',
+     *     'port' => 6379,
+     *     'index' => 0,
+     *     'persistent' => false,
+     *     'auth' => '',
+     *     'socket' => '',
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => 'phalcon',
+     *     'storageDir' => ''
+     * ]
      */
     public function newInstance(string! name, array! options = []) -> <CacheInterface>
     {

--- a/phalcon/Cache/CacheFactory.zep
+++ b/phalcon/Cache/CacheFactory.zep
@@ -38,6 +38,16 @@ class CacheFactory
 
     /**
      * Factory to create an instace from a Config object
+     *
+     * @param array|\Phalcon\Config config = [
+     *      'adapter' => 'apcu',
+     *      'options' => [
+     *          'defaultSerializer' => 'Php',
+     *          'lifetime' => 3600,
+     *          'serializer' => null,
+     *          'prefix' => 'phalcon'
+     *      ]
+     * ]
      */
     public function load(var config) -> var
     {

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -48,6 +48,13 @@ class ConfigFactory extends AbstractFactory
 
     /**
      * Load a config to create a new instance
+     *
+     * @param string|array|\Phalcon\Config config = [
+     *      'adapter' => 'ini',
+     *      'filePath' => 'config.ini',
+     *      'mode' => null,
+     *      'callbacks' => null
+     * ]
      */
     public function load(config) -> object
     {

--- a/phalcon/Db/Adapter/AbstractAdapter.zep
+++ b/phalcon/Db/Adapter/AbstractAdapter.zep
@@ -104,6 +104,18 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
 
     /**
      * Phalcon\Db\Adapter constructor
+     *
+     * @param array descriptor = [
+     *     'host' => 'localhost',
+     *     'port' => '3306',
+     *     'dbname' => 'blog',
+     *     'username' => 'sigma'
+     *     'password' => 'secret',
+     *     'dialectClass' => null,
+     *     'options' => [],
+     *     'dsn' => null,
+     *     'charset' => 'utf8mb4'
+     * ]
      */
     public function __construct(array! descriptor)
     {

--- a/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
+++ b/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
@@ -51,6 +51,18 @@ abstract class AbstractPdo extends AbstractAdapter
 
     /**
      * Constructor for Phalcon\Db\Adapter\Pdo
+     *
+     * @param array|\Phalcon\Config descriptor = [
+     *     'host' => 'localhost',
+     *     'port' => '3306',
+     *     'dbname' => 'blog',
+     *     'username' => 'sigma'
+     *     'password' => 'secret'
+     *     'dialectClass' => null,
+     *     'options' => [],
+     *     'dsn' => null,
+     *     'charset' => 'utf8mb4'
+     * ]
      */
     public function __construct(array! descriptor)
     {

--- a/phalcon/Db/Adapter/PdoFactory.zep
+++ b/phalcon/Db/Adapter/PdoFactory.zep
@@ -26,6 +26,21 @@ class PdoFactory extends AbstractFactory
 
     /**
      * Factory to create an instace from a Config object
+     *
+     * @param array|\Phalcon\Config config = [
+     *     'adapter' => 'mysql',
+     *     'options' => [
+     *         'host' => 'localhost',
+     *         'port' => '3306',
+     *         'dbname' => 'blog',
+     *         'username' => 'sigma'
+     *         'password' => 'secret',
+     *         'dialectClass' => null,
+     *         'options' => [],
+     *         'dsn' => null,
+     *         'charset' => 'utf8mb4'
+     *     ]
+     * ]
      */
     public function load(var config) -> var
     {

--- a/phalcon/Image/ImageFactory.zep
+++ b/phalcon/Image/ImageFactory.zep
@@ -30,6 +30,13 @@ class ImageFactory extends AbstractFactory
 
     /**
      * Factory to create an instace from a Config object
+     *
+     * @param array|\Phalcon\Config config = [
+     *     'adapter' => 'gd',
+     *     'file' => 'image.jpg',
+     *     'height' => null,
+     *     'width' => null
+     * ]
      */
     public function load(var config) -> <AdapterInterface>
     {

--- a/phalcon/Logger/Adapter/Stream.zep
+++ b/phalcon/Logger/Adapter/Stream.zep
@@ -63,6 +63,10 @@ class Stream extends AbstractAdapter
 
     /**
      * Constructor. Accepts the name and some options
+     *
+     * @param array options = [
+     *     'mode' => 'ab'
+     * ]
      */
     public function __construct(string! name, array options = [])
     {

--- a/phalcon/Logger/Adapter/Syslog.zep
+++ b/phalcon/Logger/Adapter/Syslog.zep
@@ -71,6 +71,10 @@ class Syslog extends AbstractAdapter
 
     /**
      * Phalcon\Logger\Adapter\Syslog constructor
+     * @param array options = [
+     *     'option' => null,
+     *     'facility' => null
+     * ]
      */
     public function __construct(string! name, array options = [])
     {

--- a/phalcon/Logger/LoggerFactory.zep
+++ b/phalcon/Logger/LoggerFactory.zep
@@ -34,6 +34,19 @@ class LoggerFactory
 
     /**
      * Factory to create an instace from a Config object
+     *
+     * @param array|\Phalcon\Config config = [
+     *     'name' => 'messages',
+     *     'adapters' => [
+     *         'adapter' => 'stream',
+     *         'name' => 'file.log',
+     *         'options' => [
+     *             'mode' => 'ab',
+     *             'option' => null,
+     *             'facility' => null
+     *         ]
+     *     ]
+     * ]
      */
     public function load(var config) -> var
     {

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1316,6 +1316,24 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * $transaction1->rollback();
      * $transaction2->rollback();
      * ```
+     *
+     * @param arrray|string|int|null parameters = [
+     *     'conditions' => ''
+     *     'columns' => '',
+     *     'bind' => [],
+     *     'bindTypes => [],
+     *     'order' => '',
+     *     'limit' => 10,
+     *     'offset' => 5,
+     *     'group' => 'name, status',
+     *     'for_updated' => false,
+     *     'shared_lock' => false,
+     *     'cache' => [
+     *         'lifetime' => 3600,
+     *         'key' => 'my-find-key'
+     *     ],
+     *     'hydration' => null
+     * ]
      */
     public static function find(var parameters = null) -> <ResultsetInterface>
     {
@@ -1416,7 +1434,23 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * );
      * ```
      *
-     * @param string|array parameters
+     * @param arrray|string|int|null parameters = [
+     *     'conditions' => ''
+     *     'columns' => '',
+     *     'bind' => [],
+     *     'bindTypes => [],
+     *     'order' => '',
+     *     'limit' => 10,
+     *     'offset' => 5,
+     *     'group' => 'name, status',
+     *     'for_updated' => false,
+     *     'shared_lock' => false,
+     *     'cache' => [
+     *         'lifetime' => 3600,
+     *         'key' => 'my-find-key'
+     *     ],
+     *     'hydration' => null
+     * ]
      */
     public static function findFirst(var parameters = null) -> <ModelInterface> | bool
     {
@@ -4958,6 +4992,33 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *     }
      * }
      *```
+     *
+     * @param array|null options = [
+     *     'reusable' => false,
+     *     'alias' => 'someAlias',
+     *     'foreignKey' => [
+     *         'message' => null,
+     *         'allowNulls' => false,
+     *         'action' => null
+     *     ],
+     *     'params' => [
+     *         'conditions' => ''
+     *         'columns' => '',
+     *         'bind' => [],
+     *         'bindTypes => [],
+     *         'order' => '',
+     *         'limit' => 10,
+     *         'offset' => 5,
+     *         'group' => 'name, status',
+     *         'for_updated' => false,
+     *         'shared_lock' => false,
+     *         'cache' => [
+     *             'lifetime' => 3600,
+     *             'key' => 'my-find-key'
+     *         ],
+     *         'hydration' => null
+     *     ]
+     * ]
      */
     protected function belongsTo(var fields, string! referenceModel, var referencedFields, options = null) -> <Relation>
     {
@@ -5043,6 +5104,33 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *     }
      * }
      *```
+     *
+     * @param array|null options = [
+     *     'reusable' => false,
+     *     'alias' => 'someAlias',
+     *     'foreignKey' => [
+     *         'message' => null,
+     *         'allowNulls' => false,
+     *         'action' => null
+     *     ],
+     *     'params' => [
+     *         'conditions' => ''
+     *         'columns' => '',
+     *         'bind' => [],
+     *         'bindTypes => [],
+     *         'order' => '',
+     *         'limit' => 10,
+     *         'offset' => 5,
+     *         'group' => 'name, status',
+     *         'for_updated' => false,
+     *         'shared_lock' => false,
+     *         'cache' => [
+     *             'lifetime' => 3600,
+     *             'key' => 'my-find-key'
+     *         ],
+     *         'hydration' => null
+     *     ]
+     * ]
      */
     protected function hasMany(var fields, string! referenceModel, var referencedFields, options = null) -> <Relation>
     {
@@ -5082,6 +5170,33 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * @param    string|array intermediateReferencedFields
      * @param    string|array referencedFields
      * @param    array options
+     *
+     * @param array|null options = [
+     *     'reusable' => false,
+     *     'alias' => 'someAlias',
+     *     'foreignKey' => [
+     *         'message' => null,
+     *         'allowNulls' => false,
+     *         'action' => null
+     *     ],
+     *     'params' => [
+     *         'conditions' => ''
+     *         'columns' => '',
+     *         'bind' => [],
+     *         'bindTypes => [],
+     *         'order' => '',
+     *         'limit' => 10,
+     *         'offset' => 5,
+     *         'group' => 'name, status',
+     *         'for_updated' => false,
+     *         'shared_lock' => false,
+     *         'cache' => [
+     *             'lifetime' => 3600,
+     *             'key' => 'my-find-key'
+     *         ],
+     *         'hydration' => null
+     *     ]
+     * ]
      */
     protected function hasManyToMany(var fields, string! intermediateModel, var intermediateFields, var intermediateReferencedFields,
         string! referenceModel, var referencedFields, options = null) -> <Relation>
@@ -5114,6 +5229,33 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *     }
      * }
      *```
+     *
+     * @param array|null options = [
+     *     'reusable' => false,
+     *     'alias' => 'someAlias',
+     *     'foreignKey' => [
+     *         'message' => null,
+     *         'allowNulls' => false,
+     *         'action' => null
+     *     ],
+     *     'params' => [
+     *         'conditions' => ''
+     *         'columns' => '',
+     *         'bind' => [],
+     *         'bindTypes => [],
+     *         'order' => '',
+     *         'limit' => 10,
+     *         'offset' => 5,
+     *         'group' => 'name, status',
+     *         'for_updated' => false,
+     *         'shared_lock' => false,
+     *         'cache' => [
+     *             'lifetime' => 3600,
+     *             'key' => 'my-find-key'
+     *         ],
+     *         'hydration' => null
+     *     ]
+     * ]
      */
     protected function hasOne(var fields, string! referenceModel, var referencedFields, options = null) -> <Relation>
     {

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -128,6 +128,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *     Router::POSITION_FIRST
      * );
      *```
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function add(string! pattern, var paths = null, var httpMethods = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -145,6 +152,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is CONNECT
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addConnect(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -153,6 +167,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is DELETE
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addDelete(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -161,6 +182,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is GET
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addGet(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -169,6 +197,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is HEAD
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addHead(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -177,6 +212,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Add a route to the router that only match if the HTTP method is OPTIONS
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addOptions(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -185,6 +227,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is PATCH
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPatch(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -193,6 +242,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is POST
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPost(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -202,6 +258,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     /**
      * Adds a route to the router that only match if the HTTP method is PURGE
      * (Squid and Varnish support)
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPurge(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -210,6 +273,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is PUT
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPut(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {
@@ -218,6 +288,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     /**
      * Adds a route to the router that only match if the HTTP method is TRACE
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addTrace(string! pattern, var paths = null, var position = Router::POSITION_LAST) -> <RouteInterface>
     {

--- a/phalcon/Mvc/Router/Group.zep
+++ b/phalcon/Mvc/Router/Group.zep
@@ -86,6 +86,13 @@ class Group implements GroupInterface
      *```php
      * $router->add("/about", "About::index");
      *```
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function add(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
     {
@@ -95,7 +102,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is CONNECT
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addConnect(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -105,7 +117,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is DELETE
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addDelete(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -115,7 +132,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is GET
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addGet(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -125,7 +147,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is HEAD
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addHead(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -135,7 +162,12 @@ class Group implements GroupInterface
     /**
      * Add a route to the router that only match if the HTTP method is OPTIONS
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addOptions(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -145,7 +177,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is PATCH
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPatch(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -155,7 +192,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is POST
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPost(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -165,7 +207,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is PURGE
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPurge(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -175,7 +222,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is PUT
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addPut(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -185,7 +237,12 @@ class Group implements GroupInterface
     /**
      * Adds a route to the router that only match if the HTTP method is TRACE
      *
-     * @param string|array paths
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     public function addTrace(string! pattern, var paths = null) -> <RouteInterface>
     {
@@ -284,6 +341,13 @@ class Group implements GroupInterface
 
     /**
      * Adds a route applying the common attributes
+     *
+     * @param string|array paths = [
+     *     'module => '',
+     *     'controller' => '',
+     *     'action' => '',
+     *     'namespace' => ''
+     * ]
      */
     protected function addRoute(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
     {

--- a/phalcon/Paginator/Adapter/QueryBuilder.zep
+++ b/phalcon/Paginator/Adapter/QueryBuilder.zep
@@ -52,6 +52,12 @@ class QueryBuilder extends AbstractAdapter
 
     /**
      * Phalcon\Paginator\Adapter\QueryBuilder
+     *
+     * @param array config = [
+     *     'limit' => 10,
+     *     'builder' => null,
+     *     'columns' => ''
+     * ]
      */
     public function __construct(array config)
     {

--- a/phalcon/Paginator/PaginatorFactory.zep
+++ b/phalcon/Paginator/PaginatorFactory.zep
@@ -48,7 +48,10 @@ class PaginatorFactory extends AbstractFactory
      *```
      *
      * @param array|\Phalcon\Config = [
-     *
+     *     'adapter' => 'queryBuilder',
+     *     'limit' => 20,
+     *     'page' => 1,
+     *     'builder' => null
      * ]
      */
     public function load(var config) -> var

--- a/phalcon/Paginator/PaginatorFactory.zep
+++ b/phalcon/Paginator/PaginatorFactory.zep
@@ -46,6 +46,10 @@ class PaginatorFactory extends AbstractFactory
      *
      * $paginator = (new PaginatorFactory())->load($options);
      *```
+     *
+     * @param array|\Phalcon\Config = [
+     *
+     * ]
      */
     public function load(var config) -> var
     {

--- a/phalcon/Session/Adapter/Libmemcached.zep
+++ b/phalcon/Session/Adapter/Libmemcached.zep
@@ -20,6 +20,21 @@ class Libmemcached extends AbstractAdapter
 {
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'servers' => [
+     *         [
+     *             'host' => 'localhost',
+     *             'port' => 11211,
+     *             'weight' => 1,
+     *
+     *         ]
+     *     ],
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => 'sess-memc-'
+     * ]
      */
     public function __construct(<AdapterFactory> factory, array! options = [])
     {

--- a/phalcon/Session/Adapter/Noop.zep
+++ b/phalcon/Session/Adapter/Noop.zep
@@ -58,6 +58,10 @@ class Noop implements SessionHandlerInterface
 
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'prefix' => ''
+     * ]
      */
     public function __construct(array! options = [])
     {

--- a/phalcon/Session/Adapter/Redis.zep
+++ b/phalcon/Session/Adapter/Redis.zep
@@ -20,6 +20,16 @@ use Phalcon\Session\Adapter\AbstractAdapter;
 {
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'prefix' => 'sess-reds-',
+     *     'host' => '127.0.0.1',
+     *     'port' => 6379,
+     *     'index' => 0,
+     *     'persistent' => false,
+     *     'auth' => '',
+     *     'socket' => ''
+     * ]
      */
     public function __construct(<AdapterFactory> factory, array! options = [])
     {

--- a/phalcon/Session/Adapter/Stream.zep
+++ b/phalcon/Session/Adapter/Stream.zep
@@ -40,6 +40,14 @@ class Stream extends Noop
      */
     private path = "";
 
+    /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'prefix' => '',
+     *     'savePath' => ''
+     * ]
+     */
     public function __construct(array! options = [])
     {
         var path, options;

--- a/phalcon/Session/Manager.zep
+++ b/phalcon/Session/Manager.zep
@@ -47,6 +47,10 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
 
     /**
      * Manager constructor.
+     *
+     * @param array options = [
+     *     'uniqueId' => null
+     * ]
      */
     public function __construct(array options = [])
     {

--- a/phalcon/Storage/Adapter/AbstractAdapter.zep
+++ b/phalcon/Storage/Adapter/AbstractAdapter.zep
@@ -60,6 +60,13 @@ abstract class AbstractAdapter implements AdapterInterface
 
     /**
      * Sets parameters based on options
+     *
+     * @param array options = [
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => ''
+     * ]
      */
     protected function __construct(<SerializerFactory> factory = null, array! options)
     {

--- a/phalcon/Storage/Adapter/Apcu.zep
+++ b/phalcon/Storage/Adapter/Apcu.zep
@@ -29,6 +29,13 @@ class Apcu extends AbstractAdapter
 
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => ''
+     * ]
      */
     public function __construct(<SerializerFactory> factory = null, array! options = [])
     {

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -29,7 +29,19 @@ class Libmemcached extends AbstractAdapter
     /**
      * Libmemcached constructor.
      *
-     * @param array $options
+     * @param array options = [
+     *     'servers' => [
+     *         [
+     *             'host' => '127.0.0.1',
+     *             'port' => 11211,
+     *             'weight' => 1
+     *         ]
+     *     ],
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => ''
+     * ]
      */
     public function __construct(<SerializerFactory> factory = null, array! options = [])
     {

--- a/phalcon/Storage/Adapter/Memory.zep
+++ b/phalcon/Storage/Adapter/Memory.zep
@@ -34,6 +34,13 @@ class Memory extends AbstractAdapter
 
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => ''
+     * ]
      */
     public function __construct(<SerializerFactory> factory = null, array! options = [])
     {

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -28,6 +28,19 @@ class Redis extends AbstractAdapter
 
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'host' => '127.0.0.1',
+     *     'port' => 6379,
+     *     'index' => 0,
+     *     'persistent' => false,
+     *     'auth' => '',
+     *     'socket' => '',
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => ''
+     * ]
      */
     public function __construct(<SerializerFactory> factory = null, array! options = [])
     {

--- a/phalcon/Storage/Adapter/Stream.zep
+++ b/phalcon/Storage/Adapter/Stream.zep
@@ -44,7 +44,13 @@ class Stream extends AbstractAdapter
     /**
      * Stream constructor.
      *
-     * @param array $options
+     * @param array options = [
+     *     'storageDir' => '',
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => ''
+     * ]
      *
      * @throws Exception
      */

--- a/phalcon/Storage/AdapterFactory.zep
+++ b/phalcon/Storage/AdapterFactory.zep
@@ -33,6 +33,27 @@ class AdapterFactory extends AbstractFactory
 
     /**
      * Create a new instance of the adapter
+     *
+     * @param array options = [
+     *     'servers' => [
+     *         [
+     *             'host' => '127.0.0.1',
+     *             'port' => 11211,
+     *             'weight' => 1
+     *         ]
+     *     ],
+     *     'defaultSerializer' => 'Php',
+     *     'lifetime' => 3600,
+     *     'serializer' => null,
+     *     'prefix' => '',
+     *     'host' => '127.0.0.1',
+     *     'port' => 6379,
+     *     'index' => 0,
+     *     'persistent' => false,
+     *     'auth' => '',
+     *     'socket' => '',
+     *     'storageDir' => '',
+     * ]
      */
     public function newInstance(string! name, array! options = []) -> <AbstractAdapter>
     {

--- a/phalcon/Tag.zep
+++ b/phalcon/Tag.zep
@@ -82,6 +82,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="check"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
      */
     public static function checkField(var parameters) -> string
     {
@@ -90,6 +97,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="color"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
      */
     public static function colorField(var parameters) -> string
     {
@@ -98,6 +112,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="date"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
      */
     public static function dateField(var parameters) -> string
     {
@@ -106,6 +127,13 @@ class Tag
 
     /**
     * Builds a HTML input[type="datetime"] tag
+    *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
     */
     public static function dateTimeField(var parameters) -> string
     {
@@ -114,6 +142,13 @@ class Tag
 
     /**
     * Builds a HTML input[type="datetime-local"] tag
+    *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
     */
     public static function dateTimeLocalField(var parameters) -> string
     {
@@ -130,6 +165,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="email"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
      */
     public static function emailField(var parameters) -> string
     {
@@ -146,6 +188,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="file"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     *     'value' => ''
+     * ]
      */
     public static function fileField(var parameters) -> string
     {
@@ -154,6 +203,15 @@ class Tag
 
     /**
      * Builds a HTML FORM tag
+     *
+     * @param array parameters = [
+     *     'method' => 'post',
+     *     'action' => '',
+     *     'parameters' => '',
+     *     'name' => '',
+     *     'class' => '',
+     *     'id' => ''
+     * ]
      */
     public static function form(var parameters) -> string
     {
@@ -492,6 +550,14 @@ class Tag
 
     /**
      * Builds a HTML input[type="hidden"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
      */
     public static function hiddenField(var parameters) -> string
     {
@@ -500,6 +566,13 @@ class Tag
 
     /**
      * Builds HTML IMG tags
+     *
+     * @param array|string parameters = [
+     *     'src' => '',
+     *     'class' => '',
+     *     'id' => '',
+     *     'name' => ''
+     * ]
      */
     public static function image(var parameters = null, bool local = true) -> string
     {
@@ -546,6 +619,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="image"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => ''
+     * ]
      */
     public static function imageInput(var parameters) -> string
     {
@@ -554,6 +634,13 @@ class Tag
 
     /**
      * Builds a SCRIPT[type="javascript"] tag
+     *
+     * @param array|string parameters = [
+     *     'local' => false,
+     *     'src' => '',
+     *     'type' => 'text/javascript'
+     *     'rel' => ''
+     * ]
      */
     public static function javascriptInclude(var parameters = null, bool local = true) -> string
     {
@@ -602,6 +689,17 @@ class Tag
 
     /**
      * Builds a HTML A tag using framework conventions
+     *
+     * @param parameters array|string = [
+     *     'action' => '',
+     *     'text' => '',
+     *     'local' => false,
+     *     'query' => '',
+     *     'class' => '',
+     *     'name' => '',
+     *     'href' => '',
+     *     'id' => ''
+     * ]
      */
     public static function linkTo(parameters, text = null, local = true) -> string
     {
@@ -653,6 +751,14 @@ class Tag
 
     /**
      * Builds a HTML input[type="month"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
      */
     public static function monthField(var parameters) -> string
     {
@@ -661,6 +767,14 @@ class Tag
 
     /**
      * Builds a HTML input[type="number"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
      */
     public static function numericField(var parameters) -> string
     {
@@ -670,6 +784,14 @@ class Tag
 
     /**
      * Builds a HTML input[type="password"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
      */
     public static function passwordField(var parameters) -> string
     {
@@ -694,6 +816,14 @@ class Tag
 
     /**
      * Builds a HTML input[type="radio"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
      */
     public static function radioField(var parameters) -> string
     {
@@ -702,6 +832,14 @@ class Tag
 
     /**
     * Builds a HTML input[type="range"] tag
+    *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
     */
     public static function rangeField(var parameters) -> string
     {
@@ -710,6 +848,19 @@ class Tag
 
     /**
      * Renders parameters keeping order in their HTML attributes
+     *
+     * @param array attributes = [
+     *     'rel' => null,
+     *     'type' => null,
+     *     'for' => null,
+     *     'src' => null,
+     *     'href' => null,
+     *     'action' => null,
+     *     'id' => null,
+     *     'name' => null,
+     *     'value' => null,
+     *     'class' => null
+     * ]
      */
     public static function renderAttributes(string! code, array! attributes) -> string
     {
@@ -794,6 +945,14 @@ class Tag
 
     /**
      * Builds a HTML input[type="search"] tag
+     *
+     * @param array parameters = [
+     *     'class' => '',
+     *     'name' => '',
+     *     'src' => '',
+     *     'id' => '',
+     *     'value' => ''
+     * ]
      */
     public static function searchField(var parameters) -> string
     {
@@ -802,6 +961,15 @@ class Tag
 
     /**
      * Builds a HTML SELECT tag using a Phalcon\Mvc\Model resultset as options
+     *
+     * @param array parameters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'useEmpty' => false,
+     *     'emptyValue' => '',
+     *     'emptyText' => '',
+     * ]
      */
     public static function select(var parameters, data = null) -> string
     {
@@ -810,6 +978,15 @@ class Tag
 
     /**
      * Builds a HTML SELECT tag using a PHP array for options
+     *
+     * @param array parameters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'useEmpty' => false,
+     *     'emptyValue' => '',
+     *     'emptyText' => '',
+     * ]
      */
     public static function selectStatic(parameters, data = null) -> string
     {
@@ -1017,6 +1194,13 @@ class Tag
 
     /**
     * Builds a HTML input[type="tel"] tag
+    *
+    * @param array parameters = [
+    *     'id' => '',
+    *     'name' => '',
+    *     'value' => '',
+    *     'class' => ''
+    * ]
     */
     public static function telField(var parameters) -> string
     {
@@ -1025,6 +1209,13 @@ class Tag
 
     /**
      * Builds a HTML TEXTAREA tag
+     *
+     * @paraym array parameters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'class' => ''
+     * ]
      */
     public static function textArea(var parameters) -> string
     {
@@ -1074,6 +1265,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="text"] tag
+     *
+     * @param array parameters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'class' => ''
+     * ]
      */
     public static function textField(var parameters) -> string
     {
@@ -1082,6 +1280,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="time"] tag
+     *
+     * @param array paramters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'class' => ''
+     * ]
      */
     public static function timeField(var parameters) -> string
     {
@@ -1090,6 +1295,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="url"] tag
+     *
+     * @param array paramters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'class' => ''
+     * ]
      */
     public static function urlField(var parameters) -> string
     {
@@ -1098,6 +1310,13 @@ class Tag
 
     /**
      * Builds a HTML input[type="week"] tag
+     *
+     * @param array parameters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'class' => ''
+     * ]
      */
     public static function weekField(var parameters) -> string
     {
@@ -1106,6 +1325,14 @@ class Tag
 
     /**
      * Builds generic INPUT tags
+     *
+     * @param array paramters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'class' => '',
+     *     'type' => ''
+     * ]
      */
     static final protected function inputField(string type, parameters, bool asValue = false) -> string
     {

--- a/phalcon/Tag/Select.zep
+++ b/phalcon/Tag/Select.zep
@@ -26,7 +26,14 @@ abstract class Select
     /**
      * Generates a SELECT tag
      *
-     * @param array parameters
+     * @param array parameters = [
+     *     'id' => '',
+     *     'name' => '',
+     *     'value' => '',
+     *     'useEmpty' => false,
+     *     'emptyValue' => '',
+     *     'emptyText' => '',
+     * ]
      * @param array data
      */
     public static function selectField(parameters, data = null) -> string

--- a/phalcon/Translate/Adapter/Csv.zep
+++ b/phalcon/Translate/Adapter/Csv.zep
@@ -29,6 +29,12 @@ class Csv extends AbstractAdapter implements ArrayAccess
 
     /**
      * Phalcon\Translate\Adapter\Csv constructor
+     *
+     * @param array options = [
+     *     'content' => '',
+     *     'delimiter' => ';',
+     *     'enclosure' => '"'
+     * ]
      */
     public function __construct(<InterpolatorFactory> interpolator, array! options)
     {

--- a/phalcon/Translate/Adapter/Gettext.zep
+++ b/phalcon/Translate/Adapter/Gettext.zep
@@ -57,6 +57,13 @@ class Gettext extends AbstractAdapter implements ArrayAccess
 
     /**
      * Phalcon\Translate\Adapter\Gettext constructor
+     *
+     * @param array options = [
+     *     'locale' => '',
+     *     'defaultDomain' => '',
+     *     'directory' => '',
+     *     'category' => ''
+     * ]
      */
     public function __construct(<InterpolatorFactory> interpolator, array! options)
     {

--- a/phalcon/Translate/Adapter/NativeArray.zep
+++ b/phalcon/Translate/Adapter/NativeArray.zep
@@ -34,6 +34,11 @@ class NativeArray extends AbstractAdapter implements ArrayAccess
 
     /**
      * Phalcon\Translate\Adapter\NativeArray constructor
+     *
+     * @param array options = [
+     *     'content' => '',
+     *     'triggerError' => false
+     * ]
      */
     public function __construct(<InterpolatorFactory> interpolator, array! options)
     {

--- a/phalcon/Translate/TranslateFactory.zep
+++ b/phalcon/Translate/TranslateFactory.zep
@@ -35,6 +35,20 @@ class TranslateFactory extends AbstractFactory
 
     /**
      * Factory to create an instace from a Config object
+     *
+     * @param array|\Phalcon\Config = [
+     *     'adapter' => 'ini,
+     *     'options' => [
+     *         'content' => '',
+     *         'delimiter' => ';',
+     *         'enclosure' => '"',
+     *         'locale' => '',
+     *         'defaultDomain' => '',
+     *         'directory' => '',
+     *         'category' => ''
+     *         'triggerError' => false
+     *     ]
+     * ]
      */
     public function load(var config) -> var
     {

--- a/phalcon/Url.zep
+++ b/phalcon/Url.zep
@@ -93,6 +93,10 @@ class Url extends AbstractInjectionAware implements UrlInterface
      *     false
      * );
      *```
+     *
+     * @param array|string uri = [
+     *     'for' => '',
+     * ]
      */
     public function get(var uri = null, var args = null, bool local = null, var baseUri = null) -> string
     {
@@ -241,6 +245,10 @@ class Url extends AbstractInjectionAware implements UrlInterface
      *     ]
      * );
      *```
+     *
+     * @param array|string uri = [
+     *     'for' => ''
+     * ]
      */
     public function getStatic(var uri = null) -> string
     {

--- a/phalcon/Validation/Validator/Alnum.zep
+++ b/phalcon/Validation/Validator/Alnum.zep
@@ -52,6 +52,20 @@ class Alnum extends AbstractValidator
     protected template = "Field :field must contain only letters and numbers";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Alpha.zep
+++ b/phalcon/Validation/Validator/Alpha.zep
@@ -53,6 +53,20 @@ class Alpha extends AbstractValidator
     protected template = "Field :field must contain only letters";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Between.zep
+++ b/phalcon/Validation/Validator/Between.zep
@@ -64,6 +64,22 @@ class Between extends AbstractValidator
     protected template = "Field :field must be within the range of :min to :max";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'minimum' => 5,
+     *     'maximum' => 50,
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Callback.zep
+++ b/phalcon/Validation/Validator/Callback.zep
@@ -64,6 +64,21 @@ class Callback extends AbstractValidator
     protected template = "Field :field must match the callback function";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'callback' => null,
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Confirmation.zep
+++ b/phalcon/Validation/Validator/Confirmation.zep
@@ -59,6 +59,23 @@ class Confirmation extends AbstractValidator
     protected template = "Field :field must be the same as :with";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'with' => '',
+     *     'labelWith' => '',
+     *     'ignoreCase' => false,
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/CreditCard.zep
+++ b/phalcon/Validation/Validator/CreditCard.zep
@@ -53,6 +53,20 @@ class CreditCard extends AbstractValidator
     protected template = "Field :field is not valid for a credit card number";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Date.zep
+++ b/phalcon/Validation/Validator/Date.zep
@@ -59,6 +59,21 @@ class Date extends AbstractValidator
     protected template = "Field :field is not a valid date";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'format' => 'Y-m-d',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Digit.zep
+++ b/phalcon/Validation/Validator/Digit.zep
@@ -53,6 +53,20 @@ class Digit extends AbstractValidator
     protected template = "Field :field must be numeric";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Email.zep
+++ b/phalcon/Validation/Validator/Email.zep
@@ -51,6 +51,21 @@ use Phalcon\Validation\AbstractValidator;
 class Email extends AbstractValidator
 {
     protected template = "Field :field must be an email address";
+
+    /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
     /**
      * Executes the validation
      */

--- a/phalcon/Validation/Validator/ExclusionIn.zep
+++ b/phalcon/Validation/Validator/ExclusionIn.zep
@@ -65,6 +65,22 @@ class ExclusionIn extends AbstractValidator
     protected template = "Field :field must not be a part of list: :domain";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'domain' => [],
+     *     'strct' => false,
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/File.zep
+++ b/phalcon/Validation/Validator/File.zep
@@ -93,6 +93,28 @@ class File extends AbstractValidatorComposite
 {
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'messageMinSize' => '',
+     *     'includedMinSize' => false,
+     *     'minSize' => 100,
+     *     'maxSize' => 1000,
+     *     'messageSize' => '',
+     *     'includedSize' => false,
+     *     'equalSize' => '',
+     *     'messageEqualSize' => '',
+     *     'allowedTypes' => [],
+     *     'messageType' => '',
+     *     'maxResolution' => '1000x1000',
+     *     'messageMaxResolution' => '',
+     *     'includedMaxResolution' => false,
+     *     'minResolution => '500x500',
+     *     'includedMinResolution' => false,
+     *     'messageMinResolution' => '',
+     *     'equalResolution' => '1000x1000',
+     *     'messageEqualResolution' => '',
+     *     'allowEmpty' => false
+     * ]
      */
     public function __construct(array! options = [])
     {

--- a/phalcon/Validation/Validator/File/Resolution/Equal.zep
+++ b/phalcon/Validation/Validator/File/Resolution/Equal.zep
@@ -58,6 +58,20 @@ class Equal extends AbstractFile
     protected template = "The resolution of the field :field has to be equal :resolution";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'resolution' => '1000x1000'
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/File/Resolution/Max.zep
+++ b/phalcon/Validation/Validator/File/Resolution/Max.zep
@@ -63,6 +63,21 @@ class Max extends AbstractFile
     protected template = "File :field exceeds the maximum resolution of :resolution";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'resolution' => '1000x1000',
+     *     'included' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/File/Resolution/Min.zep
+++ b/phalcon/Validation/Validator/File/Resolution/Min.zep
@@ -63,6 +63,21 @@ class Min extends AbstractFile
     protected template = "File :field can not have the minimum resolution of :resolution";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'resolution' => '1000x1000',
+     *     'included' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/File/Size/Equal.zep
+++ b/phalcon/Validation/Validator/File/Size/Equal.zep
@@ -63,6 +63,20 @@ class Equal extends AbstractFile
     protected template = "File :field does not have the exact :size filesize";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'size' => '2.5MB'
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/File/Size/Max.zep
+++ b/phalcon/Validation/Validator/File/Size/Max.zep
@@ -63,6 +63,21 @@ class Max extends AbstractFile
     protected template = "File :field exceeds the size of :size";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'size' => '2.5MB',
+     *     'included' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/File/Size/Min.zep
+++ b/phalcon/Validation/Validator/File/Size/Min.zep
@@ -63,6 +63,21 @@ class Min extends AbstractFile
     protected template = "File :field can not have the minimum size of :size";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'size' => '2.5MB',
+     *     'included' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Identical.zep
+++ b/phalcon/Validation/Validator/Identical.zep
@@ -58,6 +58,22 @@ class Identical extends AbstractValidator
     protected template = "Field :field does not have the expected value";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'accepted' => '',
+     *     'value' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/InclusionIn.zep
+++ b/phalcon/Validation/Validator/InclusionIn.zep
@@ -59,6 +59,22 @@ class InclusionIn extends AbstractValidator
     protected template = "Field :field must be a part of list: :domain";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'domain' => [],
+     *     'strict' => false,
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Ip.zep
+++ b/phalcon/Validation/Validator/Ip.zep
@@ -73,6 +73,22 @@ class Ip extends AbstractValidator
     protected template = "Field :field must be a valid IP address";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowPrivate' => false,
+     *     'allowReserved' => false,
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Numericality.zep
+++ b/phalcon/Validation/Validator/Numericality.zep
@@ -53,6 +53,20 @@ class Numericality extends AbstractValidator
     protected template = "Field :field does not have a valid numeric format";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/PresenceOf.zep
+++ b/phalcon/Validation/Validator/PresenceOf.zep
@@ -53,6 +53,20 @@ class PresenceOf extends AbstractValidator
     protected template = "Field :field is required";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Regex.zep
+++ b/phalcon/Validation/Validator/Regex.zep
@@ -58,6 +58,21 @@ class Regex extends AbstractValidator
     protected template = "Field :field does not match the required format";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false,
+     *     'pattern' => ''
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/StringLength.zep
+++ b/phalcon/Validation/Validator/StringLength.zep
@@ -83,6 +83,17 @@ class StringLength extends AbstractValidatorComposite
 {
     /**
      * Constructor
+     *
+     * @param array options = [
+     *     'min' => 100,
+     *     'message' => '',
+     *     'messageMinimum' => '',
+     *     'included' => '',
+     *     'includedMinimum' => false,
+     *     'max' => 1000,
+     *     'messageMaximum' => '',
+     *     'includedMaximum' => false
+     * ]
      */
     public function __construct(array! options = [])
     {

--- a/phalcon/Validation/Validator/StringLength/Max.zep
+++ b/phalcon/Validation/Validator/StringLength/Max.zep
@@ -66,6 +66,22 @@ class Max extends AbstractValidator
     protected template = "Field :field must not exceed :max characters long";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false,
+     *     'max' => 1000,
+     *     'included' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/StringLength/Min.zep
+++ b/phalcon/Validation/Validator/StringLength/Min.zep
@@ -66,6 +66,22 @@ class Min extends AbstractValidator
     protected template = "Field :field must be at least :min characters long";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false,
+     *     'min' => 1000,
+     *     'included' => false
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Uniqueness.zep
+++ b/phalcon/Validation/Validator/Uniqueness.zep
@@ -96,6 +96,23 @@ class Uniqueness extends AbstractCombinedFieldsValidator
     private columnMap = null;
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false,
+     *     'convert' => null,
+     *     'model' => null,
+     *     'except' => null
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/phalcon/Validation/Validator/Url.zep
+++ b/phalcon/Validation/Validator/Url.zep
@@ -53,6 +53,21 @@ class Url extends AbstractValidator
     protected template = "Field :field must be a url";
 
     /**
+     * Constructor
+     *
+     * @param array options = [
+     *     'message' => '',
+     *     'template' => '',
+     *     'allowEmpty' => false,
+     *     'options' => []
+     * ]
+     */
+    public function __construct(array! options = [])
+    {
+        parent::__construct(options);
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool


### PR DESCRIPTION
Hello!

* Type: new feature | documentation
* Link to issue:https://github.com/phalcon/cphalcon/issues/13991

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR - not needed really, needs to check generated stubs
- [x] I have updated the relevant CHANGELOG - not required since it doesn't add any new feature
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change - no documentation change required

Small description of change: it adds `@param array config` etc on all methods having things like options, config etc with all keys which are accepted in those arrays, using plugin https://github.com/klesun/deep-assoc-completion for phpstorm it will autocomplete it in all usages of those methods.

Thanks

