### PR TITLE
Annotations router custom action pre-format callback

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -14,6 +14,7 @@
 - Added `preload` for Volt, which will send a HTTP/2 preload header [#13128](https://github.com/phalcon/cphalcon/issues/13128)
 - Added `Phalcon\Helper\Arr::blackList()` to exclude elements of an array by the keys obtained from the elements of a blacklist [#14801](https://github.com/phalcon/cphalcon/issues/14801) [@TimurFlush](https://github.com/TimurFlush)
 - Added `Phalcon\Debug::renderHtml()` to get a HTML representation of the exception [#14794](https://github.com/phalcon/cphalcon/issues/14794) [@TimurFlush](https://github.com/TimurFlush)
+- Added `Phalcon\Mvc\Router\Annotations->setActionPreformatCallback($callback)` to set a callback which pre-formats actions to custom pattern [#14819](https://github.com/phalcon/cphalcon/pull/14819)
 
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -442,6 +442,14 @@ class Annotations extends Router
     }
 
     /**
+     * @return callable|string|null
+     */
+    public function getActionPreformatCallback()
+    {
+        return this->actionPreformatCallback;
+    }
+
+    /**
      * Changes the controller class suffix
      */
     public function setControllerSuffix(string! controllerSuffix)

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -242,7 +242,7 @@ class Annotations extends Router
     public function processActionAnnotation(string! module, string! namespaceName, string! controller, string! action,
         <Annotation> annotation)
     {
-        var name, actionName, routePrefix, paths, value, uri, route, methods,
+        var name, proxyActionName, actionName, routePrefix, paths, value, uri, route, methods,
             converts, param, convert, converterParam, routeName, beforeMatch;
         bool isRoute;
 

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -40,6 +40,8 @@ class Annotations extends Router
 {
     protected actionSuffix = "Action";
 
+    protected actionPreformatCallback;
+
     protected controllerSuffix = "Controller";
 
     protected handlers = [];
@@ -271,8 +273,14 @@ class Annotations extends Router
             return;
         }
 
-        let actionName = strtolower(str_replace(this->actionSuffix, "", action)),
+        let proxyActionName = str_replace(this->actionSuffix, "", action),
             routePrefix = this->routePrefix;
+
+        if this->actionPreformatCallback !== null {
+            let proxyActionName = call_user_func(this->actionPreformatCallback, proxyActionName);
+        }
+
+        let actionName = strtolower(proxyActionName);
 
         /**
          * Check for existing paths in the annotation
@@ -394,6 +402,43 @@ class Annotations extends Router
     public function setActionSuffix(string! actionSuffix)
     {
         let this->actionSuffix = actionSuffix;
+    }
+
+    /**
+     * Sets the action preformat callback
+     * $action here already without suffix 'Action'
+     *
+     * ```php
+     * // Array as callback
+     * $annotationRouter->setActionPreformatCallback([Text::class, 'uncamelize']);
+     *
+     * // Function as callback
+     * $annotationRouter->setActionPreformatCallback(function(action){
+     *     return action;
+     * });
+     *
+     * // String as callback
+     * $annotationRouter->setActionPreformatCallback('strtolower');
+     *
+     * // If empty method constructor called [null], sets uncamelize with - delimiter
+     * $annotationRouter->setActionPreformatCallback();
+     * ```
+     *
+     * @param callable|string|null $callback
+     */
+    public function setActionPreformatCallback(var callback = null)
+    {
+        if likely is_callable(callback) {
+            let this->actionPreformatCallback = callback;
+        } elseif callback === null {
+            let this->actionPreformatCallback = function (action) {
+                return uncamelize(action, "-");
+            };
+        } else {
+            throw new Exception(
+                "The 'callback' parameter must be either a callable or NULL."
+            );
+        }
     }
 
     /**

--- a/tests/integration/Mvc/Router/Annotations/SetActionPreformatCallbackCest.php
+++ b/tests/integration/Mvc/Router/Annotations/SetActionPreformatCallbackCest.php
@@ -22,8 +22,6 @@ use Phalcon\Text;
  */
 class SetActionPreformatCallbackCest
 {
-    public const TESTING_ACTION = 'somePrettyControllerAction';
-
     /**
      * Tests Phalcon\Mvc\Router\Annotations :: setActionPreformatCallback()
      *
@@ -35,7 +33,6 @@ class SetActionPreformatCallbackCest
         $I->wantToTest('Mvc\Router\Annotations - setDefaultAction()');
 
         $router = new Annotations(false);
-
         $callback = [Text::class, 'uncamelize'];
         $router->setActionPreformatCallback($callback);
         $attachedCallback = $router->getActionPreformatCallback();

--- a/tests/integration/Mvc/Router/Annotations/SetActionPreformatCallbackCest.php
+++ b/tests/integration/Mvc/Router/Annotations/SetActionPreformatCallbackCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Annotations;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router\Annotations;
 use Phalcon\Text;
 
 /**
@@ -33,7 +34,7 @@ class SetActionPreformatCallbackCest
     {
         $I->wantToTest('Mvc\Router\Annotations - setDefaultAction()');
 
-        $router = $this->getRouter(false);
+        $router = new Annotations(false);
 
         $callback = [Text::class, 'uncamelize'];
         $router->setActionPreformatCallback($callback);

--- a/tests/integration/Mvc/Router/Annotations/SetActionPreformatCallbackCest.php
+++ b/tests/integration/Mvc/Router/Annotations/SetActionPreformatCallbackCest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Integration\Mvc\Router\Annotations;
+
+use IntegrationTester;
+use Phalcon\Text;
+
+/**
+ * Class SetActionPreformatCallbackCest
+ */
+class SetActionPreformatCallbackCest
+{
+    public const TESTING_ACTION = 'somePrettyControllerAction';
+
+    /**
+     * Tests Phalcon\Mvc\Router\Annotations :: setActionPreformatCallback()
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-02-03
+     */
+    public function mvcRouterAnnotationsSetActionPreformatCallback(IntegrationTester $I)
+    {
+        $I->wantToTest('Mvc\Router\Annotations - setDefaultAction()');
+
+        $router = $this->getRouter(false);
+
+        $callback = [Text::class, 'uncamelize'];
+        $router->setActionPreformatCallback($callback);
+        $attachedCallback = $router->getActionPreformatCallback();
+
+        $I->assertEquals(
+            $callback,
+            $attachedCallback
+        );
+    }
+}

--- a/tests/tocheck-database/Mvc/Model/Resultset/Simple/ToArrayCest.php
+++ b/tests/tocheck-database/Mvc/Model/Resultset/Simple/ToArrayCest.php
@@ -49,7 +49,10 @@ class ToArrayCest
          * Re-create DB table with data
          */
         $db = $this->getService('db');
-        (new InvoicesMigration())($db);
+
+        $migration = new InvoicesMigration($db);
+        $migration->create();
+
         $data = [
             [1, 0, 'Title 1', 10.51, date('Y-m-d H:i:s')],
             [123, 1, 'Title 2', 5.2, date('Y-m-d H:i:s')],


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added method to set callback handler to pre-format action name in Annotation Router.
**Default behavior** of action name processing:
`PostsController::getLastUpdatedAction()` equals to uri `/posts/getlastupdated` via strtolower formatting.
**New behavior** allows to set callback, which does user defined pre-format to action name:
`PostsController::getLastUpdatedAction()` equals to uri `/posts/get-last-updated` via uncamelize passed as callback

Thanks

