### PR TITLE
T14547 syslog phpeol

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,7 @@
 ## Fixed
 - Fixed `PhalconMvc\Model` to ignore internal setters if properties have the same name as the setter [#14538](https://github.com/phalcon/cphalcon/issues/14538)
 - Fixed `Phalcon\Logger\Formatter\Line` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream` [#14547](https://github.com/phalcon/cphalcon/issues/14547)
+
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added
 - Added support for [PSR-13](https://www.php-fig.org/psr/psr-13/) links and evolvable links [#14507](https://github.com/phalcon/cphalcon/issues/14507)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -7,7 +7,7 @@
 
 ## Fixed
 - Fixed `PhalconMvc\Model` to ignore internal setters if properties have the same name as the setter [#14538](https://github.com/phalcon/cphalcon/issues/14538)
-
+- Fixed `Phalcon\Logger\Formatter\Line` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream` [#14547](https://github.com/phalcon/cphalcon/issues/14547)
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added
 - Added support for [PSR-13](https://www.php-fig.org/psr/psr-13/) links and evolvable links [#14507](https://github.com/phalcon/cphalcon/issues/14507)

--- a/phalcon/Logger/Adapter/Stream.zep
+++ b/phalcon/Logger/Adapter/Stream.zep
@@ -125,7 +125,7 @@ class Stream extends AbstractAdapter
         }
 
         let formatter        = this->getFormatter(),
-            formattedMessage = formatter->format(item);
+            formattedMessage = formatter->format(item) . PHP_EOL;
 
         fwrite(this->handler, formattedMessage);
     }

--- a/phalcon/Logger/Formatter/Json.zep
+++ b/phalcon/Logger/Formatter/Json.zep
@@ -56,6 +56,6 @@ class Json extends AbstractFormatter
                 "message"   : message,
                 "timestamp" : date(this->dateFormat, item->getTime())
             ]
-        ) . PHP_EOL;
+        );
     }
 }

--- a/phalcon/Logger/Formatter/Line.zep
+++ b/phalcon/Logger/Formatter/Line.zep
@@ -38,8 +38,8 @@ class Line extends AbstractFormatter
      */
     public function __construct(string format = "[%date%][%type%] %message%", string dateFormat = "D, d M y H:i:s O")
     {
-        let this->format = format;
-        let this->dateFormat = dateFormat;
+        let this->format     = format,
+            this->dateFormat = dateFormat;
     }
 
     /**
@@ -72,7 +72,7 @@ class Line extends AbstractFormatter
             let format = str_replace("%type%", item->getName(), format);
         }
 
-        let format = str_replace("%message%", item->getMessage(), format) . PHP_EOL;
+        let format = str_replace("%message%", item->getMessage(), format);
 
         if typeof item->getContext() === "array" {
             return this->interpolate(

--- a/tests/unit/Logger/Formatter/Json/FormatCest.php
+++ b/tests/unit/Logger/Formatter/Json/FormatCest.php
@@ -42,9 +42,8 @@ class FormatCest
         );
 
         $expected = sprintf(
-            '{"type":"debug","message":"log message","timestamp":"%s"}%s',
-            date('D, d M y H:i:s O', $time),
-            PHP_EOL
+            '{"type":"debug","message":"log message","timestamp":"%s"}',
+            date('D, d M y H:i:s O', $time)
         );
 
         $I->assertEquals(
@@ -75,9 +74,8 @@ class FormatCest
         );
 
         $expected = sprintf(
-            '{"type":"debug","message":"log message","timestamp":"%s"}%s',
-            date('YmdHis', $time),
-            PHP_EOL
+            '{"type":"debug","message":"log message","timestamp":"%s"}',
+            date('YmdHis', $time)
         );
 
         $I->assertEquals(

--- a/tests/unit/Logger/Formatter/Json/InterpolateCest.php
+++ b/tests/unit/Logger/Formatter/Json/InterpolateCest.php
@@ -70,9 +70,8 @@ class InterpolateCest
         );
 
         $expected = sprintf(
-            '{"type":"debug","message":"The sky is blue","timestamp":"%s"}%s',
-            date('D, d M y H:i:s O', $time),
-            PHP_EOL
+            '{"type":"debug","message":"The sky is blue","timestamp":"%s"}',
+            date('D, d M y H:i:s O', $time)
         );
 
         $I->assertEquals(

--- a/tests/unit/Logger/Formatter/Line/FormatCest.php
+++ b/tests/unit/Logger/Formatter/Line/FormatCest.php
@@ -41,7 +41,10 @@ class FormatCest
             $time
         );
 
-        $expected = sprintf('[%s][debug] log message', date('D, d M y H:i:s O', $time)) . PHP_EOL;
+        $expected = sprintf(
+            '[%s][debug] log message',
+            date('D, d M y H:i:s O', $time)
+        );
 
         $I->assertEquals(
             $expected,
@@ -70,7 +73,10 @@ class FormatCest
             $time
         );
 
-        $expected = sprintf('log message-[debug]-%s', date('D, d M y H:i:s O', $time)) . PHP_EOL;
+        $expected = sprintf(
+            'log message-[debug]-%s',
+            date('D, d M y H:i:s O', $time)
+        );
 
         $I->assertEquals(
             $expected,

--- a/tests/unit/Logger/Formatter/Line/InterpolateCest.php
+++ b/tests/unit/Logger/Formatter/Line/InterpolateCest.php
@@ -70,7 +70,10 @@ class InterpolateCest
             $context
         );
 
-        $expected = sprintf('[%s][debug] The sky is blue', date('D, d M y H:i:s O', $time)) . PHP_EOL;
+        $expected = sprintf(
+            '[%s][debug] The sky is blue',
+            date('D, d M y H:i:s O', $time)
+        );
 
         $I->assertEquals(
             $expected,

--- a/tests/unit/Logger/Logger/ConstructCest.php
+++ b/tests/unit/Logger/Logger/ConstructCest.php
@@ -111,9 +111,9 @@ class ConstructCest
 
         $I->seeInThisFile($expected);
 
-        $I->safeDeleteFile(
-            $outputPath . $fileName
-        );
+//        $I->safeDeleteFile(
+//            $outputPath . $fileName
+//        );
     }
 
     /**

--- a/tests/unit/Logger/Logger/ConstructCest.php
+++ b/tests/unit/Logger/Logger/ConstructCest.php
@@ -111,9 +111,9 @@ class ConstructCest
 
         $I->seeInThisFile($expected);
 
-//        $I->safeDeleteFile(
-//            $outputPath . $fileName
-//        );
+        $I->safeDeleteFile(
+            $outputPath . $fileName
+        );
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14547 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Logger\Formatter\Line` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream`

Thanks

