### PR TITLE
T14464 cast on arr collection

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,4 +1,7 @@
 # [4.0.0-rc.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.2) (2019-XX-XX)
+## Added
+- Added `cast` parameter to `Phalcon\Collection::get` and `Phalcon\Helper\Arr::get` allowing developers to cast the result returned to the type they want to. [#14465](https://github.com/phalcon/cphalcon/pull/14465)
+
 ## Changed
 - Changed all calls to `new <object>` to use the `create_instance` or `create_instance_params` for better performance. [#14419](https://github.com/phalcon/cphalcon/pull/14419)
 

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -117,7 +117,7 @@ class Collection implements
     public function get(
         string element,
         var defaultValue = null,
-        string! cast = null
+        var cast = null
     ) -> var {
         var key, value;
 
@@ -131,7 +131,7 @@ class Collection implements
 
         let value = this->data[key];
 
-        if unlikely null !== cast {
+        if unlikely typeof cast === "string" {
             settype(value, cast);
         }
 

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -114,21 +114,38 @@ class Collection implements
     /**
      * Get the element from the collection
      */
-    public function get(string element, defaultValue = null) -> var
+    public function get(string element, defaultValue = null, string cast = null) -> var
     {
-        var key;
+        var key, value;
+        array casts;
 
         if likely this->insensitive {
             let element = element->lower();
         }
 
-        if likely isset this->lowerKeys[element] {
-            let key = this->lowerKeys[element];
-
-            return this->data[key];
+        if unlikely !fetch key, this->lowerKeys[element] {
+            return defaultValue;
         }
 
-        return defaultValue;
+        let value = this->data[key],
+            casts = [
+            "array"   : 1,
+            "bool"    : 1,
+            "boolean" : 1,
+            "double"  : 1,
+            "float"   : 1,
+            "int"     : 1,
+            "integer" : 1,
+            "null"    : 1,
+            "object"  : 1,
+            "string"  : 1
+        ];
+
+        if unlikely isset casts[cast] {
+            settype(value, cast);
+        }
+
+        return value;
     }
 
     /**

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -114,10 +114,12 @@ class Collection implements
     /**
      * Get the element from the collection
      */
-    public function get(string element, defaultValue = null, string cast = null) -> var
-    {
+    public function get(
+        string element,
+        var defaultValue = null,
+        string! cast = null
+    ) -> var {
         var key, value;
-        array casts;
 
         if likely this->insensitive {
             let element = element->lower();
@@ -127,21 +129,9 @@ class Collection implements
             return defaultValue;
         }
 
-        let value = this->data[key],
-            casts = [
-            "array"   : 1,
-            "bool"    : 1,
-            "boolean" : 1,
-            "double"  : 1,
-            "float"   : 1,
-            "int"     : 1,
-            "integer" : 1,
-            "null"    : 1,
-            "object"  : 1,
-            "string"  : 1
-        ];
+        let value = this->data[key];
 
-        if unlikely isset casts[cast] {
+        if unlikely null !== cast {
             settype(value, cast);
         }
 

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -117,7 +117,7 @@ class Collection implements
     public function get(
         string element,
         var defaultValue = null,
-        var cast = null
+        string! cast = null
     ) -> var {
         var key, value;
 
@@ -131,7 +131,7 @@ class Collection implements
 
         let value = this->data[key];
 
-        if unlikely typeof cast === "string" {
+        if unlikely cast {
             settype(value, cast);
         }
 

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -112,29 +112,15 @@ class Arr
         array! collection,
         var index,
         var defaultValue = null,
-        string cast = null
+        string! cast = null
     ) -> var {
         var value;
-        array casts;
 
         if unlikely !fetch value, collection[index] {
             return defaultValue;
         }
 
-        let casts = [
-            "array"   : 1,
-            "bool"    : 1,
-            "boolean" : 1,
-            "double"  : 1,
-            "float"   : 1,
-            "int"     : 1,
-            "integer" : 1,
-            "null"    : 1,
-            "object"  : 1,
-            "string"  : 1
-        ];
-
-        if unlikely isset casts[cast] {
+        if unlikely null !== cast {
             settype(value, cast);
         }
 

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -112,7 +112,7 @@ class Arr
         array! collection,
         var index,
         var defaultValue = null,
-        var cast = null
+        string! cast = null
     ) -> var {
         var value;
 
@@ -120,7 +120,7 @@ class Arr
             return defaultValue;
         }
 
-        if unlikely typeof cast === "string" {
+        if unlikely cast {
             settype(value, cast);
         }
 

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -108,12 +108,34 @@ class Arr
     /**
      * Helper method to get an array element or a default
      */
-    final public static function get(array! collection, var index, var defaultValue = null) -> var
-    {
+    final public static function get(
+        array! collection,
+        var index,
+        var defaultValue = null,
+        string cast = null
+    ) -> var {
         var value;
+        array casts;
 
         if unlikely !fetch value, collection[index] {
             return defaultValue;
+        }
+
+        let casts = [
+            "array"   : 1,
+            "bool"    : 1,
+            "boolean" : 1,
+            "double"  : 1,
+            "float"   : 1,
+            "int"     : 1,
+            "integer" : 1,
+            "null"    : 1,
+            "object"  : 1,
+            "string"  : 1
+        ];
+
+        if unlikely isset casts[cast] {
+            settype(value, cast);
         }
 
         return value;

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -112,7 +112,7 @@ class Arr
         array! collection,
         var index,
         var defaultValue = null,
-        string! cast = null
+        var cast = null
     ) -> var {
         var value;
 
@@ -120,7 +120,7 @@ class Arr
             return defaultValue;
         }
 
-        if unlikely null !== cast {
+        if unlikely typeof cast === "string" {
             settype(value, cast);
         }
 

--- a/phalcon/Registry.zep
+++ b/phalcon/Registry.zep
@@ -126,8 +126,11 @@ final class Registry extends Collection
     /**
      * Get the element from the collection
      */
-    final public function get(string! element, var defaultValue = null, var cast = null) -> var
-    {
+    final public function get(
+        string! element,
+        var defaultValue = null,
+        string cast = null
+    ) -> var {
         return parent::get(element, defaultValue, cast);
     }
 

--- a/phalcon/Registry.zep
+++ b/phalcon/Registry.zep
@@ -126,7 +126,7 @@ final class Registry extends Collection
     /**
      * Get the element from the collection
      */
-    final public function get(string! element, var defaultValue = null, string cast = null) -> var
+    final public function get(string! element, var defaultValue = null, var cast = null) -> var
     {
         return parent::get(element, defaultValue, cast);
     }

--- a/phalcon/Registry.zep
+++ b/phalcon/Registry.zep
@@ -128,7 +128,7 @@ final class Registry extends Collection
      */
     final public function get(string! element, var defaultValue = null, string cast = null) -> var
     {
-        return parent::get(element, defaultValue);
+        return parent::get(element, defaultValue, cast);
     }
 
     /**

--- a/phalcon/Registry.zep
+++ b/phalcon/Registry.zep
@@ -129,7 +129,7 @@ final class Registry extends Collection
     final public function get(
         string! element,
         var defaultValue = null,
-        string cast = null
+        string! cast = null
     ) -> var {
         return parent::get(element, defaultValue, cast);
     }

--- a/phalcon/Registry.zep
+++ b/phalcon/Registry.zep
@@ -126,7 +126,7 @@ final class Registry extends Collection
     /**
      * Get the element from the collection
      */
-    final public function get(string! element, var defaultValue = null) -> var
+    final public function get(string! element, var defaultValue = null, string cast = null) -> var
     {
         return parent::get(element, defaultValue);
     }

--- a/tests/unit/Collection/Collection/ClearCest.php
+++ b/tests/unit/Collection/Collection/ClearCest.php
@@ -25,7 +25,7 @@ class ClearCest
      */
     public function collectionClear(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - clear()');
+        $I->wantToTest('Collection - clear()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/ConstructCest.php
+++ b/tests/unit/Collection/Collection/ConstructCest.php
@@ -25,7 +25,7 @@ class ConstructCest
      */
     public function collectionConstruct(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - __construct()');
+        $I->wantToTest('Collection - __construct()');
 
         $collection = new Collection();
 

--- a/tests/unit/Collection/Collection/CountCest.php
+++ b/tests/unit/Collection/Collection/CountCest.php
@@ -25,7 +25,7 @@ class CountCest
      */
     public function collectionCount(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - count()');
+        $I->wantToTest('Collection - count()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/GetCest.php
+++ b/tests/unit/Collection/Collection/GetCest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Collection\Collection;
 
+use Codeception\Example;
 use Phalcon\Collection;
+use stdClass;
 use UnitTester;
 
 class GetCest
@@ -66,5 +68,90 @@ class GetCest
             $expected,
             $collection->offsetGet('three')
         );
+    }
+
+    /**
+     * Tests Phalcon\Collection :: get() - cast
+     *
+     * @dataProvider getExamples
+     *
+     * @since  2019-10-12
+     */
+    public function helperArrGetCast(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Collection\Collection - get() - cast ' . $example[0]);
+
+        $collection = new Collection(
+            [
+                'value' => $example[1],
+            ]
+        );
+
+        $I->assertEquals(
+            $example[2],
+            $collection->get('value', null, $example[0])
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private function getExamples(): array
+    {
+        $sample = new stdClass();
+        $sample->one = 'two';
+
+        return [
+            [
+                'boolean',
+                1,
+                true,
+            ],
+            [
+                'bool',
+                1,
+                true,
+            ],
+            [
+                'integer',
+                "123",
+                123,
+            ],
+            [
+                'int',
+                "123",
+                123,
+            ],
+            [
+                'float',
+                "123.45",
+                123.45,
+            ],
+            [
+                'double',
+                "123.45",
+                123.45,
+            ],
+            [
+                'string',
+                123,
+                "123",
+            ],
+            [
+                'array',
+                $sample,
+                ['one' => 'two'],
+            ],
+            [
+                'object',
+                ['one' => 'two'],
+                $sample,
+            ],
+            [
+                'null',
+                1234,
+                null,
+            ],
+        ];
     }
 }

--- a/tests/unit/Collection/Collection/GetCest.php
+++ b/tests/unit/Collection/Collection/GetCest.php
@@ -27,7 +27,7 @@ class GetCest
      */
     public function collectionGet(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - get()');
+        $I->wantToTest('Collection - get()');
 
         $data = [
             'one'   => 'two',
@@ -79,7 +79,7 @@ class GetCest
      */
     public function helperArrGetCast(UnitTester $I, Example $example)
     {
-        $I->wantToTest('Collection\Collection - get() - cast ' . $example[0]);
+        $I->wantToTest('Collection - get() - cast ' . $example[0]);
 
         $collection = new Collection(
             [

--- a/tests/unit/Collection/Collection/GetIteratorCest.php
+++ b/tests/unit/Collection/Collection/GetIteratorCest.php
@@ -25,7 +25,7 @@ class GetIteratorCest
      */
     public function collectionGetIterator(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - getIterator()');
+        $I->wantToTest('Collection - getIterator()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/HasCest.php
+++ b/tests/unit/Collection/Collection/HasCest.php
@@ -25,7 +25,7 @@ class HasCest
      */
     public function collectionHas(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - has()');
+        $I->wantToTest('Collection - has()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/InitCest.php
+++ b/tests/unit/Collection/Collection/InitCest.php
@@ -25,7 +25,7 @@ class InitCest
      */
     public function collectionInit(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - init()');
+        $I->wantToTest('Collection - init()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/JsonSerializeCest.php
+++ b/tests/unit/Collection/Collection/JsonSerializeCest.php
@@ -25,7 +25,7 @@ class JsonSerializeCest
      */
     public function collectionJsonSerialize(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - jsonSerialize()');
+        $I->wantToTest('Collection - jsonSerialize()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/RemoveCest.php
+++ b/tests/unit/Collection/Collection/RemoveCest.php
@@ -25,7 +25,7 @@ class RemoveCest
      */
     public function collectionRemove(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - remove()');
+        $I->wantToTest('Collection - remove()');
         $data       = [
             'one'   => 'two',
             'three' => 'four',

--- a/tests/unit/Collection/Collection/SerializeCest.php
+++ b/tests/unit/Collection/Collection/SerializeCest.php
@@ -25,7 +25,7 @@ class SerializeCest
      */
     public function collectionSerialize(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - serialize()');
+        $I->wantToTest('Collection - serialize()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/SetCest.php
+++ b/tests/unit/Collection/Collection/SetCest.php
@@ -25,7 +25,7 @@ class SetCest
      */
     public function collectionSet(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - set()');
+        $I->wantToTest('Collection - set()');
 
         $collection = new Collection();
 

--- a/tests/unit/Collection/Collection/ToArrayCest.php
+++ b/tests/unit/Collection/Collection/ToArrayCest.php
@@ -25,7 +25,7 @@ class ToArrayCest
      */
     public function collectionToArray(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - toArray()');
+        $I->wantToTest('Collection - toArray()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/ToJsonCest.php
+++ b/tests/unit/Collection/Collection/ToJsonCest.php
@@ -25,7 +25,7 @@ class ToJsonCest
      */
     public function collectionToJson(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - toJson()');
+        $I->wantToTest('Collection - toJson()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Collection/Collection/UnserializeCest.php
+++ b/tests/unit/Collection/Collection/UnserializeCest.php
@@ -25,7 +25,7 @@ class UnserializeCest
      */
     public function collectionUnserialize(UnitTester $I)
     {
-        $I->wantToTest('Collection\Collection - unserialize()');
+        $I->wantToTest('Collection - unserialize()');
 
         $data = [
             'one'   => 'two',

--- a/tests/unit/Helper/Arr/GetCest.php
+++ b/tests/unit/Helper/Arr/GetCest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Helper\Arr;
 
+use Codeception\Example;
 use Phalcon\Helper\Arr;
+use stdClass;
 use UnitTester;
 
 class GetCest
@@ -78,5 +80,87 @@ class GetCest
             'Error',
             Arr::get($collection, 'unknown', 'Error')
         );
+    }
+    /**
+     * Tests Phalcon\Helper\Arr :: get() - cast
+     *
+     * @dataProvider getExamples
+     *
+     * @since  2019-10-12
+     */
+    public function helperArrGetCast(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Helper\Arr - get() - cast ' . $example[0]);
+
+        $collection = [
+            'value' => $example[1],
+        ];
+
+        $I->assertEquals(
+            $example[2],
+            Arr::get($collection, 'value', null, $example[0])
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private function getExamples(): array
+    {
+        $sample = new stdClass();
+        $sample->one = 'two';
+
+        return [
+            [
+                'boolean',
+                1,
+                true,
+            ],
+            [
+                'bool',
+                1,
+                true,
+            ],
+            [
+                'integer',
+                "123",
+                123,
+            ],
+            [
+                'int',
+                "123",
+                123,
+            ],
+            [
+                'float',
+                "123.45",
+                123.45,
+            ],
+            [
+                'double',
+                "123.45",
+                123.45,
+            ],
+            [
+                'string',
+                123,
+                "123",
+            ],
+            [
+                'array',
+                $sample,
+                ['one' => 'two'],
+            ],
+            [
+                'object',
+                ['one' => 'two'],
+                $sample,
+            ],
+            [
+                'null',
+                1234,
+                null,
+            ],
+        ];
     }
 }

--- a/tests/unit/Registry/ClearCest.php
+++ b/tests/unit/Registry/ClearCest.php
@@ -23,7 +23,7 @@ class ClearCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionClear(UnitTester $I)
+    public function registryClear(UnitTester $I)
     {
         $I->wantToTest('Registry - clear()');
 

--- a/tests/unit/Registry/GetCest.php
+++ b/tests/unit/Registry/GetCest.php
@@ -12,7 +12,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Registry;
 
+use Codeception\Example;
 use Phalcon\Registry;
+use stdClass;
 use UnitTester;
 
 class GetCest
@@ -23,7 +25,7 @@ class GetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionGet(UnitTester $I)
+    public function registryGet(UnitTester $I)
     {
         $I->wantToTest('Registry - get()');
 
@@ -39,5 +41,90 @@ class GetCest
             'four',
             $registry->get('three')
         );
+    }
+
+    /**
+     * Tests Phalcon\Registry :: get() - cast
+     *
+     * @dataProvider getExamples
+     *
+     * @since  2019-10-12
+     */
+    public function registryGetCast(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Registry - get() - cast ' . $example[0]);
+
+        $collection = new Registry(
+            [
+                'value' => $example[1],
+            ]
+        );
+
+        $I->assertEquals(
+            $example[2],
+            $collection->get('value', null, $example[0])
+        );
+    }
+
+    /**
+     * @return array
+     */
+    private function getExamples(): array
+    {
+        $sample = new stdClass();
+        $sample->one = 'two';
+
+        return [
+            [
+                'boolean',
+                1,
+                true,
+            ],
+            [
+                'bool',
+                1,
+                true,
+            ],
+            [
+                'integer',
+                "123",
+                123,
+            ],
+            [
+                'int',
+                "123",
+                123,
+            ],
+            [
+                'float',
+                "123.45",
+                123.45,
+            ],
+            [
+                'double',
+                "123.45",
+                123.45,
+            ],
+            [
+                'string',
+                123,
+                "123",
+            ],
+            [
+                'array',
+                $sample,
+                ['one' => 'two'],
+            ],
+            [
+                'object',
+                ['one' => 'two'],
+                $sample,
+            ],
+            [
+                'null',
+                1234,
+                null,
+            ],
+        ];
     }
 }

--- a/tests/unit/Registry/GetIteratorCest.php
+++ b/tests/unit/Registry/GetIteratorCest.php
@@ -23,7 +23,7 @@ class GetIteratorCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionGetIterator(UnitTester $I)
+    public function registryGetIterator(UnitTester $I)
     {
         $I->wantToTest('Registry - getIterator()');
 

--- a/tests/unit/Registry/HasCest.php
+++ b/tests/unit/Registry/HasCest.php
@@ -23,7 +23,7 @@ class HasCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionHas(UnitTester $I)
+    public function registryHas(UnitTester $I)
     {
         $I->wantToTest('Registry - has()');
 

--- a/tests/unit/Registry/InitCest.php
+++ b/tests/unit/Registry/InitCest.php
@@ -23,7 +23,7 @@ class InitCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionInit(UnitTester $I)
+    public function registryInit(UnitTester $I)
     {
         $I->wantToTest('Registry - init()');
 

--- a/tests/unit/Registry/JsonSerializeCest.php
+++ b/tests/unit/Registry/JsonSerializeCest.php
@@ -23,7 +23,7 @@ class JsonSerializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionJsonSerialize(UnitTester $I)
+    public function registryJsonSerialize(UnitTester $I)
     {
         $I->wantToTest('Registry - jsonSerialize()');
 

--- a/tests/unit/Registry/RemoveCest.php
+++ b/tests/unit/Registry/RemoveCest.php
@@ -23,7 +23,7 @@ class RemoveCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionRemove(UnitTester $I)
+    public function registryRemove(UnitTester $I)
     {
         $I->wantToTest('Registry - remove()');
 

--- a/tests/unit/Registry/SerializeCest.php
+++ b/tests/unit/Registry/SerializeCest.php
@@ -23,7 +23,7 @@ class SerializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionSerialize(UnitTester $I)
+    public function registrySerialize(UnitTester $I)
     {
         $I->wantToTest('Registry - serialize()');
 

--- a/tests/unit/Registry/SetCest.php
+++ b/tests/unit/Registry/SetCest.php
@@ -23,7 +23,7 @@ class SetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionSet(UnitTester $I)
+    public function registrySet(UnitTester $I)
     {
         $I->wantToTest('Registry - set()');
 

--- a/tests/unit/Registry/ToArrayCest.php
+++ b/tests/unit/Registry/ToArrayCest.php
@@ -23,7 +23,7 @@ class ToArrayCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionToArray(UnitTester $I)
+    public function registryToArray(UnitTester $I)
     {
         $I->wantToTest('Registry - toArray()');
 

--- a/tests/unit/Registry/ToJsonCest.php
+++ b/tests/unit/Registry/ToJsonCest.php
@@ -23,7 +23,7 @@ class ToJsonCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionToJson(UnitTester $I)
+    public function registryToJson(UnitTester $I)
     {
         $I->wantToTest('Registry - toJson()');
 

--- a/tests/unit/Registry/UnserializeCest.php
+++ b/tests/unit/Registry/UnserializeCest.php
@@ -23,7 +23,7 @@ class UnserializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function collectionUnserialize(UnitTester $I)
+    public function registryUnserialize(UnitTester $I)
     {
         $I->wantToTest('Registry - unserialize()');
 


### PR DESCRIPTION
Hello!

* Type: enhancement
* Link to issue: #14464 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `cast` parameter to `Phalcon\Collection::get` and `Phalcon\Helper\Arr::get` allowing developers to cast the result returned to the type they want to.

Thanks

