### PR TITLE
[#14485] ignore_unknown_columns global is respected by update and insert

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -50,6 +50,7 @@
 - Fixed `Phalcon\Translate\*` aligning `parameters` as `array` with the interpolator calls. [#14477](https://github.com/phalcon/cphalcon/pull/14477)
 - Fixed `Phalcon\Storage\AdapterFactory:newInstance` to return the correct interface [#14481](https://github.com/phalcon/cphalcon/issues/14481)
 - Fixed `Phalcon\Mvc\Dispatcher:forward` to accept an array vs a mixed variable  [#14481](https://github.com/phalcon/cphalcon/issues/14481)
+- Fixed `Phalcon\Mvc\Model::_doLowUpdate` and `Phalcon\Mvc\Model::_doLowInsert` throwing errors about column mapping when `phalcon.orm.ignore_unknown_columns` is set `On` [#14485](https://github.com/phalcon/cphalcon/issues/14485)
 
 ## Removed
 - Removed `Phalcon\Application\AbstractApplication::handle()` as it does not serve any purpose and causing issues with type hinting. [#14407](https://github.com/phalcon/cphalcon/pull/14407)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -3715,9 +3715,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             if typeof columnMap == "array" {
                 if unlikely !fetch attributeField, columnMap[field] {
-                    throw new Exception(
-                        "Column '" . field . "' isn't part of the column map"
-                    );
+                    if unlikely !globals_get("orm.ignore_unknown_columns") {
+                        throw new Exception(
+                            "Column '" . field . "' isn't part of the column map"
+                        );
+                    }
                 }
             } else {
                 let attributeField = field;
@@ -4437,9 +4439,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 for field in notNull {
                     if typeof columnMap == "array" {
                         if unlikely !fetch attributeField, columnMap[field] {
-                            throw new Exception(
-                                "Column '" . field . "' isn't part of the column map"
-                            );
+                            if unlikely !globals_get("orm.ignore_unknown_columns") {
+                                throw new Exception(
+                                    "Column '" . field . "' isn't part of the column map"
+                                );
+                            }
                         }
                     } else {
                         let attributeField = field;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14485

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change: Fixed an issue with updating and inserting data into tables with unmapped columns when `phalcon.orm.ignore_unknown_columns` is set to `true`.

Thanks

