### PR TITLE
[#14528] - Fixed jsonSerializable for collection and json serializer

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -40,6 +40,8 @@
 - Fixed `Phalcon\Annotations\Adapter\Stream::read` and `Phalcon\Annotations\Adapter\Stream::write` to use `serialize`/`unserialize` vs. `var_export` [#14515](https://github.com/phalcon/cphalcon/issues/14515)
 - Fixed `Phalcon\Http\Request::hasFiles` to return boolean and `true` if files are present [#14519](https://github.com/phalcon/cphalcon/issues/14519)
 - Fixed `Phalcon\Logger\Adapter\Syslog` to correctly log Syslog messages [#14523](https://github.com/phalcon/cphalcon/issues/14523)
+- Fixed `Phalcon\Storage\Serializer\Json` to serialize objects that implement the `JsonSerializable` interface [#14528](https://github.com/phalcon/cphalcon/issues/14528) 
+- Fixed `Phalcon\Collection` to correctly return one level nested objects that implement `JsonSerializable` [#14528](https://github.com/phalcon/cphalcon/issues/14528)
 
 ## Removed
 - Removedd `Phalcon\Logger\Formatter\Syslog` - really did not do much [#14523](https://github.com/phalcon/cphalcon/issues/14523)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -44,7 +44,7 @@
 - Fixed `Phalcon\Collection` to correctly return one level nested objects that implement `JsonSerializable` [#14528](https://github.com/phalcon/cphalcon/issues/14528)
 
 ## Removed
-- Removedd `Phalcon\Logger\Formatter\Syslog` - really did not do much [#14523](https://github.com/phalcon/cphalcon/issues/14523)
+- Removed `Phalcon\Logger\Formatter\Syslog` - really did not do much [#14523](https://github.com/phalcon/cphalcon/issues/14523)
 
 # [4.0.0-rc.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.2) (2019-10-26)
 ## Added

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -191,7 +191,20 @@ class Collection implements
      */
     public function jsonSerialize() -> array
     {
-        return this->data;
+        var key, value;
+        array records;
+
+        let records = [];
+
+        for key, value in this->data {
+            if typeof value == "object" && method_exists(value, "jsonSerialize") {
+                let records[key] = value->{"jsonSerialize"}();
+            } else {
+                let records[key] = value;
+            }
+        }
+
+        return records;
     }
 
     /**

--- a/phalcon/Storage/Serializer/Json.zep
+++ b/phalcon/Storage/Serializer/Json.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Storage\Serializer;
 
 use InvalidArgumentException;
+use JsonSerializable;
 
 class Json extends AbstractSerializer
 {
@@ -19,9 +20,9 @@ class Json extends AbstractSerializer
 	 */
 	public function serialize() -> string
 	{
-	    if typeof this->data == "object" {
+	    if typeof this->data == "object" && !(this->data instanceof JsonSerializable) {
             throw new InvalidArgumentException(
-                "Data for JSON serializer cannot be of type object"
+                "Data for JSON serializer cannot be of type object without implementing JsonSerializable"
             );
         }
 

--- a/tests/unit/Storage/Serializer/Json/SerializeCest.php
+++ b/tests/unit/Storage/Serializer/Json/SerializeCest.php
@@ -14,8 +14,11 @@ namespace Phalcon\Test\Unit\Storage\Serializer\Json;
 
 use Codeception\Example;
 use InvalidArgumentException;
+use Phalcon\Collection;
 use Phalcon\Storage\Serializer\Json;
 use UnitTester;
+use function json_decode;
+use function json_encode;
 
 class SerializeCest
 {
@@ -38,6 +41,35 @@ class SerializeCest
     }
 
     /**
+     * Tests Phalcon\Storage\Serializer\Json :: serialize() - object
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2019-11-11
+     */
+    public function storageSerializerJsonSerializeObject(UnitTester $I)
+    {
+        $I->wantToTest('Storage\Serializer\Json - serialize() - object');
+
+        $collection1 = new Collection();
+        $collection1->set('one', 'two');
+        $collection2 = new Collection();
+        $collection2->set('three', 'four');
+        $collection2->set('object', $collection1);
+
+        $serializer = new Json($collection2);
+
+        $data = [
+            'three'  => 'four',
+            'object' => [
+                'one' => 'two',
+            ],
+        ];
+        $expected = json_encode($data);
+        $actual   = $serializer->serialize();
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
      * Tests Phalcon\Storage\Serializer\Json :: serialize() - error
      *
      * @author       Phalcon Team <team@phalcon.io>
@@ -49,7 +81,7 @@ class SerializeCest
 
         $I->expectThrowable(
             new InvalidArgumentException(
-                'Data for JSON serializer cannot be of type object'
+                'Data for JSON serializer cannot be of type object without implementing JsonSerializable'
             ),
             function () {
                 $example = new \stdClass();
@@ -61,6 +93,9 @@ class SerializeCest
         );
     }
 
+    /**
+     * @return array
+     */
     private function getExamples(): array
     {
         return [


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14528 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Corrected `Phalcon\Storage\Serializer\Json` to serialize objects that implement the `JsonSerializable` interface. Corrected `Phalcon\Collection` to correctly return one level nested objects that implement `JsonSerializable`

Thanks

