### PR TITLE
T13518 isset private property

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,8 @@
 - Fixed `Phalcon\Mvc\Model\Criteria` Di isn't set when using `Criteria::fromInput()` [#14538](https://github.com/phalcon/cphalcon/issues/14639)
 - Fixed `Phalcon\Db\Dialect\Mysql` removing unnecessary parentheses for `double` and `float` [#14645](https://github.com/phalcon/cphalcon/pull/14645) [@pfz](https://github.com/pfz)
 - Fixed `Phalcon\Http\Cookie::delete` to parse the correct parameters - cannot use alternative syntax until PHP 7.3 [#14643](https://github.com/phalcon/cphalcon/issues/14643)
+- Fixed `Phalcon\Mvc\Model::__isset` to take into account non visible properties by checking the getter if it exists [#13518](https://github.com/phalcon/cphalcon/issues/13518) [#13900](https://github.com/phalcon/cphalcon/issues/13900)
+- Fixed `Phalcon\Mvc\Model::__set` to return a more informative message if we are tying to access a non visible property [#13518](https://github.com/phalcon/cphalcon/issues/13518) [#13900](https://github.com/phalcon/cphalcon/issues/13900) 
 
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-12-21)
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -326,7 +326,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      */
     public function __isset(string! property) -> bool
     {
-        var modelName, manager, relation;
+        var manager, method, modelName, relation, result;
 
         let modelName = get_class(this),
             manager   = <ManagerInterface> this->getModelsManager();
@@ -339,7 +339,16 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             property
         );
 
-        return typeof relation == "object";
+        if typeof relation === "object" {
+            let result = true;
+        } else {
+            // If this is a property
+            let method = "get" . camelize(property);
+
+            let result = method_exists(this, method);
+        }
+
+        return result;
     }
 
     /**
@@ -457,7 +466,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
             if unlikely !manager->isVisibleModelProperty(this, property) {
                 throw new Exception(
-                    "Property '" . property . "' does not have a setter."
+                    "Cannot access property '" . property . "' (not public)."
                 );
             }
         }

--- a/tests/_data/fixtures/models/Invoices.php
+++ b/tests/_data/fixtures/models/Invoices.php
@@ -22,8 +22,21 @@ class Invoices extends Model
     public $inv_total;
     public $inv_created_at;
 
+    private $secretValue;
+    private $superSecret;
+
     public function initialize()
     {
         $this->setSource('co_invoices');
+    }
+
+    public function setSecretValue($value)
+    {
+        $this->secretValue = $value;
+    }
+
+    public function getSecretValue()
+    {
+        return $this->secretValue;
     }
 }

--- a/tests/integration/Mvc/Model/UnderscoreGetCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreGetCest.php
@@ -14,8 +14,13 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Model;
 
 use IntegrationTester;
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Mvc\Model\Resultset\Simple;
+use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use Phalcon\Test\Models;
+use Phalcon\Test\Models\Invoices;
+use Phalcon\Test\Models\InvoicesSchema;
 
 class UnderscoreGetCest
 {
@@ -32,165 +37,217 @@ class UnderscoreGetCest
         $this->container['db']->close();
     }
 
+//    /**
+//     * Tests Phalcon\Mvc\Model :: __get()
+//     *
+//     * @author Balázs Németh <https://github.com/zsilbi>
+//     * @since  2019-05-07
+//     */
+//    public function mvcModelUnderscoreGet(IntegrationTester $I)
+//    {
+//        $I->wantToTest('Mvc\Model - __get()');
+//
+//        $user = new Models\Users();
+//
+//        $user->id   = 999;
+//        $user->name = 'Test';
+//
+//        $I->assertEquals(
+//            999,
+//            $user->id
+//        );
+//
+//        $I->assertEquals(
+//            'Test',
+//            $user->name
+//        );
+//    }
+//
+//    /**
+//     * Tests Phalcon\Mvc\Model :: __get() whether it is using getters correctly
+//     *
+//     * @author Balázs Németh <https://github.com/zsilbi>
+//     * @since  2019-05-07
+//     */
+//    public function mvcModelUnderscoreGetIsUsingGetters(IntegrationTester $I)
+//    {
+//        $I->wantToTest("Mvc\Model - __get() whether it is using getters correctly");
+//
+//        $model = new Models\Select();
+//        $model->setId(123);
+//
+//        $I->assertEquals(
+//            123,
+//            $model->id
+//        );
+//
+//        $associativeArray = [
+//            'firstName' => 'First name',
+//            'lastName'  => 'Last name',
+//        ];
+//
+//        $model->setName($associativeArray);
+//
+//        $I->assertEquals(
+//            $associativeArray,
+//            $model->name
+//        );
+//
+//        $model->setText('MyText');
+//
+//        $I->assertEquals(
+//            'MyText',
+//            $model->text
+//        );
+//    }
+//
+//    /**
+//     * Tests Phalcon\Mvc\Model :: __get() related records
+//     *
+//     * @author Balázs Németh <https://github.com/zsilbi>
+//     * @since  2019-05-07
+//     */
+//    public function mvcModelUnderscoreGetRelated(IntegrationTester $I)
+//    {
+//        $I->wantToTest('Mvc\Model - __get() related records');
+//
+//        /**
+//         * Belongs-to relationship
+//         */
+//        $robotPart = Models\RobotsParts::findFirst();
+//
+//        $part = $robotPart->part;
+//
+//        $I->assertInstanceOf(
+//            Models\Parts::class,
+//            $part
+//        );
+//
+//        /**
+//         * Testing has-one relationship
+//         */
+//        $customer = Models\Customers::findFirst();
+//
+//        $user = $customer->user;
+//
+//        $I->assertInstanceOf(
+//            Models\Users::class,
+//            $user
+//        );
+//
+//        /**
+//         * Has-many relationship
+//         */
+//        $robot = Models\Robots::findFirst();
+//
+//        $robotParts = $robot->robotsParts;
+//
+//        $I->assertInstanceOf(
+//            Simple::class,
+//            $robotParts
+//        );
+//    }
+//
+//    /**
+//     * Tests Phalcon\Mvc\Model :: __get() dirty related records
+//     *
+//     * @author Balázs Németh <https://github.com/zsilbi>
+//     * @since  2019-05-07
+//     */
+//    public function mvcModelUnderscoreGetDirtyRelated(IntegrationTester $I)
+//    {
+//        $I->wantToTest('Mvc\Model - __get() dirty related records');
+//
+//        $robot = Models\Robots::findFirst();
+//
+//        /**
+//         * Fill up the related cache with data
+//         */
+//        $robotsParts = $robot->robotsParts;
+//
+//        $I->assertInstanceOf(
+//            Simple::class,
+//            $robotsParts
+//        );
+//
+//        /**
+//         * Add new related records
+//         */
+//        $robot->robotsParts = [
+//            new Models\RobotsParts(),
+//            new Models\RobotsParts(),
+//        ];
+//
+//        /**
+//         * Test if the new records were returned
+//         */
+//        $dirtyRobotsParts = $robot->robotsParts;
+//
+//        $I->assertInternalType(
+//            'array',
+//            $dirtyRobotsParts
+//        );
+//
+//        $I->assertCount(
+//            2,
+//            $dirtyRobotsParts
+//        );
+//
+//        $I->assertInstanceOf(
+//            Models\RobotsParts::class,
+//            $dirtyRobotsParts[0]
+//        );
+//    }
+
     /**
-     * Tests Phalcon\Mvc\Model :: __get()
+     * Tests Phalcon\Mvc\Model :: __get() private property
      *
-     * @author Balázs Németh <https://github.com/zsilbi>
-     * @since  2019-05-07
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-24
      */
-    public function mvcModelUnderscoreGet(IntegrationTester $I)
+    public function mvcModelUnderscorePrivateProperty(IntegrationTester $I)
     {
-        $I->wantToTest('Mvc\Model - __get()');
+        $I->wantToTest('Mvc\Model - __get() private property');
 
-        $user = new Models\Users();
+        /**
+         * Setup the table
+         */
+        (new InvoicesMigration())($this->container->get('db'));
 
-        $user->id   = 999;
-        $user->name = 'Test';
+        $model = new Invoices();
 
-        $I->assertEquals(
-            999,
-            $user->id
-        );
+        $I->assertFalse(isset($model->superSecret));
+        $I->assertTrue(isset($model->secretValue));
 
-        $I->assertEquals(
-            'Test',
-            $user->name
-        );
+        $model->setSecretValue(123);
+        $I->assertEquals(123, $model->getSecretValue());
+        $model->secretValue = 123;
+        $I->assertEquals(123, $model->secretValue);
     }
 
     /**
-     * Tests Phalcon\Mvc\Model :: __get() whether it is using getters correctly
+     * Tests Phalcon\Mvc\Model :: __get() private property - exception
      *
-     * @author Balázs Németh <https://github.com/zsilbi>
-     * @since  2019-05-07
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-12-24
      */
-    public function mvcModelUnderscoreGetIsUsingGetters(IntegrationTester $I)
+    public function mvcModelUnderscorePrivatePropertyException(IntegrationTester $I)
     {
-        $I->wantToTest("Mvc\Model - __get() whether it is using getters correctly");
-
-        $model = new Models\Select();
-        $model->setId(123);
-
-        $I->assertEquals(
-            123,
-            $model->id
-        );
-
-        $associativeArray = [
-            'firstName' => 'First name',
-            'lastName'  => 'Last name',
-        ];
-
-        $model->setName($associativeArray);
-
-        $I->assertEquals(
-            $associativeArray,
-            $model->name
-        );
-
-        $model->setText('MyText');
-
-        $I->assertEquals(
-            'MyText',
-            $model->text
-        );
-    }
-
-    /**
-     * Tests Phalcon\Mvc\Model :: __get() related records
-     *
-     * @author Balázs Németh <https://github.com/zsilbi>
-     * @since  2019-05-07
-     */
-    public function mvcModelUnderscoreGetRelated(IntegrationTester $I)
-    {
-        $I->wantToTest('Mvc\Model - __get() related records');
+        $I->wantToTest('Mvc\Model - __get() private property - exception');
 
         /**
-         * Belongs-to relationship
+         * Setup the table
          */
-        $robotPart = Models\RobotsParts::findFirst();
+        (new InvoicesMigration())($this->container->get('db'));
 
-        $part = $robotPart->part;
-
-        $I->assertInstanceOf(
-            Models\Parts::class,
-            $part
-        );
-
-        /**
-         * Testing has-one relationship
-         */
-        $customer = Models\Customers::findFirst();
-
-        $user = $customer->user;
-
-        $I->assertInstanceOf(
-            Models\Users::class,
-            $user
-        );
-
-        /**
-         * Has-many relationship
-         */
-        $robot = Models\Robots::findFirst();
-
-        $robotParts = $robot->robotsParts;
-
-        $I->assertInstanceOf(
-            \Phalcon\Mvc\Model\Resultset\Simple::class,
-            $robotParts
-        );
-    }
-
-    /**
-     * Tests Phalcon\Mvc\Model :: __get() dirty related records
-     *
-     * @author Balázs Németh <https://github.com/zsilbi>
-     * @since  2019-05-07
-     */
-    public function mvcModelUnderscoreGetDirtyRelated(IntegrationTester $I)
-    {
-        $I->wantToTest('Mvc\Model - __get() dirty related records');
-
-        $robot = Models\Robots::findFirst();
-
-        /**
-         * Fill up the related cache with data
-         */
-        $robotsParts = $robot->robotsParts;
-
-        $I->assertInstanceOf(
-            \Phalcon\Mvc\Model\Resultset\Simple::class,
-            $robotsParts
-        );
-
-        /**
-         * Add new related records
-         */
-        $robot->robotsParts = [
-            new Models\RobotsParts(),
-            new Models\RobotsParts(),
-        ];
-
-        /**
-         * Test if the new records were returned
-         */
-        $dirtyRobotsParts = $robot->robotsParts;
-
-        $I->assertInternalType(
-            'array',
-            $dirtyRobotsParts
-        );
-
-        $I->assertCount(
-            2,
-            $dirtyRobotsParts
-        );
-
-        $I->assertInstanceOf(
-            Models\RobotsParts::class,
-            $dirtyRobotsParts[0]
+        $I->expectThrowable(
+            new Exception(
+                "Cannot access property 'superSecret' (not public)."
+            ),
+            function () {
+                $model = new Invoices();
+                $model->superSecret = 123;
+            }
         );
     }
 }

--- a/tests/integration/Mvc/Model/UnderscoreGetCest.php
+++ b/tests/integration/Mvc/Model/UnderscoreGetCest.php
@@ -37,167 +37,167 @@ class UnderscoreGetCest
         $this->container['db']->close();
     }
 
-//    /**
-//     * Tests Phalcon\Mvc\Model :: __get()
-//     *
-//     * @author Balázs Németh <https://github.com/zsilbi>
-//     * @since  2019-05-07
-//     */
-//    public function mvcModelUnderscoreGet(IntegrationTester $I)
-//    {
-//        $I->wantToTest('Mvc\Model - __get()');
-//
-//        $user = new Models\Users();
-//
-//        $user->id   = 999;
-//        $user->name = 'Test';
-//
-//        $I->assertEquals(
-//            999,
-//            $user->id
-//        );
-//
-//        $I->assertEquals(
-//            'Test',
-//            $user->name
-//        );
-//    }
-//
-//    /**
-//     * Tests Phalcon\Mvc\Model :: __get() whether it is using getters correctly
-//     *
-//     * @author Balázs Németh <https://github.com/zsilbi>
-//     * @since  2019-05-07
-//     */
-//    public function mvcModelUnderscoreGetIsUsingGetters(IntegrationTester $I)
-//    {
-//        $I->wantToTest("Mvc\Model - __get() whether it is using getters correctly");
-//
-//        $model = new Models\Select();
-//        $model->setId(123);
-//
-//        $I->assertEquals(
-//            123,
-//            $model->id
-//        );
-//
-//        $associativeArray = [
-//            'firstName' => 'First name',
-//            'lastName'  => 'Last name',
-//        ];
-//
-//        $model->setName($associativeArray);
-//
-//        $I->assertEquals(
-//            $associativeArray,
-//            $model->name
-//        );
-//
-//        $model->setText('MyText');
-//
-//        $I->assertEquals(
-//            'MyText',
-//            $model->text
-//        );
-//    }
-//
-//    /**
-//     * Tests Phalcon\Mvc\Model :: __get() related records
-//     *
-//     * @author Balázs Németh <https://github.com/zsilbi>
-//     * @since  2019-05-07
-//     */
-//    public function mvcModelUnderscoreGetRelated(IntegrationTester $I)
-//    {
-//        $I->wantToTest('Mvc\Model - __get() related records');
-//
-//        /**
-//         * Belongs-to relationship
-//         */
-//        $robotPart = Models\RobotsParts::findFirst();
-//
-//        $part = $robotPart->part;
-//
-//        $I->assertInstanceOf(
-//            Models\Parts::class,
-//            $part
-//        );
-//
-//        /**
-//         * Testing has-one relationship
-//         */
-//        $customer = Models\Customers::findFirst();
-//
-//        $user = $customer->user;
-//
-//        $I->assertInstanceOf(
-//            Models\Users::class,
-//            $user
-//        );
-//
-//        /**
-//         * Has-many relationship
-//         */
-//        $robot = Models\Robots::findFirst();
-//
-//        $robotParts = $robot->robotsParts;
-//
-//        $I->assertInstanceOf(
-//            Simple::class,
-//            $robotParts
-//        );
-//    }
-//
-//    /**
-//     * Tests Phalcon\Mvc\Model :: __get() dirty related records
-//     *
-//     * @author Balázs Németh <https://github.com/zsilbi>
-//     * @since  2019-05-07
-//     */
-//    public function mvcModelUnderscoreGetDirtyRelated(IntegrationTester $I)
-//    {
-//        $I->wantToTest('Mvc\Model - __get() dirty related records');
-//
-//        $robot = Models\Robots::findFirst();
-//
-//        /**
-//         * Fill up the related cache with data
-//         */
-//        $robotsParts = $robot->robotsParts;
-//
-//        $I->assertInstanceOf(
-//            Simple::class,
-//            $robotsParts
-//        );
-//
-//        /**
-//         * Add new related records
-//         */
-//        $robot->robotsParts = [
-//            new Models\RobotsParts(),
-//            new Models\RobotsParts(),
-//        ];
-//
-//        /**
-//         * Test if the new records were returned
-//         */
-//        $dirtyRobotsParts = $robot->robotsParts;
-//
-//        $I->assertInternalType(
-//            'array',
-//            $dirtyRobotsParts
-//        );
-//
-//        $I->assertCount(
-//            2,
-//            $dirtyRobotsParts
-//        );
-//
-//        $I->assertInstanceOf(
-//            Models\RobotsParts::class,
-//            $dirtyRobotsParts[0]
-//        );
-//    }
+    /**
+     * Tests Phalcon\Mvc\Model :: __get()
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-05-07
+     */
+    public function mvcModelUnderscoreGet(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model - __get()');
+
+        $user = new Models\Users();
+
+        $user->id   = 999;
+        $user->name = 'Test';
+
+        $I->assertEquals(
+            999,
+            $user->id
+        );
+
+        $I->assertEquals(
+            'Test',
+            $user->name
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: __get() whether it is using getters correctly
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-05-07
+     */
+    public function mvcModelUnderscoreGetIsUsingGetters(IntegrationTester $I)
+    {
+        $I->wantToTest("Mvc\Model - __get() whether it is using getters correctly");
+
+        $model = new Models\Select();
+        $model->setId(123);
+
+        $I->assertEquals(
+            123,
+            $model->id
+        );
+
+        $associativeArray = [
+            'firstName' => 'First name',
+            'lastName'  => 'Last name',
+        ];
+
+        $model->setName($associativeArray);
+
+        $I->assertEquals(
+            $associativeArray,
+            $model->name
+        );
+
+        $model->setText('MyText');
+
+        $I->assertEquals(
+            'MyText',
+            $model->text
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: __get() related records
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-05-07
+     */
+    public function mvcModelUnderscoreGetRelated(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model - __get() related records');
+
+        /**
+         * Belongs-to relationship
+         */
+        $robotPart = Models\RobotsParts::findFirst();
+
+        $part = $robotPart->part;
+
+        $I->assertInstanceOf(
+            Models\Parts::class,
+            $part
+        );
+
+        /**
+         * Testing has-one relationship
+         */
+        $customer = Models\Customers::findFirst();
+
+        $user = $customer->user;
+
+        $I->assertInstanceOf(
+            Models\Users::class,
+            $user
+        );
+
+        /**
+         * Has-many relationship
+         */
+        $robot = Models\Robots::findFirst();
+
+        $robotParts = $robot->robotsParts;
+
+        $I->assertInstanceOf(
+            Simple::class,
+            $robotParts
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: __get() dirty related records
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2019-05-07
+     */
+    public function mvcModelUnderscoreGetDirtyRelated(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Model - __get() dirty related records');
+
+        $robot = Models\Robots::findFirst();
+
+        /**
+         * Fill up the related cache with data
+         */
+        $robotsParts = $robot->robotsParts;
+
+        $I->assertInstanceOf(
+            Simple::class,
+            $robotsParts
+        );
+
+        /**
+         * Add new related records
+         */
+        $robot->robotsParts = [
+            new Models\RobotsParts(),
+            new Models\RobotsParts(),
+        ];
+
+        /**
+         * Test if the new records were returned
+         */
+        $dirtyRobotsParts = $robot->robotsParts;
+
+        $I->assertInternalType(
+            'array',
+            $dirtyRobotsParts
+        );
+
+        $I->assertCount(
+            2,
+            $dirtyRobotsParts
+        );
+
+        $I->assertInstanceOf(
+            Models\RobotsParts::class,
+            $dirtyRobotsParts[0]
+        );
+    }
 
     /**
      * Tests Phalcon\Mvc\Model :: __get() private property


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #13518 #13900 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::__isset` to take into account non visible properties by checking the getter if it exists
Fixed `Phalcon\Mvc\Model::__set` to return a more informative message if we are tying to access a non visible property


Thanks

