### PR TITLE
T14519 request hasfiles

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -16,6 +16,7 @@
  - Added `Phalcon\Mvc\Model\ManagerInterface::addHasOneThrough()`
  - Added `Phalcon\Mvc\Model\ManagerInterface::existsHasOneThrough()`
  - Added `Phalcon\Mvc\Model\ManagerInterface::getHasOneThrough()`
+ - Added `Phalcon\Http\Request::numFiles` to return the number of files in the request [#14519](https://github.com/phalcon/cphalcon/issues/14519)
 
 ## Changed
 - Changed `Phalcon\Paginator\Adapter\Model`
@@ -37,6 +38,7 @@
 - Fixed `Phalcon\Mvc\Model\Manager::getRelations()` and `getRelationsBetween()` to return many-to-many relations correctly [#14509](https://github.com/phalcon/cphalcon/pull/14509)
 - Fixed `Phalcon\Logger` to correctly allow transactional logging [#14514](https://github.com/phalcon/cphalcon/issues/14514)
 - Fixed `Phalcon\Annotations\Adapter\Stream::read` and `Phalcon\Annotations\Adapter\Stream::write` to use `serialize`/`unserialize` vs. `var_export` [#14515](https://github.com/phalcon/cphalcon/issues/14515)
+- Fixed `Phalcon\Http\Request::hasFiles` to return boolean and `true` if files are present [#14519](https://github.com/phalcon/cphalcon/issues/14519)
 
 ## Removed
 

--- a/phalcon/Annotations/Adapter/Stream.zep
+++ b/phalcon/Annotations/Adapter/Stream.zep
@@ -12,6 +12,7 @@ namespace Phalcon\Annotations\Adapter;
 
 use Phalcon\Annotations\Reflection;
 use Phalcon\Annotations\Exception;
+use RuntimeException;
 
 /**
  * Stores the parsed annotations in files. This adapter is suitable for production

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -855,7 +855,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
         if null === requestURI {
             return "";
         }
-        
+
         if onlyPath {
             let requestURI = explode('?', requestURI)[0];
         }
@@ -887,39 +887,11 @@ class Request extends AbstractInjectionAware implements RequestInterface
     }
 
     /**
-     * Returns the number of files available
-     *
-     * TODO: Check this
+     * Returns if the request has files or not
      */
-    public function hasFiles(bool onlySuccessful = false) -> long
+    public function hasFiles() -> bool
     {
-        var files, file, error;
-        int numberFiles = 0;
-
-        let files = _FILES;
-
-        if typeof files != "array" {
-            return 0;
-        }
-
-        for file in files {
-            if fetch error, file["error"] {
-                if typeof error != "array" {
-                    if !error || !onlySuccessful {
-                        let numberFiles++;
-                    }
-                }
-
-                if typeof error == "array" {
-                    let numberFiles += this->hasFileHelper(
-                        error,
-                        onlySuccessful
-                    );
-                }
-            }
-        }
-
-        return numberFiles;
+        return this->numFiles(true) > 0;
     }
 
     /**
@@ -1164,6 +1136,40 @@ class Request extends AbstractInjectionAware implements RequestInterface
         }
 
         return false;
+    }
+
+    /**
+     * Returns the number of files available
+     */
+    public function numFiles(bool onlySuccessful = false) -> long
+    {
+        var files, file, error;
+        int numberFiles = 0;
+
+        let files = _FILES;
+
+        if typeof files != "array" {
+            return 0;
+        }
+
+        for file in files {
+            if fetch error, file["error"] {
+                if typeof error != "array" {
+                    if !error || !onlySuccessful {
+                        let numberFiles++;
+                    }
+                }
+
+                if typeof error == "array" {
+                    let numberFiles += this->hasFileHelper(
+                        error,
+                        onlySuccessful
+                    );
+                }
+            }
+        }
+
+        return numberFiles;
     }
 
     /**

--- a/phalcon/Http/RequestInterface.zep
+++ b/phalcon/Http/RequestInterface.zep
@@ -281,9 +281,8 @@ interface RequestInterface
 
     /**
      * Checks whether request include attached files
-     * TODO: We need to check the name. Not very intuitive
      */
-    public function hasFiles(bool onlySuccessful = false) -> long;
+    public function hasFiles() -> bool;
 
     /**
      * Checks whether headers has certain index
@@ -377,4 +376,9 @@ interface RequestInterface
      * if $_SERVER["REQUEST_METHOD"] === "TRACE"
      */
     public function isTrace() -> bool;
+
+    /**
+     * Returns the number of files available
+     */
+    public function numFiles(bool onlySuccessful = false) -> long;
 }

--- a/tests/integration/Mvc/Model/Query/Builder/LimitCest.php
+++ b/tests/integration/Mvc/Model/Query/Builder/LimitCest.php
@@ -37,7 +37,7 @@ class LimitCest
      * Tests Phalcon\Mvc\Model\Query\Builder :: limit()
      *
      * @issue  https://github.com/phalcon/cphalcon/issues/12419
-     * @author       Serghei Iakovelv <serghei@phalcon.io>
+     * @author       Phalcon Team <team@phalcon.io>
      * @since        2016-12-18
      *
      * @dataProvider limitOffsetProvider

--- a/tests/integration/Mvc/Model/Refactor-CriteriaCest.php
+++ b/tests/integration/Mvc/Model/Refactor-CriteriaCest.php
@@ -65,7 +65,7 @@ class CriteriaCest
      * Tests work with limit / offset
      *
      * @issue  https://github.com/phalcon/cphalcon/issues/12419
-     * @author Serghei Iakovelv <serghei@phalcon.io>
+     * @author Phalcon Team <team@phalcon.io>
      * @since  2016-12-18
      *
      * @dataProvider getLimitOffset

--- a/tests/unit/Http/Request/AuthHeaderCest.php
+++ b/tests/unit/Http/Request/AuthHeaderCest.php
@@ -24,7 +24,7 @@ class AuthHeaderCest extends HttpBase
      *
      * @test
      * @issue  https://github.com/phalcon/cphalcon/issues/12480
-     * @author       Serghei Iakovelv <serghei@phalcon.io>
+     * @author       Phalcon Team <team@phalcon.io>
      * @since        2016-12-18
      *
      * @dataProvider basicAuthProvider
@@ -67,7 +67,7 @@ class AuthHeaderCest extends HttpBase
      *
      * @test
      * @issue  https://github.com/phalcon/cphalcon/issues/13327
-     * @author Serghei Iakovelv <serghei@phalcon.io>
+     * @author Phalcon Team <team@phalcon.io>
      * @since  2018-03-25
      */
     public function shouldFireEventWhenResolveAuthorization(UnitTester $I)
@@ -104,7 +104,7 @@ class AuthHeaderCest extends HttpBase
      *
      * @test
      * @issue  https://github.com/phalcon/cphalcon/issues/13327
-     * @author Serghei Iakovelv <serghei@phalcon.io>
+     * @author Phalcon Team <team@phalcon.io>
      * @since  2018-03-25
      */
     public function shouldEnableCustomAuthorizationResolver(UnitTester $I)
@@ -137,7 +137,7 @@ class AuthHeaderCest extends HttpBase
      *
      * @test
      * @issue  https://github.com/phalcon/cphalcon/issues/13327
-     * @author Serghei Iakovelv <serghei@phalcon.io>
+     * @author Phalcon Team <team@phalcon.io>
      * @since  2018-03-25
      */
     public function shouldResolveCustomAuthorizationHeaders(UnitTester $I)

--- a/tests/unit/Http/Request/HasFilesCest.php
+++ b/tests/unit/Http/Request/HasFilesCest.php
@@ -21,7 +21,7 @@ class HasFilesCest extends HttpBase
     /**
      * Tests Request::hasFiles
      *
-     * @author       Serghei Iakovelv <serghei@phalcon.io>
+     * @author       Phalcon Team <team@phalcon.io>
      * @since        2016-01-31
      */
     public function testRequestHasFiles(UnitTester $I)

--- a/tests/unit/Http/Request/HasFilesCest.php
+++ b/tests/unit/Http/Request/HasFilesCest.php
@@ -23,113 +23,32 @@ class HasFilesCest extends HttpBase
      *
      * @author       Serghei Iakovelv <serghei@phalcon.io>
      * @since        2016-01-31
-     *
-     * @dataProvider filesProvider
      */
-    public function testRequestHasFiles(UnitTester $I, Example $example)
+    public function testRequestHasFiles(UnitTester $I)
     {
-        $files          = $example[0];
-        $all            = $example[1];
-        $onlySuccessful = $example[2];
+        $existing = $_FILES ?? [];
 
         $request = $this->getRequestObject();
-        $_FILES  = $files;
+        $_FILES   = [];
 
-        $I->assertEquals(
-            $all,
-            $request->hasFiles(false)
+        $I->assertFalse(
+            $request->hasFiles()
         );
 
-        $I->assertEquals(
-            $onlySuccessful,
-            $request->hasFiles(true)
-        );
-    }
-
-    private function filesProvider(): array
-    {
-        return [
-            [
-                [
-                    'test' => [
-                        'name'     => 'name',
-                        'type'     => 'text/plain',
-                        'size'     => 1,
-                        'tmp_name' => 'tmp_name',
-                        'error'    => 0,
-                    ],
-                ],
-                1,
-                1,
-            ],
-            [
-                [
-                    'test' => [
-                        'name'     => ['name1', 'name2'],
-                        'type'     => ['text/plain', 'text/plain'],
-                        'size'     => [1, 1],
-                        'tmp_name' => ['tmp_name1', 'tmp_name2'],
-                        'error'    => [0, 0],
-                    ],
-                ],
-                2,
-                2,
-            ],
-            [
-                [
-                    'photo' => [
-                        'name'     => [
-                            0 => '',
-                            1 => '',
-                            2 => [0 => '', 1 => '', 2 => ''],
-                            3 => [0 => ''],
-                            4 => [0 => [0 => '']],
-                            5 => [0 => [0 => [0 => [0 => '']]]],
-                        ],
-                        'type'     => [
-                            0 => '',
-                            1 => '',
-                            2 => [0 => '', 1 => '', 2 => ''],
-                            3 => [0 => ''],
-                            4 => [0 => [0 => '']],
-                            5 => [0 => [0 => [0 => [0 => '']]]],
-                        ],
-                        'tmp_name' => [
-                            0 => '',
-                            1 => '',
-                            2 => [0 => '', 1 => '', 2 => ''],
-                            3 => [0 => ''],
-                            4 => [0 => [0 => '']],
-                            5 => [0 => [0 => [0 => [0 => '']]]],
-                        ],
-                        'error'    => [
-                            0 => 4,
-                            1 => 4,
-                            2 => [0 => 4, 1 => 4, 2 => 4],
-                            3 => [0 => 4],
-                            4 => [0 => [0 => 4]],
-                            5 => [0 => [0 => [0 => [0 => 4]]]],
-                        ],
-                        'size'     => [
-                            0 => '',
-                            1 => '',
-                            2 => [0 => '', 1 => '', 2 => ''],
-                            3 => [0 => ''],
-                            4 => [0 => [0 => '']],
-                            5 => [0 => [0 => [0 => [0 => '']]]],
-                        ],
-                    ],
-                    'test'  => [
-                        'name'     => '',
-                        'type'     => '',
-                        'tmp_name' => '',
-                        'error'    => 4,
-                        'size'     => 0,
-                    ],
-                ],
-                9,
-                0,
+        $_FILES = [
+            'test' => [
+                'name'     => 'name',
+                'type'     => 'text/plain',
+                'size'     => 1,
+                'tmp_name' => 'tmp_name',
+                'error'    => 0,
             ],
         ];
+
+        $I->assertTrue(
+            $request->hasFiles()
+        );
+
+        $_FILES = $existing;
     }
 }

--- a/tests/unit/Http/Request/NumFilesCest.php
+++ b/tests/unit/Http/Request/NumFilesCest.php
@@ -21,8 +21,8 @@ class NumFilesCest extends HttpBase
     /**
      * Tests Request::numFiles
      *
-     * @author       Serghei Iakovelv <serghei@phalcon.io>
-     * @since        2016-01-31
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-11-07
      *
      * @dataProvider filesProvider
      */
@@ -37,12 +37,12 @@ class NumFilesCest extends HttpBase
 
         $I->assertEquals(
             $all,
-            $request->hasFiles(false)
+            $request->numFiles(false)
         );
 
         $I->assertEquals(
             $onlySuccessful,
-            $request->hasFiles(true)
+            $request->numFiles(true)
         );
     }
 

--- a/tests/unit/Http/Request/NumFilesCest.php
+++ b/tests/unit/Http/Request/NumFilesCest.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Test\Unit\Http\Request;
+
+use Codeception\Example;
+use Phalcon\Test\Unit\Http\Helper\HttpBase;
+use UnitTester;
+
+class NumFilesCest extends HttpBase
+{
+    /**
+     * Tests Request::numFiles
+     *
+     * @author       Serghei Iakovelv <serghei@phalcon.io>
+     * @since        2016-01-31
+     *
+     * @dataProvider filesProvider
+     */
+    public function testRequestNumFiles(UnitTester $I, Example $example)
+    {
+        $files          = $example[0];
+        $all            = $example[1];
+        $onlySuccessful = $example[2];
+
+        $request = $this->getRequestObject();
+        $_FILES  = $files;
+
+        $I->assertEquals(
+            $all,
+            $request->hasFiles(false)
+        );
+
+        $I->assertEquals(
+            $onlySuccessful,
+            $request->hasFiles(true)
+        );
+    }
+
+    private function filesProvider(): array
+    {
+        return [
+            [
+                [
+                    'test' => [
+                        'name'     => 'name',
+                        'type'     => 'text/plain',
+                        'size'     => 1,
+                        'tmp_name' => 'tmp_name',
+                        'error'    => 0,
+                    ],
+                ],
+                1,
+                1,
+            ],
+            [
+                [
+                    'test' => [
+                        'name'     => ['name1', 'name2'],
+                        'type'     => ['text/plain', 'text/plain'],
+                        'size'     => [1, 1],
+                        'tmp_name' => ['tmp_name1', 'tmp_name2'],
+                        'error'    => [0, 0],
+                    ],
+                ],
+                2,
+                2,
+            ],
+            [
+                [
+                    'photo' => [
+                        'name'     => [
+                            0 => '',
+                            1 => '',
+                            2 => [0 => '', 1 => '', 2 => ''],
+                            3 => [0 => ''],
+                            4 => [0 => [0 => '']],
+                            5 => [0 => [0 => [0 => [0 => '']]]],
+                        ],
+                        'type'     => [
+                            0 => '',
+                            1 => '',
+                            2 => [0 => '', 1 => '', 2 => ''],
+                            3 => [0 => ''],
+                            4 => [0 => [0 => '']],
+                            5 => [0 => [0 => [0 => [0 => '']]]],
+                        ],
+                        'tmp_name' => [
+                            0 => '',
+                            1 => '',
+                            2 => [0 => '', 1 => '', 2 => ''],
+                            3 => [0 => ''],
+                            4 => [0 => [0 => '']],
+                            5 => [0 => [0 => [0 => [0 => '']]]],
+                        ],
+                        'error'    => [
+                            0 => 4,
+                            1 => 4,
+                            2 => [0 => 4, 1 => 4, 2 => 4],
+                            3 => [0 => 4],
+                            4 => [0 => [0 => 4]],
+                            5 => [0 => [0 => [0 => [0 => 4]]]],
+                        ],
+                        'size'     => [
+                            0 => '',
+                            1 => '',
+                            2 => [0 => '', 1 => '', 2 => ''],
+                            3 => [0 => ''],
+                            4 => [0 => [0 => '']],
+                            5 => [0 => [0 => [0 => [0 => '']]]],
+                        ],
+                    ],
+                    'test'  => [
+                        'name'     => '',
+                        'type'     => '',
+                        'tmp_name' => '',
+                        'error'    => 4,
+                        'size'     => 0,
+                    ],
+                ],
+                9,
+                0,
+            ],
+        ];
+    }
+}

--- a/tests/unit/Http/Request/RequestCest.php
+++ b/tests/unit/Http/Request/RequestCest.php
@@ -341,7 +341,7 @@ class RequestCest extends HttpBase
      *
      * @test
      * @issue  https://github.com/phalcon/cphalcon/issues/12478
-     * @author       Serghei Iakovelv <serghei@phalcon.io>
+     * @author       Phalcon Team <team@phalcon.io>
      * @since        2016-12-18
      *
      * @dataProvider overridenMethodProvider
@@ -641,7 +641,7 @@ class RequestCest extends HttpBase
     /**
      * Tests uploaded files
      *
-     * @author Serghei Iakovelv <serghei@phalcon.io>
+     * @author Phalcon Team <team@phalcon.io>
      * @since  2016-01-31
      */
     public function testGetUploadedFiles(UnitTester $I)


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14519 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Http\Request::numFiles` to return the number of files in the request
Fixed `Phalcon\Http\Request::hasFiles` to return boolean and `true` if files are present

Thanks

