### PR TITLE
Fixed issue 14756 - File not found if path contains .

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -9,6 +9,7 @@
 - Fixed `Phalcon\Storage\Adapter\Stream::getKeys()` bug in the absence of a directory with a prefix name [#14725](https://github.com/phalcon/cphalcon/issues/14725), [#14721](https://github.com/phalcon/cphalcon/pull/14721)
 - Fixed `Phalcon\Debug::onUncaughtException` Should accept `\Throwable` instead of `\Exception` as an argument [#14738](https://github.com/phalcon/cphalcon/pull/14738)
 - Fixed `Phalcon\Mvc\Model\Binder` to now correctly call `has` and `set` on the cache object [#14743](https://github.com/phalcon/cphalcon/pull/14743)
+- Fixed `Phalcon\Config\ConfigFactory` to always add the correct extension [#14756](https://github.com/phalcon/cphalcon/issues/14756)
 
 # [4.0.2](https://github.com/phalcon/cphalcon/releases/tag/v4.0.1) (2020-01-12)
 ## Fixed

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -101,9 +101,8 @@ class ConfigFactory extends AbstractFactory
             first   = config["filePath"],
             second  = null;
 
-        if !strpos(first, ".") {
-            let first = first . "." . lcfirst(adapter);
-        }
+
+        let first = first . "." . lcfirst(adapter);
 
         if "ini" === adapter {
             let second = Arr::get(config, "mode", 1);

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -57,7 +57,7 @@ class ConfigFactory extends AbstractFactory
      */
     public function load(config) -> object
     {
-        var adapter, extension, first, oldConfig, second;
+        var adapter, extension, first, oldConfig, second, pathParts;
 
         if typeof config === "string" {
             let oldConfig = config,
@@ -101,8 +101,8 @@ class ConfigFactory extends AbstractFactory
             first   = config["filePath"],
             second  = null;
 
-
-        let first = first . "." . lcfirst(adapter);
+        pathParts = pathinfo(first);
+        let first = pathParts["dirname"] . DIRECTORY_SEPARATOR . pathParts["filename"];
 
         if "ini" === adapter {
             let second = Arr::get(config, "mode", 1);

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -57,7 +57,7 @@ class ConfigFactory extends AbstractFactory
      */
     public function load(config) -> object
     {
-        var adapter, extension, first, oldConfig, second, pathParts;
+        var adapter, extension, first, oldConfig, second;
 
         if typeof config === "string" {
             let oldConfig = config,
@@ -101,8 +101,9 @@ class ConfigFactory extends AbstractFactory
             first   = config["filePath"],
             second  = null;
 
-        let pathParts = pathinfo(first);
-        let first = pathParts["dirname"] . DIRECTORY_SEPARATOR . pathParts["filename"];
+        if (empty(pathinfo(first, PATHINFO_EXTENSION))) {
+            let first = first . "." . lcfirst(adapter);
+        }
 
         if "ini" === adapter {
             let second = Arr::get(config, "mode", 1);

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -101,7 +101,7 @@ class ConfigFactory extends AbstractFactory
             first   = config["filePath"],
             second  = null;
 
-        pathParts = pathinfo(first);
+        let pathParts = pathinfo(first);
         let first = pathParts["dirname"] . DIRECTORY_SEPARATOR . pathParts["filename"];
 
         if "ini" === adapter {

--- a/tests/_data/assets/config/config-with.in-file.name.ini
+++ b/tests/_data/assets/config/config-with.in-file.name.ini
@@ -1,0 +1,58 @@
+[annotations]
+adapter = apcu
+options.prefix = annotations
+options.lifetime = 3600
+
+[cache]
+adapter = libmemcached
+options.prefix = app-data
+
+[config]
+adapter = ini
+filePath = PATH_DATA"assets/config/config-with.in-file.name"
+filePathExtension = PATH_DATA"assets/config/config-with.in-file.name.ini"
+
+[database]
+adapter = mysql
+options.host = DATA_MYSQL_HOST
+options.username = DATA_MYSQL_USER
+options.password = DATA_MYSQL_PASS
+options.dbname = DATA_MYSQL_NAME
+options.port = DATA_MYSQL_PORT
+options.charset = DATA_MYSQL_CHARSET
+
+[image]
+adapter = imagick
+file = PATH_DATA"assets/images/phalconphp.jpg"
+
+[logger]
+name = "my-logger"
+options.adapters.0.adapter      = stream
+options.adapters.0.options.name = PATH_OUTPUT"tests/logs/factory.log"
+options.adapters.1.adapter      = stream
+options.adapters.1.options.name = PATH_OUTPUT"tests/logs/factory2.log"
+
+[paginator]
+adapter = queryBuilder
+options.limit = 20
+options.page = 1
+
+[translate]
+adapter = gettext
+options.locale = en_US.utf8
+options.defaultDomain = messages
+options.directory = PATH_DATA"assets/translation/gettext"
+options.category = LC_MESSAGES
+
+
+
+
+[session]
+uniqueId = my-private-app
+host = 127.0.0.1
+port = 11211
+persistent = true
+lifetime = 3600
+prefix = my_
+adapter = Files
+

--- a/tests/_data/assets/config/config-with.in-file.name.ini
+++ b/tests/_data/assets/config/config-with.in-file.name.ini
@@ -9,7 +9,7 @@ options.prefix = app-data
 
 [config]
 adapter = ini
-filePath = PATH_DATA"assets/config/config-with.in-file.name"
+filePath = PATH_DATA"assets/config/config-with.in-file.name.ini"
 filePathExtension = PATH_DATA"assets/config/config-with.in-file.name.ini"
 
 [database]

--- a/tests/unit/Config/ConfigFactory/LoadCest.php
+++ b/tests/unit/Config/ConfigFactory/LoadCest.php
@@ -53,6 +53,22 @@ class LoadCest
             Ini::class,
             $ini
         );
+
+        //Issue 14756
+        $configFile = dataDir('assets/config/config-with.in-file.name.ini');
+        $ini = new Ini($configFile, INI_SCANNER_NORMAL);
+        $I->assertInstanceOf(
+            Ini::class,
+            $ini
+        );
+
+        /** @var Ini $ini */
+        $ini = (new ConfigFactory())->load($ini->config->toArray());
+
+        $I->assertInstanceOf(
+            Ini::class,
+            $ini
+        );
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: Fixed #14756

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Without doing a file exists check we aren't able to detect if extension is set.
I would like to make the users responsibility to not add the extension like it's described in the docs. 
