### PR TITLE
[cache] - Cache Serializer options

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -10,6 +10,7 @@
 - Fixed `Phalcon\Db\Adapter\Pdo\Postgresql` to correctly identify `bool` fields instead of treating them as `tinyint` [#14722](https://github.com/phalcon/cphalcon/issues/14722) [@tidytrax](https://github.com/tidytrax)
 - Fixed `Phalcon\Cli\Console` to pass current container to the `Phalcon\Mvc\ModuleDefinitionInterface::registerAutoloaders()` [#14787](https://github.com/phalcon/cphalcon/issues/14787) [@TimurFlush](https://github.com/TimurFlush)
 - Fixed `Phalcon\Db\Dialect\Mysql::createTable()` to create default value with CURRENT_TIMESTAMP ON UPDATE/DELETE [#14797]
+- Fixed `Phalcon\Storage\Adapter\*` to no longer accept the `serializer` option as it was clashing with the factory [#14828](https://github.com/phalcon/cphalcon/pull/14828)
 
 # [4.0.3](https://github.com/phalcon/cphalcon/releases/tag/v4.0.3) (2020-01-25)
 ## Added

--- a/phalcon/Storage/Adapter/AbstractAdapter.zep
+++ b/phalcon/Storage/Adapter/AbstractAdapter.zep
@@ -75,8 +75,7 @@ abstract class AbstractAdapter implements AdapterInterface
          */
         let this->serializerFactory = factory,
             this->defaultSerializer = Arr::get(options, "defaultSerializer", "Php"),
-            this->lifetime          = Arr::get(options, "lifetime", 3600),
-            this->serializer        = Arr::get(options, "serializer", null);
+            this->lifetime          = Arr::get(options, "lifetime", 3600);
 
         if isset options["prefix"] {
             let this->prefix = options["prefix"];


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Storage\Adapter\*` to no longer accept the `serializer` option as it was clashing with the factory

Thanks

