### PR TITLE
#13655 - All tests for Annotations\Annotation

### DIFF
--- a/tests/unit/Annotations/Annotation/ConstructCest.php
+++ b/tests/unit/Annotations/Annotation/ConstructCest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
+use Phalcon\Annotations\Adapter\AdapterInterface;
 use UnitTester;
 
 class ConstructCest
@@ -20,13 +22,20 @@ class ConstructCest
     /**
      * Tests Phalcon\Annotations\Annotation :: __construct()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationConstruct(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - __construct()');
 
-        $I->skipTest('Need implementation');
+        $oAnnotation = new Annotation([
+            'name' => 'NovAnnotation'
+        ]);
+
+        $I->assertInstanceOf(
+            Annotation::class,
+            $oAnnotation
+        );
     }
 }

--- a/tests/unit/Annotations/Annotation/ConstructCest.php
+++ b/tests/unit/Annotations/Annotation/ConstructCest.php
@@ -29,13 +29,13 @@ class ConstructCest
     {
         $I->wantToTest('Annotations\Annotation - __construct()');
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name' => 'NovAnnotation'
         ]);
 
         $I->assertInstanceOf(
             Annotation::class,
-            $oAnnotation
+            $annotation
         );
     }
 }

--- a/tests/unit/Annotations/Annotation/GetArgumentCest.php
+++ b/tests/unit/Annotations/Annotation/GetArgumentCest.php
@@ -13,20 +13,45 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetArgumentCest
 {
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: getArgument()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetArgument(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getArgument()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => [
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue
+                    ]
+                ],
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue1
+                    ]
+                ]
+            ]
+        ]);
+        
+        $I->assertEquals($oAnnotation->getArgument(0), $sValue);
+
+        $I->assertEquals($oAnnotation->getArgument(1), $sValue1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetArgumentCest.php
+++ b/tests/unit/Annotations/Annotation/GetArgumentCest.php
@@ -29,29 +29,29 @@ class GetArgumentCest
     {
         $I->wantToTest('Annotations\Annotation - getArgument()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
+        $value = 'test';
+        $value1 = 'test1';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
             'arguments'  => [
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue
+                        'value' => $value
                     ]
                 ],
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue1
+                        'value' => $value1
                     ]
                 ]
             ]
         ]);
         
-        $I->assertEquals($oAnnotation->getArgument(0), $sValue);
+        $I->assertEquals($annotation->getArgument(0), $value);
 
-        $I->assertEquals($oAnnotation->getArgument(1), $sValue1);
+        $I->assertEquals($annotation->getArgument(1), $value1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetArgumentsCest.php
+++ b/tests/unit/Annotations/Annotation/GetArgumentsCest.php
@@ -13,20 +13,43 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetArgumentsCest
 {
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: getArguments()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetArguments(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getArguments()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => [
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue
+                    ]
+                ],
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue1
+                    ]
+                ]
+            ]
+        ]);
+
+        $I->assertEquals([$sValue, $sValue1], $oAnnotation->getArguments());
     }
 }

--- a/tests/unit/Annotations/Annotation/GetArgumentsCest.php
+++ b/tests/unit/Annotations/Annotation/GetArgumentsCest.php
@@ -29,27 +29,27 @@ class GetArgumentsCest
     {
         $I->wantToTest('Annotations\Annotation - getArguments()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
+        $value = 'test';
+        $value1 = 'test1';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
             'arguments'  => [
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue
+                        'value' => $value
                     ]
                 ],
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue1
+                        'value' => $value1
                     ]
                 ]
             ]
         ]);
 
-        $I->assertEquals([$sValue, $sValue1], $oAnnotation->getArguments());
+        $I->assertEquals([$value, $value1], $annotation->getArguments());
     }
 }

--- a/tests/unit/Annotations/Annotation/GetExprArgumentsCest.php
+++ b/tests/unit/Annotations/Annotation/GetExprArgumentsCest.php
@@ -29,29 +29,29 @@ class GetExprArgumentsCest
     {
         $I->wantToTest('Annotations\Annotation - getExprArguments()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
+        $value = 'test';
+        $value1 = 'test1';
 
-        $aExpr = [
+        $expr = [
             [
                 'expr' => [
                     'type'  => $this->PHANNOT_T_STRING,
-                    'value' => $sValue
+                    'value' => $value
                 ]
             ],
             [
                 'expr' => [
                     'type'  => $this->PHANNOT_T_STRING,
-                    'value' => $sValue1
+                    'value' => $value1
                 ]
             ]
         ];
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
-            'arguments'  => $aExpr
+            'arguments'  => $expr
         ]);
 
-        $I->assertEquals($oAnnotation->getExprArguments(), $aExpr);
+        $I->assertEquals($annotation->getExprArguments(), $expr);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetExprArgumentsCest.php
+++ b/tests/unit/Annotations/Annotation/GetExprArgumentsCest.php
@@ -13,20 +13,45 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetExprArgumentsCest
 {
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: getExprArguments()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetExprArguments(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getExprArguments()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+
+        $aExpr = [
+            [
+                'expr' => [
+                    'type'  => $this->PHANNOT_T_STRING,
+                    'value' => $sValue
+                ]
+            ],
+            [
+                'expr' => [
+                    'type'  => $this->PHANNOT_T_STRING,
+                    'value' => $sValue1
+                ]
+            ]
+        ];
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => $aExpr
+        ]);
+
+        $I->assertEquals($oAnnotation->getExprArguments(), $aExpr);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetExpressionCest.php
+++ b/tests/unit/Annotations/Annotation/GetExpressionCest.php
@@ -13,20 +13,51 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetExpressionCest
 {
+    private $PHANNOT_T_STRING = 303;
+
     /**
      * Tests Phalcon\Annotations\Annotation :: getExpression()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetExpression(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getExpression()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+
+        $aOneExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue
+        ];
+
+        $aTwoExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue1
+        ];
+
+        $aExpr = [
+            [
+                'expr' => $aOneExpr
+            ],
+            [
+                'expr' => $aTwoExpr
+            ]
+        ];
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => $aExpr
+        ]);
+
+        $I->assertEquals($oAnnotation->GetExpression($aOneExpr), $sValue);
+        $I->assertEquals($oAnnotation->GetExpression($aTwoExpr), $sValue1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetExpressionCest.php
+++ b/tests/unit/Annotations/Annotation/GetExpressionCest.php
@@ -30,34 +30,34 @@ class GetExpressionCest
     {
         $I->wantToTest('Annotations\Annotation - getExpression()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
+        $value = 'test';
+        $value1 = 'test1';
 
-        $aOneExpr = [
+        $oneExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue
+            'value' => $value
         ];
 
-        $aTwoExpr = [
+        $twoExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue1
+            'value' => $value1
         ];
 
-        $aExpr = [
+        $expr = [
             [
-                'expr' => $aOneExpr
+                'expr' => $oneExpr
             ],
             [
-                'expr' => $aTwoExpr
+                'expr' => $twoExpr
             ]
         ];
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
-            'arguments'  => $aExpr
+            'arguments'  => $expr
         ]);
 
-        $I->assertEquals($oAnnotation->GetExpression($aOneExpr), $sValue);
-        $I->assertEquals($oAnnotation->GetExpression($aTwoExpr), $sValue1);
+        $I->assertEquals($annotation->GetExpression($oneExpr), $value);
+        $I->assertEquals($annotation->GetExpression($twoExpr), $value1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetNameCest.php
+++ b/tests/unit/Annotations/Annotation/GetNameCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetNameCest
@@ -20,13 +21,19 @@ class GetNameCest
     /**
      * Tests Phalcon\Annotations\Annotation :: getName()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetName(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getName()');
 
-        $I->skipTest('Need implementation');
+        $sName = 'NovAnnotation';
+
+        $oAnnotation = new Annotation([
+            'name' => 'NovAnnotation'
+        ]);
+
+        $I->assertEquals($oAnnotation->getName(), $sName);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetNameCest.php
+++ b/tests/unit/Annotations/Annotation/GetNameCest.php
@@ -28,12 +28,12 @@ class GetNameCest
     {
         $I->wantToTest('Annotations\Annotation - getName()');
 
-        $sName = 'NovAnnotation';
+        $name = 'NovAnnotation';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name' => 'NovAnnotation'
         ]);
 
-        $I->assertEquals($oAnnotation->getName(), $sName);
+        $I->assertEquals($annotation->getName(), $name);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetNamedArgumentCest.php
+++ b/tests/unit/Annotations/Annotation/GetNamedArgumentCest.php
@@ -30,59 +30,59 @@ class GetNamedArgumentCest
     {
         $I->wantToTest('Annotations\Annotation - getNamedArgument()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
-        $sValue2 = 'test2';
+        $value = 'test';
+        $value1 = 'test1';
+        $value2 = 'test2';
 
-        $aOneExpr = [
+        $oneExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue
+            'value' => $value
         ];
 
-        $aTwoExpr = [
+        $twoExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue1
+            'value' => $value1
         ];
 
-        $aThreeExpr = [
+        $threeExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue2
+            'value' => $value2
         ];
 
-        $sName  = 'one_item';
-        $sName1 = 'two_item';
-        $sName2 = 'three_item';
+        $name  = 'one_item';
+        $name1 = 'two_item';
+        $name2 = 'three_item';
         
-        $sExprName  = 'first_argument';
-        $sExprName1 = 'second_argument';
+        $exprName  = 'first_argument';
+        $exprName1 = 'second_argument';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
             'arguments'  => [
                 [
-                    'name' => $sExprName,
+                    'name' => $exprName,
                     'expr' => [
                         'type'  => $this->PHANNOT_T_ARRAY,
                         'items' => [
                             [
-                                'name' => $sName,
-                                'expr' => $aOneExpr
+                                'name' => $name,
+                                'expr' => $oneExpr
                             ],
                             [
-                                'name' => $sName1,
-                                'expr' => $aTwoExpr
+                                'name' => $name1,
+                                'expr' => $twoExpr
                             ]
                         ]
                     ]
                 ],
                 [
-                    'name' => $sExprName1,
+                    'name' => $exprName1,
                     'expr' => [
                         'type'  => $this->PHANNOT_T_ARRAY,
                         'items' => [
                             [
-                                'name' => $sName2,
-                                'expr' => $aThreeExpr
+                                'name' => $name2,
+                                'expr' => $threeExpr
                             ]
                         ]
                     ]
@@ -90,17 +90,17 @@ class GetNamedArgumentCest
             ]
         ]);
 
-        $aResult = [
-            $sName  => $sValue,
-            $sName1 => $sValue1
+        $result = [
+            $name  => $value,
+            $name1 => $value1
         ];
 
-        $I->assertEquals($oAnnotation->getNamedArgument($sExprName), $aResult);
+        $I->assertEquals($annotation->getNamedArgument($exprName), $result);
 
-        $aResult1 = [
-            $sName2  => $sValue2
+        $result1 = [
+            $name2  => $value2
         ];
         
-        $I->assertEquals($oAnnotation->getNamedArgument($sExprName1), $aResult1);
+        $I->assertEquals($annotation->getNamedArgument($exprName1), $result1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetNamedArgumentCest.php
+++ b/tests/unit/Annotations/Annotation/GetNamedArgumentCest.php
@@ -13,20 +13,94 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetNamedArgumentCest
 {
+    private $PHANNOT_T_ARRAY = 308;
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: getNamedArgument()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetNamedArgument(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getNamedArgument()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+        $sValue2 = 'test2';
+
+        $aOneExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue
+        ];
+
+        $aTwoExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue1
+        ];
+
+        $aThreeExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue2
+        ];
+
+        $sName  = 'one_item';
+        $sName1 = 'two_item';
+        $sName2 = 'three_item';
+        
+        $sExprName  = 'first_argument';
+        $sExprName1 = 'second_argument';
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => [
+                [
+                    'name' => $sExprName,
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_ARRAY,
+                        'items' => [
+                            [
+                                'name' => $sName,
+                                'expr' => $aOneExpr
+                            ],
+                            [
+                                'name' => $sName1,
+                                'expr' => $aTwoExpr
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'name' => $sExprName1,
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_ARRAY,
+                        'items' => [
+                            [
+                                'name' => $sName2,
+                                'expr' => $aThreeExpr
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $aResult = [
+            $sName  => $sValue,
+            $sName1 => $sValue1
+        ];
+
+        $I->assertEquals($oAnnotation->getNamedArgument($sExprName), $aResult);
+
+        $aResult1 = [
+            $sName2  => $sValue2
+        ];
+        
+        $I->assertEquals($oAnnotation->getNamedArgument($sExprName1), $aResult1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetNamedParameterCest.php
+++ b/tests/unit/Annotations/Annotation/GetNamedParameterCest.php
@@ -13,20 +13,94 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class GetNamedParameterCest
 {
+    private $PHANNOT_T_ARRAY = 308;
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: getNamedParameter()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationGetNamedParameter(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - getNamedParameter()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+        $sValue2 = 'test2';
+
+        $aOneExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue
+        ];
+
+        $aTwoExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue1
+        ];
+
+        $aThreeExpr = [
+            'type'  => $this->PHANNOT_T_STRING,
+            'value' => $sValue2
+        ];
+
+        $sName  = 'one_item';
+        $sName1 = 'two_item';
+        $sName2 = 'three_item';
+        
+        $sExprName  = 'first_argument';
+        $sExprName1 = 'second_argument';
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => [
+                [
+                    'name' => $sExprName,
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_ARRAY,
+                        'items' => [
+                            [
+                                'name' => $sName,
+                                'expr' => $aOneExpr
+                            ],
+                            [
+                                'name' => $sName1,
+                                'expr' => $aTwoExpr
+                            ]
+                        ]
+                    ]
+                ],
+                [
+                    'name' => $sExprName1,
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_ARRAY,
+                        'items' => [
+                            [
+                                'name' => $sName2,
+                                'expr' => $aThreeExpr
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ]);
+
+        $aResult = [
+            $sName  => $sValue,
+            $sName1 => $sValue1
+        ];
+
+        $I->assertEquals($oAnnotation->getNamedParameter($sExprName), $aResult);
+
+        $aResult1 = [
+            $sName2  => $sValue2
+        ];
+        
+        $I->assertEquals($oAnnotation->getNamedParameter($sExprName1), $aResult1);
     }
 }

--- a/tests/unit/Annotations/Annotation/GetNamedParameterCest.php
+++ b/tests/unit/Annotations/Annotation/GetNamedParameterCest.php
@@ -30,59 +30,59 @@ class GetNamedParameterCest
     {
         $I->wantToTest('Annotations\Annotation - getNamedParameter()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
-        $sValue2 = 'test2';
+        $value = 'test';
+        $value1 = 'test1';
+        $value2 = 'test2';
 
-        $aOneExpr = [
+        $oneExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue
+            'value' => $value
         ];
 
-        $aTwoExpr = [
+        $twoExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue1
+            'value' => $value1
         ];
 
-        $aThreeExpr = [
+        $threeExpr = [
             'type'  => $this->PHANNOT_T_STRING,
-            'value' => $sValue2
+            'value' => $value2
         ];
 
-        $sName  = 'one_item';
-        $sName1 = 'two_item';
-        $sName2 = 'three_item';
+        $name  = 'one_item';
+        $name1 = 'two_item';
+        $name2 = 'three_item';
         
-        $sExprName  = 'first_argument';
-        $sExprName1 = 'second_argument';
+        $exprName  = 'first_argument';
+        $exprName1 = 'second_argument';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
             'arguments'  => [
                 [
-                    'name' => $sExprName,
+                    'name' => $exprName,
                     'expr' => [
                         'type'  => $this->PHANNOT_T_ARRAY,
                         'items' => [
                             [
-                                'name' => $sName,
-                                'expr' => $aOneExpr
+                                'name' => $name,
+                                'expr' => $oneExpr
                             ],
                             [
-                                'name' => $sName1,
-                                'expr' => $aTwoExpr
+                                'name' => $name1,
+                                'expr' => $twoExpr
                             ]
                         ]
                     ]
                 ],
                 [
-                    'name' => $sExprName1,
+                    'name' => $exprName1,
                     'expr' => [
                         'type'  => $this->PHANNOT_T_ARRAY,
                         'items' => [
                             [
-                                'name' => $sName2,
-                                'expr' => $aThreeExpr
+                                'name' => $name2,
+                                'expr' => $threeExpr
                             ]
                         ]
                     ]
@@ -90,17 +90,17 @@ class GetNamedParameterCest
             ]
         ]);
 
-        $aResult = [
-            $sName  => $sValue,
-            $sName1 => $sValue1
+        $result = [
+            $name  => $value,
+            $name1 => $value1
         ];
 
-        $I->assertEquals($oAnnotation->getNamedParameter($sExprName), $aResult);
+        $I->assertEquals($annotation->getNamedParameter($exprName), $result);
 
-        $aResult1 = [
-            $sName2  => $sValue2
+        $result1 = [
+            $name2  => $value2
         ];
         
-        $I->assertEquals($oAnnotation->getNamedParameter($sExprName1), $aResult1);
+        $I->assertEquals($annotation->getNamedParameter($exprName1), $result1);
     }
 }

--- a/tests/unit/Annotations/Annotation/HasArgumentCest.php
+++ b/tests/unit/Annotations/Annotation/HasArgumentCest.php
@@ -13,20 +13,47 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class HasArgumentCest
 {
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: hasArgument()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationHasArgument(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - hasArgument()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => [
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue
+                    ]
+                ],
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue1
+                    ]
+                ]
+            ]
+        ]);
+        
+        $I->assertTrue($oAnnotation->hasArgument(0));
+
+        $I->assertTrue($oAnnotation->hasArgument(1));
+
+        $I->assertFalse($oAnnotation->hasArgument(2));
     }
 }

--- a/tests/unit/Annotations/Annotation/HasArgumentCest.php
+++ b/tests/unit/Annotations/Annotation/HasArgumentCest.php
@@ -29,31 +29,31 @@ class HasArgumentCest
     {
         $I->wantToTest('Annotations\Annotation - hasArgument()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
+        $value = 'test';
+        $value1 = 'test1';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
             'arguments'  => [
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue
+                        'value' => $value
                     ]
                 ],
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue1
+                        'value' => $value1
                     ]
                 ]
             ]
         ]);
         
-        $I->assertTrue($oAnnotation->hasArgument(0));
+        $I->assertTrue($annotation->hasArgument(0));
 
-        $I->assertTrue($oAnnotation->hasArgument(1));
+        $I->assertTrue($annotation->hasArgument(1));
 
-        $I->assertFalse($oAnnotation->hasArgument(2));
+        $I->assertFalse($annotation->hasArgument(2));
     }
 }

--- a/tests/unit/Annotations/Annotation/NumberArgumentsCest.php
+++ b/tests/unit/Annotations/Annotation/NumberArgumentsCest.php
@@ -13,20 +13,43 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Annotations\Annotation;
 
+use Phalcon\Annotations\Annotation;
 use UnitTester;
 
 class NumberArgumentsCest
 {
+    private $PHANNOT_T_STRING = 303;
     /**
      * Tests Phalcon\Annotations\Annotation :: numberArguments()
      *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2020-01-22
      */
     public function annotationsAnnotationNumberArguments(UnitTester $I)
     {
         $I->wantToTest('Annotations\Annotation - numberArguments()');
 
-        $I->skipTest('Need implementation');
+        $sValue = 'test';
+        $sValue1 = 'test1';
+
+        $oAnnotation = new Annotation([
+            'name'       => 'NovAnnotation',
+            'arguments'  => [
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue
+                    ]
+                ],
+                [
+                    'expr' => [
+                        'type'  => $this->PHANNOT_T_STRING,
+                        'value' => $sValue1
+                    ]
+                ]
+            ]
+        ]);
+        
+        $I->assertEquals($oAnnotation->numberArguments(), 2);
     }
 }

--- a/tests/unit/Annotations/Annotation/NumberArgumentsCest.php
+++ b/tests/unit/Annotations/Annotation/NumberArgumentsCest.php
@@ -29,27 +29,27 @@ class NumberArgumentsCest
     {
         $I->wantToTest('Annotations\Annotation - numberArguments()');
 
-        $sValue = 'test';
-        $sValue1 = 'test1';
+        $value = 'test';
+        $value1 = 'test1';
 
-        $oAnnotation = new Annotation([
+        $annotation = new Annotation([
             'name'       => 'NovAnnotation',
             'arguments'  => [
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue
+                        'value' => $value
                     ]
                 ],
                 [
                     'expr' => [
                         'type'  => $this->PHANNOT_T_STRING,
-                        'value' => $sValue1
+                        'value' => $value1
                     ]
                 ]
             ]
         ]);
         
-        $I->assertEquals($oAnnotation->numberArguments(), 2);
+        $I->assertEquals($annotation->numberArguments(), 2);
     }
 }


### PR DESCRIPTION
Hello team!
I'm happy to tell you that I have tested Annotation class.
But I have some problems about constants. 
I can't get the value of PHANNOT_T_ARRAY, PHANNOT_T_STRING, ... 
These constants come from https://github.com/phalcon/cphalcon/blob/a48b31967a1ce27c10cbed61bee42e0c90addc86/ext/phalcon/annotations/scanner.h
I have made a private property to handle this but I'm not proud of it.
Any ideas ?
Thanks

* Type: code quality
* Link to issue: #13655

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

