### PR TITLE
Fix mysql column numeric default

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)
+- Fixed schema manipulation in `Phalcon\Db\Dialect\Mysql`, remove unnecessary `NULL` in column definition, unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -50,8 +50,6 @@ class Mysql extends Dialect
 
         if column->isNotNull() {
             let sql .= " NOT NULL";
-        } else {
-            let sql .= " NULL";
         }
 
         if column->isAutoIncrement() {
@@ -190,8 +188,6 @@ class Mysql extends Dialect
              */
             if column->isNotNull() {
                 let columnLine .= " NOT NULL";
-            } else {
-                let columnLine .= " NULL";
             }
 
             /**
@@ -704,8 +700,6 @@ class Mysql extends Dialect
 
         if column->isNotNull() {
             let sql .= " NOT NULL";
-        } else {
-            let sql .= " NULL";
         }
 
         if column->isAutoIncrement() {

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -41,7 +41,7 @@ class Mysql extends Dialect
         if column->hasDefault() {
             let defaultValue = column->getDefault();
 
-            if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") {
+            if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") || is_int(defaultValue) || is_float(defaultValue) {
                 let sql .= " DEFAULT " . defaultValue;
             } else {
                 let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
@@ -175,7 +175,7 @@ class Mysql extends Dialect
                 if (defaultValue === null) {
                     let columnLine .= " DEFAULT NULL";
                 } else {
-                    if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") {
+                    if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") || is_int(defaultValue) || is_float(defaultValue) {
                         let columnLine .= " DEFAULT " . defaultValue;
                     } else {
                         let columnLine .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
@@ -691,16 +691,16 @@ class Mysql extends Dialect
         if column->hasDefault() {
             let defaultValue = column->getDefault();
 
-            if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") {
+            if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") || is_int(defaultValue) || is_float(defaultValue) {
                 let sql .= " DEFAULT " . defaultValue;
-            } else {
+            }  else {
                 let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
             }
         }
 
         if column->isNotNull() {
             let sql .= " NOT NULL";
-        }
+        } 
 
         if column->isAutoIncrement() {
             let sql .= " AUTO_INCREMENT";

--- a/tests/integration/Db/Dialect/Mysql/AddColumnCest.php
+++ b/tests/integration/Db/Dialect/Mysql/AddColumnCest.php
@@ -29,21 +29,39 @@ class AddColumnCest
     {
         $I->wantToTest('Db\Adapter\Pdo\Mysql - addColumn()');
 
-        $column = new Column(
-            'updated_at',
+        $additions = [
             [
-                'type' => Column::TYPE_TIMESTAMP,
-                'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
-                'notNull' => false,
-                'after' => 'created_at'
+                new Column(
+                    'updated_at',
+                    [
+                        'type' => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+                        'notNull' => false,
+                        'after' => 'created_at'
+                    ]
+                ),
+                'ALTER TABLE `test` ADD `updated_at` TIMESTAMP ' .
+                    'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created_at`'
+            ],
+            [
+                new Column(
+                    'numeric_val',
+                    [
+                        'type' => Column::TYPE_FLOAT,
+                        'default' => 21.42,
+                        'notNull' => true,
+                        'after' => 'updated_at'
+                    ]
+                ),
+                'ALTER TABLE `test` ADD `numeric_val` FLOAT DEFAULT 21.42 NOT NULL AFTER `updated_at`'
             ]
-        );
+        ];
 
         $mysql = new Mysql();
-        $sql = $mysql->addColumn('test', '', $column);
-        $expected = 'ALTER TABLE `test` ADD `updated_at` TIMESTAMP ' .
-            'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NULL AFTER `created_at`';
-
-        $I->assertSame($expected, $sql);
+        foreach ($additions as [$column, $expected]) {
+            $sql = $mysql->addColumn('test', '', $column);
+            
+            $I->assertSame($expected, $sql);
+        }
     }
 }

--- a/tests/integration/Db/Dialect/Mysql/CreateTableCest.php
+++ b/tests/integration/Db/Dialect/Mysql/CreateTableCest.php
@@ -51,6 +51,14 @@ class CreateTableCest
                         'after' => 'created_at'
                     ]
                 ),
+                new Column(
+                    'numeric_val',
+                    [
+                        'type' => Column::TYPE_FLOAT,
+                        'notNull' => false,
+                        'after' => 'updated_at'
+                    ]
+                ),
             ],
             'indexes' => [
                 new Index('PRIMARY', ['id'], 'PRIMARY'),
@@ -62,7 +70,8 @@ class CreateTableCest
         $expected = <<<SQL
 CREATE TABLE `test` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
-	`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NULL,
+	`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	`numeric_val` FLOAT,
 	PRIMARY KEY (`id`)
 )
 SQL;

--- a/tests/integration/Db/Dialect/Mysql/ModifyColumnCest.php
+++ b/tests/integration/Db/Dialect/Mysql/ModifyColumnCest.php
@@ -29,31 +29,54 @@ class ModifyColumnCest
     {
         $I->wantToTest('Db\Adapter\Pdo\Mysql - modifyColumn()');
 
-        $currentColumn = new Column(
-            'updated_at',
+        $modifications = [
             [
-                'type' => Column::TYPE_TIMESTAMP,
-                'default' => "CURRENT_TIMESTAMP",
-                'notNull' => false,
-                'after' => 'created_at'
-            ]
-        );
-
-        $column = new Column(
-            'updated_at',
+                new Column(
+                    'updated_at',
+                    [
+                        'type' => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP",
+                        'notNull' => false,
+                        'after' => 'created_at'
+                    ]
+                ), new Column(
+                    'updated_at',
+                    [
+                        'type' => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+                        'notNull' => false,
+                        'after' => 'created_at'
+                    ]
+                ),
+                'ALTER TABLE `test` MODIFY `updated_at` TIMESTAMP ' .
+                    'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created_at`'
+            ],
             [
-                'type' => Column::TYPE_TIMESTAMP,
-                'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
-                'notNull' => false,
-                'after' => 'created_at'
+                new Column(
+                    'numeric_val',
+                    [
+                        'type' => Column::TYPE_FLOAT,
+                        'notNull' => true,
+                        'after' => 'updated_at'
+                    ]
+                ), new Column(
+                    'numeric_val',
+                    [
+                        'type' => Column::TYPE_FLOAT,
+                        'default' => 21.42,
+                        'notNull' => false,
+                        'after' => 'updated_at'
+                    ]
+                ),
+                'ALTER TABLE `test` MODIFY `numeric_val` FLOAT DEFAULT 21.42 AFTER `updated_at`'
             ]
-        );
+        ];
 
         $mysql = new Mysql();
-        $sql = $mysql->modifyColumn('test', '', $column, $currentColumn);
-        $expected = 'ALTER TABLE `test` MODIFY `updated_at` TIMESTAMP ' .
-            'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP NULL AFTER `created_at`';
+        foreach ($modifications as [$currentColumn, $column, $expected]) {
+            $sql = $mysql->modifyColumn('test', '', $column, $currentColumn);
 
-        $I->assertSame($expected, $sql);
+            $I->assertSame($expected, $sql);
+        }
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

- In Mysql, column manipulation is generating some lonely NULL at the end of a definition (compare to valid NOT NULL. This could mess up with some parsers.
- Remove quotes around numerical default Mysql column value