### PR TITLE
Cleanup packages in Packagecloud

### DIFF
--- a/.ci/cleanup-packages.php
+++ b/.ci/cleanup-packages.php
@@ -58,7 +58,7 @@ class PackageCloud
     {
         $now = new \DateTime();
 
-        $packages =  $this->query("/api/v1/repos/" . $this->user . "/" . $this->repo . "/packages.json?per_page=1");
+        $packages =  $this->query("/api/v1/repos/" . $this->user . "/" . $this->repo . "/packages.json?per_page=100");
         $outdatedPackages =  [];
         foreach ($packages as $package) {
             $packageDate = \DateTime::createFromFormat("Y-m-d\TH:i:s.u\Z", $package->created_at);

--- a/.ci/cleanup-packages.php
+++ b/.ci/cleanup-packages.php
@@ -43,7 +43,14 @@ class PackageCloud
         if (false === ($retval = curl_exec($ch))) {
             print_r(curl_error($ch));
         } else {
-            return json_decode($retval);
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            switch ($httpCode) {
+                case "200":
+                    return json_decode($retval);
+                    break;
+                default:
+                    exit("Unable to connect to api");
+            }
         }
     }
 

--- a/.ci/cleanup-packages.php
+++ b/.ci/cleanup-packages.php
@@ -54,7 +54,7 @@ class PackageCloud
         $packages =  $this->query("/api/v1/repos/" . $this->user . "/" . $this->repo . "/packages.json?per_page=1");
         $outdatedPackages =  [];
         foreach ($packages as $package) {
-            $packageDate = DateTime::createFromFormat("Y-m-d\TH:i:s.u\Z", $package->created_at);
+            $packageDate = \DateTime::createFromFormat("Y-m-d\TH:i:s.u\Z", $package->created_at);
             $age = $packageDate->diff($now)->days;
             if ($age > $days) {
                 $package->age = $age;

--- a/.ci/cleanup-packages.php
+++ b/.ci/cleanup-packages.php
@@ -42,8 +42,10 @@ class PackageCloud
 
         if (false === ($retval = curl_exec($ch))) {
             print_r(curl_error($ch));
+            curl_close($ch);
         } else {
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
             switch ($httpCode) {
                 case "200":
                     return json_decode($retval);
@@ -89,8 +91,10 @@ class PackageCloud
 
         if (false === ($retval = curl_exec($ch))) {
             print_r(curl_error($ch));
+            curl_close($ch);
         } else {
             $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            curl_close($ch);
             switch ($httpCode) {
                 case "200":
                     echo "done" . PHP_EOL;

--- a/.ci/cleanup-packages.php
+++ b/.ci/cleanup-packages.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace PhalconCi;
+
+class PackageCloud
+{
+    protected const API_ENDPOINT = "packagecloud.io";
+
+    private $apiKey;
+    private $user;
+    private $repo;
+
+    public function __construct($apiKey, $user, $repo)
+    {
+        $this->apiKey = $apiKey;
+        $this->user = $user;
+        $this->repo = $repo;
+    }
+
+    protected function buildRequestUrl($url)
+    {
+        $baseUrl = "https://" . $this->apiKey . ":@"  . self::API_ENDPOINT;
+        return $baseUrl . $url;
+    }
+
+    protected function getCurl()
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        return $ch;
+    }
+
+    public function query($url)
+    {
+        echo "Opening: " . $url . PHP_EOL;
+
+        $ch = $this->getCurl();
+
+        curl_setopt($ch, CURLOPT_URL, $this->buildRequestUrl($url));
+
+        if (false === ($retval = curl_exec($ch))) {
+            print_r(curl_error($ch));
+        } else {
+            return json_decode($retval);
+        }
+    }
+
+    public function getOutdatedPackages($days = 30)
+    {
+        $now = new \DateTime();
+
+        $packages =  $this->query("/api/v1/repos/" . $this->user . "/" . $this->repo . "/packages.json?per_page=1");
+        $outdatedPackages =  [];
+        foreach ($packages as $package) {
+            $packageDate = DateTime::createFromFormat("Y-m-d\TH:i:s.u\Z", $package->created_at);
+            $age = $packageDate->diff($now)->days;
+            if ($age > $days) {
+                $package->age = $age;
+                $outdatedPackages[] = $package;
+            }
+        }
+        return $outdatedPackages;
+    }
+
+    public function deleteOutdatedPackages($days = 30)
+    {
+        $packages = $this->getOutdatedPackages($days);
+        foreach ($packages as $package) {
+            $this->deletePackage($package->destroy_url, $package->age);
+        }
+    }
+
+    public function deletePackage($packageUrl, $age)
+    {
+        echo "Deleting: " . $packageUrl . " [" . $age . " days old]... ";
+        $ch = $this->getCurl();
+
+        curl_setopt($ch, CURLOPT_URL, $this->buildRequestUrl($packageUrl));
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
+
+        if (false === ($retval = curl_exec($ch))) {
+            print_r(curl_error($ch));
+        } else {
+            $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+            switch ($httpCode) {
+                case "200":
+                    echo "done" . PHP_EOL;
+                    break;
+                default:
+                    echo "fail" . PHP_EOL;
+            }
+            return json_decode($retval);
+        }
+    }
+}
+
+$packageCloud = new PackageCloud(getenv('PACKAGECLOUD_TOKEN'), "phalcon", "nightly");
+$packageCloud->deleteOutdatedPackages(30); //days

--- a/.github/workflows/packagecloud-cleanup.yml
+++ b/.github/workflows/packagecloud-cleanup.yml
@@ -14,3 +14,5 @@ jobs:
           php-version: '7.4'
       - name: Cleanup Packagecloud
         run: php .ci/cleanup-packages.php
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}

--- a/.github/workflows/packagecloud-cleanup.yml
+++ b/.github/workflows/packagecloud-cleanup.yml
@@ -1,6 +1,5 @@
 name: Cleanup Packagecloud packages
 on:
-  push:
   schedule:
     - cron: '0 2 * * *' # Daily at 02:00
 jobs:

--- a/.github/workflows/packagecloud-cleanup.yml
+++ b/.github/workflows/packagecloud-cleanup.yml
@@ -1,8 +1,6 @@
 name: Cleanup Packagecloud packages
 on:
   push:
-    branches:
-      - master
   schedule:
     - cron: '0 2 * * *' # Daily at 02:00
 jobs:

--- a/.github/workflows/packagecloud-cleanup.yml
+++ b/.github/workflows/packagecloud-cleanup.yml
@@ -1,0 +1,18 @@
+name: Cleanup Packagecloud packages
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 2 * * *' # Daily at 02:00
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: '7.4'
+      - name: Cleanup Packagecloud
+        run: php .ci/cleanup-packages.php


### PR DESCRIPTION
Hello!

* Type: code quality 
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Every night at 2 this will run and cleanup our nightly builds on Packagecloud for packages older then 30 days. (max 100 per run, due to api limit)
I think schedule only runs on default branch so this could be only working after merging to master.
