### PR TITLE
T14688 session key unique

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,6 +4,7 @@
 ## Changed
 - Changed the logic when logging times for `Phalcon\Logger` to use `DateTimeImmutable` so as to handle microseconds if necessary. [#2893](https://github.com/phalcon/cphalcon/issues/2893)
 - Changed `Phalcon\Http\Cookie::send` and `Phalcon\Http\Cookie::delete` to allow for `samesite` to be passed in the `options` when using PHP > 7.3 [#14627](https://github.com/phalcon/cphalcon/issues/14627)
+
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Criteria` Di isn't set when using `Criteria::fromInput()` [#14538](https://github.com/phalcon/cphalcon/issues/14639)
 - Fixed `Phalcon\Db\Dialect\Mysql` removing unnecessary parentheses for `double` and `float` [#14645](https://github.com/phalcon/cphalcon/pull/14645) [@pfz](https://github.com/pfz)
@@ -11,6 +12,7 @@
 - Fixed `Phalcon\Mvc\Model::__isset` to take into account non visible properties by checking the getter if it exists [#13518](https://github.com/phalcon/cphalcon/issues/13518) [#13900](https://github.com/phalcon/cphalcon/issues/13900)
 - Fixed `Phalcon\Mvc\Model::__set` to return a more informative message if we are tying to access a non visible property [#13518](https://github.com/phalcon/cphalcon/issues/13518) [#13900](https://github.com/phalcon/cphalcon/issues/13900)
 - Fixed `Phalcon\Mvc\Model\Resultset\Simple::toArray` to correctly process virtual fields [#14669](https://github.com/phalcon/cphalcon/issues/14669)
+- Fixed `Phalcon\Session\Manager::getUniqueKey` to prefix the key only if `uniqueId` is present [#14688](https://github.com/phalcon/cphalcon/issues/14688)
 
 # [4.0.0](https://github.com/phalcon/cphalcon/releases/tag/v4.0.0) (2019-12-21)
 

--- a/phalcon/Session/Manager.zep
+++ b/phalcon/Session/Manager.zep
@@ -359,6 +359,14 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
      */
     private function getUniqueKey(string key) -> string
     {
-        return this->uniqueId . "#" . key;
+        var uniqueId;
+
+        let uniqueId = this->uniqueId;
+
+		if !empty uniqueId {
+			return this->uniqueId . "#" . key;
+		} else {
+			return key;
+		}
     }
 }

--- a/tests/integration/Session/Manager/ExistsDestroyCest.php
+++ b/tests/integration/Session/Manager/ExistsDestroyCest.php
@@ -32,6 +32,9 @@ class ExistsDestroyCest
     public function sessionManagerExistsDestroy(IntegrationTester $I)
     {
         $I->wantToTest('Session\Manager - exists()/destroy()');
+        $store = $_SESSION ?? [];
+        $_SESSION = [];
+
         $manager = new Manager();
         $files   = $this->getSessionStream();
         $manager->setAdapter($files);
@@ -46,6 +49,8 @@ class ExistsDestroyCest
 
         $actual = $manager->exists();
         $I->assertFalse($actual);
+
+        $_SESSION = $store;
     }
 
     /**
@@ -60,6 +65,9 @@ class ExistsDestroyCest
     public function sessionManagerDestroySuperGlobal(IntegrationTester $I)
     {
         $I->wantToTest('Session\Manager - destroy() - clean $_SESSION');
+        $store = $_SESSION ?? [];
+        $_SESSION = [];
+
         $manager = new Manager();
         $files   = $this->getSessionStream();
         $manager->setAdapter($files);
@@ -71,13 +79,57 @@ class ExistsDestroyCest
         $I->assertTrue($actual);
 
         $manager->set('test1', __METHOD__);
-        $I->assertArrayHasKey('#test1', $_SESSION);
-        $I->assertContains(__METHOD__, $_SESSION['#test1']);
+        $I->assertArrayHasKey('test1', $_SESSION);
+        $I->assertContains(__METHOD__, $_SESSION['test1']);
 
         $manager->destroy();
-        $I->assertArrayNotHasKey('#test1', $_SESSION);
+        $I->assertArrayNotHasKey('test1', $_SESSION);
 
         $actual = $manager->exists();
         $I->assertFalse($actual);
+
+        $_SESSION = $store;
+    }
+
+    /**
+     * Tests Phalcon\Session\Manager :: destroy() - clean $_SESSION with uniquid
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-01-06
+     */
+    public function sessionManagerDestroySuperGlobalUniquid(IntegrationTester $I)
+    {
+        $I->wantToTest('Session\Manager - destroy() - clean $_SESSION with uniquid');
+
+        $store = $_SESSION ?? [];
+        $_SESSION = [];
+
+        $manager = new Manager();
+        $files   = $this->getSessionStream();
+        $manager->setAdapter($files);
+        $manager->setOptions(
+            [
+                'uniqueId' => 'aaa'
+            ]
+        );
+
+        $actual = $manager->start();
+        $I->assertTrue($actual);
+
+        $actual = $manager->exists();
+        $I->assertTrue($actual);
+
+        $manager->set('test1', __METHOD__);
+
+        $I->assertArrayHasKey('aaa#test1', $_SESSION);
+        $I->assertContains(__METHOD__, $_SESSION['aaa#test1']);
+
+        $manager->destroy();
+        $I->assertArrayNotHasKey('aaa#test1', $_SESSION);
+
+        $actual = $manager->exists();
+        $I->assertFalse($actual);
+
+        $_SESSION = $store;
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14688 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Session\Manager::getUniqueKey` to prefix the key only if `uniqueId` is present

Thanks

