### PR TITLE
Enable windows osx tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -341,7 +341,6 @@ jobs:
           vendor/bin/codecept build
 
       - name: Run unit tests
-        continue-on-error: true #remove after bug fix #14763
         run: vendor/bin/codecept run --ext DotReporter unit
 
       - name: Run cli tests
@@ -527,7 +526,6 @@ jobs:
           vendor/bin/codecept build
 
       - name: Run unit tests
-        continue-on-error: true #remove after bug fix #14763
         run: vendor/bin/codecept run --ext DotReporter unit
 
       - name: Run cli tests

--- a/tests/unit/Annotations/Reader/ParseCest.php
+++ b/tests/unit/Annotations/Reader/ParseCest.php
@@ -50,7 +50,7 @@ class ParseCest
     public function testParseWithInvalidAnnotation(UnitTester $I)
     {
         $filename    = 'fixtures' . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'TestInvalid.php';
-        $includeFile = dataDir(str_replace("/", DIRECTORY_SEPARATOR, $filename));
+        $includeFile = dataDir(str_replace("\\", DIRECTORY_SEPARATOR, $filename));
 
         $I->seeFileFound($includeFile);
 

--- a/tests/unit/Annotations/Reader/ParseCest.php
+++ b/tests/unit/Annotations/Reader/ParseCest.php
@@ -50,7 +50,7 @@ class ParseCest
     public function testParseWithInvalidAnnotation(UnitTester $I)
     {
         $filename    = 'fixtures' . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'TestInvalid.php';
-        $includeFile = str_replace("\\", DIRECTORY_SEPARATOR, dataDir($filename));
+        $includeFile = str_replace("/", DIRECTORY_SEPARATOR, dataDir($filename));
 
         $I->seeFileFound($includeFile);
 
@@ -59,7 +59,7 @@ class ParseCest
         $file = dataDir($filename);
 
         //directory based on DIRECTORY_SEPARATOR
-        $file = str_replace("\\", DIRECTORY_SEPARATOR, $file);
+        $file = str_replace("/", DIRECTORY_SEPARATOR, $file);
 
         $I->expectThrowable(
             new Exception('Syntax error, unexpected EOF in ' . $file),

--- a/tests/unit/Annotations/Reader/ParseCest.php
+++ b/tests/unit/Annotations/Reader/ParseCest.php
@@ -50,7 +50,7 @@ class ParseCest
     public function testParseWithInvalidAnnotation(UnitTester $I)
     {
         $filename    = 'fixtures' . DIRECTORY_SEPARATOR . 'Annotations' . DIRECTORY_SEPARATOR . 'TestInvalid.php';
-        $includeFile = dataDir(str_replace("\\", DIRECTORY_SEPARATOR, $filename));
+        $includeFile = str_replace("\\", DIRECTORY_SEPARATOR, dataDir($filename));
 
         $I->seeFileFound($includeFile);
 


### PR DESCRIPTION
Hello!

* Type code quality
* Link to issue: https://github.com/phalcon/cphalcon/issues/14775

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Allowing failing windows or osx test to break the build. 