### PR TITLE
Adding Ability to use actual config object in Grouped

### DIFF
--- a/phalcon/Config/Adapter/Grouped.zep
+++ b/phalcon/Config/Adapter/Grouped.zep
@@ -81,7 +81,10 @@ class Grouped extends Config
             let configInstance = configName;
 
             // Set to default adapter if passed as string
-            if typeof configName === "string" {
+            if typeof configName === "Phalcon\\Config" {
+                this->merge(configInstance);
+                continue;
+            } elseif typeof configName === "string" {
                 if "" === defaultAdapter {
                     this->merge(
                         (new ConfigFactory())->load(configName)
@@ -108,15 +111,6 @@ class Grouped extends Config
 
                 let configArray    = configInstance["config"],
                     configInstance = new Config(configArray);
-            } elseif "config" === configInstance["adapter"] {
-                if !isset configInstance["config"] {
-                    throw new Exception(
-                        "To use 'config' adapter you have to specify " .
-                        "the 'config' as a Phalcon\\Config instance."
-                    );
-                }
-
-                let configInstance = configInstance["config"];
             } else {
                 let configInstance = (new ConfigFactory())->load(configInstance);
             }

--- a/phalcon/Config/Adapter/Grouped.zep
+++ b/phalcon/Config/Adapter/Grouped.zep
@@ -81,7 +81,7 @@ class Grouped extends Config
             let configInstance = configName;
 
             // Set to default adapter if passed as string
-            if typeof configName === "Phalcon\\Config" {
+            if configName instanceof "Phalcon\\Config" {
                 this->merge(configInstance);
                 continue;
             } elseif typeof configName === "string" {

--- a/phalcon/Config/Adapter/Grouped.zep
+++ b/phalcon/Config/Adapter/Grouped.zep
@@ -108,6 +108,15 @@ class Grouped extends Config
 
                 let configArray    = configInstance["config"],
                     configInstance = new Config(configArray);
+            } elseif "config" === configInstance["adapter"] {
+                if !isset configInstance["config"] {
+                    throw new Exception(
+                        "To use 'config' adapter you have to specify " .
+                        "the 'config' as a Phalcon\\Config instance."
+                    );
+                }
+
+                let configInstance = configInstance["config"];
             } else {
                 let configInstance = (new ConfigFactory())->load(configInstance);
             }

--- a/tests/unit/Config/Adapter/Grouped/ConstructCest.php
+++ b/tests/unit/Config/Adapter/Grouped/ConstructCest.php
@@ -133,24 +133,4 @@ class ConstructCest
             }
         );
     }
-
-    /**
-     * Tests Phalcon\Config\Adapter\Grouped :: __construct() - exception
-     *
-     * @author Fenikkusu
-     * @since  2017-06-06
-     */
-    public function configAdapterGroupedConstructThrowsConfigException(UnitTester $I)
-    {
-        $I->wantToTest("Config\Adapter\Grouped - construct config without config throws exception");
-
-        $I->expectThrowable(new Exception("To use 'config' adapter you have to specify the 'config' as a Phalcon\Config instance."),
-            function () {
-                new Grouped([
-                        [
-                            'adapter' => 'config',
-                        ],
-                    ]);
-            });
-    }
 }

--- a/tests/unit/Config/Adapter/Grouped/ConstructCest.php
+++ b/tests/unit/Config/Adapter/Grouped/ConstructCest.php
@@ -142,11 +142,11 @@ class ConstructCest
     {
         $I->wantToTest("Config\Adapter\Grouped - construct config without config throws exception");
 
-        $I->expectThrowable(new Exception("To use 'config' adapter you have to specify the 'config' as a Phalcon\\Config instance."),
+        $I->expectThrowable(new Exception("To use 'config' adapter you have to specify the 'config' as a Phalcon\Config instance."),
             function () {
                 new Grouped([
                         [
-                            'adapter' => 'array',
+                            'adapter' => 'config',
                         ],
                     ]);
             });

--- a/tests/unit/Config/Adapter/Grouped/ConstructCest.php
+++ b/tests/unit/Config/Adapter/Grouped/ConstructCest.php
@@ -24,6 +24,11 @@ use function dataDir;
 class ConstructCest
 {
     use ConfigTrait;
+    
+    public function _after()
+    {
+        unset($this->config['test']['property']); //Removing Extra Property
+    }
 
     /**
      * Tests Phalcon\Config\Adapter\Grouped :: __construct() - complex instance

--- a/tests/unit/Config/Adapter/Grouped/ConstructCest.php
+++ b/tests/unit/Config/Adapter/Grouped/ConstructCest.php
@@ -57,14 +57,11 @@ class ConstructCest
                     ],
                 ],
             ],
-            [
-                'adapter' => 'config',
-                'config' => new Config([
-                    'test' => [
-                        'property' => 'blah'
-                    ]
-                ]),
-            ]
+            new Config([
+                'test' => [
+                    'property' => 'blah'
+                ]
+            ]),
         ];
 
         foreach ([[], ['']] as $parameters) {

--- a/tests/unit/Config/Adapter/Grouped/ConstructCest.php
+++ b/tests/unit/Config/Adapter/Grouped/ConstructCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Config\Adapter\Grouped;
 
+use Phalcon\Config;
 use Phalcon\Config\Adapter\Grouped;
 use Phalcon\Config\Exception;
 use Phalcon\Test\Fixtures\Traits\ConfigTrait;
@@ -35,6 +36,7 @@ class ConstructCest
         $I->wantToTest("Config\Adapter\Grouped - construct - complex instance");
 
         $this->config['test']['property2'] = 'something-else';
+        $this->config['test']['property'] = 'blah';
 
         $config = [
             dataDir('assets/config/config.php'),
@@ -50,6 +52,14 @@ class ConstructCest
                     ],
                 ],
             ],
+            [
+                'adapter' => 'config',
+                'config' => new Config([
+                    'test' => [
+                        'property' => 'blah'
+                    ]
+                ]),
+            ]
         ];
 
         foreach ([[], ['']] as $parameters) {
@@ -120,5 +130,25 @@ class ConstructCest
                 );
             }
         );
+    }
+
+    /**
+     * Tests Phalcon\Config\Adapter\Grouped :: __construct() - exception
+     *
+     * @author Fenikkusu
+     * @since  2017-06-06
+     */
+    public function configAdapterGroupedConstructThrowsConfigException(UnitTester $I)
+    {
+        $I->wantToTest("Config\Adapter\Grouped - construct config without config throws exception");
+
+        $I->expectThrowable(new Exception("To use 'config' adapter you have to specify the 'config' as a Phalcon\\Config instance."),
+            function () {
+                new Grouped([
+                        [
+                            'adapter' => 'array',
+                        ],
+                    ]);
+            });
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: N/A

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

The change allows you to use existing `Phalcon\Config` objects when building a `Phalcon\Config\Adapter\Grouped`

Previously:

```php

$configA = new \Phalcon\Config(['a' => 'b']);

$configB = new \Phalcon\Config\Adapter\Grouped([['adapter' => 'array', 'config' => $configA->toArray(), ['adapter' => 'json', ...]);

```

Now:

```php

$configA = new \Phalcon\Config(['a' => 'b']);
$configB = new \Phalcon\Config\Adapter\Grouped([$configA, ['adapter' => 'json', ...]);

```

My specific use case for this stems from having a default configuration object that already existed and merging it with other configurations.

Thanks
