### PR TITLE
Add test case in AssignCest class [PHP 7.4]

### DIFF
--- a/tests/database/Mvc/Model/AssignCest.php
+++ b/tests/database/Mvc/Model/AssignCest.php
@@ -90,7 +90,6 @@ class AssignCest
         );
     }
 
-
     /**
      * Tests Phalcon\Mvc\Model :: assign() - incomplete
      *
@@ -121,5 +120,35 @@ class AssignCest
             ],
             $invoice->toArray()
         );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: assign() - auto_increment primary
+     *
+     * Current test serves for example with PHP 7.4 and nullable model's property.
+     * > Uncaught Error: Typed property Model::$id must not be accessed before initialization
+     *
+     * Example: public ?int $id = null;
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-02-13
+     */
+    public function mvcModelAssignAutoPrimary(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - assign() - auto_increment primary');
+
+        $data  = [
+            'inv_cst_id'      => 2,
+            'inv_status_flag' => 3,
+            'inv_title'       => uniqid('inv-'),
+            'inv_total'       => 100.12,
+            'inv_created_at'  => date('Y-m-d H:i:s'),
+        ];
+
+        $invoice = new Invoices();
+        $invoice->assign($data, array_keys($data));
+
+        $I->assertArrayHasKey('inv_id', $invoice->toArray());
+        $I->assertEmpty($invoice->toArray()['inv_id']);
     }
 }


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Current test serves for example with PHP 7.4 and nullable model's property.
> Uncaught Error: Typed property Model::$id must not be accessed before initialization

Example: `public ?int $id = null;`

Thanks

