### PR TITLE
T14743 binder cache

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -8,6 +8,7 @@
 - Fixed `Phalcon\Mvc\View\Engine\Volt` to produce the correct order of variables for the `join` filter [#14771](https://github.com/phalcon/cphalcon/issues/14771)
 - Fixed `Phalcon\Storage\Adapter\Stream::getKeys()` bug in the absence of a directory with a prefix name [#14725](https://github.com/phalcon/cphalcon/issues/14725), [#14721](https://github.com/phalcon/cphalcon/pull/14721)
 - Fixed `Phalcon\Debug::onUncaughtException` Should accept `\Throwable` instead of `\Exception` as an argument [#14738](https://github.com/phalcon/cphalcon/pull/14738)
+- Fixed `Phalcon\Mvc\Model\Binder` to now correctly call `has` and `set` on the cache object [#14743](https://github.com/phalcon/cphalcon/pull/14743)
 
 # [4.0.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.1) (2020-01-12)
 ## Fixed

--- a/phalcon/Mvc/Model/Binder.zep
+++ b/phalcon/Mvc/Model/Binder.zep
@@ -121,7 +121,7 @@ class Binder implements BinderInterface
 
         let cache = this->cache;
 
-        if cache === null || !cache->exists(cacheKey) {
+        if cache === null || !cache->has(cacheKey) {
             return null;
         }
 
@@ -213,7 +213,7 @@ class Binder implements BinderInterface
         }
 
         if cache != null {
-            cache->save(cacheKey, paramsCache);
+            cache->set(cacheKey, paramsCache);
         }
 
         let this->internalCache[cacheKey] = paramsCache;


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14743 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Binder` to now correctly call `has` and `set` on the cache object

Thanks

