### PR TITLE
Update runLoggerFile - Avoid seconds

### DIFF
--- a/tests/_data/fixtures/Traits/LoggerTrait.php
+++ b/tests/_data/fixtures/Traits/LoggerTrait.php
@@ -41,11 +41,18 @@ trait LoggerTrait
 
         $I->amInPath(logsDir());
         $I->openFile($fileName);
+        
+        //extract seconds 
+        $sSeconds = date('s',strtotime($logTime));
+        
+        //prepare regex to avoid seconds
+        $sRegexDate = str_replace($sSeconds, '[0-9]{2}\\', $logTime);
 
-        $I->seeInThisFile(
+        //Check with a regex and avoid seconds
+        $I->seeThisFileMatches(
             sprintf(
-                '[%s][%s] ' . $logString,
-                $logTime,
+                '/\[%s\]\[%s\] ' . $logString . '/',
+                $sRegexDate,
                 $level
             )
         );


### PR DESCRIPTION
I create a regex to check date in the log entries. With the regex, I considered that the instruction may take a few seconds.

Hello team!

* Type: bug fix
* Link to issue: #14717

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

