### PR TITLE
fix return type constraint

### DIFF
--- a/CHANGELOG-3.4.md
+++ b/CHANGELOG-3.4.md
@@ -1,3 +1,7 @@
+# [3.4.6]
+- Fixed some `return type` constraint issues, or elseif your `phalcon.so` was built with `zephir`, it would raise errors in runtime. [#14682](https://github.com/phalcon/cphalcon/pull/14682)
+
+
 # [3.4.5](https://github.com/phalcon/cphalcon/releases/tag/v3.4.5) (2019-10-30)
 - Fixed segfault in `Phalcon\Mvc\Micro\LazyLoader::__call()` when the handler has a syntax error. [#12396](https://github.com/phalcon/cphalcon/issues/12396)
 - Fixed RuntimeException in `Phalcon\Db\Adapter\Pdo` Trying to call method upper on a non-object. [#14330](https://github.com/phalcon/cphalcon/issues/14330)

--- a/ext/phalcon/mvc/url/utils.c
+++ b/ext/phalcon/mvc/url/utils.c
@@ -189,7 +189,11 @@ void phalcon_replace_paths(zval *return_value, zval *pattern, zval *paths, zval 
 	unsigned int bracket_count = 0, parentheses_count = 0, intermediate = 0;
 	unsigned char ch;
 	smart_str route_str = {0};
+#if PHP_VERSION_ID < 70000
 	ulong position = 1;
+#else
+	zend_ulong position = 1;
+#endif
 	int i;
 	zval *replace, replace_copy;
 	int use_copy, looking_placeholder = 0;

--- a/phalcon/flash/direct.zep
+++ b/phalcon/flash/direct.zep
@@ -32,9 +32,9 @@ class Direct extends FlashBase
 	/**
 	 * Outputs a message
 	 */
-	public function message(string type, var message) -> string
+	public function message(string type, var message) -> void
 	{
-		return this->outputMessage(type, message);
+		this->outputMessage(type, message);
 	}
 
 	/**

--- a/phalcon/flash/direct.zep
+++ b/phalcon/flash/direct.zep
@@ -32,9 +32,9 @@ class Direct extends FlashBase
 	/**
 	 * Outputs a message
 	 */
-	public function message(string type, var message) -> void
+	public function message(string type, var message)
 	{
-		this->outputMessage(type, message);
+		return this->outputMessage(type, message);
 	}
 
 	/**

--- a/phalcon/flash/session.zep
+++ b/phalcon/flash/session.zep
@@ -80,7 +80,7 @@ class Session extends FlashBase
 	/**
 	 * Adds a message to the session flasher
 	 */
-	public function message(string type, string message) -> void
+	public function message(string type, string message)
 	{
 		var messages;
 

--- a/phalcon/flashinterface.zep
+++ b/phalcon/flashinterface.zep
@@ -50,5 +50,5 @@ interface FlashInterface
 	/**
 	 * Outputs a message
 	 */
-	public function message(string type, string message) -> void;
+	public function message(string type, string message);
 }

--- a/phalcon/mvc/dispatcher.zep
+++ b/phalcon/mvc/dispatcher.zep
@@ -217,7 +217,7 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
 	 *
 	 * @param array forward
 	 */
-	public function forward(var forward)
+	public function forward(var forward) -> void
 	{
 		var eventsManager;
 

--- a/phalcon/mvc/model.zep
+++ b/phalcon/mvc/model.zep
@@ -330,7 +330,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Sets the DependencyInjection connection service name
 	 */
-	public function setConnectionService(string! connectionService) -> <Model>
+	public function setConnectionService(string! connectionService) -> <ModelInterface>
 	{
 		(<ManagerInterface> this->_modelsManager)->setConnectionService(this, connectionService);
 		return this;
@@ -339,7 +339,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Sets the DependencyInjection connection service name used to read data
 	 */
-	public function setReadConnectionService(string! connectionService) -> <Model>
+	public function setReadConnectionService(string! connectionService) -> <ModelInterface>
 	{
 		(<ManagerInterface> this->_modelsManager)->setReadConnectionService(this, connectionService);
 		return this;
@@ -348,7 +348,7 @@ abstract class Model implements EntityInterface, ModelInterface, ResultInterface
 	/**
 	 * Sets the DependencyInjection connection service name used to write data
 	 */
-	public function setWriteConnectionService(string! connectionService) -> <Model>
+	public function setWriteConnectionService(string! connectionService) -> <ModelInterface>
 	{
 		return (<ManagerInterface> this->_modelsManager)->setWriteConnectionService(this, connectionService);
 	}

--- a/phalcon/mvc/modelinterface.zep
+++ b/phalcon/mvc/modelinterface.zep
@@ -54,17 +54,17 @@ interface ModelInterface
 	/**
 	 * Sets both read/write connection services
 	 */
-	public function setConnectionService(string connectionService) -> void;
+	public function setConnectionService(string connectionService) -> <ModelInterface>;
 
 	/**
 	 * Sets the DependencyInjection connection service used to write data
 	 */
-	public function setWriteConnectionService(string connectionService) -> void;
+	public function setWriteConnectionService(string connectionService) -> <ModelInterface>;
 
 	/**
 	 * Sets the DependencyInjection connection service used to read data
 	 */
-	public function setReadConnectionService(string connectionService) -> void;
+	public function setReadConnectionService(string connectionService) -> <ModelInterface>;
 
 	/**
 	 * Returns DependencyInjection connection service used to read data

--- a/phalcon/mvc/router.zep
+++ b/phalcon/mvc/router.zep
@@ -326,7 +326,7 @@ class Router implements InjectionAwareInterface, RouterInterface, EventsAwareInt
 	 * $router->handle("/posts/edit/1");
 	 *</code>
 	 */
-	public function handle(string uri = null)
+	public function handle(string uri = null) -> void
 	{
 		var realUri, request, currentHostName, routeFound, parts,
 			params, matches, notFoundPaths,

--- a/phalcon/mvc/router/annotations.zep
+++ b/phalcon/mvc/router/annotations.zep
@@ -82,7 +82,7 @@ class Annotations extends Router
 	/**
 	 * Produce the routing parameters from the rewrite information
 	 */
-	public function handle(string! uri = null)
+	public function handle(string! uri = null) -> void
 	{
 		var realUri, annotationsService, handlers, controllerSuffix,
 			scope, prefix, dependencyInjector, handler, controllerName,

--- a/phalcon/mvc/router/route.zep
+++ b/phalcon/mvc/router/route.zep
@@ -149,7 +149,7 @@ class Route implements RouteInterface
 	 * );
 	 *</code>
 	 */
-	public function via(var httpMethods) -> <Route>
+	public function via(var httpMethods) -> <RouteInterface>
 	{
 		let this->_methods = httpMethods;
 		return this;
@@ -448,7 +448,7 @@ class Route implements RouteInterface
 	 * )->setName("about");
 	 *</code>
 	 */
-	public function setName(string name) -> <Route>
+	public function setName(string name) -> <RouteInterface>
 	{
 		let this->_name = name;
 		return this;

--- a/phalcon/mvc/router/routeinterface.zep
+++ b/phalcon/mvc/router/routeinterface.zep
@@ -44,7 +44,7 @@ interface RouteInterface
 	/**
 	 * Set one or more HTTP methods that constraint the matching of the route
 	 */
-	public function via(var httpMethods) -> void;
+	public function via(var httpMethods) -> <RouteInterface>;
 
 	/**
 	 * Reconfigure the route adding a new pattern and a set of paths
@@ -59,7 +59,7 @@ interface RouteInterface
 	/**
 	 * Sets the route's name
 	 */
-	public function setName(string name) -> void;
+	public function setName(string name) -> <RouteInterface>;
 
 	/**
 	 * Sets a set of HTTP methods that constraint the matching of the route

--- a/phalcon/mvc/routerinterface.zep
+++ b/phalcon/mvc/routerinterface.zep
@@ -21,6 +21,7 @@ namespace Phalcon\Mvc;
 
 use Phalcon\Mvc\Router\RouteInterface;
 use Phalcon\Mvc\Router\GroupInterface;
+use Phalcon\Mvc\RouterInterface;
 
 /**
  * Phalcon\Mvc\RouterInterface
@@ -33,22 +34,22 @@ interface RouterInterface
 	/**
 	 * Sets the name of the default module
 	 */
-	public function setDefaultModule(string! moduleName) -> void;
+	public function setDefaultModule(string! moduleName) -> <RouterInterface>;
 
 	/**
 	 * Sets the default controller name
 	 */
-	public function setDefaultController(string! controllerName) -> void;
+	public function setDefaultController(string! controllerName) -> <RouterInterface>;
 
 	/**
 	 * Sets the default action name
 	 */
-	public function setDefaultAction(string! actionName) -> void;
+	public function setDefaultAction(string! actionName) -> <RouterInterface>;
 
 	/**
 	 * Sets an array of default paths
 	 */
-	public function setDefaults(array! defaults) -> void;
+	public function setDefaults(array! defaults) -> <RouterInterface>;
 
 	/**
 	 * Handles routing information received from the rewrite engine


### PR DESCRIPTION
Hello!

* Type: bug fix 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

When building with zephir, these `return type` don't constrain with it's `parent class` or `interface`.

...  and then these errors will be raised in runtime:

```
PHP Fatal error:  Declaration of Phalcon\Mvc\Router::setDefaultModule(string $moduleName): Phalcon\Mvc\RouterInterface must be compatible with Phalcon\Mvc\RouterInterface::setDefaultModule(string $moduleName): void in Unknown on line 0
PHP Fatal error:  Declaration of Phalcon\Mvc\Router::setDefaultController(string $controllerName): Phalcon\Mvc\RouterInterface must be compatible with Phalcon\Mvc\RouterInterface::setDefaultController(string $controllerName): void in Unknown on line 0
```

- phalcon: 3.4.5
- php 7.3.9
- zephir parser: 1.3.3
- zephir: 0.12.15

Thanks

