### PR TITLE
Fixed Storage\Adapter\Redis::settimeout

### DIFF
--- a/phalcon/cache/backend/redis.zep
+++ b/phalcon/cache/backend/redis.zep
@@ -258,7 +258,7 @@ class Redis extends Backend
 
 		// Don't set expiration for negative ttl or zero
 		if tt1 >= 1 {
-			redis->settimeout(lastKey, tt1);
+			redis->expire(lastKey, tt1);
 		}
 
 		let options = this->_options;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14281

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Replace deprecated settimeout function with expire
Thanks

