### PR TITLE
Fixed Model\Manager::getRelations() and getRelationsBetween()

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -34,6 +34,7 @@
 - Fixed `Phalcon\Mvc\Model` to include correct model instances in messages metadata [#14510](https://github.com/phalcon/cphalcon/pull/14502)
 - Fixed `Phalcon\Di\Injectable::__get()` to return shared instance by default [#14491](https://github.com/phalcon/cphalcon/issues/14491)
 - Fixed `Phalcon\Mvc\View::loadTemplateEngines()` to not share engine with other views by default [#14491](https://github.com/phalcon/cphalcon/issues/14491)
+- Fixed `Phalcon\Mvc\Model\Manager::getRelations()` and `getRelationsBetween()` to return many-to-many relations correctly [#14509](https://github.com/phalcon/cphalcon/pull/14509)
 
 ## Removed
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1860,7 +1860,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         /**
          * Get many-to-many relations
          */
-        if fetch relations, this->hasManyToMany[entityName] {
+        if fetch relations, this->hasManyToManySingle[entityName] {
             for relation in relations {
                 let allRelations[] = relation;
             }
@@ -1904,6 +1904,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          * Check whether it's a has-one-through relationship
          */
         if fetch relations, this->hasOneThrough[keyRelation] {
+            return relations;
+        }
+
+        /**
+        * Check whether it's a has-many-to-many relationship
+        */
+        if fetch relations, this->hasManyToMany[keyRelation] {
             return relations;
         }
 


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Fixed `Phalcon\Mvc\Model\Manager::getRelations()` and `getRelationsBetween()` to return many-to-many relations correctly.

Thanks,
zsilbi