### PR TITLE
T14679 filter non existing 2

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -34,6 +34,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)
 - Changed `Phalcon\Db\Adapter\*::getRawSQLStatement()` to return the full SQL query with parameters [#12196](https://github.com/phalcon/cphalcon/issues/12196)
+- Changed `Phalcon\Filter::sanitize` to throw a `E_USER_NOTICE` when a filter does not exist. [#14679](https://github.com/phalcon/cphalcon/issues/14679)
 
 ## Fixed
 - Fixed `Phalcon\Db\Dialect\Mysql::getColumnDefinition` to recognize `size` for `DATETIME`, `TIME` and `TIMESTAMP` columns [#13297](https://github.com/phalcon/cphalcon/issues/13297)

--- a/phalcon/Filter.zep
+++ b/phalcon/Filter.zep
@@ -253,6 +253,11 @@ class Filter implements FilterInterface
         var sanitizerObject, params;
 
         if !this->has(sanitizerName) {
+            trigger_error(
+                "Sanitizer '" . sanitizerName . "' is not registered",
+                E_USER_NOTICE
+            );
+
             return value;
         }
 

--- a/phalcon/Filter.zep
+++ b/phalcon/Filter.zep
@@ -253,10 +253,12 @@ class Filter implements FilterInterface
         var sanitizerObject, params;
 
         if !this->has(sanitizerName) {
-            trigger_error(
-                "Sanitizer '" . sanitizerName . "' is not registered",
-                E_USER_NOTICE
-            );
+            if unlikely !empty sanitizerName {
+                trigger_error(
+                    "Sanitizer '" . sanitizerName . "' is not registered",
+                    E_USER_NOTICE
+                );
+            }
 
             return value;
         }

--- a/phalcon/Filter/FilterFactory.zep
+++ b/phalcon/Filter/FilterFactory.zep
@@ -28,27 +28,27 @@ class FilterFactory
     protected function getAdapters() -> array
     {
         return [
-            "absint"      : "Phalcon\\Filter\\Sanitize\\AbsInt",
-            "alnum"       : "Phalcon\\Filter\\Sanitize\\Alnum",
-            "alpha"       : "Phalcon\\Filter\\Sanitize\\Alpha",
-            "bool"        : "Phalcon\\Filter\\Sanitize\\BoolVal",
-            "email"       : "Phalcon\\Filter\\Sanitize\\Email",
-            "float"       : "Phalcon\\Filter\\Sanitize\\FloatVal",
-            "int"         : "Phalcon\\Filter\\Sanitize\\IntVal",
-            "lower"       : "Phalcon\\Filter\\Sanitize\\Lower",
-            "lowerFirst"  : "Phalcon\\Filter\\Sanitize\\LowerFirst",
-            "regex"       : "Phalcon\\Filter\\Sanitize\\Regex",
-            "remove"      : "Phalcon\\Filter\\Sanitize\\Remove",
-            "replace"     : "Phalcon\\Filter\\Sanitize\\Replace",
-            "special"     : "Phalcon\\Filter\\Sanitize\\Special",
-            "specialFull" : "Phalcon\\Filter\\Sanitize\\SpecialFull",
-            "string"      : "Phalcon\\Filter\\Sanitize\\StringVal",
-            "striptags"   : "Phalcon\\Filter\\Sanitize\\Striptags",
-            "trim"        : "Phalcon\\Filter\\Sanitize\\Trim",
-            "upper"       : "Phalcon\\Filter\\Sanitize\\Upper",
-            "upperFirst"  : "Phalcon\\Filter\\Sanitize\\UpperFirst",
-            "upperWords"  : "Phalcon\\Filter\\Sanitize\\UpperWords",
-            "url"         : "Phalcon\\Filter\\Sanitize\\Url"
+            Filter::FILTER_ABSINT     : "Phalcon\\Filter\\Sanitize\\AbsInt",
+            Filter::FILTER_ALNUM      : "Phalcon\\Filter\\Sanitize\\Alnum",
+            Filter::FILTER_ALPHA      : "Phalcon\\Filter\\Sanitize\\Alpha",
+            Filter::FILTER_BOOL       : "Phalcon\\Filter\\Sanitize\\BoolVal",
+            Filter::FILTER_EMAIL      : "Phalcon\\Filter\\Sanitize\\Email",
+            Filter::FILTER_FLOAT      : "Phalcon\\Filter\\Sanitize\\FloatVal",
+            Filter::FILTER_INT        : "Phalcon\\Filter\\Sanitize\\IntVal",
+            Filter::FILTER_LOWER      : "Phalcon\\Filter\\Sanitize\\Lower",
+            Filter::FILTER_LOWERFIRST : "Phalcon\\Filter\\Sanitize\\LowerFirst",
+            Filter::FILTER_REGEX      : "Phalcon\\Filter\\Sanitize\\Regex",
+            Filter::FILTER_REMOVE     : "Phalcon\\Filter\\Sanitize\\Remove",
+            Filter::FILTER_REPLACE    : "Phalcon\\Filter\\Sanitize\\Replace",
+            Filter::FILTER_SPECIAL    : "Phalcon\\Filter\\Sanitize\\Special",
+            Filter::FILTER_SPECIALFULL: "Phalcon\\Filter\\Sanitize\\SpecialFull",
+            Filter::FILTER_STRING     : "Phalcon\\Filter\\Sanitize\\StringVal",
+            Filter::FILTER_STRIPTAGS  : "Phalcon\\Filter\\Sanitize\\Striptags",
+            Filter::FILTER_TRIM       : "Phalcon\\Filter\\Sanitize\\Trim",
+            Filter::FILTER_UPPER      : "Phalcon\\Filter\\Sanitize\\Upper",
+            Filter::FILTER_UPPERFIRST : "Phalcon\\Filter\\Sanitize\\UpperFirst",
+            Filter::FILTER_UPPERWORDS : "Phalcon\\Filter\\Sanitize\\UpperWords",
+            Filter::FILTER_URL        : "Phalcon\\Filter\\Sanitize\\Url"
         ];
     }
 }

--- a/tests/unit/Filter/Filter/SanitizeMultipleCest.php
+++ b/tests/unit/Filter/Filter/SanitizeMultipleCest.php
@@ -15,6 +15,9 @@ namespace Phalcon\Test\Unit\Filter\Filter;
 
 use Phalcon\Filter\FilterFactory;
 use UnitTester;
+use function restore_error_handler;
+use function set_error_handler;
+use const E_USER_NOTICE;
 
 class SanitizeMultipleCest
 {
@@ -89,5 +92,46 @@ class SanitizeMultipleCest
         $expected = '-had-a-little-lamb';
         $actual   = $filter->sanitize($value, $filters);
         $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests sanitizing array with multiple filters and one not existing
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-02-22
+     */
+    public function filterFilterSanitizeWithMultipleFiltersNotExisting(UnitTester $I)
+    {
+        $locator = new FilterFactory();
+        $filter  = $locator->newInstance();
+
+        $value    = '  mary had a little lamb ';
+        $filters  = [
+            'trim',
+            'something',
+        ];
+        $expected = 'had a little lamb';
+
+        $error = [];
+        set_error_handler(
+            function ($number, $message, $file, $line, $context) use (&$error) {
+                $error = [
+                    'number'  => $number,
+                    'message' => $message,
+                    'file'    => $file,
+                    'line'    => $line,
+                    'context' => $context,
+                ];
+            }
+        );
+
+        $actual = $filter->sanitize($value, $filters);
+        restore_error_handler();
+
+        $I->assertEquals(E_USER_NOTICE, $error['number']);
+        $I->assertEquals(
+            "Sanitizer 'something' is not registered",
+            $error['message']
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: enhancement
* Link to issue: #14679 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Filter::sanitize` to throw a `E_USER_NOTICE` when a filter does not exist.

Thanks

