### PR TITLE
Model::__callStatic() enhancements

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,7 @@
 
 ## Changed
 - Changed all calls to `new <object>` to use the `create_instance` or `create_instance_params` for better performance. [#14419](https://github.com/phalcon/cphalcon/pull/14419)
+- Changed `Phalcon\Mvc\Model::__callStatic()` to throw an exception if the called method is unknown. [#14467](https://github.com/phalcon/cphalcon/pull/14467)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::parse()` Corrected syntax recognize for "set" keyword. [#14288](https://github.com/phalcon/cphalcon/issues/14288)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 ## Changed
 - Changed all calls to `new <object>` to use the `create_instance` or `create_instance_params` for better performance. [#14419](https://github.com/phalcon/cphalcon/pull/14419)
 - Changed `Phalcon\Mvc\Model::__callStatic()` to throw an exception if the called method is unknown. [#14467](https://github.com/phalcon/cphalcon/pull/14467)
+- Changed `Phalcon\Mvc\Model` to accept `0`, `null` and `""` as valid parameter for `findByField()`, `findFirstByField()` and `countByField()`. [#14467](https://github.com/phalcon/cphalcon/pull/14467)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::parse()` Corrected syntax recognize for "set" keyword. [#14288](https://github.com/phalcon/cphalcon/issues/14288)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -180,7 +180,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Handles method calls when a method is not implemented
      *
-     * @return    mixed
+     * @return mixed
+     * @throws \Phalcon\Mvc\Model\Exception If the method doesn't exist
      */
     public function __call(string method, array arguments)
     {
@@ -225,10 +226,26 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * Handles method calls when a static method is not implemented
      *
      * @return mixed
+     * @throws \Phalcon\Mvc\Model\Exception If the method doesn't exist
      */
     public static function __callStatic(string method, array arguments)
     {
-        return self::_invokeFinder(method, arguments);
+        var modelName, records;
+
+        let records = self::_invokeFinder(method, arguments);
+
+        if records !== false {
+            return records;
+        }
+
+        let modelName = get_called_class();
+
+        /**
+         * The method doesn't exist throw an exception
+         */
+        throw new Exception(
+            "The method '" . method . "' doesn't exist on model '" . modelName . "'"
+        );
     }
 
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4234,7 +4234,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     protected final static function _invokeFinder(string method, array arguments)
     {
         var extraMethod, type, modelName, value, model, attributes, field,
-            extraMethodFirst, metaData;
+            extraMethodFirst, metaData, params;
 
         let extraMethod = null;
 
@@ -4271,7 +4271,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             return false;
         }
 
-        if unlikely !fetch value, arguments[0] {
+        if unlikely !isset arguments[0] {
             throw new Exception(
                 "The static method '" . method . "' requires one argument"
             );
@@ -4316,15 +4316,23 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
         }
 
+        fetch value, arguments[0];
+
+        if value !== null {
+            let params = [
+                 "conditions": "[" . field . "] = ?0",
+                 "bind"      : [value]
+            ];
+        } else {
+            let params = [
+                 "conditions": "[" . field . "] IS NULL"
+            ];
+        }
+
         /**
          * Execute the query
          */
-        return {modelName}::{type}(
-            [
-                "conditions": "[" . field . "] = ?0",
-                "bind"      : [value]
-            ]
-        );
+        return {modelName}::{type}(params);
     }
 
     /**

--- a/tests/integration/Mvc/Model/UnderscoreCallStaticCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreCallStaticCest.php
@@ -164,7 +164,7 @@ class UnderscoreCallStaticCest
          */
         $I->expectThrowable(
             new Exception(
-                "Cannot resolve attribute 'unknownField' in the model"
+                "Cannot resolve attribute 'UnknownField' in the model"
             ),
             function () {
                 Models\Robots::findFirstByUnknownField(1);
@@ -176,7 +176,7 @@ class UnderscoreCallStaticCest
          */
         $I->expectThrowable(
             new Exception(
-                "Cannot resolve attribute 'unknownField' in the model"
+                "Cannot resolve attribute 'UnknownField' in the model"
             ),
             function () {
                 Models\Robots::countByUnknownField(1);

--- a/tests/integration/Mvc/Model/UnderscoreCallStaticCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreCallStaticCest.php
@@ -12,18 +12,175 @@
 namespace Phalcon\Test\Integration\Mvc\Model;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Mvc\Model\Resultset;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models;
 
 class UnderscoreCallStaticCest
 {
+    use DiTrait;
+
+    public function _before(IntegrationTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDiMysql();
+    }
+
+    public function _after(IntegrationTester $I)
+    {
+        $this->container['db']->close();
+    }
+
     /**
      * Tests Phalcon\Mvc\Model :: __callStatic()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-10-14
      */
     public function mvcModelUnderscoreCallStatic(IntegrationTester $I)
     {
         $I->wantToTest("Mvc\Model - __callStatic()");
-        $I->skipTest('Need implementation');
+
+        $robot = Models\Robots::findFirst();
+
+        /**
+         * Testing Model::findByField()
+         */
+        $magicRobots = Models\Robots::findById(
+            $robot->id
+        );
+
+        $I->assertInstanceOf(
+            Resultset\Simple::class,
+            $magicRobots
+        );
+
+        $I->assertCount(
+            1,
+            $magicRobots
+        );
+
+        $I->assertInstanceOf(
+            Models\Robots::class,
+            $magicRobots->getFirst()
+        );
+
+        $I->assertEquals(
+            $robot,
+            $magicRobots->getFirst()
+        );
+
+        /**
+         * Testing Model::findByField()
+         * with impossible conditions
+         */
+        $nonExistentRobots = Models\Robots::findById(0);
+
+        $I->assertInstanceOf(
+            Resultset\Simple::class,
+            $nonExistentRobots
+        );
+
+        $I->assertCount(
+            0,
+            $nonExistentRobots
+        );
+
+        /**
+         * Testing Model::findFirstByField()
+         */
+        $firstMagicRobot = Models\Robots::findFirstById(
+            $robot->id
+        );
+
+        $I->assertInstanceOf(
+            Models\Robots::class,
+            $firstMagicRobot
+        );
+
+        $I->assertEquals(
+            $robot,
+            $firstMagicRobot
+        );
+
+        /**
+         * Testing Model::findFirstByField()
+         * with impossible conditions
+         */
+        $nonExistentRobot = Models\Robots::findFirstById(0);
+
+        $I->assertNull(
+            $nonExistentRobot
+        );
+
+        /**
+         * Testing Model::countByField()
+         */
+        $countMagicRobots = Models\Robots::countById(
+            $robot->id
+        );
+
+        $I->assertInternalType(
+            'int',
+            $countMagicRobots
+        );
+
+        $I->assertEquals(
+            1,
+            $countMagicRobots
+        );
+
+        /**
+         * Testing Model::countByField()
+         * with impossible conditions
+         */
+        $countEmptyMagicRobots = Models\Robots::countById(0);
+
+        $I->assertInternalType(
+            'int',
+            $countEmptyMagicRobots
+        );
+
+        $I->assertEquals(
+            0,
+            $countEmptyMagicRobots
+        );
+
+        /**
+         * Testing with unknown method
+         */
+        $I->expectThrowable(
+            new Exception(
+                "The method 'nonExistentStaticMethod' doesn't exist on model '" . Models\Robots::class . "'"
+            ),
+            function () {
+                Models\Robots::nonExistentStaticMethod();
+            }
+        );
+
+        /**
+         * Testing Model::findFirstByField() with unknown field
+         */
+        $I->expectThrowable(
+            new Exception(
+                "Cannot resolve attribute 'unknownField' in the model"
+            ),
+            function () {
+                Models\Robots::findFirstByUnknownField();
+            }
+        );
+
+        /**
+         * Testing Model::countByField() with unknown field
+         */
+        $I->expectThrowable(
+            new Exception(
+                "Cannot resolve attribute 'unknownField' in the model"
+            ),
+            function () {
+                Models\Robots::countByUnknownField();
+            }
+        );
     }
 }

--- a/tests/integration/Mvc/Model/UnderscoreCallStaticCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreCallStaticCest.php
@@ -135,7 +135,7 @@ class UnderscoreCallStaticCest
          * Testing Model::countByField()
          * with impossible conditions
          */
-        $countEmptyMagicRobots = Models\Robots::countById(0);
+        $countEmptyMagicRobots = Models\Robots::countById(null);
 
         $I->assertInternalType(
             'int',
@@ -155,7 +155,7 @@ class UnderscoreCallStaticCest
                 "The method 'nonExistentStaticMethod' doesn't exist on model '" . Models\Robots::class . "'"
             ),
             function () {
-                Models\Robots::nonExistentStaticMethod();
+                Models\Robots::nonExistentStaticMethod(1);
             }
         );
 
@@ -167,7 +167,7 @@ class UnderscoreCallStaticCest
                 "Cannot resolve attribute 'unknownField' in the model"
             ),
             function () {
-                Models\Robots::findFirstByUnknownField();
+                Models\Robots::findFirstByUnknownField(1);
             }
         );
 
@@ -179,7 +179,7 @@ class UnderscoreCallStaticCest
                 "Cannot resolve attribute 'unknownField' in the model"
             ),
             function () {
-                Models\Robots::countByUnknownField();
+                Models\Robots::countByUnknownField(1);
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: #14467

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

`Phalcon\Mvc\Model::__callStatic()` now throws an exception if the called method is unknown.
Added tests for `Phalcon\Mvc\Model::__callStatic()`.

Thanks,
zsilbi