### PR TITLE
Fixed Mysql column definition

### DIFF
--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -853,8 +853,6 @@ class Mysql extends Dialect
             } else {
                 let columnSql .= ")";
             }
-        } else {
-            let columnSql .= ")";
         }
 
         return columnSql;

--- a/tests/_data/fixtures/Traits/DialectTrait.php
+++ b/tests/_data/fixtures/Traits/DialectTrait.php
@@ -203,6 +203,12 @@ trait DialectTrait
                     'autoIncrement' => true,
                 ]
             ),
+            'column24'  => new Column(
+                'column24',
+                [
+                    'type'     => Column::TYPE_FLOAT,
+                ]
+            ),
         ];
     }
 

--- a/tests/integration/Db/Dialect/Mysql/GetColumnDefinitionCest.php
+++ b/tests/integration/Db/Dialect/Mysql/GetColumnDefinitionCest.php
@@ -64,6 +64,9 @@ class GetColumnDefinitionCest
             ['column11', 'BIGINT(20) UNSIGNED'],
             ['column12', 'ENUM("A", "B", "C")'],
             ['column13', 'TIMESTAMP'],
+            ['column19', 'DOUBLE'],
+            ['column20', 'DOUBLE UNSIGNED'],
+            ['column24', 'FLOAT'],
         ];
     }
 }


### PR DESCRIPTION
remove unwanted parenthesis closure for DOUBLE, FLOAT... definitions
