### PR TITLE
T13128 http2 preload 2

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -11,6 +11,7 @@
 - Added additional HTML helpers under `Phalcon\Html\Helper`: `Anchor`, `Base`, `Body`, `Button`, `Close`, `Element`, `Form`, `Img`, `Input\Color`, `Input\Date`, `Input\DateTime`, `Input\DateTimeLocal`, `Input\Email`, `Input\File`, `Input\Hidden`, `Input\Image`, `Input\Input`, `Input\Month`, `Input\Numeric`, `Input\Password`, `Input\Range`, `Input\Select`, `Input\Search`, `Input\Submit`, `Input\Tel`, `Input\Text`, `Input\Textarea`, `Input\Time`, `Input\Url`, `Input\Week`, `Label`, `Link`, `Meta`, `Ol`, `Script`, `Style`, `Title`, `Ul` 
 [#14696](https://github.com/phalcon/cphalcon/issues/14696)
 - Added `Phalcon\Http\Request::getPreferredIsoLocaleVariant()` to return the base language if this is a specific one (`en` vs `en-US`) [#3135](https://github.com/phalcon/cphalcon/issues/3135)
+- Added `preload` for Volt, which will send a HTTP/2 preload header [#13128](https://github.com/phalcon/cphalcon/issues/13128)
 
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)

--- a/phalcon/Mvc/View/Engine/Volt/Compiler.zep
+++ b/phalcon/Mvc/View/Engine/Volt/Compiler.zep
@@ -1573,9 +1573,8 @@ class Compiler implements InjectionAwareInterface
             extensions, functions, definition, extendedBlocks, block,
             currentBlock, exprLevel, escapedCode, method, arrayHelpers;
 
-        let code = null;
-
-        let funcArguments = null;
+        let code          = null,
+            funcArguments = null;
 
         if fetch funcArguments, expr["arguments"] {
             let arguments = this->expression(funcArguments);
@@ -1821,6 +1820,10 @@ class Compiler implements InjectionAwareInterface
 
             if name == "version_id" {
                 return "Phalcon\\Version::getId()";
+            }
+
+            if name == "prefetch" {
+                return "$this->tag->prefetch(" . arguments . ")";
             }
 
             /**

--- a/phalcon/Mvc/View/Engine/Volt/Compiler.zep
+++ b/phalcon/Mvc/View/Engine/Volt/Compiler.zep
@@ -1822,8 +1822,8 @@ class Compiler implements InjectionAwareInterface
                 return "Phalcon\\Version::getId()";
             }
 
-            if name == "prefetch" {
-                return "$this->tag->prefetch(" . arguments . ")";
+            if name == "preload" {
+                return "$this->tag->preload(" . arguments . ")";
             }
 
             /**

--- a/phalcon/Tag.zep
+++ b/phalcon/Tag.zep
@@ -12,6 +12,8 @@ namespace Phalcon;
 
 use Phalcon\Di\DiInterface;
 use Phalcon\Escaper\EscaperInterface;
+use Phalcon\Html\Link\Link;
+use Phalcon\Html\Link\Serializer\Header;
 use Phalcon\Helper\Str;
 use Phalcon\Tag\Select;
 use Phalcon\Tag\Exception;

--- a/phalcon/Tag.zep
+++ b/phalcon/Tag.zep
@@ -795,6 +795,55 @@ class Tag
     }
 
     /**
+     * Parses the preload element passed and sets the necessary link headers
+     */
+    public static function preload(var parameters) -> string
+    {
+        var attributes, container, header, href, link, params, response;
+
+        let params = [];
+
+        if typeof parameters !== "array" {
+            let params = [parameters];
+        } else {
+            let params = parameters;
+        }
+
+        /**
+         * Grab the element
+         */
+        fetch href, params[0];
+
+        let container = self::getDI();
+
+        /**
+         * Check if we have the response object in the container
+         */
+        if container && container->has("response") {
+            if isset params[1] {
+                let attributes = params[1];
+            } else {
+                let attributes = ["as" : "style"];
+            }
+
+            /**
+             * href comes wrapped with ''. Remove them
+             */
+            let response = container->get("response"),
+                link     = new Link(
+                    "preload",
+                    str_replace("'", "", href),
+                    attributes
+                ),
+                header   = "Link: " . (new Header())->serialize([link]);
+
+            response->setRawHeader(header);
+        }
+
+        return href;
+    }
+
+    /**
      * Builds a HTML input[type="radio"] tag
      *
      * @param array parameters = [

--- a/tests/integration/Mvc/View/Engine/Volt/Compiler/FunctionCallCest.php
+++ b/tests/integration/Mvc/View/Engine/Volt/Compiler/FunctionCallCest.php
@@ -189,14 +189,14 @@ class FunctionCallCest
                 '<?= constant(\'abc\') ?>',
             ],
             [
-                'prefetch',
-                '{{ prefetch(\'abc.css\') }}',
-                '<?= $this->tag->prefetch(\'abc.css\') ?>',
+                'preload',
+                '{{ preload(\'abc.css\') }}',
+                '<?= $this->tag->preload(\'abc.css\') ?>',
             ],
             [
-                'prefetch array',
-                '{{ prefetch(\'abc.jpg\', [\'as\' : \'image\']) }}',
-                '<?= $this->tag->prefetch(\'abc.jpg\', [\'as\' => \'image\']) ?>',
+                'preload array',
+                '{{ preload(\'abc.jpg\', [\'as\' : \'image\']) }}',
+                '<?= $this->tag->preload(\'abc.jpg\', [\'as\' => \'image\']) ?>',
             ],
             [
                 'somefunction',

--- a/tests/integration/Mvc/View/Engine/Volt/Compiler/FunctionCallCest.php
+++ b/tests/integration/Mvc/View/Engine/Volt/Compiler/FunctionCallCest.php
@@ -13,22 +13,196 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Integration\Mvc\View\Engine\Volt\Compiler;
 
+use Codeception\Example;
 use IntegrationTester;
+use Phalcon\Mvc\View\Engine\Volt\Compiler;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
 
 /**
  * Class FunctionCallCest
  */
 class FunctionCallCest
 {
+    use DiTrait;
+
     /**
      * Tests Phalcon\Mvc\View\Engine\Volt\Compiler :: functionCall()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @param IntegrationTester $I
+     * @param Example           $example
+     *
+     * @dataProvider getExamples
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2020-01-11
      */
-    public function mvcViewEngineVoltCompilerFunctionCall(IntegrationTester $I)
+    public function mvcViewEngineVoltCompilerFunctionCall(IntegrationTester $I, Example $example)
     {
-        $I->wantToTest('Mvc\View\Engine\Volt\Compiler - functionCall()');
-        $I->skipTest('Need implementation');
+        $I->wantToTest('Mvc\View\Engine\Volt\Compiler - functionCall() ' . $example[0]);
+
+        $volt = new Compiler();
+
+        $expected = $example[2];
+        $actual   = $volt->compileString($example[1]);
+
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return array
+     */
+    private function getExamples(): array
+    {
+        return [
+            [
+                'get_content',
+                '{{ content() }}',
+                '<?= $this->getContent() ?>',
+            ],
+            [
+                'content',
+                '{{ content() }}',
+                '<?= $this->getContent() ?>',
+            ],
+            [
+                'partial',
+                '{{ partial("abc.volt") }}',
+                '<?= $this->partial(\'abc.volt\') ?>',
+            ],
+            [
+                'link_to',
+                '{{ link_to(\'abc\') }}',
+                '<?= $this->tag->linkTo([\'abc\']) ?>',
+            ],
+            [
+                'image',
+                '{{ image(\'abc\') }}',
+                '<?= $this->tag->image([\'abc\']) ?>',
+            ],
+            [
+                'form',
+                '{{ form(\'abc\') }}',
+                '<?= $this->tag->form([\'abc\']) ?>',
+            ],
+            [
+                'submit_button',
+                '{{ submit_button(\'abc\') }}',
+                '<?= $this->tag->submitButton([\'abc\']) ?>',
+            ],
+            [
+                'radio_field',
+                '{{ radio_field(\'abc\') }}',
+                '<?= $this->tag->radioField([\'abc\']) ?>',
+            ],
+            [
+                'check_field',
+                '{{ check_field(\'abc\') }}',
+                '<?= $this->tag->checkField([\'abc\']) ?>',
+            ],
+            [
+                'file_field',
+                '{{ file_field(\'abc\') }}',
+                '<?= $this->tag->fileField([\'abc\']) ?>',
+            ],
+            [
+                'hidden_field',
+                '{{ hidden_field(\'abc\') }}',
+                '<?= $this->tag->hiddenField([\'abc\']) ?>',
+            ],
+            [
+                'password_field',
+                '{{ password_field(\'abc\') }}',
+                '<?= $this->tag->passwordField([\'abc\']) ?>',
+            ],
+            [
+                'text_area',
+                '{{ text_area(\'abc\') }}',
+                '<?= $this->tag->textArea([\'abc\']) ?>',
+            ],
+            [
+                'text_field',
+                '{{ text_field(\'abc\') }}',
+                '<?= $this->tag->textField([\'abc\']) ?>',
+            ],
+            [
+                'email_field',
+                '{{ email_field(\'abc\') }}',
+                '<?= $this->tag->emailField([\'abc\']) ?>',
+            ],
+            [
+                'date_field',
+                '{{ date_field(\'abc\') }}',
+                '<?= $this->tag->dateField([\'abc\']) ?>',
+            ],
+            [
+                'tel_field',
+                '{{ tel_field(\'abc\') }}',
+                '<?= $this->tag->telField([\'abc\']) ?>',
+            ],
+            [
+                'numeric_field',
+                '{{ numeric_field(\'abc\') }}',
+                '<?= $this->tag->numericField([\'abc\']) ?>',
+            ],
+            [
+                'image_input',
+                '{{ image_input(\'abc\') }}',
+                '<?= $this->tag->imageInput([\'abc\']) ?>',
+            ],
+            [
+                'url',
+                '{{ url(\'abc\') }}',
+                '<?= $this->url->get(\'abc\') ?>',
+            ],
+            [
+                'static_url',
+                '{{ static_url(\'abc\') }}',
+                '<?= $this->url->getStatic(\'abc\') ?>',
+            ],
+            [
+                'date',
+                '{{ date(\'abc\') }}',
+                '<?= date(\'abc\') ?>',
+            ],
+            [
+                'time',
+                '{{ time() }}',
+                '<?= time() ?>',
+            ],
+            [
+                'dump',
+                '{{ dump(\'abc\') }}',
+                '<?= var_dump(\'abc\') ?>',
+            ],
+            [
+                'version',
+                '{{ version() }}',
+                '<?= Phalcon\Version::get() ?>',
+            ],
+            [
+                'version_id',
+                '{{ version_id() }}',
+                '<?= Phalcon\Version::getId() ?>',
+            ],
+            [
+                'constant',
+                '{{ constant(\'abc\') }}',
+                '<?= constant(\'abc\') ?>',
+            ],
+            [
+                'prefetch',
+                '{{ prefetch(\'abc.css\') }}',
+                '<?= $this->tag->prefetch(\'abc.css\') ?>',
+            ],
+            [
+                'prefetch array',
+                '{{ prefetch(\'abc.jpg\', [\'as\' : \'image\']) }}',
+                '<?= $this->tag->prefetch(\'abc.jpg\', [\'as\' => \'image\']) ?>',
+            ],
+            [
+                'somefunction',
+                '{{ somefunction(\'abc\') }}',
+                '<?= $this->callMacro(\'somefunction\', [\'abc\']) ?>',
+            ],
+        ];
     }
 }

--- a/tests/unit/Tag/PrefetchCest.php
+++ b/tests/unit/Tag/PrefetchCest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Tag;
+
+use Phalcon\Http\Response;
+use Phalcon\Mvc\View\Engine\Volt\Compiler;
+use Phalcon\Tag;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use UnitTester;
+
+class PrefetchCest
+{
+    use DiTrait;
+
+    /**
+     * Tests Phalcon\Tag :: setTitleSeparator()
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2012-09-05
+     * @since  2018-11-13
+     */
+    public function tagPrefetch(UnitTester $I)
+    {
+        $I->wantToTest('Tag - prefetch()');
+
+        /**
+         * Making sure we have a response object
+         */
+        $this->setNewFactoryDefault();
+
+        /** @var Response $response */
+        $response = $this->container->get('response');
+        Tag::setDI($this->container);
+
+        $expected = "abc.css";
+        $actual = Tag::prefetch(["abc.css"]);
+        $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'Link: <abc.css>; rel="preload"; as="style"' => null,
+        ];
+        $actual   = $response->getHeaders()->toArray();
+        $I->assertEquals($expected, $actual);
+
+        $expected = "abc.jpg";
+        $actual = Tag::prefetch(['abc.jpg', ['as' => 'image']]);
+        $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'Link: <abc.css>; rel="preload"; as="style"' => null,
+            'Link: <abc.jpg>; rel="preload"; as="image"' => null,
+        ];
+        $actual   = $response->getHeaders()->toArray();
+        $I->assertEquals($expected, $actual);
+
+        $expected = "abc.css";
+        $actual = Tag::prefetch(['abc.css', ['as' => 'style', 'nopush' => true]]);
+        $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'Link: <abc.css>; rel="preload"; as="style"' => null,
+            'Link: <abc.jpg>; rel="preload"; as="image"' => null,
+            'Link: <abc.css>; rel="preload"; as="style"; nopush' => null,
+        ];
+        $actual   = $response->getHeaders()->toArray();
+        $I->assertEquals($expected, $actual);
+    }
+}

--- a/tests/unit/Tag/PreloadCest.php
+++ b/tests/unit/Tag/PreloadCest.php
@@ -14,12 +14,11 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Tag;
 
 use Phalcon\Http\Response;
-use Phalcon\Mvc\View\Engine\Volt\Compiler;
 use Phalcon\Tag;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use UnitTester;
 
-class PrefetchCest
+class PreloadCest
 {
     use DiTrait;
 
@@ -30,9 +29,9 @@ class PrefetchCest
      * @since  2012-09-05
      * @since  2018-11-13
      */
-    public function tagPrefetch(UnitTester $I)
+    public function tagPreload(UnitTester $I)
     {
-        $I->wantToTest('Tag - prefetch()');
+        $I->wantToTest('Tag - preload()');
 
         /**
          * Making sure we have a response object
@@ -44,7 +43,7 @@ class PrefetchCest
         Tag::setDI($this->container);
 
         $expected = "abc.css";
-        $actual = Tag::prefetch(["abc.css"]);
+        $actual = Tag::preload(["abc.css"]);
         $I->assertEquals($expected, $actual);
 
         $expected = [
@@ -54,7 +53,7 @@ class PrefetchCest
         $I->assertEquals($expected, $actual);
 
         $expected = "abc.jpg";
-        $actual = Tag::prefetch(['abc.jpg', ['as' => 'image']]);
+        $actual = Tag::preload(['abc.jpg', ['as' => 'image']]);
         $I->assertEquals($expected, $actual);
 
         $expected = [
@@ -65,7 +64,7 @@ class PrefetchCest
         $I->assertEquals($expected, $actual);
 
         $expected = "abc.css";
-        $actual = Tag::prefetch(['abc.css', ['as' => 'style', 'nopush' => true]]);
+        $actual = Tag::preload(['abc.css', ['as' => 'style', 'nopush' => true]]);
         $I->assertEquals($expected, $actual);
 
         $expected = [


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #13128 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `preload` for Volt, which will send a HTTP/2 preload header

Thanks

