### PR TITLE
[#14556] - Corrected getQuery to treat 0 as not empty

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -18,6 +18,7 @@
 - Fixed `Phalcon\Helper\Arr::validateAny` and `Phalcon\Helper\Arr::validateAll`to use `null` as default for the callback method [#14551](https://github.com/phalcon/cphalcon/issues/14551)
 - Fixed `Phalcon\Escaper::escapeHtml` and `Phalcon\Escaper::escapeHtmlAttr` to allow `null` values [#14553](https://github.com/phalcon/cphalcon/issues/14553)
 - Fixed `Phalcon\Mvc\Model::cloneResultMap` to correctly recognize aliased fields and include them in the resultset [#14488](https://github.com/phalcon/cphalcon/issues/14488)
+- Fixed `Phalcon\Http\Request::getQuery`,`Phalcon\Http\Request::getPut`,`Phalcon\Http\Request::getPost` to treat `0` as non empty for `allowNoEmpty` [#14556](https://github.com/phalcon/cphalcon/issues/14556)
 
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -15,6 +15,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use JsonSerializable;
+use Phalcon\Helper\Json;
 use Serializable;
 use Traversable;
 
@@ -313,7 +314,7 @@ class Collection implements
      */
     public function toJson(int options = 79) -> string
     {
-        return json_encode(this->toArray(), options);
+        return Json::encode(this->toArray(), options);
     }
 
     /**

--- a/phalcon/Config/Adapter/Json.zep
+++ b/phalcon/Config/Adapter/Json.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Config\Adapter;
 
 use Phalcon\Config;
+use Phalcon\Helper\Json;
 
 /**
  * Reads JSON files and converts them to Phalcon\Config objects.
@@ -40,7 +41,7 @@ class Json extends Config
     public function __construct(string! filePath)
     {
         parent::__construct(
-            json_decode(
+            Json::decode(
                 file_get_contents(filePath),
                 true
             )

--- a/phalcon/Debug/Dump.zep
+++ b/phalcon/Debug/Dump.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Debug;
 
 use Phalcon\Di;
+use Phalcon\Helper\Json;
 use Reflection;
 use ReflectionClass;
 use ReflectionProperty;
@@ -127,7 +128,7 @@ class Dump
      */
     public function toJson(var variable) -> string
     {
-        return json_encode(
+        return Json::encode(
             variable,
             JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
         );

--- a/phalcon/Helper/Json.zep
+++ b/phalcon/Helper/Json.zep
@@ -80,8 +80,8 @@ class Json
      * ```
      *
      * @param mixed  $data        JSON data to parse
-     * @param int    $depth       Recursion depth.
      * @param int    $options     Bitmask of JSON decode options.
+     * @param int    $depth       Recursion depth.
      *
      * @return mixed
      *
@@ -90,13 +90,13 @@ class Json
      */
     final public static function encode(
         var data,
-        int depth = 512,
-        int options = 0
+        int options = 0,
+        int depth = 512
     ) -> string
     {
         var encoded;
 
-        let encoded = json_encode(data, depth, options);
+        let encoded = json_encode(data, options, depth);
 
         if unlikely JSON_ERROR_NONE !== json_last_error() {
             throw new InvalidArgumentException(

--- a/phalcon/Helper/Json.zep
+++ b/phalcon/Helper/Json.zep
@@ -26,7 +26,7 @@ class Json
      *
      * $data = '{"one":"two","0":"three"}';
      *
-     * var_dump(Json::decode($data))
+     * var_dump(Json::decode($data));
      * // [
      * //     'one' => 'two',
      * //     'three'
@@ -64,7 +64,7 @@ class Json
     }
 
     /**
-     * Encoxes a string using `json_encode` and throws an exception if the
+     * Encodes a string using `json_encode` and throws an exception if the
      * JSON data cannot be encoded
      *
      * ```php

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -1256,8 +1256,14 @@ class Request extends AbstractInjectionAware implements RequestInterface
      * Helper to get data from superglobals, applying filters if needed.
      * If no parameters are given the superglobal is returned.
      */
-    final protected function getHelper(array source, string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    final protected function getHelper(
+        array source,
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         var value, filterService;
 
         if name === null {
@@ -1273,7 +1279,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
                 value         = filterService->sanitize(value, filters, noRecursive);
         }
 
-        if empty value && notAllowEmpty {
+        if !is_numeric(value) && empty value && notAllowEmpty {
             return defaultValue;
         }
 

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -1274,13 +1274,13 @@ class Request extends AbstractInjectionAware implements RequestInterface
             return defaultValue;
         }
 
+        if !is_numeric(value) && empty value && notAllowEmpty {
+            return defaultValue;
+        }
+
         if filters !== null {
             let filterService = this->getFilterService(),
                 value         = filterService->sanitize(value, filters, noRecursive);
-        }
-
-        if !is_numeric(value) && empty value && notAllowEmpty {
-            return defaultValue;
         }
 
         return value;

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -14,6 +14,7 @@ use Phalcon\Di\DiInterface;
 use Phalcon\Di\AbstractInjectionAware;
 use Phalcon\Events\ManagerInterface;
 use Phalcon\Filter\FilterInterface;
+use Phalcon\Helper\Json;
 use Phalcon\Http\Request\File;
 use Phalcon\Http\Request\FileInterface;
 use Phalcon\Http\Request\Exception;
@@ -508,7 +509,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
             return false;
         }
 
-        return json_decode(rawBody, associative);
+        return Json::decode(rawBody, associative);
     }
 
     /**

--- a/phalcon/Http/Response.zep
+++ b/phalcon/Http/Response.zep
@@ -15,6 +15,7 @@ use DateTimeZone;
 use Phalcon\Di;
 use Phalcon\Di\DiInterface;
 use Phalcon\Helper\Fs;
+use Phalcon\Helper\Json;
 use Phalcon\Http\Response\Exception;
 use Phalcon\Http\Response\HeadersInterface;
 use Phalcon\Http\Response\CookiesInterface;

--- a/phalcon/Http/Response.zep
+++ b/phalcon/Http/Response.zep
@@ -562,7 +562,7 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
                     mb_detect_order(),
                     true
                 );
-            }                
+            }
             this->setRawHeader("Content-Description: File Transfer");
             this->setRawHeader("Content-Type: application/octet-stream");
             this->setRawHeader("Content-Transfer-Encoding: binary");
@@ -638,7 +638,7 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
         this->setContentType("application/json", "UTF-8");
 
         this->setContent(
-            json_encode(content, jsonOptions, depth)
+            Json::encode(content, jsonOptions, depth)
         );
 
         return this;

--- a/phalcon/Logger/Formatter/Json.zep
+++ b/phalcon/Logger/Formatter/Json.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Logger\Formatter;
 
+use Phalcon\Helper\Json;
 use Phalcon\Logger\Item;
 
 /**
@@ -50,7 +51,7 @@ class Json extends AbstractFormatter
             let message = item->getMessage();
         }
 
-        return json_encode(
+        return Json::encode(
             [
                 "type"      : item->getName(),
                 "message"   : message,

--- a/tests/unit/Http/Request/GetPostCest.php
+++ b/tests/unit/Http/Request/GetPostCest.php
@@ -14,36 +14,113 @@ namespace Phalcon\Test\Unit\Http\Request;
 
 use Phalcon\Di;
 use Phalcon\Di\FactoryDefault;
+use Phalcon\Http\Request;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
 use UnitTester;
 
 class GetPostCest //extends HttpBase
 {
+    use DiTrait;
+
     /**
      * Tests Phalcon\Http\Request :: getPost()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @since  2019-12-01
      */
     public function httpRequestGetPost(UnitTester $I)
     {
         $I->wantToTest('Http\Request - getPost()');
 
-        $oldPost       = $_POST;
-        $_POST['test'] = -1234;
+        $this->setNewFactoryDefault();
 
-        $container = new FactoryDefault();
-        Di::reset();
-        Di::setDefault($container);
+        $existing = $_POST ?? [];
 
-        $request = $container['request'];
+        $_POST['status'] = ' Active ';
+        $request = new Request();
 
-//        $request = $this->getRequestObject();
+        $expected = ' Active ';
+        $actual   = $request->getPost('status');
+        $I->assertEquals($expected, $actual);
 
-        $I->assertEquals(
-            1234,
-            $request->getPost('test', 'absint')
-        );
+        $_POST = $existing;
+    }
 
-        $_POST = $oldPost;
+    /**
+     * Tests Phalcon\Http\Request :: getPost() - filter
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-01
+     */
+    public function httpRequestGetPostFilter(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPost() - filter');
+
+        $this->setNewFactoryDefault();
+
+        $existing = $_POST ?? [];
+
+        $_POST['status'] = ' Active ';
+        $request = new Request();
+        $request->setDI($this->container);
+
+        $expected = 'Active';
+        $actual   = $request->getPost('status', 'trim');
+        $I->assertEquals($expected, $actual);
+
+        $expected = 'active';
+        $actual   = $request->getPost('status', ['trim', 'lower']);
+        $I->assertEquals($expected, $actual);
+
+        $_POST = $existing;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getPost() - default
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-01
+     */
+    public function httpRequestGetPostDefault(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPost() - default');
+
+        $this->setNewFactoryDefault();
+
+        $existing = $_POST ?? [];
+
+        $request = new Request();
+        $request->setDI($this->container);
+
+        $expected = 'default';
+        $actual   = $request->getPost('status', null, 'default');
+        $I->assertEquals($expected, $actual);
+
+        $_POST = $existing;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getPost() - allowNoEmpty
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-01
+     */
+    public function httpRequestGetPostAllowNoEmpty(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPost() - allowNoEmpty');
+
+        $this->setNewFactoryDefault();
+
+        $existing = $_POST ?? [];
+
+        $_POST['status'] = ' 0 ';
+        $request = new Request();
+        $request->setDI($this->container);
+
+        $expected = '0';
+        $actual   = $request->getPost('status', 'trim', 'zero value', true);
+        $I->assertEquals($expected, $actual);
+
+        $_POST = $existing;
     }
 }

--- a/tests/unit/Http/Request/GetQueryCest.php
+++ b/tests/unit/Http/Request/GetQueryCest.php
@@ -12,20 +12,113 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Http\Request;
 
+use Phalcon\Http\Request;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
 use UnitTester;
 
 class GetQueryCest
 {
+    use DiTrait;
+
     /**
      * Tests Phalcon\Http\Request :: getQuery()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @since  2019-12-01
      */
     public function httpRequestGetQuery(UnitTester $I)
     {
         $I->wantToTest('Http\Request - getQuery()');
 
-        $I->skipTest('Need implementation');
+        $this->setNewFactoryDefault();
+
+        $existing = $_GET ?? [];
+
+        $_GET['status'] = ' Active ';
+        $request = new Request();
+
+        $expected = ' Active ';
+        $actual   = $request->getQuery('status');
+        $I->assertEquals($expected, $actual);
+
+        $_GET = $existing;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getQuery() - filter
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-01
+     */
+    public function httpRequestGetQueryFilter(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getQuery() - filter');
+
+        $this->setNewFactoryDefault();
+
+        $existing = $_GET ?? [];
+
+        $_GET['status'] = ' Active ';
+        $request = new Request();
+        $request->setDI($this->container);
+
+        $expected = 'Active';
+        $actual   = $request->getQuery('status', 'trim');
+        $I->assertEquals($expected, $actual);
+
+        $expected = 'active';
+        $actual   = $request->getQuery('status', ['trim', 'lower']);
+        $I->assertEquals($expected, $actual);
+
+        $_GET = $existing;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getQuery() - default
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-01
+     */
+    public function httpRequestGetQueryDefault(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getQuery() - default');
+
+        $this->setNewFactoryDefault();
+
+        $existing = $_GET ?? [];
+
+        $request = new Request();
+        $request->setDI($this->container);
+
+        $expected = 'default';
+        $actual   = $request->getQuery('status', null, 'default');
+        $I->assertEquals($expected, $actual);
+
+        $_GET = $existing;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getQuery() - allowNoEmpty
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-01
+     */
+    public function httpRequestGetQueryAllowNoEmpty(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getQuery() - allowNoEmpty');
+
+        $this->setNewFactoryDefault();
+
+        $existing = $_GET ?? [];
+
+        $_GET['status'] = ' 0 ';
+        $request = new Request();
+        $request->setDI($this->container);
+
+        $expected = '0';
+        $actual   = $request->getQuery('status', 'trim', 'zero value', true);
+        $I->assertEquals($expected, $actual);
+
+        $_GET = $existing;
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14556 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Http\Request::getQuery`,`Phalcon\Http\Request::getPut`,`Phalcon\Http\Request::getPost` to treat `0` as non empty for `allowNoEmpty`

Thanks

