### PR TITLE
#14717 - Log Test - Compare seconds

### DIFF
--- a/tests/_data/fixtures/Traits/LoggerTrait.php
+++ b/tests/_data/fixtures/Traits/LoggerTrait.php
@@ -43,21 +43,21 @@ trait LoggerTrait
         $I->amInPath(logsDir());
         $I->openFile($fileName);
         
-        //Check if the $logString is in the log file
+        // Check if the $logString is in the log file
         $I->seeInThisFile($logString);
 
-        //Check if the level is in the log file
+        // Check if the level is in the log file
         $I->seeInThisFile('['.$level.']');
 
-        //Check time content
+        // Check time content
         $sContent = file_get_contents($fileName);
 
-        //Get time part
+        // Get time part
         $aDate = [];
         preg_match('/\[(.*)\]\['.$level.'\]/', $sContent, $aDate);
         $I->assertEquals(count($aDate), 2);
 
-        //Get Extract time
+        // Get Extract time
         $sDate              = end($aDate);
         $sLogDateTime       = new DateTime($sDate);
         $sDateTimeAfterLog  = new DateTime($logTime);

--- a/tests/_data/fixtures/Traits/LoggerTrait.php
+++ b/tests/_data/fixtures/Traits/LoggerTrait.php
@@ -44,10 +44,10 @@ trait LoggerTrait
         $I->openFile($fileName);
         
         //Check if the $logString is in the log file
-        $I->seeInThisFile($logTime);
+        $I->seeInThisFile($logString);
 
         //Check if the level is in the log file
-        $I->seeInThisFile($level);
+        $I->seeInThisFile('['.$level.']');
 
         //Check time content
         $sContent = file_get_contents($fileName);

--- a/tests/_data/fixtures/Traits/LoggerTrait.php
+++ b/tests/_data/fixtures/Traits/LoggerTrait.php
@@ -65,7 +65,7 @@ trait LoggerTrait
         $nInterval          = $sLogDateTime->diff($sDateTimeAfterLog)->format('%s');
         $nSecondThreshold   = 60;
 
-        $I->assertLessThan($nSecondThreshold,$nInterval);
+        $I->assertLessThan($nSecondThreshold, $nInterval);
 
         $I->safeDeleteFile($fileName);
     }

--- a/tests/_data/fixtures/Traits/LoggerTrait.php
+++ b/tests/_data/fixtures/Traits/LoggerTrait.php
@@ -14,6 +14,7 @@ namespace Phalcon\Test\Fixtures\Traits;
 use Phalcon\Logger\Adapter\Stream;
 use Phalcon\Logger\Exception;
 use Phalcon\Logger;
+use DateTime;
 use UnitTester;
 
 use function logsDir;
@@ -42,20 +43,29 @@ trait LoggerTrait
         $I->amInPath(logsDir());
         $I->openFile($fileName);
         
-        //extract seconds 
-        $sSeconds = date('s',strtotime($logTime));
-        
-        //prepare regex to avoid seconds
-        $sRegexDate = str_replace($sSeconds, '[0-9]{2}\\', $logTime);
+        //Check if the $logString is in the log file
+        $I->seeInThisFile($logTime);
 
-        //Check with a regex and avoid seconds
-        $I->seeThisFileMatches(
-            sprintf(
-                '/\[%s\]\[%s\] ' . $logString . '/',
-                $sRegexDate,
-                $level
-            )
-        );
+        //Check if the level is in the log file
+        $I->seeInThisFile($level);
+
+        //Check time content
+        $sContent = file_get_contents($fileName);
+
+        //Get time part
+        $aDate = [];
+        preg_match('/\[(.*)\]\['.$level.'\]/', $sContent, $aDate);
+        $I->assertEquals(count($aDate), 2);
+
+        //Get Extract time
+        $sDate              = end($aDate);
+        $sLogDateTime       = new DateTime($sDate);
+        $sDateTimeAfterLog  = new DateTime($logTime);
+
+        $nInterval          = $sLogDateTime->diff($sDateTimeAfterLog)->format('%s');
+        $nSecondThreshold   = 60;
+
+        $I->assertLessThan($nSecondThreshold,$nInterval);
 
         $I->safeDeleteFile($fileName);
     }


### PR DESCRIPTION
Hello team!
I hope that this bug fix will work:

- I check if the logString is in the log file.

- I also check if the level of the log is present.

- Then I get the time in the log file and compare it with the time when the log is triggered.

If the difference between the two is less than 60, the test is passed.

* Type: bug fix
* Link to issue: #14717

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

