### PR TITLE
Fix/ syslog logger options

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -40,6 +40,7 @@
 - Fixed `Phalcon\Cache::checkKey()` added `.` to key characters pattern [#14457](https://github.com/phalcon/cphalcon/pull/14457)
 - Fixed `Phalcon\Mvc\Model\Manager` to store reusable related records correctly. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
 - Fixed `Phalcon\Mvc\Model::__call()` not to throw an exception when the return value is `null` for related records. [#14444](https://github.com/phalcon/cphalcon/pull/14444)
+- Fixed `Phalcon\Logger\Adapter\Syslog::__construct()` incorrect receipt of the `option` from the `options` parameter. [#14470](https://github.com/phalcon/cphalcon/pull/14470)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/phalcon/Logger/Adapter/Syslog.zep
+++ b/phalcon/Logger/Adapter/Syslog.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Logger\Adapter;
 
 use LogicException;
+use Phalcon\Helper\Arr;
 use Phalcon\Logger;
 use Phalcon\Logger\Adapter;
 use Phalcon\Logger\Exception;
@@ -74,19 +75,9 @@ class Syslog extends AbstractAdapter
      */
     public function __construct(string! name, array options = [])
     {
-        var option, facility;
-
-        if fetch option, options["option"] {
-            let option = LOG_ODELAY;
-        }
-
-        if !fetch facility, options["facility"] {
-            let facility = LOG_USER;
-        }
-
         let this->name     = name,
-            this->facility = facility,
-            this->option   = option;
+            this->facility = Arr::get(options, "facility", LOG_USER),
+            this->option   = Arr::get(options, "option", LOG_ODELAY);
     }
 
     /**

--- a/phalcon/Logger/LoggerFactory.zep
+++ b/phalcon/Logger/LoggerFactory.zep
@@ -16,7 +16,7 @@ use Phalcon\Logger;
 use Phalcon\Logger\AdapterFactory;
 
 /**
- * PhalconNG\Logger\LoggerFactory
+ * Phalcon\Logger\LoggerFactory
  *
  * Logger factory
  */

--- a/tests/unit/Logger/Adapter/Syslog/ConstructCest.php
+++ b/tests/unit/Logger/Adapter/Syslog/ConstructCest.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Unit\Logger\Adapter\Syslog;
+
+use Codeception\Example;
+use Phalcon\Logger\Adapter\Syslog;
+use UnitTester;
+
+class ConstructCest
+{
+    /**
+     * Tests Phalcon\Logger\Adapter\Syslog :: __construct()
+     *
+     * @dataProvider getExamples
+     *
+     * @since        2019-10-14
+     */
+    public function loggerAdapterSyslogConstructOptionsCast(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Logger\Adapter\Syslog - __construct() - options');
+
+        $streamName = $I->getNewFileName('log', 'log');
+
+        $adapter  = new Syslog($streamName, $example['options']);
+        $property = $I->getProtectedProperty($adapter, $example['property']);
+
+        $I->assertEquals(
+            $example['expected'],
+            $property
+        );
+    }
+
+    private function getExamples(): array
+    {
+        return [
+            [
+                'options'  => [],
+                'property' => 'option',
+                'expected' => LOG_ODELAY,
+            ],
+            [
+                'options'  => ['option' => LOG_ALERT | LOG_INFO],
+                'property' => 'option',
+                'expected' => LOG_ALERT | LOG_INFO,
+            ],
+            [
+                'options'  => [],
+                'property' => 'facility',
+                'expected' => LOG_USER,
+            ],
+            [
+                'options'  => ['facility' => LOG_DAEMON],
+                'property' => 'facility',
+                'expected' => LOG_DAEMON,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
incorrect receipt of the `option` from the `options` parameter

Thanks

