### PR TITLE
[#14549] - Fixed settings for metadata redis/apcu

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,7 @@
 ## Fixed
 - Fixed `PhalconMvc\Model` to ignore internal setters if properties have the same name as the setter [#14538](https://github.com/phalcon/cphalcon/issues/14538)
 - Fixed `Phalcon\Logger\Formatter\Line` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream` [#14547](https://github.com/phalcon/cphalcon/issues/14547)
+- Fixed `Phalcon\Mvc\Model\MetaData\Apcu` and `Phalcon\Mvc\Model\MetaData\Redis` to allow setting the `prefix` and `lifetime` using the options or use the default. [#14549](https://github.com/phalcon/cphalcon/issues/14549)
 
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added

--- a/phalcon/Mvc/Model/MetaData/Apcu.zep
+++ b/phalcon/Mvc/Model/MetaData/Apcu.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Mvc\Model\MetaData;
 
+use Phalcon\Helper\Arr;
 use Phalcon\Mvc\Model\MetaData;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Cache\AdapterFactory;
@@ -41,8 +42,8 @@ class Apcu extends MetaData
      */
     public function __construct(<AdapterFactory> factory, array! options = null)
     {
-        let options["prefix"]   = "ph-mm-apcu-",
-            options["lifetime"] = 172800,
+        let options["prefix"]   = Arr::get(options, "prefix", "ph-mm-apcu-"),
+            options["lifetime"] = Arr::get(options, "lifetime", 172800),
             this->adapter       = factory->newInstance("apcu", options);
     }
 }

--- a/phalcon/Mvc/Model/MetaData/Redis.zep
+++ b/phalcon/Mvc/Model/MetaData/Redis.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Mvc\Model\MetaData;
 
+use Phalcon\Helper\Arr;
 use Phalcon\Mvc\Model\MetaData;
 use Phalcon\Cache\AdapterFactory;
 
@@ -43,8 +44,8 @@ class Redis extends MetaData
      */
     public function __construct(<AdapterFactory> factory, array! options = [])
     {
-        let options["prefix"]   = "ph-mm-reds-",
-            options["lifetime"] = 172800,
+        let options["prefix"]   = Arr::get(options, "prefix", "ph-mm-reds-"),
+            options["lifetime"] = Arr::get(options, "lifetime", 172800),
             this->adapter       = factory->newInstance("redis", options);
     }
 

--- a/tests/integration/Mvc/Model/MetaData/Apcu/ConstructCest.php
+++ b/tests/integration/Mvc/Model/MetaData/Apcu/ConstructCest.php
@@ -46,7 +46,6 @@ class ConstructCest
                 return new Apcu(
                     $factory,
                     [
-                        'prefix'   => 'app\\',
                         'lifetime' => 60,
                     ]
                 );


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14549 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\MetaData\Apcu` and `Phalcon\Mvc\Model\MetaData\Redis` to allow setting the `prefix` and `lifetime` using the options or use the default.

Thanks

