### PR TITLE
T2893 logger date format

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,7 +5,8 @@
 - Changed the logic when logging times for `Phalcon\Logger` to use `DateTimeImmutable` so as to handle microseconds if necessary. [#2893](https://github.com/phalcon/cphalcon/issues/2893)
 
 ## Fixed
-- Fixed `Phalcon\Mvc\Model\Criteria` Di isn't set when using Criteria::fromInput() [#14538](https://github.com/phalcon/cphalcon/issues/14639)
+- Fixed `Phalcon\Mvc\Model\Criteria` Di isn't set when using `Criteria::fromInput()` [#14538](https://github.com/phalcon/cphalcon/issues/14639)
+- Fixed `Phalcon\Db\Dialect\Mysql` removing unnecessary parentheses for `double` and `float` [#14645](https://github.com/phalcon/cphalcon/pull/14645) [@pfz](https://github.com/pfz)
 
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-12-21)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -2,6 +2,7 @@
 ## Added
 
 ## Changed
+- Changed the logic when logging times for `Phalcon\Logger` to use `DateTimeImmutable` so as to handle microseconds if necessary. [#2893](https://github.com/phalcon/cphalcon/issues/2893)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Criteria` Di isn't set when using Criteria::fromInput() [#14538](https://github.com/phalcon/cphalcon/issues/14639)

--- a/phalcon/Logger/Formatter/AbstractFormatter.zep
+++ b/phalcon/Logger/Formatter/AbstractFormatter.zep
@@ -58,7 +58,7 @@ abstract class AbstractFormatter implements FormatterInterface
     {
         var date, timezone;
 
-        let timezone = date_default_timezone_get();
+        let timezone = date_default_timezone_get(),
             date     = new DateTimeImmutable("now", new DateTimeZone(timezone));
 
         return date->format(this->dateFormat);

--- a/phalcon/Logger/Formatter/AbstractFormatter.zep
+++ b/phalcon/Logger/Formatter/AbstractFormatter.zep
@@ -10,10 +10,20 @@
 
 namespace Phalcon\Logger\Formatter;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Phalcon\Logger;
+use Phalcon\Logger\Item;
 
 abstract class AbstractFormatter implements FormatterInterface
 {
+    /**
+     * Default date format
+     *
+     * @var string
+     */
+    protected dateFormat { get, set };
+
     /**
      * Interpolates context values into the message placeholders
      *
@@ -37,5 +47,25 @@ abstract class AbstractFormatter implements FormatterInterface
         }
 
         return message;
+    }
+
+    /**
+     * Returns the date formatted for the logger.
+     * @todo Not using the set time from the Item since we have interface
+     * misalignment which will break semver This will change in the future
+     */
+    protected function getFormattedDate() -> string
+    {
+        var date, timezone;
+
+        let timezone = date_default_timezone_get();
+
+        if !timezone {
+            let timezone = "UTC";
+        }
+
+        let date = new DateTimeImmutable("now", new DateTimeZone(timezone));
+
+        return date->format(this->dateFormat);
     }
 }

--- a/phalcon/Logger/Formatter/AbstractFormatter.zep
+++ b/phalcon/Logger/Formatter/AbstractFormatter.zep
@@ -59,12 +59,7 @@ abstract class AbstractFormatter implements FormatterInterface
         var date, timezone;
 
         let timezone = date_default_timezone_get();
-
-        if !timezone {
-            let timezone = "UTC";
-        }
-
-        let date = new DateTimeImmutable("now", new DateTimeZone(timezone));
+            date     = new DateTimeImmutable("now", new DateTimeZone(timezone));
 
         return date->format(this->dateFormat);
     }

--- a/phalcon/Logger/Formatter/Json.zep
+++ b/phalcon/Logger/Formatter/Json.zep
@@ -21,13 +21,6 @@ use Phalcon\Logger\Item;
 class Json extends AbstractFormatter
 {
     /**
-     * Default date format
-     *
-     * @var string
-     */
-    protected dateFormat { get, set };
-
-    /**
      * Phalcon\Logger\Formatter\Json construct
      */
     public function __construct(string dateFormat = "c")
@@ -55,7 +48,7 @@ class Json extends AbstractFormatter
             [
                 "type"      : item->getName(),
                 "message"   : message,
-                "timestamp" : date(this->dateFormat, item->getTime())
+                "timestamp" : this->getFormattedDate()
             ]
         );
     }

--- a/phalcon/Logger/Formatter/Line.zep
+++ b/phalcon/Logger/Formatter/Line.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Logger\Formatter;
 
+use DateTime;
 use Phalcon\Logger\Item;
 
 /**
@@ -19,13 +20,6 @@ use Phalcon\Logger\Item;
  */
 class Line extends AbstractFormatter
 {
-    /**
-     * Default date format
-     *
-     * @var string
-     */
-    protected dateFormat { get, set };
-
     /**
      * Format applied to each message
      *
@@ -57,10 +51,7 @@ class Line extends AbstractFormatter
         if memstr(format, "%date%") {
             let format = str_replace(
                 "%date%",
-                date(
-                    this->dateFormat,
-                    item->getTime()
-                ),
+                this->getFormattedDate(),
                 format
             );
         }

--- a/phalcon/Logger/Item.zep
+++ b/phalcon/Logger/Item.zep
@@ -50,6 +50,7 @@ class Item
 
     /**
      * Phalcon\Logger\Item constructor
+     * @todo Remove the time or change the signature to an array
      */
     public function __construct(string message, string name, int type, int time = 0, var context = [])
     {

--- a/tests/unit/Logger/Formatter/Line/FormatCest.php
+++ b/tests/unit/Logger/Formatter/Line/FormatCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Logger\Formatter\Line;
 
+use DateTime;
 use Phalcon\Logger;
 use Phalcon\Logger\Formatter\Line;
 use Phalcon\Logger\Item;
@@ -82,5 +83,35 @@ class FormatCest
             $expected,
             $formatter->format($item)
         );
+    }
+
+    /**
+     * Tests Phalcon\Logger\Formatter\Line :: format() -custom with miliseconds
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-23
+     */
+    public function loggerFormatterLineFormatCustomWithMiliseconds(UnitTester $I)
+    {
+        $I->wantToTest('Logger\Formatter\Line - format() - custom - with milliseconds');
+
+        $formatter = new Line(
+            '%message%-[%type%]-%date%',
+            'U.u'
+        );
+
+        $item = new Item(
+            'log message',
+            'debug',
+            Logger::DEBUG,
+            time()
+        );
+
+        $result = $formatter->format($item);
+        $parts  = explode('-', $result);
+        $parts  = explode('.', $parts[2]);
+        $I->assertCount(2, $parts);
+        $I->assertGreaterThan(0, (int) $parts[0]);
+        $I->assertGreaterThan(0, (int) $parts[1]);
     }
 }


### PR DESCRIPTION
Hello!

* Type: enhancement
* Link to issue: #2893 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed the logic when logging times for `Phalcon\Logger` to use `DateTimeImmutable` so as to handle microseconds if necessary.

Thanks

