### PR TITLE
Model has-one-through relations

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,14 @@
   - Added `Phalcon\Html\Link\Serializer\Header`
   - Added `Phalcon\Html\Link\Serializer\SerializerInterface`
 - Added `Phalcon\Collection:getKeys` and `Phalcon\Collection\getValues` for getting data from the collection [#14507](https://github.com/phalcon/cphalcon/issues/14507)
+- Added has-one-through relations to `Phalcon\Mvc\Model` and `Phalcon\Mvc\Model\Manager` [#14511](https://github.com/phalcon/cphalcon/pull/14511)
+ - Added `Phalcon\Mvc\Model::hasOneThrough()`
+ - Added `Phalcon\Mvc\Model\Manager::addHasOneThrough()`
+ - Added `Phalcon\Mvc\Model\Manager::existsHasOneThrough()`
+ - Added `Phalcon\Mvc\Model\Manager::getHasOneThrough()`
+ - Added `Phalcon\Mvc\Model\ManagerInterface::addHasOneThrough()`
+ - Added `Phalcon\Mvc\Model\ManagerInterface::existsHasOneThrough()`
+ - Added `Phalcon\Mvc\Model\ManagerInterface::getHasOneThrough()`
 
 ## Changed
 - Changed `Phalcon\Paginator\Adapter\Model`

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -5178,6 +5178,49 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     }
 
     /**
+     * Setup a 1-1 relation between two models, through an intermediate
+     * relation
+     *
+     *```php
+     * class Robots extends \Phalcon\Mvc\Model
+     * {
+     *     public function initialize()
+     *     {
+     *         // Setup a 1-1 relation to one item from Parts through RobotsParts
+     *         $this->hasOneThrough(
+     *             "id",
+     *             RobotsParts::class,
+     *             "robots_id",
+     *             "parts_id",
+     *             Parts::class,
+     *             "id",
+     *         );
+     *     }
+     * }
+     *```
+     *
+     * @param    string|array fields
+     * @param    string|array intermediateFields
+     * @param    string|array intermediateReferencedFields
+     * @param    string|array referencedFields
+     * @param    array options
+     */
+    protected function hasOneThrough(var fields, string! intermediateModel, var intermediateFields, var intermediateReferencedFields,
+        string! referenceModel, var referencedFields, options = null) -> <Relation>
+    {
+        return (<ManagerInterface> this->modelsManager)->addHasOneThrough(
+            this,
+            fields,
+            intermediateModel,
+            intermediateFields,
+            intermediateReferencedFields,
+            referenceModel,
+            referencedFields,
+            options
+        );
+    }
+
+    /**
      * Sets if the model must keep the original record snapshot in memory
      *
      *```php

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4754,7 +4754,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     connection->rollback(nesting);
 
                     throw new Exception(
-                        "Only objects/arrays can be stored as part of has-many/has-one/has-many-to-many relations"
+                        "Only objects/arrays can be stored as part of has-many/has-one/has-one-through/has-many-to-many relations"
                     );
                 }
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4725,7 +4725,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             columns, referencedModel, referencedFields, relatedRecords, value,
             recordAfter, intermediateModel, intermediateFields,
             intermediateValue, intermediateModelName,
-            intermediateReferencedFields;
+            intermediateReferencedFields, existingIntermediateModel;
         bool isThrough;
 
         let nesting = false,
@@ -4853,6 +4853,23 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                         let intermediateModel = manager->load(
                             intermediateModelName
                         );
+
+                        /**
+                         *  Has-one-thorugh relations can only use one intermediate model.
+                         *  If it already exist, it can be updated with the new referenced keys.
+                         */
+                        if relation->getType() == Relation::HAS_ONE_THROUGH {
+                            let existingIntermediateModel = intermediateModel->findFirst(
+                                [
+                                    "[" . intermediateFields . "] = ?0",
+                                    "bind": [value]
+                                ]
+                            );
+
+                            if existingIntermediateModel instanceof ModelInterface {
+                                let intermediateModel = existingIntermediateModel;
+                            }
+                        }
 
                         /**
                          * Write value in the intermediate model

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4866,7 +4866,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                 ]
                             );
 
-                            if existingIntermediateModel instanceof ModelInterface {
+                            if existingIntermediateModel {
                                 let intermediateModel = existingIntermediateModel;
                             }
                         }

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4855,8 +4855,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                         );
 
                         /**
-                         *  Has-one-thorugh relations can only use one intermediate model.
-                         *  If it already exist, it can be updated with the new referenced keys.
+                         *  Has-one-through relations can only use one intermediate model.
+                         *  If it already exist, it can be updated with the new referenced key.
                          */
                         if relation->getType() == Relation::HAS_ONE_THROUGH {
                             let existingIntermediateModel = intermediateModel->findFirst(

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -17,6 +17,7 @@ use Phalcon\Mvc\Model\ResultsetInterface;
 use Phalcon\Mvc\Model\ManagerInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Events\EventsAwareInterface;
+use Phalcon\Mvc\Model\Query;
 use Phalcon\Mvc\Model\QueryInterface;
 use Phalcon\Mvc\Model\Query\Builder;
 use Phalcon\Mvc\Model\Query\BuilderInterface;
@@ -107,6 +108,16 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Has one relations by model
      */
     protected hasOneSingle = [];
+
+    /**
+     * Has one through relations
+     */
+    protected hasOneThrough = [];
+
+    /**
+     * Has one through relations by model
+     */
+    protected hasOneThroughSingle = [];
 
     /**
      * Mark initialized models
@@ -765,6 +776,125 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
+     * Setups a relation 1-1 between two models using an intermediate model
+     *
+     * @param    string fields
+     * @param    string intermediateFields
+     * @param    string intermediateReferencedFields
+     * @param    string referencedFields
+     * @param   array options
+     */
+    public function addHasOneThrough(<ModelInterface> model, var fields, string! intermediateModel,
+        var intermediateFields, var intermediateReferencedFields, string! referencedModel, var referencedFields, var options = null) -> <RelationInterface>
+    {
+        var entityName, referencedEntity, hasOneThrough, relation, relations,
+            alias, lowerAlias, singleRelations, intermediateEntity;
+        string keyRelation;
+
+        let entityName = get_class_lower(model),
+            intermediateEntity = strtolower(intermediateModel),
+            referencedEntity = strtolower(referencedModel),
+            keyRelation = entityName . "$" . referencedEntity;
+
+        let hasOneThrough = this->hasOneThrough;
+
+        if !fetch relations, hasOneThrough[keyRelation] {
+            let relations = [];
+        }
+
+        /**
+         * Check if the number of fields are the same from the model to the
+         * intermediate model
+         */
+        if typeof intermediateFields == "array" {
+            if unlikely count(fields) != count(intermediateFields) {
+                throw new Exception(
+                    "Number of referenced fields are not the same"
+                );
+            }
+        }
+
+        /**
+         * Check if the number of fields are the same from the intermediate
+         * model to the referenced model
+         */
+        if typeof intermediateReferencedFields == "array" {
+            if unlikely count(fields) != count(intermediateFields) {
+                throw new Exception(
+                    "Number of referenced fields are not the same"
+                );
+            }
+        }
+
+        /**
+         * Create a relationship instance
+         */
+        let relation = new Relation(
+            Relation::HAS_ONE_THROUGH,
+            referencedModel,
+            fields,
+            referencedFields,
+            options
+        );
+
+        /**
+         * Set extended intermediate relation data
+         */
+        relation->setIntermediateRelation(
+            intermediateFields,
+            intermediateModel,
+            intermediateReferencedFields
+        );
+
+        /**
+         * Check an alias for the relation
+         */
+        if fetch alias, options["alias"] {
+            if typeof alias != "string" {
+                throw new Exception("Relation alias must be a string");
+            }
+
+            let lowerAlias = strtolower(alias);
+        } else {
+            let lowerAlias = referencedEntity;
+        }
+
+        /**
+         * Append a new relationship
+         */
+        let relations[] = relation;
+
+        /**
+         * Update the global alias
+         */
+        let this->aliases[entityName . "$" . lowerAlias] = relation;
+
+        /**
+         * Update the relations
+         */
+        let this->hasOneThrough[keyRelation] = relations;
+
+        /**
+         * Get existing relations by model
+         */
+        if !fetch singleRelations, this->hasOneThroughSingle[entityName] {
+            let singleRelations = [];
+        }
+
+        /**
+         * Append a new relationship
+         */
+        let singleRelations[] = relation;
+
+        /**
+         * Update relations by model
+         */
+        let this->hasOneThroughSingle[entityName] = singleRelations;
+
+        return relation;
+    }
+
+    /**
      * Setup a relation reverse many to one between two models
      *
      * @param    array options
@@ -1131,6 +1261,31 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
+     * Checks whether a model has a hasOneThrough relation with another model
+     */
+    public function existsHasOneThrough(string! modelName, string! modelRelation) -> bool
+    {
+        var entityName;
+        string keyRelation;
+
+        let entityName = strtolower(modelName);
+
+        /**
+         * Relationship unique key
+         */
+        let keyRelation = entityName . "$" . strtolower(modelRelation);
+
+        /**
+         * Initialize the model first
+         */
+        if !isset this->initialized[entityName] {
+            this->load(modelName);
+        }
+
+        return isset this->hasOneThrough[keyRelation];
+    }
+
+    /**
      * Checks whether a model has a hasManyToMany relation with another model
      */
     public function existsHasManyToMany(string! modelName, string! modelRelation) -> bool
@@ -1243,7 +1398,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         var referencedModel, intermediateModel, intermediateFields, fields,
             builder, extraParameters, refPosition, field, referencedFields,
             findParams, findArguments, uniqueKey, records, arguments, rows,
-            firstRow;
+            firstRow, query;
         array placeholders, conditions, joinConditions;
         bool reusable;
         string retrieveMethod;
@@ -1331,9 +1486,19 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
             /**
              * Get the query
-             * Execute the query
              */
-            return builder->getQuery()->execute();
+            let query = <QueryInterface> builder->getQuery();
+
+            switch relation->getType() {
+                case Relation::HAS_MANY_THROUGH:
+                    return query->execute();
+
+                case Relation::HAS_ONE_THROUGH:
+                    return query->setUniqueRow(true)->execute();
+
+                default:
+                    throw new Exception("Unknown relation type");
+            }
         }
 
         let conditions = [];
@@ -1607,6 +1772,20 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
+     * Gets hasOneThrough relations defined on a model
+     */
+    public function getHasOneThrough(<ModelInterface> model) -> <RelationInterface[]> | array
+    {
+        var relations;
+
+        if !fetch relations, this->hasOneThroughSingle[get_class_lower(model)] {
+            return [];
+        }
+
+        return relations;
+    }
+
+    /**
      * Gets hasManyToMany relations defined on a model
      */
     public function getHasManyToMany(<ModelInterface> model) -> <RelationInterface[]> | array
@@ -1670,6 +1849,15 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         }
 
         /**
+         * Get has-one-through relations
+         */
+        if fetch relations, this->hasOneThroughSingle[entityName] {
+            for relation in relations {
+                let allRelations[] = relation;
+            }
+        }
+
+        /**
          * Get many-to-many relations
          */
         if fetch relations, this->hasManyToMany[entityName] {
@@ -1709,6 +1897,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          * Check whether it's a has-one relationship
          */
         if fetch relations, this->hasOne[keyRelation] {
+            return relations;
+        }
+
+        /**
+         * Check whether it's a has-one-through relationship
+         */
+        if fetch relations, this->hasOneThrough[keyRelation] {
             return relations;
         }
 

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -55,6 +55,18 @@ interface ManagerInterface
     public function addHasOne(<ModelInterface> model, fields, string! referencedModel, referencedFields, options = null) -> <RelationInterface>;
 
     /**
+     * Setups a 1-1 relation between two models using an intermediate table
+     *
+     * @param    string fields
+     * @param    string intermediateFields
+     * @param    string intermediateReferencedFields
+     * @param    string referencedFields
+     * @param   array options
+     */
+    public function addHasOneThrough(<ModelInterface> model, var fields, string! intermediateModel,
+        var intermediateFields, var intermediateReferencedFields, string! referencedModel, var referencedFields, var options = null) -> <RelationInterface>;
+
+    /**
      * Setups a relation n-m between two models
      *
      * @param    string fields
@@ -99,6 +111,11 @@ interface ManagerInterface
      * Checks whether a model has a hasOne relation with another model
      */
     public function existsHasOne(string! modelName, string! modelRelation) -> bool;
+
+    /**
+     * Checks whether a model has a hasOneThrough relation with another model
+     */
+    public function existsHasOneThrough(string! modelName, string! modelRelation) -> bool;
 
     /**
      * Checks whether a model has a hasManyToMany relation with another model
@@ -148,12 +165,17 @@ interface ManagerInterface
     public function getHasOne(<ModelInterface> model) -> <RelationInterface[]> | array;
 
     /**
+     * Gets hasOneThrough relations defined on a model
+     */
+    public function getHasOneThrough(<ModelInterface> model) -> <RelationInterface[]> | array;
+
+    /**
      * Gets hasOne relations defined on a model
      */
     public function getHasOneAndHasMany(<ModelInterface> model) -> <RelationInterface[]>;
 
     /**
-     * Gets belongsTo related records from a model
+     * Gets hasOne related records from a model
      *
      * @param string            $modelName
      * @param string            $modelRelation

--- a/tests/_data/fixtures/models/Relations/RelationsParts.php
+++ b/tests/_data/fixtures/models/Relations/RelationsParts.php
@@ -36,7 +36,10 @@ class RelationsParts extends Model
             'parts_id',
             'robots_id',
             RelationsRobots::class,
-            'id'
+            'id',
+            [
+                'alias' => 'oneRobot'
+            ]
         );
     }
 }

--- a/tests/_data/fixtures/models/Relations/RelationsParts.php
+++ b/tests/_data/fixtures/models/Relations/RelationsParts.php
@@ -29,5 +29,14 @@ class RelationsParts extends Model
                 ],
             ]
         );
+
+        $this->hasOneThrough(
+            'id',
+            RelationsRobotsParts::class,
+            'parts_id',
+            'robots_id',
+            RelationsRobots::class,
+            'id'
+        );
     }
 }

--- a/tests/integration/Mvc/Model/Manager/AddHasOneThroughCest.php
+++ b/tests/integration/Mvc/Model/Manager/AddHasOneThroughCest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Integration\Mvc\Model\Manager;
+
+use IntegrationTester;
+
+/**
+ * Class AddHasOneThroughCest
+ */
+class AddHasOneThroughCest
+{
+    /**
+     * Tests Phalcon\Mvc\Model\Manager :: addHasOneThrough()
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-11-02
+     */
+    public function mvcModelManagerAddHasOneThrough(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Manager - addHasOneThrough()');
+        $I->skipTest('Need implementation');
+    }
+}

--- a/tests/integration/Mvc/Model/Manager/ExistsHasOneThroughCest.php
+++ b/tests/integration/Mvc/Model/Manager/ExistsHasOneThroughCest.php
@@ -1,0 +1,82 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Integration\Mvc\Model\Manager;
+
+use Codeception\Example;
+use IntegrationTester;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Relations\RelationsParts;
+use Phalcon\Test\Models\Relations\RelationsRobots;
+
+class ExistsHasOneThroughCest
+{
+    use DiTrait;
+
+    public function _before(IntegrationTester $I)
+    {
+        $this->setNewFactoryDefault();
+    }
+
+    public function _after(IntegrationTester $I)
+    {
+        $this->container['db']->close();
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Manager :: existsHasOneThrough()
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-11-02
+     *
+     * @dataProvider adaptersProvider
+     */
+    public function mvcModelManagerExistsHasOneThrough(IntegrationTester $I, Example $example)
+    {
+        $I->wantToTest('Mvc\Model\Manager - existsHasOneThrough()');
+
+        $diFunction = 'setDi' . $example[0];
+
+        $this->{$diFunction}();
+
+        $manager = $this->container->getShared('modelsManager');
+
+        $I->assertFalse(
+            $manager->existsHasOneThrough(
+                RelationsRobots::class,
+                RelationsParts::class
+            )
+        );
+
+        $I->assertTrue(
+            $manager->existsHasOneThrough(
+                RelationsParts::class,
+                RelationsRobots::class
+            )
+        );
+    }
+
+    private function adaptersProvider(): array
+    {
+        return [
+            [
+                'Mysql',
+            ],
+            [
+                'Postgresql',
+            ],
+            [
+                'Sqlite',
+            ],
+        ];
+    }
+}

--- a/tests/integration/Mvc/Model/Manager/GetHasOneThroughCest.php
+++ b/tests/integration/Mvc/Model/Manager/GetHasOneThroughCest.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Integration\Mvc\Model\Manager;
+
+use IntegrationTester;
+
+/**
+ * Class GetHasOneThroughCest
+ */
+class GetHasOneThroughCest
+{
+    /**
+     * Tests Phalcon\Mvc\Model\Manager :: getHasOneThrough()
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-11-02
+     */
+    public function mvcModelManagerGetHasOneThrough(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Manager - getHasOneThrough()');
+        $I->skipTest('Need implementation');
+    }
+}

--- a/tests/integration/Mvc/Model/UnderscoreSetCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreSetCest.php
@@ -196,6 +196,32 @@ class UnderscoreSetCest
     }
 
     /**
+     * Tests Phalcon\Mvc\Model :: __set() with has-one-through related record
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-11-03
+     */
+    public function mvcModelUnderscoreSetWithHasOneThroughRelatedRecord(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model - __set() with has-one-through related record');
+
+        $robot = new Models\Relations\Robots();
+
+        $relationsParts           = new Models\Relations\RelationsParts();
+        $relationsParts->oneRobot = $robot;
+
+        $I->assertInstanceOf(
+            Models\Relations\Robots::class,
+            $relationsParts->oneRobot
+        );
+
+        $I->assertEquals(
+            Model::DIRTY_STATE_TRANSIENT,
+            $relationsParts->getDirtyState()
+        );
+    }
+
+    /**
      * Tests Phalcon\Mvc\Model :: __set() with an array as properties of a has-one related record
      *
      * @author Balázs Németh <https://github.com/zsilbi>


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

This is very similar to  `hasManyToMany`, but it can only use one intermediate row.
The related record is either `ModelInterface`, or `null`.

This is kind of an antipattern, but it can be useful when you have to work with a poorly designed database structure that can't be altered.

Thanks,
zsilbi

