### PR TITLE
Renamed conversor to converter

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,3 +1,12 @@
+# [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-????) (2019-xx-xx)
+
+## Added
+
+## Changed
+- Changed `PhalconMvc\Router\Annotations` to use `converters` instead of `conversors` [#14532](https://github.com/phalcon/cphalcon/issues/14532)
+
+## Fixed
+
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added
 - Added support for [PSR-13](https://www.php-fig.org/psr/psr-13/) links and evolvable links [#14507](https://github.com/phalcon/cphalcon/issues/14507)

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -241,7 +241,7 @@ class Annotations extends Router
         <Annotation> annotation)
     {
         var name, actionName, routePrefix, paths, value, uri, route, methods,
-            converts, param, convert, conversorParam, routeName, beforeMatch;
+            converts, param, convert, converterParam, routeName, beforeMatch;
         bool isRoute;
 
         let isRoute = false,
@@ -347,18 +347,18 @@ class Annotations extends Router
         }
 
         /**
-         * Add the conversors
+         * Add the converters
          */
-        let converts = annotation->getNamedArgument("conversors");
+        let converts = annotation->getNamedArgument("converters");
 
         if typeof converts == "array" {
-            for conversorParam, convert in converts {
-                route->convert(conversorParam, convert);
+            for converterParam, convert in converts {
+                route->convert(converterParam, convert);
             }
         }
 
         /**
-         * Add the conversors
+         * Add the converters
          */
         let beforeMatch = annotation->getNamedArgument("beforeMatch");
 


### PR DESCRIPTION
Hello!

* Type: bug
* Link to issue: #14532 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `PhalconMvc\Router\Annotations` to use `converters` instead of `conversors`

Thanks

