### PR TITLE
T14553 escaper nulls

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -15,6 +15,7 @@
 - Fixed `Phalcon\Security::getRandomBytes` to return `int` [#14551](https://github.com/phalcon/cphalcon/issues/14551)
 - Fixed `Phalcon\Security` to use `10` as the default work factor [#14551](https://github.com/phalcon/cphalcon/issues/14551)
 - Fixed `Phalcon\Helper\Arr::validateAny` and `Phalcon\Helper\Arr::validateAll`to use `null` as default for the callback method [#14551](https://github.com/phalcon/cphalcon/issues/14551)
+- Fixed `Phalcon\Escaper::escapeHtml` and `Phalcon\Escaper::escapeHtmlAttr` to allow `null` values  [#14553](https://github.com/phalcon/cphalcon/issues/14553)
  
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added

--- a/phalcon/Escaper.zep
+++ b/phalcon/Escaper.zep
@@ -121,7 +121,7 @@ class Escaper implements EscaperInterface
     /**
      * Escapes a HTML string. Internally uses htmlspecialchars
      */
-    public function escapeHtml(string text) -> string
+    public function escapeHtml(string text = null) -> string
     {
         return htmlspecialchars(
             text,
@@ -134,7 +134,7 @@ class Escaper implements EscaperInterface
     /**
      * Escapes a HTML attribute string
      */
-    public function escapeHtmlAttr(string attribute) -> string
+    public function escapeHtmlAttr(string attribute = null) -> string
     {
         return htmlspecialchars(
             attribute,

--- a/tests/unit/Escaper/EscapeHtmlAttrCest.php
+++ b/tests/unit/Escaper/EscapeHtmlAttrCest.php
@@ -74,6 +74,29 @@ class EscapeHtmlAttrCest
                 'expected'      => 'That&#039;s right',
                 'text'          => "That's right",
             ],
+            [
+                'htmlQuoteType' => ENT_HTML401,
+                'expected'      => '',
+                'text'          => null,
+            ],
+
+            [
+                'htmlQuoteType' => ENT_XML1,
+                'expected'      => '',
+                'text'          => null,
+            ],
+
+            [
+                'htmlQuoteType' => ENT_XHTML,
+                'expected'      => '',
+                'text'          => null,
+            ],
+
+            [
+                'htmlQuoteType' => ENT_HTML5,
+                'expected'      => '',
+                'text'          => null,
+            ],
         ];
     }
 }

--- a/tests/unit/Escaper/EscapeHtmlCest.php
+++ b/tests/unit/Escaper/EscapeHtmlCest.php
@@ -34,4 +34,22 @@ class EscapeHtmlCest
             $escaper->escapeHtml('<h1></h1>')
         );
     }
+
+    /**
+     * Tests Phalcon\Escaper :: escapeHtml() - null
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-11-22
+     */
+    public function escaperEscapeHtmlNull(UnitTester $I)
+    {
+        $I->wantToTest('Escaper - escapeHtml() - null');
+
+        $escaper = new Escaper();
+
+        $I->assertEquals(
+            '',
+            $escaper->escapeHtml(null)
+        );
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14553 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Escaper::escapeHtml` and `Phalcon\Escaper::escapeHtmlAttr` to allow `null` values

Thanks

