### PR TITLE
4.0.x add lazy loader handler get

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,6 +1,8 @@
 # [4.0.3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.3) (XXX-XX-XX)
 ## Added
 
+- Added `Phalcon\Mvc\Micro\LazyLoader::getHandler()` to return real handler when using lazy loaded controllers for `Phalcon\Mvc\Micro`
+
 ## Changed
 
 ## Fixed

--- a/phalcon/Mvc/Micro/LazyLoader.zep
+++ b/phalcon/Mvc/Micro/LazyLoader.zep
@@ -19,7 +19,7 @@ use Phalcon\Mvc\Model\BinderInterface;
  */
 class LazyLoader
 {
-    protected handler;
+    protected handler { get };
 
     protected definition { get };
 

--- a/tests/integration/Mvc/Micro/GetActiveHandlerCest.php
+++ b/tests/integration/Mvc/Micro/GetActiveHandlerCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Micro;
 
 use IntegrationTester;
+use Phalcon\Mvc\Micro;
 
 /**
  * Class GetActiveHandlerCest
@@ -30,5 +31,12 @@ class GetActiveHandlerCest
     {
         $I->wantToTest('Mvc\Micro - getActiveHandler()');
         $I->skipTest('Need implementation');
+    }
+
+    public function lazyLoaderActiveHandler(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Micro - getActiveHandler() with lazy loader');
+        $app = new Micro();
+        $app->get('/api/site', [$handler, 'find']);
     }
 }

--- a/tests/integration/Mvc/Micro/GetActiveHandlerCest.php
+++ b/tests/integration/Mvc/Micro/GetActiveHandlerCest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Test\Integration\Mvc\Micro;
 
 use IntegrationTester;
 use Phalcon\Mvc\Micro;
+use Phalcon\Test\Fixtures\Micro\RestHandler;
 
 /**
  * Class GetActiveHandlerCest
@@ -37,6 +38,12 @@ class GetActiveHandlerCest
     {
         $I->wantToTest('Mvc\Micro - getActiveHandler() with lazy loader');
         $app = new Micro();
-        $app->get('/api/site', [$handler, 'find']);
+        $microCollection = new Micro\Collection();
+        $microCollection->setHandler(RestHandler::class, true);
+        $microCollection->get('/api/site', 'find');
+        $app->mount($microCollection);
+        $app->handle('/api/site');
+        $I->assertInstanceOf(Micro\LazyLoader::class, $app->getActiveHandler());
+        $I->assertInstanceOf(RestHandler::class, $app->getActiveHandler()->getHandler());
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change: It adds `getHandler` method on `Phalcon\Mvc\Micro\LazyLoader`. This way you can return an actual object handling your endpoint. Since people mostly uses controllers as handlers it could be viable to clear controllers after any action(like added properties to controllers from injectable class).

Thanks

