### PR TITLE
Introduce a list of code owners [ci skip]

### DIFF
--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -14,11 +14,13 @@ Sample of querying command:
 N: Ruud Boon
 E: ruud@phalcon.io
 W: https://ruudboon.io
+P: 0xF2E9F914DFA1BCD7
 D: Core Team
 
 N: Nikolaos Dimopoulos
 E: niden@phalcon.io
 W: https://niden.net
+P: 0x93F8CA07B9C8C41D
 D: Core Team
 
 N: Serghei Iakovlev

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -1,0 +1,25 @@
+This file is a list of the people responsible for ensuring that patches for a
+particular part of Phalcon are reviewed, either by themself or by someone else.
+They are also the gatekeepers for their part of Phalcon, with the final word on
+what goes in or not.
+
+The list is sorted by surname and formatted to allow easy grepping and
+beautification by scripts.  The fields are: name (N), email (E), web-address
+(W), PGP key ID and fingerprint (P), description (D), and snail-mail address
+(S).
+
+N: Nikolaos Dimopoulos
+E: niden@phalcon.io
+W: https://niden.net
+D: Core Team
+
+N: Ruud Boon
+E: ruud@phalcon.io
+W: http://www.ruudboon.io
+D: Core Team
+
+N: Serghei Iakovlev
+E: serghei@phalcon.io
+W: https://serghei.blog
+P: 0x1E0B5331219BEA88
+D: CI/CD Integration, Zephir support, Parsers and Scanners, Volt, Annotation, PHQL support

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -1,21 +1,24 @@
 This file is a list of the people responsible for ensuring that patches for a
-particular part of Phalcon are reviewed, either by themself or by someone else.
-They are also the gatekeepers for their part of Phalcon, with the final word on
-what goes in or not.
+particular part of Phalcon are reviewed, either by themselves or by someone
+else. They are also the gatekeepers for their part of Phalcon, with the final
+word on what goes in or not.
 
-The list is sorted by surname and formatted to allow easy grepping and
+The list is sorted by last name and formatted to allow easy grepping and
 beautification by scripts.  The fields are: name (N), email (E), web-address
 (W), PGP key ID and fingerprint (P), description (D), and snail-mail address
 (S).
 
-N: Nikolaos Dimopoulos
-E: niden@phalcon.io
-W: https://niden.net
-D: Core Team
+Sample of querying command:
+  cat CODE_OWNERS.TXT | awk -v RS='' -v ORS='\n\n' '/Volt/'
 
 N: Ruud Boon
 E: ruud@phalcon.io
-W: http://www.ruudboon.io
+W: https://ruudboon.io
+D: Core Team
+
+N: Nikolaos Dimopoulos
+E: niden@phalcon.io
+W: https://niden.net
 D: Core Team
 
 N: Serghei Iakovlev


### PR DESCRIPTION
Hello!

* Type: new feature | documentation
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

While effective code review is essential to every successful project, it’s not always clear who should review files.  Now we can can define exactly which people and teams need to review projects using CODE_OWNERS.TXT file.

Right now I specified the "description" section for Nikolaos and Ruud as a "Core Team" but this is too general and should be changed in the near future. What exactly may be used as a "description" section? Well, I guess any isolated part of the framework may be used as a such section, e.g.:
- ORM
- Windows Support
- macOS Support
- Documentation
- HTTP stack
- CLI stack
- Testing
- Phalcon attributes
- "All parts of Phalcon not covered by someone else"
- PSR integration
- etc

Please note, I didn't add all contributors in this patch. All other contributors will be added privately if need arises.

Thanks

