### PR TITLE
T14575 cache keys

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -20,6 +20,7 @@
 - Fixed `Phalcon\Mvc\Model::cloneResultMap` to correctly recognize aliased fields and include them in the resultset [#14488](https://github.com/phalcon/cphalcon/issues/14488)
 - Fixed `Phalcon\Http\Request::getQuery`,`Phalcon\Http\Request::getPut`,`Phalcon\Http\Request::getPost` to treat `0` as non empty for `allowNoEmpty` [#14556](https://github.com/phalcon/cphalcon/issues/14556)
 - Fixed `Phalcon\Router::handle()` to use the `/` route on empty string [#14559](https://github.com/phalcon/cphalcon/issues/14559)
+- Fixed `Phalcon\Storage\Adapter\Libmemcached::getKeys` and `Phalcon\Storage\Adapter\Redis::getKeys` to return the keys that are prefixed only for that adapter [#14575](https://github.com/phalcon/cphalcon/issues/14575)
 
 # [4.0.0-rc.r3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0-rc.3) (2019-11-16)
 ## Added

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -34,7 +34,6 @@ class Arr
         return array_chunk(collection, size, preserveKeys);
     }
 
-
     /**
      * Helper method to filter the collection
      *

--- a/phalcon/Helper/Arr.zep
+++ b/phalcon/Helper/Arr.zep
@@ -26,9 +26,30 @@ class Arr
      *
      * @return array
      */
-    final public static function chunk(array! collection, int size, bool preserveKeys = false) -> array
-    {
+    final public static function chunk(
+        array! collection,
+        int size,
+        bool preserveKeys = false
+    ) -> array {
         return array_chunk(collection, size, preserveKeys);
+    }
+
+
+    /**
+     * Helper method to filter the collection
+     *
+     * @param array    $collection
+     * @param callable $method
+     *
+     * @return array
+     */
+    final public static function filter(array collection, var method = null) -> array
+    {
+        if null === method || !is_callable(method)  {
+            return collection;
+        }
+
+        return array_filter(collection, method);
     }
 
     /**
@@ -44,7 +65,7 @@ class Arr
     {
         var filtered;
 
-        let filtered = self::filterCollection(collection, method);
+        let filtered = self::filter(collection, method);
 
         return reset(filtered);
     }
@@ -62,7 +83,7 @@ class Arr
     {
         var filtered;
 
-        let filtered = self::filterCollection(collection, method);
+        let filtered = self::filter(collection, method);
 
         reset(filtered);
 
@@ -196,7 +217,7 @@ class Arr
     {
         var filtered;
 
-        let filtered = self::filterCollection(collection, method);
+        let filtered = self::filter(collection, method);
 
         return end(filtered);
     }
@@ -214,7 +235,7 @@ class Arr
     {
         var filtered;
 
-        let filtered = self::filterCollection(collection, method);
+        let filtered = self::filter(collection, method);
 
         end(filtered);
 
@@ -230,8 +251,11 @@ class Arr
      *
      * @return array
      */
-    final public static function order(array! collection, var attribute, string order = "asc") -> array
-    {
+    final public static function order(
+        array! collection,
+        var attribute,
+        string order = "asc"
+    ) -> array {
         var item, key;
         array sorted;
 
@@ -291,8 +315,11 @@ class Arr
      *
      * @return array
      */
-    final public static function set(array! collection, var value, var index = null) -> array
-    {
+    final public static function set(
+        array! collection,
+        var value,
+        var index = null
+    ) -> array {
         if null === index {
             let collection[] = value;
         } else {
@@ -363,7 +390,7 @@ class Arr
      */
     final public static function validateAll(array! collection, var method = null) -> bool
     {
-        return count(self::filterCollection(collection, method)) === count(collection);
+        return count(self::filter(collection, method)) === count(collection);
     }
 
     /**
@@ -377,24 +404,7 @@ class Arr
      */
     final public static function validateAny(array! collection, var method = null) -> bool
     {
-        return count(self::filterCollection(collection, method)) > 0;
-    }
-
-    /**
-     * Helper method to filter the collection
-     *
-     * @param array    $collection
-     * @param callable $method
-     *
-     * @return array
-     */
-    final private static function filterCollection(array collection, var method = null) -> array
-    {
-        if null === method || !is_callable(method)  {
-            return collection;
-        }
-
-        return array_filter(collection, method);
+        return count(self::filter(collection, method)) > 0;
     }
 
     /**

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -161,16 +161,18 @@ class Libmemcached extends AbstractAdapter
      */
     public function getKeys() -> array
     {
-    	var keys, results;
+    	var key, keys;
+    	array results;
 
-        let keys    = this->getAdapter()->getAllKeys(),
-            keys    = !keys ? [] : keys,
-            results = array_filter(
-                keys,
-                function ($value) {
-                    return substr($value, 0, strlen($this->prefix)) === $this->prefix;
-                }
-            );
+        let results = [],
+            keys    = this->getAdapter()->getAllKeys(),
+            keys    = !keys ? [] : keys;
+
+        for key in keys {
+            if substr(value, 0, strlen(this->prefix)) === this->prefix {
+                let results[] = key;
+            }
+        }
 
         return results;
     }

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -161,17 +161,16 @@ class Libmemcached extends AbstractAdapter
      */
     public function getKeys() -> array
     {
-    	var key, keys;
-    	array results;
+    	var keys, results;
 
         let keys    = this->getAdapter()->getAllKeys(),
             keys    = !keys ? [] : keys,
             results = Arr::filter(
-            keys,
-            function ($value) {
-                return substr($value, 0, strlen($this->prefix)) === $this->prefix;
-            }
-        );
+                keys,
+                function ($value) {
+                    return substr($value, 0, strlen($this->prefix)) === $this->prefix;
+                }
+            );
 
         return results;
     }

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -64,7 +64,7 @@ class Libmemcached extends AbstractAdapter
      */
     public function decrement(string! key, int value = 1) -> int | bool
     {
-        return this->getAdapter()->decrement(this->getPrefixedKey(key), value);
+        return this->getAdapter()->decrement(key, value);
     }
 
     /**
@@ -77,7 +77,7 @@ class Libmemcached extends AbstractAdapter
      */
     public function delete(string! key) -> bool
     {
-        return this->getAdapter()->delete(this->getPrefixedKey(key), 0);
+        return this->getAdapter()->delete(key, 0);
     }
 
     /**
@@ -92,7 +92,7 @@ class Libmemcached extends AbstractAdapter
     public function get(string! key, var defaultValue = null) -> var
     {
         return this->getUnserializedData(
-            this->getAdapter()->get(this->getPrefixedKey(key)),
+            this->getAdapter()->get(key),
             defaultValue
         );
     }
@@ -189,7 +189,7 @@ class Libmemcached extends AbstractAdapter
         var connection, result;
 
         let connection = this->getAdapter(),
-            result     = connection->get(this->getPrefixedKey(key));
+            result     = connection->get(key);
 
         return \Memcached::RES_NOTFOUND !== connection->getResultCode();
     }
@@ -205,7 +205,7 @@ class Libmemcached extends AbstractAdapter
      */
     public function increment(string! key, int value = 1) -> int | bool
     {
-        return this->getAdapter()->increment(this->getPrefixedKey(key), value);
+        return this->getAdapter()->increment(key, value);
     }
 
     /**
@@ -221,7 +221,7 @@ class Libmemcached extends AbstractAdapter
     public function set(string! key, var value, var ttl = null) -> bool
     {
         return this->getAdapter()->set(
-            this->getPrefixedKey(key),
+            key,
             this->getSerializedData(value),
             this->getTtl(ttl)
         );

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -169,7 +169,7 @@ class Libmemcached extends AbstractAdapter
             keys    = !keys ? [] : keys;
 
         for key in keys {
-            if substr(value, 0, strlen(this->prefix)) === this->prefix {
+            if substr(key, 0, strlen(this->prefix)) === this->prefix {
                 let results[] = key;
             }
         }

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -165,7 +165,7 @@ class Libmemcached extends AbstractAdapter
 
         let keys    = this->getAdapter()->getAllKeys(),
             keys    = !keys ? [] : keys,
-            results = Arr::filter(
+            results = array_filter(
                 keys,
                 function ($value) {
                     return substr($value, 0, strlen($this->prefix)) === $this->prefix;

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -163,7 +163,7 @@ class Redis extends AbstractAdapter
 
         let keys    = this->getAdapter()->keys("*"),
             keys    = !keys ? [] : keys,
-            results = Arr::filter(
+            results = array_filter(
                 keys,
                 function ($value) {
                     return substr($value, 0, strlen($this->prefix)) === $this->prefix;

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -159,16 +159,18 @@ class Redis extends AbstractAdapter
      */
     public function getKeys() -> array
     {
-    	var keys, results;
+    	var key, keys;
+    	array results;
 
-        let keys    = this->getAdapter()->keys("*"),
-            keys    = !keys ? [] : keys,
-            results = array_filter(
-                keys,
-                function ($value) {
-                    return substr($value, 0, strlen($this->prefix)) === $this->prefix;
-                }
-            );
+        let results = [],
+            keys    = this->getAdapter()->keys("*"),
+            keys    = !keys ? [] : keys;
+
+        for key in keys {
+            if substr(value, 0, strlen(this->prefix)) === this->prefix {
+                let results[] = key;
+            }
+        }
 
         return results;
     }

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -67,7 +67,7 @@ class Redis extends AbstractAdapter
      */
     public function decrement(string! key, int value = 1) -> int | bool
     {
-        return this->getAdapter()->decrBy(key, value);
+        return this->getAdapter()->decrBy(this->getPrefixedKey(key), value);
     }
 
     /**
@@ -80,7 +80,7 @@ class Redis extends AbstractAdapter
      */
     public function delete(string! key) -> bool
     {
-        return (bool) this->getAdapter()->del(key);
+        return (bool) this->getAdapter()->del(this->getPrefixedKey(key));
     }
 
     /**
@@ -95,7 +95,7 @@ class Redis extends AbstractAdapter
     public function get(string! key, var defaultValue = null) -> var
     {
         return this->getUnserializedData(
-            this->getAdapter()->get(key),
+            this->getAdapter()->get(this->getPrefixedKey(key)),
             defaultValue
         );
     }
@@ -159,7 +159,19 @@ class Redis extends AbstractAdapter
      */
     public function getKeys() -> array
     {
-        return this->getAdapter()->keys("*");
+    	var key, keys;
+    	array results;
+
+        let keys    = this->getAdapter()->keys("*"),
+            keys    = !keys ? [] : keys,
+            results = Arr::filter(
+            keys,
+            function ($value) {
+                return substr($value, 0, strlen($this->prefix)) === $this->prefix;
+            }
+        );
+
+        return results;
     }
 
     /**
@@ -172,7 +184,7 @@ class Redis extends AbstractAdapter
      */
     public function has(string! key) -> bool
     {
-        return (bool) this->getAdapter()->exists(key);
+        return (bool) this->getAdapter()->exists(this->getPrefixedKey(key));
     }
 
     /**
@@ -186,7 +198,7 @@ class Redis extends AbstractAdapter
      */
     public function increment(string! key, int value = 1) -> int | bool
     {
-        return this->getAdapter()->incrBy(key, value);
+        return this->getAdapter()->incrBy(this->getPrefixedKey(key), value);
     }
 
     /**
@@ -202,7 +214,7 @@ class Redis extends AbstractAdapter
     public function set(string! key, var value, var ttl = null) -> bool
     {
         return this->getAdapter()->set(
-            key,
+            this->getPrefixedKey(key),
             this->getSerializedData(value),
             this->getTtl(ttl)
         );

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -167,7 +167,7 @@ class Redis extends AbstractAdapter
             keys    = !keys ? [] : keys;
 
         for key in keys {
-            if substr(value, 0, strlen(this->prefix)) === this->prefix {
+            if substr(key, 0, strlen(this->prefix)) === this->prefix {
                 let results[] = key;
             }
         }

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -67,7 +67,7 @@ class Redis extends AbstractAdapter
      */
     public function decrement(string! key, int value = 1) -> int | bool
     {
-        return this->getAdapter()->decrBy(this->getPrefixedKey(key), value);
+        return this->getAdapter()->decrBy(key, value);
     }
 
     /**
@@ -80,7 +80,7 @@ class Redis extends AbstractAdapter
      */
     public function delete(string! key) -> bool
     {
-        return (bool) this->getAdapter()->del(this->getPrefixedKey(key));
+        return (bool) this->getAdapter()->del(key);
     }
 
     /**
@@ -95,7 +95,7 @@ class Redis extends AbstractAdapter
     public function get(string! key, var defaultValue = null) -> var
     {
         return this->getUnserializedData(
-            this->getAdapter()->get(this->getPrefixedKey(key)),
+            this->getAdapter()->get(key),
             defaultValue
         );
     }
@@ -184,7 +184,7 @@ class Redis extends AbstractAdapter
      */
     public function has(string! key) -> bool
     {
-        return (bool) this->getAdapter()->exists(this->getPrefixedKey(key));
+        return (bool) this->getAdapter()->exists(key);
     }
 
     /**
@@ -198,7 +198,7 @@ class Redis extends AbstractAdapter
      */
     public function increment(string! key, int value = 1) -> int | bool
     {
-        return this->getAdapter()->incrBy(this->getPrefixedKey(key), value);
+        return this->getAdapter()->incrBy(key, value);
     }
 
     /**
@@ -214,7 +214,7 @@ class Redis extends AbstractAdapter
     public function set(string! key, var value, var ttl = null) -> bool
     {
         return this->getAdapter()->set(
-            this->getPrefixedKey(key),
+            key,
             this->getSerializedData(value),
             this->getTtl(ttl)
         );

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -159,17 +159,16 @@ class Redis extends AbstractAdapter
      */
     public function getKeys() -> array
     {
-    	var key, keys;
-    	array results;
+    	var keys, results;
 
         let keys    = this->getAdapter()->keys("*"),
             keys    = !keys ? [] : keys,
             results = Arr::filter(
-            keys,
-            function ($value) {
-                return substr($value, 0, strlen($this->prefix)) === $this->prefix;
-            }
-        );
+                keys,
+                function ($value) {
+                    return substr($value, 0, strlen($this->prefix)) === $this->prefix;
+                }
+            );
 
         return results;
     }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14575 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Storage\Adapter\Libmemcached::getKeys` and `Phalcon\Storage\Adapter\Redis::getKeys` to return the keys that are prefixed only for that adapter

Thanks

