### PR TITLE
Test CheckField

### DIFF
--- a/tests/unit/Tag/CheckFieldCest.php
+++ b/tests/unit/Tag/CheckFieldCest.php
@@ -12,20 +12,128 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Tag;
 
+use Phalcon\Test\Fixtures\Helpers\TagHelper;
+
 use UnitTester;
 
-class CheckFieldCest
+class CheckFieldCest extends TagHelper
 {
+    protected $function  = 'checkField';
+    protected $inputType = 'checkbox';
+
     /**
-     * Tests Phalcon\Tag :: checkField()
+     * Tests Phalcon\Tag :: weekField() - setDefault
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
-     */
-    public function tagCheckField(UnitTester $I)
+     * @since  2014-09-05
+    */
+    public function tagFieldWithSetDefault(UnitTester $I)
     {
-        $I->wantToTest('Tag - checkField()');
+        $I->wantToTest(
+            sprintf(
+                'Tag - %s() - setDefault()',
+                $this->function
+            )
+        );
 
-        $I->skipTest('Need implementation');
+        $options = [
+            'x_name',
+            'name'  => 'x_other',
+            'class' => 'x_class',
+            'size'  => '10',
+        ];
+
+        $expected = '<input type="' . $this->inputType . '" id="x_name" '
+            . 'name="x_other" value="x_value" class="x_class" size="10" checked="checked"';
+
+        $this->testFieldParameter($I, $this->function, $options, $expected, false, 'setDefault');
+        $this->testFieldParameter($I, $this->function, $options, $expected, true, 'setDefault');
+    }
+
+    /**
+     * Tests Phalcon\Tag :: weekField() - displayTo
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2014-09-05
+    */
+    public function tagFieldWithDisplayTo(UnitTester $I)
+    {
+        $I->wantToTest(
+            sprintf(
+                'Tag - %s() - string displayTo()',
+                $this->function
+            )
+        );
+
+        $options = [
+            'x_name',
+            'name'  => 'x_other',
+            'class' => 'x_class',
+            'size'  => '10',
+        ];
+
+        $expected = '<input type="' . $this->inputType . '" id="x_name" '
+            . 'name="x_other" value="x_value" class="x_class" size="10" checked="checked"';
+
+        $this->testFieldParameter($I, $this->function, $options, $expected, false, 'displayTo');
+        $this->testFieldParameter($I, $this->function, $options, $expected, true, 'displayTo');
+    }
+
+    /**
+     * Tests Phalcon\Tag :: weekField() - setDefault and element not present
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2014-09-05
+     */
+    public function tagFieldWithSetDefaultElementNotPresent(UnitTester $I)
+    {
+        $I->wantToTest(
+            sprintf(
+                'Tag - %s() - setDefault() element not present',
+                $this->function
+            )
+        );
+
+        $options = [
+            'x_name',
+            'name'  => 'x_other',
+            'class' => 'x_class',
+            'size'  => '10',
+        ];
+
+        $expected = '<input type="' . $this->inputType . '" id="x_name" '
+            . 'name="x_other" value="x_value" class="x_class" size="10" checked="checked"';
+
+        $this->testFieldParameter($I, $this->function, $options, $expected, false, 'setDefault');
+        $this->testFieldParameter($I, $this->function, $options, $expected, true, 'setDefault');
+    }
+
+    /**
+     * Tests Phalcon\Tag :: weekField() - displayTo and element not present
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2014-09-05
+     */
+    public function tagFieldWithDisplayToElementNotPresent(UnitTester $I)
+    {
+        $I->wantToTest(
+            sprintf(
+                'Tag - %s() - displayTo() element not present',
+                $this->function
+            )
+        );
+
+        $options = [
+            'x_name',
+            'name'  => 'x_other',
+            'class' => 'x_class',
+            'size'  => '10',
+        ];
+
+        $expected = '<input type="' . $this->inputType . '" id="x_name" '
+            . 'name="x_other" value="x_value" class="x_class" size="10" checked="checked"';
+
+        $this->testFieldParameter($I, $this->function, $options, $expected, false, 'displayTo');
+        $this->testFieldParameter($I, $this->function, $options, $expected, true, 'displayTo');
     }
 }


### PR DESCRIPTION
Hello!

I overridden some function of TagHelper like :
* tagFieldWithSetDefault
* tagFieldWithDisplayTo
* tagFieldWithSetDefaultElementNotPresent
* tagFieldWithDisplayToElementNotPresent

I did it because I had to add the attribute checked="checked" in the expected value.

* Type: code quality
* Link to issue:  #14588

