### PR TITLE
Returning Instead Of Breaking - Stop Processing Additional View Directories

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -43,6 +43,7 @@
 - Fixed `Phalcon\Mvc\Model\MetaDataInterface::getIdentityField` and `Phalcon\Mvc\Model\MetaData::getIdentityField` to also return `null` if the identity field is not present [#14523](https://github.com/phalcon/cphalcon/issues/14523) 
 - Fixed `Phalcon\Storage\Serializer\Json` to serialize objects that implement the `JsonSerializable` interface [#14528](https://github.com/phalcon/cphalcon/issues/14528) 
 - Fixed `Phalcon\Collection` to correctly return one level nested objects that implement `JsonSerializable` [#14528](https://github.com/phalcon/cphalcon/issues/14528)
+- Fixed `Phalcon\Mvc\View` to only include first found instance of view when using multiple view directories [#12977](https://github.com/phalcon/cphalcon/issues/12977)
 
 ## Removed
 - Removed `Phalcon\Logger\Formatter\Syslog` - really did not do much [#14523](https://github.com/phalcon/cphalcon/issues/14523)

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -929,12 +929,10 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
         bool silence,
         bool mustClean = true
     ) {
-        bool notExists;
         var basePath, engine, eventsManager, extension, viewsDir, viewsDirPath,
             viewEnginePath, viewEnginePaths, viewParams;
 
-        let notExists       = true,
-            basePath        = this->basePath,
+        let basePath        = this->basePath,
             viewParams      = this->viewParams,
             eventsManager   = <ManagerInterface> this->eventsManager,
             viewEnginePaths = [];
@@ -967,12 +965,6 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
 
                     engine->render(viewEnginePath, viewParams, mustClean);
 
-                    /**
-                     * Call afterRenderView if there is an events manager
-                     * available
-                     */
-                    let notExists = false;
-
                     if typeof eventsManager == "object" {
                         eventsManager->fire("view:afterRenderView", this);
                     }
@@ -984,21 +976,19 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
             }
         }
 
-        if notExists {
-            /**
-             * Notify about not found views
-             */
-            if typeof eventsManager == "object" {
-                let this->activeRenderPaths = viewEnginePaths;
+        /**
+         * Notify about not found views
+         */
+        if typeof eventsManager == "object" {
+            let this->activeRenderPaths = viewEnginePaths;
 
-                eventsManager->fire("view:notFoundView", this, viewEnginePath);
-            }
+            eventsManager->fire("view:notFoundView", this, viewEnginePath);
+        }
 
-            if !silence {
-                throw new Exception(
-                    "View '" . viewPath . "' was not found in any of the views directory"
-                );
-            }
+        if !silence {
+            throw new Exception(
+                "View '" . viewPath . "' was not found in any of the views directory"
+            );
         }
     }
 

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -976,7 +976,8 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
                     if typeof eventsManager == "object" {
                         eventsManager->fire("view:afterRenderView", this);
                     }
-                    break;
+
+                    return;
                 }
 
                 let viewEnginePaths[] = viewEnginePath;

--- a/tests/_data/fixtures/views-alt/simple/params.phtml
+++ b/tests/_data/fixtures/views-alt/simple/params.phtml
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @var string $name
+ * @var int $age
+ */
+echo "My name is $name and I am not $age years old";

--- a/tests/integration/Mvc/View/RenderCest.php
+++ b/tests/integration/Mvc/View/RenderCest.php
@@ -53,4 +53,34 @@ class RenderCest
             $view->getContent()
         );
     }
+
+    public function doesNotRenderMultiple(IntegrationTester $I)
+    {
+        $view = new View();
+
+        $view->setViewsDir(
+            [
+                dataDir('fixtures/views'),
+                dataDir('fixtures/views-alt')
+            ]
+        );
+
+        $view->start();
+
+        $view->render(
+            'simple',
+            'params',
+            [
+                'name' => 'Sam',
+                'age'  => 20,
+            ]
+        );
+
+        $view->finish();
+
+        $I->assertEquals(
+            'My name is Sam and I am 20 years old',
+            $view->getContent()
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/12977 | https://github.com/phalcon/cphalcon/issues/11633

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

If you specify multiple view directories using, it creates an abnormality where the same file will be included from every view directory it exists. Rather than continuing the view directory loop, this breaks out of the function completely.

Thanks

