### PR TITLE
Fix return type docblock

### DIFF
--- a/phalcon/Mvc/Model/Criteria.zep
+++ b/phalcon/Mvc/Model/Criteria.zep
@@ -643,7 +643,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * limit was set without an offset, an array with 'number' and 'offset' keys
      * if an offset was set with the limit, or null if limit has not been set.
      *
-     * @return int|array|null
+     * @return string|null
      */
     public function getLimit() -> string | null
     {


### PR DESCRIPTION
Hello!

* Type: documentation
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed return type docblock
