### PR TITLE
Any character not < Ascii 123 must be converted.

### DIFF
--- a/ext/kernel/filter.c
+++ b/ext/kernel/filter.c
@@ -218,7 +218,7 @@ void zephir_escape_multi(zval *return_value, zval *param, const char *escape_cha
 		/**
 		 * Alphanumeric characters are not escaped
 		 */
-		if (value < 256 && isalnum(value)) {
+		if (value < 123 && isalnum(value)) {
 			smart_str_appendc(&escaped_str, (unsigned char) value);
 			continue;
 		}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

