### PR TITLE
Fix ManyToMany select query across multiple schemas

### DIFF
--- a/phalcon/mvc/model/query.zep
+++ b/phalcon/mvc/model/query.zep
@@ -1272,7 +1272,7 @@ class Query implements QueryInterface, InjectionAwareInterface
 
 				[
 					"type" : joinType,
-					"source" : intermediateSource,
+					"source" : [intermediateSource, intermediateSchema],
 					"conditions" : [[
 						"type" : "binary-op",
 						"op" : "=",


### PR DESCRIPTION
Hello!

* Type: bug fix 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist

When creating a ManyToMany relationship between models that are in different schemas on the same MySQL database, the select query doesn't fully reference the intermediate model's schema

For example, 

```
SCHEMA: hardware
===============
create robot
(
    robot_id          int(10) auto_increment  primary key,
    robot_name        varchar(100) null
);

create robot_part
(
    robot_part_id      int(10)  auto_increment  primary key,
    robot_part_name    varchar(100) null
);
```
```
SCHEMA: app
===============
create table robot_to_robot_part
(
    robot_id          int(10) primary key,
    robot_part_id     int(10) primary key,
);

```
```
class Robot extends Model
{
    public function initialize()
    {
        $this->setSchema('hardware');
        $this->setSource('robot');

        $this->hasManyToMany(
        $this->hasManyToMany(
            'robot_id',
            RobotToRobotPart::class,
            'robot_id',
            'robot_part_id',
            RobotPart::class,
            'robot_part_id'
        );
    }
}

class RobotPart extends Model
{
    public function initialize()
    {
        $this->setSchema('hardware');
        $this->setSource('robot_part');
    }
}

class RobotToRobotPart extends Model
{
    public function initialize()
    {
        $this->setSchema('app');
        $this->setSource('robot_to_robot_part');
    }
}
```

Now doing a query
```
    $builder = $di->get(Services::MODELS_MANAGER)->createBuilder();
    $builder->from(Robot::class);
    $builder->join(RobotPart::class);
    print_r($builder->getQuery()->getSql());
```

The query is 
```
SELECT 
    * 
FROM 
    `hardware`.`robot`  
INNER JOIN 
    `robot_to_robot_part` ON `robot`.`robot_id` = `robot_to_robot_part`.`robot_id` 
INNER JOIN 
    `hardware`.`robot_part` ON `robot_to_robot_part`.`robot_part_id` = `robot_part`.`robot_part_id`
```

Expected query should reference the app schema as follow
```
SELECT 
    * 
FROM 
    `hardware`.`robot`  
INNER JOIN 
    `app`. `robot_to_robot_part` ON `robot`.`robot_id` = `robot_to_robot_part`.`robot_id` 
INNER JOIN 
    `hardware`.`robot_part` ON `robot_to_robot_part`.`robot_part_id` = `robot_part`.`robot_part_id`
```

This pull request fixes the intermediate model referencing when building the query

Thanks

