### PR TITLE
Fix bug FindFirst and update PostgreSQL tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -246,7 +246,7 @@ jobs:
         env:
           DATA_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
           DATA_MEMCACHED_PORT: ${{ job.services.memcached.ports['11211'] }}
-        run: vendor/bin/codecept run --ext DotReporter --debug database --env sqlite -g sqlite
+        run: vendor/bin/codecept run --ext DotReporter database --env sqlite -g sqlite
 
       - name: Run database tests Postgres
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -246,7 +246,7 @@ jobs:
         env:
           DATA_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
           DATA_MEMCACHED_PORT: ${{ job.services.memcached.ports['11211'] }}
-        run: vendor/bin/codecept run --ext DotReporter database --env sqlite -g sqlite
+        run: vendor/bin/codecept run --ext DotReporter --debug database --env sqlite -g sqlite
 
       - name: Run database tests Postgres
         env:

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -4,7 +4,7 @@
 ## Changed
 
 ## Fixed
-- Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874)
+- Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -1,3 +1,11 @@
+# [4.0.6](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-xx-xx)
+## Added
+
+## Changed
+
+## Fixed
+- Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874)
+
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added
 

--- a/ext/kernel/filter.c
+++ b/ext/kernel/filter.c
@@ -218,7 +218,7 @@ void zephir_escape_multi(zval *return_value, zval *param, const char *escape_cha
 		/**
 		 * Alphanumeric characters are not escaped
 		 */
-		if (value < 256 && isalnum(value)) {
+		if (value < 123 && isalnum(value)) {
 			smart_str_appendc(&escaped_str, (unsigned char) value);
 			continue;
 		}

--- a/ext/kernel/filter.c
+++ b/ext/kernel/filter.c
@@ -218,7 +218,7 @@ void zephir_escape_multi(zval *return_value, zval *param, const char *escape_cha
 		/**
 		 * Alphanumeric characters are not escaped
 		 */
-		if (value < 123 && isalnum(value)) {
+		if (value < 256 && isalnum(value)) {
 			smart_str_appendc(&escaped_str, (unsigned char) value);
 			continue;
 		}

--- a/ext/phalcon/mvc/model/query/builder.zep.c
+++ b/ext/phalcon/mvc/model/query/builder.zep.c
@@ -1024,12 +1024,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getOrderBy) {
  */
 PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 
-	zend_string *_12$$25, *_21$$34, *_32$$42;
-	zend_ulong _11$$25, _20$$34, _31$$42;
+	zend_string *_14$$27, *_23$$36, *_34$$44;
+	zend_ulong _13$$27, _22$$36, _33$$44;
 	zval _3$$8;
-	zend_bool noPrimary = 0, _86$$85;
+	zend_bool noPrimary = 0, _88$$87;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-	zval __$null, container, models, conditions, model, metaData, modelInstance, primaryKeys, firstPrimaryKey, columnMap, modelAlias, attributeField, phql, column, columns, selectedColumns, selectedColumn, selectedModel, selectedModels, columnAlias, modelColumnAlias, joins, join, joinModel, joinConditions, joinAlias, joinType, group, groupItems, groupItem, having, order, orderItems, orderItem, limit, number, offset, forUpdate, distinct, _0, _2$$8, _4$$17, _5$$17, _6$$13, _7$$13, _8$$13, *_9$$25, _10$$25, _17$$25, _13$$28, _14$$28, _15$$31, _16$$31, *_18$$34, _19$$34, _26$$34, _22$$36, _23$$37, _24$$39, _25$$40, _27$$41, _28$$41, *_29$$42, _30$$42, _37$$42, _38$$42, _33$$44, _34$$44, _35$$47, _36$$47, _39$$49, _40$$49, *_41$$50, _42$$50, _43$$52, _44$$52, _45$$53, _46$$53, _47$$54, _48$$54, _49$$55, _50$$57, _51$$57, _52$$58, _53$$58, _54$$59, _55$$59, _56$$60, _57$$62, *_58$$63, _59$$63, _62$$63, _63$$63, _60$$64, _61$$65, _64$$67, *_65$$69, _66$$69, _77$$69, _78$$69, itemExplode$$72, _67$$72, _68$$72, _69$$72, _70$$72, _71$$70, itemExplode$$75, _72$$75, _73$$75, _74$$75, _75$$75, _76$$73, _79$$76, _80$$82, _81$$85, _82$$85, _83$$85, _84$$85, _85$$85, _87$$86, _88$$86, _89$$86, _90$$86, _91$$86;
+	zval __$null, container, models, conditions, model, metaData, modelInstance, primaryKeys, firstPrimaryKey, columnMap, modelAlias, attributeField, phql, column, columns, selectedColumns, selectedColumn, selectedModel, selectedModels, columnAlias, modelColumnAlias, joins, join, joinModel, joinConditions, joinAlias, joinType, group, groupItems, groupItem, having, order, orderItems, orderItem, limit, number, offset, forUpdate, distinct, columnType, primaryKeyType, textTypes, _0, _2$$8, _4$$17, _5$$17, _6$$19, _7$$20, _8$$13, _9$$13, _10$$13, *_11$$27, _12$$27, _19$$27, _15$$30, _16$$30, _17$$33, _18$$33, *_20$$36, _21$$36, _28$$36, _24$$38, _25$$39, _26$$41, _27$$42, _29$$43, _30$$43, *_31$$44, _32$$44, _39$$44, _40$$44, _35$$46, _36$$46, _37$$49, _38$$49, _41$$51, _42$$51, *_43$$52, _44$$52, _45$$54, _46$$54, _47$$55, _48$$55, _49$$56, _50$$56, _51$$57, _52$$59, _53$$59, _54$$60, _55$$60, _56$$61, _57$$61, _58$$62, _59$$64, *_60$$65, _61$$65, _64$$65, _65$$65, _62$$66, _63$$67, _66$$69, *_67$$71, _68$$71, _79$$71, _80$$71, itemExplode$$74, _69$$74, _70$$74, _71$$74, _72$$74, _73$$72, itemExplode$$77, _74$$77, _75$$77, _76$$77, _77$$77, _78$$75, _81$$78, _82$$84, _83$$87, _84$$87, _85$$87, _86$$87, _87$$87, _89$$88, _90$$88, _91$$88, _92$$88, _93$$88;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
 	zephir_fcall_cache_entry *_1 = NULL;
 	zval *this_ptr = getThis();
@@ -1073,85 +1073,90 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	ZVAL_UNDEF(&offset);
 	ZVAL_UNDEF(&forUpdate);
 	ZVAL_UNDEF(&distinct);
+	ZVAL_UNDEF(&columnType);
+	ZVAL_UNDEF(&primaryKeyType);
+	ZVAL_UNDEF(&textTypes);
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_2$$8);
 	ZVAL_UNDEF(&_4$$17);
 	ZVAL_UNDEF(&_5$$17);
-	ZVAL_UNDEF(&_6$$13);
-	ZVAL_UNDEF(&_7$$13);
+	ZVAL_UNDEF(&_6$$19);
+	ZVAL_UNDEF(&_7$$20);
 	ZVAL_UNDEF(&_8$$13);
-	ZVAL_UNDEF(&_10$$25);
-	ZVAL_UNDEF(&_17$$25);
-	ZVAL_UNDEF(&_13$$28);
-	ZVAL_UNDEF(&_14$$28);
-	ZVAL_UNDEF(&_15$$31);
-	ZVAL_UNDEF(&_16$$31);
-	ZVAL_UNDEF(&_19$$34);
-	ZVAL_UNDEF(&_26$$34);
-	ZVAL_UNDEF(&_22$$36);
-	ZVAL_UNDEF(&_23$$37);
-	ZVAL_UNDEF(&_24$$39);
-	ZVAL_UNDEF(&_25$$40);
-	ZVAL_UNDEF(&_27$$41);
-	ZVAL_UNDEF(&_28$$41);
-	ZVAL_UNDEF(&_30$$42);
-	ZVAL_UNDEF(&_37$$42);
-	ZVAL_UNDEF(&_38$$42);
-	ZVAL_UNDEF(&_33$$44);
-	ZVAL_UNDEF(&_34$$44);
-	ZVAL_UNDEF(&_35$$47);
-	ZVAL_UNDEF(&_36$$47);
-	ZVAL_UNDEF(&_39$$49);
-	ZVAL_UNDEF(&_40$$49);
-	ZVAL_UNDEF(&_42$$50);
-	ZVAL_UNDEF(&_43$$52);
+	ZVAL_UNDEF(&_9$$13);
+	ZVAL_UNDEF(&_10$$13);
+	ZVAL_UNDEF(&_12$$27);
+	ZVAL_UNDEF(&_19$$27);
+	ZVAL_UNDEF(&_15$$30);
+	ZVAL_UNDEF(&_16$$30);
+	ZVAL_UNDEF(&_17$$33);
+	ZVAL_UNDEF(&_18$$33);
+	ZVAL_UNDEF(&_21$$36);
+	ZVAL_UNDEF(&_28$$36);
+	ZVAL_UNDEF(&_24$$38);
+	ZVAL_UNDEF(&_25$$39);
+	ZVAL_UNDEF(&_26$$41);
+	ZVAL_UNDEF(&_27$$42);
+	ZVAL_UNDEF(&_29$$43);
+	ZVAL_UNDEF(&_30$$43);
+	ZVAL_UNDEF(&_32$$44);
+	ZVAL_UNDEF(&_39$$44);
+	ZVAL_UNDEF(&_40$$44);
+	ZVAL_UNDEF(&_35$$46);
+	ZVAL_UNDEF(&_36$$46);
+	ZVAL_UNDEF(&_37$$49);
+	ZVAL_UNDEF(&_38$$49);
+	ZVAL_UNDEF(&_41$$51);
+	ZVAL_UNDEF(&_42$$51);
 	ZVAL_UNDEF(&_44$$52);
-	ZVAL_UNDEF(&_45$$53);
-	ZVAL_UNDEF(&_46$$53);
-	ZVAL_UNDEF(&_47$$54);
-	ZVAL_UNDEF(&_48$$54);
-	ZVAL_UNDEF(&_49$$55);
-	ZVAL_UNDEF(&_50$$57);
+	ZVAL_UNDEF(&_45$$54);
+	ZVAL_UNDEF(&_46$$54);
+	ZVAL_UNDEF(&_47$$55);
+	ZVAL_UNDEF(&_48$$55);
+	ZVAL_UNDEF(&_49$$56);
+	ZVAL_UNDEF(&_50$$56);
 	ZVAL_UNDEF(&_51$$57);
-	ZVAL_UNDEF(&_52$$58);
-	ZVAL_UNDEF(&_53$$58);
-	ZVAL_UNDEF(&_54$$59);
-	ZVAL_UNDEF(&_55$$59);
-	ZVAL_UNDEF(&_56$$60);
-	ZVAL_UNDEF(&_57$$62);
-	ZVAL_UNDEF(&_59$$63);
-	ZVAL_UNDEF(&_62$$63);
-	ZVAL_UNDEF(&_63$$63);
-	ZVAL_UNDEF(&_60$$64);
+	ZVAL_UNDEF(&_52$$59);
+	ZVAL_UNDEF(&_53$$59);
+	ZVAL_UNDEF(&_54$$60);
+	ZVAL_UNDEF(&_55$$60);
+	ZVAL_UNDEF(&_56$$61);
+	ZVAL_UNDEF(&_57$$61);
+	ZVAL_UNDEF(&_58$$62);
+	ZVAL_UNDEF(&_59$$64);
 	ZVAL_UNDEF(&_61$$65);
-	ZVAL_UNDEF(&_64$$67);
+	ZVAL_UNDEF(&_64$$65);
+	ZVAL_UNDEF(&_65$$65);
+	ZVAL_UNDEF(&_62$$66);
+	ZVAL_UNDEF(&_63$$67);
 	ZVAL_UNDEF(&_66$$69);
-	ZVAL_UNDEF(&_77$$69);
-	ZVAL_UNDEF(&_78$$69);
-	ZVAL_UNDEF(&itemExplode$$72);
-	ZVAL_UNDEF(&_67$$72);
-	ZVAL_UNDEF(&_68$$72);
-	ZVAL_UNDEF(&_69$$72);
-	ZVAL_UNDEF(&_70$$72);
-	ZVAL_UNDEF(&_71$$70);
-	ZVAL_UNDEF(&itemExplode$$75);
-	ZVAL_UNDEF(&_72$$75);
-	ZVAL_UNDEF(&_73$$75);
-	ZVAL_UNDEF(&_74$$75);
-	ZVAL_UNDEF(&_75$$75);
-	ZVAL_UNDEF(&_76$$73);
-	ZVAL_UNDEF(&_79$$76);
-	ZVAL_UNDEF(&_80$$82);
-	ZVAL_UNDEF(&_81$$85);
-	ZVAL_UNDEF(&_82$$85);
-	ZVAL_UNDEF(&_83$$85);
-	ZVAL_UNDEF(&_84$$85);
-	ZVAL_UNDEF(&_85$$85);
-	ZVAL_UNDEF(&_87$$86);
-	ZVAL_UNDEF(&_88$$86);
-	ZVAL_UNDEF(&_89$$86);
-	ZVAL_UNDEF(&_90$$86);
-	ZVAL_UNDEF(&_91$$86);
+	ZVAL_UNDEF(&_68$$71);
+	ZVAL_UNDEF(&_79$$71);
+	ZVAL_UNDEF(&_80$$71);
+	ZVAL_UNDEF(&itemExplode$$74);
+	ZVAL_UNDEF(&_69$$74);
+	ZVAL_UNDEF(&_70$$74);
+	ZVAL_UNDEF(&_71$$74);
+	ZVAL_UNDEF(&_72$$74);
+	ZVAL_UNDEF(&_73$$72);
+	ZVAL_UNDEF(&itemExplode$$77);
+	ZVAL_UNDEF(&_74$$77);
+	ZVAL_UNDEF(&_75$$77);
+	ZVAL_UNDEF(&_76$$77);
+	ZVAL_UNDEF(&_77$$77);
+	ZVAL_UNDEF(&_78$$75);
+	ZVAL_UNDEF(&_81$$78);
+	ZVAL_UNDEF(&_82$$84);
+	ZVAL_UNDEF(&_83$$87);
+	ZVAL_UNDEF(&_84$$87);
+	ZVAL_UNDEF(&_85$$87);
+	ZVAL_UNDEF(&_86$$87);
+	ZVAL_UNDEF(&_87$$87);
+	ZVAL_UNDEF(&_89$$88);
+	ZVAL_UNDEF(&_90$$88);
+	ZVAL_UNDEF(&_91$$88);
+	ZVAL_UNDEF(&_92$$88);
+	ZVAL_UNDEF(&_93$$88);
 	ZVAL_UNDEF(&_3$$8);
 
 	ZEPHIR_MM_GROW();
@@ -1167,12 +1172,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	ZEPHIR_CPY_WRT(&models, &_0);
 	if (Z_TYPE_P(&models) == IS_ARRAY) {
 		if (UNEXPECTED(!(zephir_fast_count_int(&models)))) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 624);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 625);
 			return;
 		}
 	} else {
 		if (UNEXPECTED(!zephir_is_true(&models))) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 630);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 631);
 			return;
 		}
 	}
@@ -1181,11 +1186,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	if (zephir_is_numeric(&conditions)) {
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
 			if (UNEXPECTED(zephir_fast_count_int(&models) > 1)) {
-				ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Cannot build the query. Invalid condition", "phalcon/Mvc/Model/Query/Builder.zep", 645);
+				ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Cannot build the query. Invalid condition", "phalcon/Mvc/Model/Query/Builder.zep", 646);
 				return;
 			}
 			ZEPHIR_OBS_VAR(&model);
-			zephir_array_fetch_long(&model, &models, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 648);
+			zephir_array_fetch_long(&model, &models, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 649);
 		} else {
 			ZEPHIR_CPY_WRT(&model, &models);
 		}
@@ -1222,25 +1227,55 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 						ZEPHIR_CONCAT_SVS(&_5$$17, "Column '", &firstPrimaryKey, "' isn't part of the column map");
 						ZEPHIR_CALL_METHOD(NULL, &_4$$17, "__construct", NULL, 6, &_5$$17);
 						zephir_check_call_status();
-						zephir_throw_exception_debug(&_4$$17, "phalcon/Mvc/Model/Query/Builder.zep", 684);
+						zephir_throw_exception_debug(&_4$$17, "phalcon/Mvc/Model/Query/Builder.zep", 685);
 						ZEPHIR_MM_RESTORE();
 						return;
 					}
 				} else {
 					ZEPHIR_CPY_WRT(&attributeField, &firstPrimaryKey);
 				}
-				ZEPHIR_CALL_METHOD(&_6$$13, this_ptr, "autoescape", NULL, 487, &model);
+				ZEPHIR_CALL_METHOD(&columnType, &metaData, "getdatatypes", NULL, 0, &modelInstance);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&_7$$13, this_ptr, "autoescape", NULL, 487, &attributeField);
+				ZEPHIR_OBS_VAR(&primaryKeyType);
+				if (zephir_array_isset_fetch(&primaryKeyType, &columnType, &firstPrimaryKey, 0)) {
+					ZEPHIR_INIT_VAR(&textTypes);
+					zephir_create_array(&textTypes, 6, 0);
+					ZEPHIR_INIT_VAR(&_6$$19);
+					ZVAL_LONG(&_6$$19, 5);
+					zephir_array_fast_append(&textTypes, &_6$$19);
+					ZEPHIR_INIT_NVAR(&_6$$19);
+					ZVAL_LONG(&_6$$19, 24);
+					zephir_array_fast_append(&textTypes, &_6$$19);
+					ZEPHIR_INIT_NVAR(&_6$$19);
+					ZVAL_LONG(&_6$$19, 23);
+					zephir_array_fast_append(&textTypes, &_6$$19);
+					ZEPHIR_INIT_NVAR(&_6$$19);
+					ZVAL_LONG(&_6$$19, 6);
+					zephir_array_fast_append(&textTypes, &_6$$19);
+					ZEPHIR_INIT_NVAR(&_6$$19);
+					ZVAL_LONG(&_6$$19, 25);
+					zephir_array_fast_append(&textTypes, &_6$$19);
+					ZEPHIR_INIT_NVAR(&_6$$19);
+					ZVAL_LONG(&_6$$19, 2);
+					zephir_array_fast_append(&textTypes, &_6$$19);
+					if (1 == zephir_fast_in_array(&primaryKeyType, &textTypes)) {
+						ZEPHIR_INIT_VAR(&_7$$20);
+						ZEPHIR_CONCAT_SVS(&_7$$20, "'", &conditions, "'");
+						ZEPHIR_CPY_WRT(&conditions, &_7$$20);
+					}
+				}
+				ZEPHIR_CALL_METHOD(&_8$$13, this_ptr, "autoescape", NULL, 487, &model);
 				zephir_check_call_status();
-				ZEPHIR_INIT_VAR(&_8$$13);
-				ZEPHIR_CONCAT_VSVSV(&_8$$13, &_6$$13, ".", &_7$$13, " = ", &conditions);
-				ZEPHIR_CPY_WRT(&conditions, &_8$$13);
+				ZEPHIR_CALL_METHOD(&_9$$13, this_ptr, "autoescape", NULL, 487, &attributeField);
+				zephir_check_call_status();
+				ZEPHIR_INIT_VAR(&_10$$13);
+				ZEPHIR_CONCAT_VSVSV(&_10$$13, &_8$$13, ".", &_9$$13, " = ", &conditions);
+				ZEPHIR_CPY_WRT(&conditions, &_10$$13);
 				noPrimary = 0;
 			}
 		}
 		if (UNEXPECTED(noPrimary)) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Source related to this model does not have a primary key defined", "phalcon/Mvc/Model/Query/Builder.zep", 701);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Source related to this model does not have a primary key defined", "phalcon/Mvc/Model/Query/Builder.zep", 717);
 			return;
 		}
 	}
@@ -1263,35 +1298,35 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		if (Z_TYPE_P(&columns) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&selectedColumns);
 			array_init(&selectedColumns);
-			zephir_is_iterable(&columns, 0, "phalcon/Mvc/Model/Query/Builder.zep", 734);
+			zephir_is_iterable(&columns, 0, "phalcon/Mvc/Model/Query/Builder.zep", 750);
 			if (Z_TYPE_P(&columns) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&columns), _11$$25, _12$$25, _9$$25)
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&columns), _13$$27, _14$$27, _11$$27)
 				{
 					ZEPHIR_INIT_NVAR(&columnAlias);
-					if (_12$$25 != NULL) { 
-						ZVAL_STR_COPY(&columnAlias, _12$$25);
+					if (_14$$27 != NULL) { 
+						ZVAL_STR_COPY(&columnAlias, _14$$27);
 					} else {
-						ZVAL_LONG(&columnAlias, _11$$25);
+						ZVAL_LONG(&columnAlias, _13$$27);
 					}
 					ZEPHIR_INIT_NVAR(&column);
-					ZVAL_COPY(&column, _9$$25);
+					ZVAL_COPY(&column, _11$$27);
 					if (Z_TYPE_P(&columnAlias) == IS_LONG) {
-						zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 728);
+						zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 744);
 					} else {
-						ZEPHIR_CALL_METHOD(&_13$$28, this_ptr, "autoescape", NULL, 487, &columnAlias);
+						ZEPHIR_CALL_METHOD(&_15$$30, this_ptr, "autoescape", NULL, 487, &columnAlias);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_14$$28);
-						ZEPHIR_CONCAT_VSV(&_14$$28, &column, " AS ", &_13$$28);
-						zephir_array_append(&selectedColumns, &_14$$28, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 730);
+						ZEPHIR_INIT_NVAR(&_16$$30);
+						ZEPHIR_CONCAT_VSV(&_16$$30, &column, " AS ", &_15$$30);
+						zephir_array_append(&selectedColumns, &_16$$30, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 746);
 					}
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &columns, "rewind", NULL, 0);
 				zephir_check_call_status();
 				while (1) {
-					ZEPHIR_CALL_METHOD(&_10$$25, &columns, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_12$$27, &columns, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_10$$25)) {
+					if (!zend_is_true(&_12$$27)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&columnAlias, &columns, "key", NULL, 0);
@@ -1299,13 +1334,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 					ZEPHIR_CALL_METHOD(&column, &columns, "current", NULL, 0);
 					zephir_check_call_status();
 						if (Z_TYPE_P(&columnAlias) == IS_LONG) {
-							zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 728);
+							zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 744);
 						} else {
-							ZEPHIR_CALL_METHOD(&_15$$31, this_ptr, "autoescape", NULL, 487, &columnAlias);
+							ZEPHIR_CALL_METHOD(&_17$$33, this_ptr, "autoescape", NULL, 487, &columnAlias);
 							zephir_check_call_status();
-							ZEPHIR_INIT_NVAR(&_16$$31);
-							ZEPHIR_CONCAT_VSV(&_16$$31, &column, " AS ", &_15$$31);
-							zephir_array_append(&selectedColumns, &_16$$31, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 730);
+							ZEPHIR_INIT_NVAR(&_18$$33);
+							ZEPHIR_CONCAT_VSV(&_18$$33, &column, " AS ", &_17$$33);
+							zephir_array_append(&selectedColumns, &_18$$33, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 746);
 						}
 					ZEPHIR_CALL_METHOD(NULL, &columns, "next", NULL, 0);
 					zephir_check_call_status();
@@ -1313,9 +1348,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 			}
 			ZEPHIR_INIT_NVAR(&column);
 			ZEPHIR_INIT_NVAR(&columnAlias);
-			ZEPHIR_INIT_VAR(&_17$$25);
-			zephir_fast_join_str(&_17$$25, SL(", "), &selectedColumns);
-			zephir_concat_self(&phql, &_17$$25);
+			ZEPHIR_INIT_VAR(&_19$$27);
+			zephir_fast_join_str(&_19$$27, SL(", "), &selectedColumns);
+			zephir_concat_self(&phql, &_19$$27);
 		} else {
 			zephir_concat_self(&phql, &columns);
 		}
@@ -1323,37 +1358,37 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
 			ZEPHIR_INIT_NVAR(&selectedColumns);
 			array_init(&selectedColumns);
-			zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 755);
+			zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 771);
 			if (Z_TYPE_P(&models) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _20$$34, _21$$34, _18$$34)
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _22$$36, _23$$36, _20$$36)
 				{
 					ZEPHIR_INIT_NVAR(&modelColumnAlias);
-					if (_21$$34 != NULL) { 
-						ZVAL_STR_COPY(&modelColumnAlias, _21$$34);
+					if (_23$$36 != NULL) { 
+						ZVAL_STR_COPY(&modelColumnAlias, _23$$36);
 					} else {
-						ZVAL_LONG(&modelColumnAlias, _20$$34);
+						ZVAL_LONG(&modelColumnAlias, _22$$36);
 					}
 					ZEPHIR_INIT_NVAR(&model);
-					ZVAL_COPY(&model, _18$$34);
+					ZVAL_COPY(&model, _20$$36);
 					ZEPHIR_INIT_NVAR(&selectedColumn);
 					if (Z_TYPE_P(&modelColumnAlias) == IS_LONG) {
-						ZEPHIR_CALL_METHOD(&_22$$36, this_ptr, "autoescape", NULL, 487, &model);
+						ZEPHIR_CALL_METHOD(&_24$$38, this_ptr, "autoescape", NULL, 487, &model);
 						zephir_check_call_status();
-						ZEPHIR_CONCAT_VS(&selectedColumn, &_22$$36, ".*");
+						ZEPHIR_CONCAT_VS(&selectedColumn, &_24$$38, ".*");
 					} else {
-						ZEPHIR_CALL_METHOD(&_23$$37, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
+						ZEPHIR_CALL_METHOD(&_25$$39, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
 						zephir_check_call_status();
-						ZEPHIR_CONCAT_VS(&selectedColumn, &_23$$37, ".*");
+						ZEPHIR_CONCAT_VS(&selectedColumn, &_25$$39, ".*");
 					}
-					zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 752);
+					zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 768);
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &models, "rewind", NULL, 0);
 				zephir_check_call_status();
 				while (1) {
-					ZEPHIR_CALL_METHOD(&_19$$34, &models, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_21$$36, &models, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_19$$34)) {
+					if (!zend_is_true(&_21$$36)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&modelColumnAlias, &models, "key", NULL, 0);
@@ -1362,67 +1397,67 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 					zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&selectedColumn);
 						if (Z_TYPE_P(&modelColumnAlias) == IS_LONG) {
-							ZEPHIR_CALL_METHOD(&_24$$39, this_ptr, "autoescape", NULL, 487, &model);
+							ZEPHIR_CALL_METHOD(&_26$$41, this_ptr, "autoescape", NULL, 487, &model);
 							zephir_check_call_status();
-							ZEPHIR_CONCAT_VS(&selectedColumn, &_24$$39, ".*");
+							ZEPHIR_CONCAT_VS(&selectedColumn, &_26$$41, ".*");
 						} else {
-							ZEPHIR_CALL_METHOD(&_25$$40, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
+							ZEPHIR_CALL_METHOD(&_27$$42, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
 							zephir_check_call_status();
-							ZEPHIR_CONCAT_VS(&selectedColumn, &_25$$40, ".*");
+							ZEPHIR_CONCAT_VS(&selectedColumn, &_27$$42, ".*");
 						}
-						zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 752);
+						zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 768);
 					ZEPHIR_CALL_METHOD(NULL, &models, "next", NULL, 0);
 					zephir_check_call_status();
 				}
 			}
 			ZEPHIR_INIT_NVAR(&model);
 			ZEPHIR_INIT_NVAR(&modelColumnAlias);
-			ZEPHIR_INIT_VAR(&_26$$34);
-			zephir_fast_join_str(&_26$$34, SL(", "), &selectedColumns);
-			zephir_concat_self(&phql, &_26$$34);
+			ZEPHIR_INIT_VAR(&_28$$36);
+			zephir_fast_join_str(&_28$$36, SL(", "), &selectedColumns);
+			zephir_concat_self(&phql, &_28$$36);
 		} else {
-			ZEPHIR_CALL_METHOD(&_27$$41, this_ptr, "autoescape", NULL, 487, &models);
+			ZEPHIR_CALL_METHOD(&_29$$43, this_ptr, "autoescape", NULL, 487, &models);
 			zephir_check_call_status();
-			ZEPHIR_INIT_VAR(&_28$$41);
-			ZEPHIR_CONCAT_VS(&_28$$41, &_27$$41, ".*");
-			zephir_concat_self(&phql, &_28$$41);
+			ZEPHIR_INIT_VAR(&_30$$43);
+			ZEPHIR_CONCAT_VS(&_30$$43, &_29$$43, ".*");
+			zephir_concat_self(&phql, &_30$$43);
 		}
 	}
 	if (Z_TYPE_P(&models) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&selectedModels);
 		array_init(&selectedModels);
-		zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 777);
+		zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 793);
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _31$$42, _32$$42, _29$$42)
+			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _33$$44, _34$$44, _31$$44)
 			{
 				ZEPHIR_INIT_NVAR(&modelAlias);
-				if (_32$$42 != NULL) { 
-					ZVAL_STR_COPY(&modelAlias, _32$$42);
+				if (_34$$44 != NULL) { 
+					ZVAL_STR_COPY(&modelAlias, _34$$44);
 				} else {
-					ZVAL_LONG(&modelAlias, _31$$42);
+					ZVAL_LONG(&modelAlias, _33$$44);
 				}
 				ZEPHIR_INIT_NVAR(&model);
-				ZVAL_COPY(&model, _29$$42);
+				ZVAL_COPY(&model, _31$$44);
 				if (Z_TYPE_P(&modelAlias) == IS_STRING) {
-					ZEPHIR_CALL_METHOD(&_33$$44, this_ptr, "autoescape", NULL, 487, &model);
+					ZEPHIR_CALL_METHOD(&_35$$46, this_ptr, "autoescape", NULL, 487, &model);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&_34$$44, this_ptr, "autoescape", NULL, 487, &modelAlias);
+					ZEPHIR_CALL_METHOD(&_36$$46, this_ptr, "autoescape", NULL, 487, &modelAlias);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&selectedModel);
-					ZEPHIR_CONCAT_VSV(&selectedModel, &_33$$44, " AS ", &_34$$44);
+					ZEPHIR_CONCAT_VSV(&selectedModel, &_35$$46, " AS ", &_36$$46);
 				} else {
 					ZEPHIR_CALL_METHOD(&selectedModel, this_ptr, "autoescape", NULL, 487, &model);
 					zephir_check_call_status();
 				}
-				zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 774);
+				zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 790);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &models, "rewind", NULL, 0);
 			zephir_check_call_status();
 			while (1) {
-				ZEPHIR_CALL_METHOD(&_30$$42, &models, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_32$$44, &models, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_30$$42)) {
+				if (!zend_is_true(&_32$$44)) {
 					break;
 				}
 				ZEPHIR_CALL_METHOD(&modelAlias, &models, "key", NULL, 0);
@@ -1430,121 +1465,121 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 				ZEPHIR_CALL_METHOD(&model, &models, "current", NULL, 0);
 				zephir_check_call_status();
 					if (Z_TYPE_P(&modelAlias) == IS_STRING) {
-						ZEPHIR_CALL_METHOD(&_35$$47, this_ptr, "autoescape", NULL, 487, &model);
+						ZEPHIR_CALL_METHOD(&_37$$49, this_ptr, "autoescape", NULL, 487, &model);
 						zephir_check_call_status();
-						ZEPHIR_CALL_METHOD(&_36$$47, this_ptr, "autoescape", NULL, 487, &modelAlias);
+						ZEPHIR_CALL_METHOD(&_38$$49, this_ptr, "autoescape", NULL, 487, &modelAlias);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&selectedModel);
-						ZEPHIR_CONCAT_VSV(&selectedModel, &_35$$47, " AS ", &_36$$47);
+						ZEPHIR_CONCAT_VSV(&selectedModel, &_37$$49, " AS ", &_38$$49);
 					} else {
 						ZEPHIR_CALL_METHOD(&selectedModel, this_ptr, "autoescape", NULL, 487, &model);
 						zephir_check_call_status();
 					}
-					zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 774);
+					zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 790);
 				ZEPHIR_CALL_METHOD(NULL, &models, "next", NULL, 0);
 				zephir_check_call_status();
 			}
 		}
 		ZEPHIR_INIT_NVAR(&model);
 		ZEPHIR_INIT_NVAR(&modelAlias);
-		ZEPHIR_INIT_VAR(&_37$$42);
-		zephir_fast_join_str(&_37$$42, SL(", "), &selectedModels);
-		ZEPHIR_INIT_VAR(&_38$$42);
-		ZEPHIR_CONCAT_SV(&_38$$42, " FROM ", &_37$$42);
-		zephir_concat_self(&phql, &_38$$42);
+		ZEPHIR_INIT_VAR(&_39$$44);
+		zephir_fast_join_str(&_39$$44, SL(", "), &selectedModels);
+		ZEPHIR_INIT_VAR(&_40$$44);
+		ZEPHIR_CONCAT_SV(&_40$$44, " FROM ", &_39$$44);
+		zephir_concat_self(&phql, &_40$$44);
 	} else {
-		ZEPHIR_CALL_METHOD(&_39$$49, this_ptr, "autoescape", NULL, 487, &models);
+		ZEPHIR_CALL_METHOD(&_41$$51, this_ptr, "autoescape", NULL, 487, &models);
 		zephir_check_call_status();
-		ZEPHIR_INIT_VAR(&_40$$49);
-		ZEPHIR_CONCAT_SV(&_40$$49, " FROM ", &_39$$49);
-		zephir_concat_self(&phql, &_40$$49);
+		ZEPHIR_INIT_VAR(&_42$$51);
+		ZEPHIR_CONCAT_SV(&_42$$51, " FROM ", &_41$$51);
+		zephir_concat_self(&phql, &_42$$51);
 	}
 	zephir_read_property(&_0, this_ptr, SL("joins"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&joins, &_0);
 	if (Z_TYPE_P(&joins) == IS_ARRAY) {
-		zephir_is_iterable(&joins, 0, "phalcon/Mvc/Model/Query/Builder.zep", 832);
+		zephir_is_iterable(&joins, 0, "phalcon/Mvc/Model/Query/Builder.zep", 848);
 		if (Z_TYPE_P(&joins) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&joins), _41$$50)
+			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&joins), _43$$52)
 			{
 				ZEPHIR_INIT_NVAR(&join);
-				ZVAL_COPY(&join, _41$$50);
+				ZVAL_COPY(&join, _43$$52);
 				ZEPHIR_OBS_NVAR(&joinModel);
-				zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 792);
+				zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 808);
 				ZEPHIR_OBS_NVAR(&joinConditions);
-				zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 797);
+				zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 813);
 				ZEPHIR_OBS_NVAR(&joinAlias);
-				zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 802);
+				zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 818);
 				ZEPHIR_OBS_NVAR(&joinType);
-				zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 807);
+				zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 823);
 				if (zephir_is_true(&joinType)) {
-					ZEPHIR_CALL_METHOD(&_43$$52, this_ptr, "autoescape", NULL, 487, &joinModel);
+					ZEPHIR_CALL_METHOD(&_45$$54, this_ptr, "autoescape", NULL, 487, &joinModel);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_44$$52);
-					ZEPHIR_CONCAT_SVSV(&_44$$52, " ", &joinType, " JOIN ", &_43$$52);
-					zephir_concat_self(&phql, &_44$$52);
+					ZEPHIR_INIT_NVAR(&_46$$54);
+					ZEPHIR_CONCAT_SVSV(&_46$$54, " ", &joinType, " JOIN ", &_45$$54);
+					zephir_concat_self(&phql, &_46$$54);
 				} else {
-					ZEPHIR_CALL_METHOD(&_45$$53, this_ptr, "autoescape", NULL, 487, &joinModel);
+					ZEPHIR_CALL_METHOD(&_47$$55, this_ptr, "autoescape", NULL, 487, &joinModel);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_46$$53);
-					ZEPHIR_CONCAT_SV(&_46$$53, " JOIN ", &_45$$53);
-					zephir_concat_self(&phql, &_46$$53);
+					ZEPHIR_INIT_NVAR(&_48$$55);
+					ZEPHIR_CONCAT_SV(&_48$$55, " JOIN ", &_47$$55);
+					zephir_concat_self(&phql, &_48$$55);
 				}
 				if (zephir_is_true(&joinAlias)) {
-					ZEPHIR_CALL_METHOD(&_47$$54, this_ptr, "autoescape", NULL, 487, &joinAlias);
+					ZEPHIR_CALL_METHOD(&_49$$56, this_ptr, "autoescape", NULL, 487, &joinAlias);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_48$$54);
-					ZEPHIR_CONCAT_SV(&_48$$54, " AS ", &_47$$54);
-					zephir_concat_self(&phql, &_48$$54);
+					ZEPHIR_INIT_NVAR(&_50$$56);
+					ZEPHIR_CONCAT_SV(&_50$$56, " AS ", &_49$$56);
+					zephir_concat_self(&phql, &_50$$56);
 				}
 				if (zephir_is_true(&joinConditions)) {
-					ZEPHIR_INIT_NVAR(&_49$$55);
-					ZEPHIR_CONCAT_SV(&_49$$55, " ON ", &joinConditions);
-					zephir_concat_self(&phql, &_49$$55);
+					ZEPHIR_INIT_NVAR(&_51$$57);
+					ZEPHIR_CONCAT_SV(&_51$$57, " ON ", &joinConditions);
+					zephir_concat_self(&phql, &_51$$57);
 				}
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &joins, "rewind", NULL, 0);
 			zephir_check_call_status();
 			while (1) {
-				ZEPHIR_CALL_METHOD(&_42$$50, &joins, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_44$$52, &joins, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_42$$50)) {
+				if (!zend_is_true(&_44$$52)) {
 					break;
 				}
 				ZEPHIR_CALL_METHOD(&join, &joins, "current", NULL, 0);
 				zephir_check_call_status();
 					ZEPHIR_OBS_NVAR(&joinModel);
-					zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 792);
+					zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 808);
 					ZEPHIR_OBS_NVAR(&joinConditions);
-					zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 797);
+					zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 813);
 					ZEPHIR_OBS_NVAR(&joinAlias);
-					zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 802);
+					zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 818);
 					ZEPHIR_OBS_NVAR(&joinType);
-					zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 807);
+					zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 823);
 					if (zephir_is_true(&joinType)) {
-						ZEPHIR_CALL_METHOD(&_50$$57, this_ptr, "autoescape", NULL, 487, &joinModel);
+						ZEPHIR_CALL_METHOD(&_52$$59, this_ptr, "autoescape", NULL, 487, &joinModel);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_51$$57);
-						ZEPHIR_CONCAT_SVSV(&_51$$57, " ", &joinType, " JOIN ", &_50$$57);
-						zephir_concat_self(&phql, &_51$$57);
+						ZEPHIR_INIT_NVAR(&_53$$59);
+						ZEPHIR_CONCAT_SVSV(&_53$$59, " ", &joinType, " JOIN ", &_52$$59);
+						zephir_concat_self(&phql, &_53$$59);
 					} else {
-						ZEPHIR_CALL_METHOD(&_52$$58, this_ptr, "autoescape", NULL, 487, &joinModel);
+						ZEPHIR_CALL_METHOD(&_54$$60, this_ptr, "autoescape", NULL, 487, &joinModel);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_53$$58);
-						ZEPHIR_CONCAT_SV(&_53$$58, " JOIN ", &_52$$58);
-						zephir_concat_self(&phql, &_53$$58);
+						ZEPHIR_INIT_NVAR(&_55$$60);
+						ZEPHIR_CONCAT_SV(&_55$$60, " JOIN ", &_54$$60);
+						zephir_concat_self(&phql, &_55$$60);
 					}
 					if (zephir_is_true(&joinAlias)) {
-						ZEPHIR_CALL_METHOD(&_54$$59, this_ptr, "autoescape", NULL, 487, &joinAlias);
+						ZEPHIR_CALL_METHOD(&_56$$61, this_ptr, "autoescape", NULL, 487, &joinAlias);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_55$$59);
-						ZEPHIR_CONCAT_SV(&_55$$59, " AS ", &_54$$59);
-						zephir_concat_self(&phql, &_55$$59);
+						ZEPHIR_INIT_NVAR(&_57$$61);
+						ZEPHIR_CONCAT_SV(&_57$$61, " AS ", &_56$$61);
+						zephir_concat_self(&phql, &_57$$61);
 					}
 					if (zephir_is_true(&joinConditions)) {
-						ZEPHIR_INIT_NVAR(&_56$$60);
-						ZEPHIR_CONCAT_SV(&_56$$60, " ON ", &joinConditions);
-						zephir_concat_self(&phql, &_56$$60);
+						ZEPHIR_INIT_NVAR(&_58$$62);
+						ZEPHIR_CONCAT_SV(&_58$$62, " ON ", &joinConditions);
+						zephir_concat_self(&phql, &_58$$62);
 					}
 				ZEPHIR_CALL_METHOD(NULL, &joins, "next", NULL, 0);
 				zephir_check_call_status();
@@ -1554,9 +1589,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	}
 	if (Z_TYPE_P(&conditions) == IS_STRING) {
 		if (!(ZEPHIR_IS_EMPTY(&conditions))) {
-			ZEPHIR_INIT_VAR(&_57$$62);
-			ZEPHIR_CONCAT_SV(&_57$$62, " WHERE ", &conditions);
-			zephir_concat_self(&phql, &_57$$62);
+			ZEPHIR_INIT_VAR(&_59$$64);
+			ZEPHIR_CONCAT_SV(&_59$$64, " WHERE ", &conditions);
+			zephir_concat_self(&phql, &_59$$64);
 		}
 	}
 	zephir_read_property(&_0, this_ptr, SL("group"), PH_NOISY_CC | PH_READONLY);
@@ -1564,48 +1599,48 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	if (Z_TYPE_P(&group) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&groupItems);
 		array_init(&groupItems);
-		zephir_is_iterable(&group, 0, "phalcon/Mvc/Model/Query/Builder.zep", 852);
+		zephir_is_iterable(&group, 0, "phalcon/Mvc/Model/Query/Builder.zep", 868);
 		if (Z_TYPE_P(&group) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&group), _58$$63)
+			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&group), _60$$65)
 			{
 				ZEPHIR_INIT_NVAR(&groupItem);
-				ZVAL_COPY(&groupItem, _58$$63);
-				ZEPHIR_CALL_METHOD(&_60$$64, this_ptr, "autoescape", NULL, 487, &groupItem);
+				ZVAL_COPY(&groupItem, _60$$65);
+				ZEPHIR_CALL_METHOD(&_62$$66, this_ptr, "autoescape", NULL, 487, &groupItem);
 				zephir_check_call_status();
-				zephir_array_append(&groupItems, &_60$$64, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 849);
+				zephir_array_append(&groupItems, &_62$$66, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 865);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &group, "rewind", NULL, 0);
 			zephir_check_call_status();
 			while (1) {
-				ZEPHIR_CALL_METHOD(&_59$$63, &group, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_61$$65, &group, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_59$$63)) {
+				if (!zend_is_true(&_61$$65)) {
 					break;
 				}
 				ZEPHIR_CALL_METHOD(&groupItem, &group, "current", NULL, 0);
 				zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&_61$$65, this_ptr, "autoescape", NULL, 487, &groupItem);
+					ZEPHIR_CALL_METHOD(&_63$$67, this_ptr, "autoescape", NULL, 487, &groupItem);
 					zephir_check_call_status();
-					zephir_array_append(&groupItems, &_61$$65, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 849);
+					zephir_array_append(&groupItems, &_63$$67, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 865);
 				ZEPHIR_CALL_METHOD(NULL, &group, "next", NULL, 0);
 				zephir_check_call_status();
 			}
 		}
 		ZEPHIR_INIT_NVAR(&groupItem);
-		ZEPHIR_INIT_VAR(&_62$$63);
-		zephir_fast_join_str(&_62$$63, SL(", "), &groupItems);
-		ZEPHIR_INIT_VAR(&_63$$63);
-		ZEPHIR_CONCAT_SV(&_63$$63, " GROUP BY ", &_62$$63);
-		zephir_concat_self(&phql, &_63$$63);
+		ZEPHIR_INIT_VAR(&_64$$65);
+		zephir_fast_join_str(&_64$$65, SL(", "), &groupItems);
+		ZEPHIR_INIT_VAR(&_65$$65);
+		ZEPHIR_CONCAT_SV(&_65$$65, " GROUP BY ", &_64$$65);
+		zephir_concat_self(&phql, &_65$$65);
 	}
 	zephir_read_property(&_0, this_ptr, SL("having"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&having, &_0);
 	if (Z_TYPE_P(&having) != IS_NULL) {
 		if (!(ZEPHIR_IS_EMPTY(&having))) {
-			ZEPHIR_INIT_VAR(&_64$$67);
-			ZEPHIR_CONCAT_SV(&_64$$67, " HAVING ", &having);
-			zephir_concat_self(&phql, &_64$$67);
+			ZEPHIR_INIT_VAR(&_66$$69);
+			ZEPHIR_CONCAT_SV(&_66$$69, " HAVING ", &having);
+			zephir_concat_self(&phql, &_66$$69);
 		}
 	}
 	zephir_read_property(&_0, this_ptr, SL("order"), PH_NOISY_CC | PH_READONLY);
@@ -1614,76 +1649,76 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		if (Z_TYPE_P(&order) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&orderItems);
 			array_init(&orderItems);
-			zephir_is_iterable(&order, 0, "phalcon/Mvc/Model/Query/Builder.zep", 896);
+			zephir_is_iterable(&order, 0, "phalcon/Mvc/Model/Query/Builder.zep", 912);
 			if (Z_TYPE_P(&order) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&order), _65$$69)
+				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&order), _67$$71)
 				{
 					ZEPHIR_INIT_NVAR(&orderItem);
-					ZVAL_COPY(&orderItem, _65$$69);
+					ZVAL_COPY(&orderItem, _67$$71);
 					if (Z_TYPE_P(&orderItem) == IS_LONG) {
-						zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 879);
+						zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 895);
 						continue;
 					}
-					if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 884) != 0) {
-						ZEPHIR_INIT_NVAR(&itemExplode$$72);
-						zephir_fast_explode_str(&itemExplode$$72, SL(" "), &orderItem, LONG_MAX);
-						zephir_array_fetch_long(&_68$$72, &itemExplode$$72, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 888);
-						ZEPHIR_CALL_METHOD(&_67$$72, this_ptr, "autoescape", NULL, 487, &_68$$72);
+					if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 900) != 0) {
+						ZEPHIR_INIT_NVAR(&itemExplode$$74);
+						zephir_fast_explode_str(&itemExplode$$74, SL(" "), &orderItem, LONG_MAX);
+						zephir_array_fetch_long(&_70$$74, &itemExplode$$74, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
+						ZEPHIR_CALL_METHOD(&_69$$74, this_ptr, "autoescape", NULL, 487, &_70$$74);
 						zephir_check_call_status();
-						zephir_array_fetch_long(&_69$$72, &itemExplode$$72, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 888);
-						ZEPHIR_INIT_NVAR(&_70$$72);
-						ZEPHIR_CONCAT_VSV(&_70$$72, &_67$$72, " ", &_69$$72);
-						zephir_array_append(&orderItems, &_70$$72, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 888);
+						zephir_array_fetch_long(&_71$$74, &itemExplode$$74, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
+						ZEPHIR_INIT_NVAR(&_72$$74);
+						ZEPHIR_CONCAT_VSV(&_72$$74, &_69$$74, " ", &_71$$74);
+						zephir_array_append(&orderItems, &_72$$74, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 904);
 						continue;
 					}
-					ZEPHIR_CALL_METHOD(&_71$$70, this_ptr, "autoescape", NULL, 487, &orderItem);
+					ZEPHIR_CALL_METHOD(&_73$$72, this_ptr, "autoescape", NULL, 487, &orderItem);
 					zephir_check_call_status();
-					zephir_array_append(&orderItems, &_71$$70, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 893);
+					zephir_array_append(&orderItems, &_73$$72, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 909);
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &order, "rewind", NULL, 0);
 				zephir_check_call_status();
 				while (1) {
-					ZEPHIR_CALL_METHOD(&_66$$69, &order, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_68$$71, &order, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_66$$69)) {
+					if (!zend_is_true(&_68$$71)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&orderItem, &order, "current", NULL, 0);
 					zephir_check_call_status();
 						if (Z_TYPE_P(&orderItem) == IS_LONG) {
-							zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 879);
+							zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 895);
 							continue;
 						}
-						if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 884) != 0) {
-							ZEPHIR_INIT_NVAR(&itemExplode$$75);
-							zephir_fast_explode_str(&itemExplode$$75, SL(" "), &orderItem, LONG_MAX);
-							zephir_array_fetch_long(&_73$$75, &itemExplode$$75, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 888);
-							ZEPHIR_CALL_METHOD(&_72$$75, this_ptr, "autoescape", NULL, 487, &_73$$75);
+						if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 900) != 0) {
+							ZEPHIR_INIT_NVAR(&itemExplode$$77);
+							zephir_fast_explode_str(&itemExplode$$77, SL(" "), &orderItem, LONG_MAX);
+							zephir_array_fetch_long(&_75$$77, &itemExplode$$77, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
+							ZEPHIR_CALL_METHOD(&_74$$77, this_ptr, "autoescape", NULL, 487, &_75$$77);
 							zephir_check_call_status();
-							zephir_array_fetch_long(&_74$$75, &itemExplode$$75, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 888);
-							ZEPHIR_INIT_NVAR(&_75$$75);
-							ZEPHIR_CONCAT_VSV(&_75$$75, &_72$$75, " ", &_74$$75);
-							zephir_array_append(&orderItems, &_75$$75, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 888);
+							zephir_array_fetch_long(&_76$$77, &itemExplode$$77, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
+							ZEPHIR_INIT_NVAR(&_77$$77);
+							ZEPHIR_CONCAT_VSV(&_77$$77, &_74$$77, " ", &_76$$77);
+							zephir_array_append(&orderItems, &_77$$77, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 904);
 							continue;
 						}
-						ZEPHIR_CALL_METHOD(&_76$$73, this_ptr, "autoescape", NULL, 487, &orderItem);
+						ZEPHIR_CALL_METHOD(&_78$$75, this_ptr, "autoescape", NULL, 487, &orderItem);
 						zephir_check_call_status();
-						zephir_array_append(&orderItems, &_76$$73, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 893);
+						zephir_array_append(&orderItems, &_78$$75, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 909);
 					ZEPHIR_CALL_METHOD(NULL, &order, "next", NULL, 0);
 					zephir_check_call_status();
 				}
 			}
 			ZEPHIR_INIT_NVAR(&orderItem);
-			ZEPHIR_INIT_VAR(&_77$$69);
-			zephir_fast_join_str(&_77$$69, SL(", "), &orderItems);
-			ZEPHIR_INIT_VAR(&_78$$69);
-			ZEPHIR_CONCAT_SV(&_78$$69, " ORDER BY ", &_77$$69);
-			zephir_concat_self(&phql, &_78$$69);
+			ZEPHIR_INIT_VAR(&_79$$71);
+			zephir_fast_join_str(&_79$$71, SL(", "), &orderItems);
+			ZEPHIR_INIT_VAR(&_80$$71);
+			ZEPHIR_CONCAT_SV(&_80$$71, " ORDER BY ", &_79$$71);
+			zephir_concat_self(&phql, &_80$$71);
 		} else {
-			ZEPHIR_INIT_VAR(&_79$$76);
-			ZEPHIR_CONCAT_SV(&_79$$76, " ORDER BY ", &order);
-			zephir_concat_self(&phql, &_79$$76);
+			ZEPHIR_INIT_VAR(&_81$$78);
+			ZEPHIR_CONCAT_SV(&_81$$78, " ORDER BY ", &order);
+			zephir_concat_self(&phql, &_81$$78);
 		}
 	}
 	zephir_read_property(&_0, this_ptr, SL("limit"), PH_NOISY_CC | PH_READONLY);
@@ -1693,7 +1728,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		ZVAL_NULL(&number);
 		if (Z_TYPE_P(&limit) == IS_ARRAY) {
 			ZEPHIR_OBS_NVAR(&number);
-			zephir_array_fetch_string(&number, &limit, SL("number"), PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 910);
+			zephir_array_fetch_string(&number, &limit, SL("number"), PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 926);
 			ZEPHIR_OBS_VAR(&offset);
 			if (zephir_array_isset_string_fetch(&offset, &limit, SL("offset"), 0)) {
 				if (!(zephir_is_numeric(&offset))) {
@@ -1704,8 +1739,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		} else {
 			if (zephir_is_numeric(&limit)) {
 				ZEPHIR_CPY_WRT(&number, &limit);
-				zephir_read_property(&_80$$82, this_ptr, SL("offset"), PH_NOISY_CC | PH_READONLY);
-				ZEPHIR_CPY_WRT(&offset, &_80$$82);
+				zephir_read_property(&_82$$84, this_ptr, SL("offset"), PH_NOISY_CC | PH_READONLY);
+				ZEPHIR_CPY_WRT(&offset, &_82$$84);
 				if (Z_TYPE_P(&offset) != IS_NULL) {
 					if (!(zephir_is_numeric(&offset))) {
 						ZEPHIR_INIT_NVAR(&offset);
@@ -1716,34 +1751,34 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		}
 		if (zephir_is_numeric(&number)) {
 			zephir_concat_self_str(&phql, SL(" LIMIT :APL0:"));
-			ZVAL_LONG(&_81$$85, 10);
-			ZEPHIR_CALL_FUNCTION(&_82$$85, "intval", NULL, 49, &number, &_81$$85);
+			ZVAL_LONG(&_83$$87, 10);
+			ZEPHIR_CALL_FUNCTION(&_84$$87, "intval", NULL, 49, &number, &_83$$87);
 			zephir_check_call_status();
-			ZEPHIR_INIT_VAR(&_83$$85);
-			ZVAL_STRING(&_83$$85, "APL0");
-			zephir_update_property_array(this_ptr, SL("bindParams"), &_83$$85, &_82$$85);
-			ZEPHIR_INIT_VAR(&_84$$85);
-			ZVAL_STRING(&_84$$85, "APL0");
-			ZEPHIR_INIT_VAR(&_85$$85);
-			ZVAL_LONG(&_85$$85, 1);
-			zephir_update_property_array(this_ptr, SL("bindTypes"), &_84$$85, &_85$$85);
-			_86$$85 = zephir_is_numeric(&offset);
-			if (_86$$85) {
-				_86$$85 = !ZEPHIR_IS_LONG_IDENTICAL(&offset, 0);
+			ZEPHIR_INIT_VAR(&_85$$87);
+			ZVAL_STRING(&_85$$87, "APL0");
+			zephir_update_property_array(this_ptr, SL("bindParams"), &_85$$87, &_84$$87);
+			ZEPHIR_INIT_VAR(&_86$$87);
+			ZVAL_STRING(&_86$$87, "APL0");
+			ZEPHIR_INIT_VAR(&_87$$87);
+			ZVAL_LONG(&_87$$87, 1);
+			zephir_update_property_array(this_ptr, SL("bindTypes"), &_86$$87, &_87$$87);
+			_88$$87 = zephir_is_numeric(&offset);
+			if (_88$$87) {
+				_88$$87 = !ZEPHIR_IS_LONG_IDENTICAL(&offset, 0);
 			}
-			if (_86$$85) {
+			if (_88$$87) {
 				zephir_concat_self_str(&phql, SL(" OFFSET :APL1:"));
-				ZVAL_LONG(&_87$$86, 10);
-				ZEPHIR_CALL_FUNCTION(&_88$$86, "intval", NULL, 49, &offset, &_87$$86);
+				ZVAL_LONG(&_89$$88, 10);
+				ZEPHIR_CALL_FUNCTION(&_90$$88, "intval", NULL, 49, &offset, &_89$$88);
 				zephir_check_call_status();
-				ZEPHIR_INIT_VAR(&_89$$86);
-				ZVAL_STRING(&_89$$86, "APL1");
-				zephir_update_property_array(this_ptr, SL("bindParams"), &_89$$86, &_88$$86);
-				ZEPHIR_INIT_VAR(&_90$$86);
-				ZVAL_STRING(&_90$$86, "APL1");
-				ZEPHIR_INIT_VAR(&_91$$86);
-				ZVAL_LONG(&_91$$86, 1);
-				zephir_update_property_array(this_ptr, SL("bindTypes"), &_90$$86, &_91$$86);
+				ZEPHIR_INIT_VAR(&_91$$88);
+				ZVAL_STRING(&_91$$88, "APL1");
+				zephir_update_property_array(this_ptr, SL("bindParams"), &_91$$88, &_90$$88);
+				ZEPHIR_INIT_VAR(&_92$$88);
+				ZVAL_STRING(&_92$$88, "APL1");
+				ZEPHIR_INIT_VAR(&_93$$88);
+				ZVAL_LONG(&_93$$88, 1);
+				zephir_update_property_array(this_ptr, SL("bindTypes"), &_92$$88, &_93$$88);
 			}
 		}
 	}
@@ -1800,7 +1835,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getQuery) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_2$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 969);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 985);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -1882,7 +1917,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, groupBy) {
 
 
 	if (Z_TYPE_P(group) == IS_STRING) {
-		if (zephir_memnstr_str(group, SL(","), "phalcon/Mvc/Model/Query/Builder.zep", 1025)) {
+		if (zephir_memnstr_str(group, SL(","), "phalcon/Mvc/Model/Query/Builder.zep", 1041)) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			ZEPHIR_INIT_VAR(&_1$$4);
 			ZVAL_STRING(&_1$$4, " ");
@@ -3127,7 +3162,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionBetween) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1508);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1524);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3244,7 +3279,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1556);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1572);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3265,7 +3300,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 	array_init(&bindParams);
 	ZEPHIR_INIT_VAR(&bindKeys);
 	array_init(&bindKeys);
-	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1587);
+	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1603);
 	if (Z_TYPE_P(&values) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&values), _7)
 		{
@@ -3278,7 +3313,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 			ZEPHIR_CPY_WRT(&key, &_10$$5);
 			ZEPHIR_INIT_NVAR(&queryKey);
 			ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1578);
+			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1594);
 			zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 			hiddenParam++;
 		} ZEND_HASH_FOREACH_END();
@@ -3300,7 +3335,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 				ZEPHIR_CPY_WRT(&key, &_12$$6);
 				ZEPHIR_INIT_NVAR(&queryKey);
 				ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1578);
+				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1594);
 				zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 				hiddenParam++;
 			ZEPHIR_CALL_METHOD(NULL, &values, "next", NULL, 0);
@@ -3399,7 +3434,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotBetween) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1610);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1626);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3516,7 +3551,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1657);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1673);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3537,7 +3572,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 	array_init(&bindParams);
 	ZEPHIR_INIT_VAR(&bindKeys);
 	array_init(&bindKeys);
-	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1688);
+	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1704);
 	if (Z_TYPE_P(&values) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&values), _7)
 		{
@@ -3550,7 +3585,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 			ZEPHIR_CPY_WRT(&key, &_10$$5);
 			ZEPHIR_INIT_NVAR(&queryKey);
 			ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1679);
+			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1695);
 			zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 			hiddenParam++;
 		} ZEND_HASH_FOREACH_END();
@@ -3572,7 +3607,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 				ZEPHIR_CPY_WRT(&key, &_12$$6);
 				ZEPHIR_INIT_NVAR(&queryKey);
 				ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1679);
+				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1695);
 				zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 				hiddenParam++;
 			ZEPHIR_CALL_METHOD(NULL, &values, "next", NULL, 0);

--- a/ext/phalcon/mvc/model/query/builder.zep.c
+++ b/ext/phalcon/mvc/model/query/builder.zep.c
@@ -1024,12 +1024,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getOrderBy) {
  */
 PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 
-	zend_string *_14$$27, *_23$$36, *_34$$44;
-	zend_ulong _13$$27, _22$$36, _33$$44;
+	zend_string *_13$$26, *_22$$35, *_33$$43;
+	zend_ulong _12$$26, _21$$35, _32$$43;
 	zval _3$$8;
-	zend_bool noPrimary = 0, _88$$87;
+	zend_bool noPrimary = 0, _87$$86;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-	zval __$null, container, models, conditions, model, metaData, modelInstance, primaryKeys, firstPrimaryKey, columnMap, modelAlias, attributeField, phql, column, columns, selectedColumns, selectedColumn, selectedModel, selectedModels, columnAlias, modelColumnAlias, joins, join, joinModel, joinConditions, joinAlias, joinType, group, groupItems, groupItem, having, order, orderItems, orderItem, limit, number, offset, forUpdate, distinct, columnType, primaryKeyType, textTypes, _0, _2$$8, _4$$17, _5$$17, _6$$19, _7$$20, _8$$13, _9$$13, _10$$13, *_11$$27, _12$$27, _19$$27, _15$$30, _16$$30, _17$$33, _18$$33, *_20$$36, _21$$36, _28$$36, _24$$38, _25$$39, _26$$41, _27$$42, _29$$43, _30$$43, *_31$$44, _32$$44, _39$$44, _40$$44, _35$$46, _36$$46, _37$$49, _38$$49, _41$$51, _42$$51, *_43$$52, _44$$52, _45$$54, _46$$54, _47$$55, _48$$55, _49$$56, _50$$56, _51$$57, _52$$59, _53$$59, _54$$60, _55$$60, _56$$61, _57$$61, _58$$62, _59$$64, *_60$$65, _61$$65, _64$$65, _65$$65, _62$$66, _63$$67, _66$$69, *_67$$71, _68$$71, _79$$71, _80$$71, itemExplode$$74, _69$$74, _70$$74, _71$$74, _72$$74, _73$$72, itemExplode$$77, _74$$77, _75$$77, _76$$77, _77$$77, _78$$75, _81$$78, _82$$84, _83$$87, _84$$87, _85$$87, _86$$87, _87$$87, _89$$88, _90$$88, _91$$88, _92$$88, _93$$88;
+	zval __$null, container, models, conditions, model, metaData, modelInstance, primaryKeys, firstPrimaryKey, columnMap, modelAlias, attributeField, phql, column, columns, selectedColumns, selectedColumn, selectedModel, selectedModels, columnAlias, modelColumnAlias, joins, join, joinModel, joinConditions, joinAlias, joinType, group, groupItems, groupItem, having, order, orderItems, orderItem, limit, number, offset, forUpdate, distinct, _0, _2$$8, _4$$17, _5$$17, _6$$19, _7$$13, _8$$13, _9$$13, *_10$$26, _11$$26, _18$$26, _14$$29, _15$$29, _16$$32, _17$$32, *_19$$35, _20$$35, _27$$35, _23$$37, _24$$38, _25$$40, _26$$41, _28$$42, _29$$42, *_30$$43, _31$$43, _38$$43, _39$$43, _34$$45, _35$$45, _36$$48, _37$$48, _40$$50, _41$$50, *_42$$51, _43$$51, _44$$53, _45$$53, _46$$54, _47$$54, _48$$55, _49$$55, _50$$56, _51$$58, _52$$58, _53$$59, _54$$59, _55$$60, _56$$60, _57$$61, _58$$63, *_59$$64, _60$$64, _63$$64, _64$$64, _61$$65, _62$$66, _65$$68, *_66$$70, _67$$70, _78$$70, _79$$70, itemExplode$$73, _68$$73, _69$$73, _70$$73, _71$$73, _72$$71, itemExplode$$76, _73$$76, _74$$76, _75$$76, _76$$76, _77$$74, _80$$77, _81$$83, _82$$86, _83$$86, _84$$86, _85$$86, _86$$86, _88$$87, _89$$87, _90$$87, _91$$87, _92$$87;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
 	zephir_fcall_cache_entry *_1 = NULL;
 	zval *this_ptr = getThis();
@@ -1073,90 +1073,86 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	ZVAL_UNDEF(&offset);
 	ZVAL_UNDEF(&forUpdate);
 	ZVAL_UNDEF(&distinct);
-	ZVAL_UNDEF(&columnType);
-	ZVAL_UNDEF(&primaryKeyType);
-	ZVAL_UNDEF(&textTypes);
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_2$$8);
 	ZVAL_UNDEF(&_4$$17);
 	ZVAL_UNDEF(&_5$$17);
 	ZVAL_UNDEF(&_6$$19);
-	ZVAL_UNDEF(&_7$$20);
+	ZVAL_UNDEF(&_7$$13);
 	ZVAL_UNDEF(&_8$$13);
 	ZVAL_UNDEF(&_9$$13);
-	ZVAL_UNDEF(&_10$$13);
-	ZVAL_UNDEF(&_12$$27);
-	ZVAL_UNDEF(&_19$$27);
-	ZVAL_UNDEF(&_15$$30);
-	ZVAL_UNDEF(&_16$$30);
-	ZVAL_UNDEF(&_17$$33);
-	ZVAL_UNDEF(&_18$$33);
-	ZVAL_UNDEF(&_21$$36);
-	ZVAL_UNDEF(&_28$$36);
+	ZVAL_UNDEF(&_11$$26);
+	ZVAL_UNDEF(&_18$$26);
+	ZVAL_UNDEF(&_14$$29);
+	ZVAL_UNDEF(&_15$$29);
+	ZVAL_UNDEF(&_16$$32);
+	ZVAL_UNDEF(&_17$$32);
+	ZVAL_UNDEF(&_20$$35);
+	ZVAL_UNDEF(&_27$$35);
+	ZVAL_UNDEF(&_23$$37);
 	ZVAL_UNDEF(&_24$$38);
-	ZVAL_UNDEF(&_25$$39);
+	ZVAL_UNDEF(&_25$$40);
 	ZVAL_UNDEF(&_26$$41);
-	ZVAL_UNDEF(&_27$$42);
-	ZVAL_UNDEF(&_29$$43);
-	ZVAL_UNDEF(&_30$$43);
-	ZVAL_UNDEF(&_32$$44);
-	ZVAL_UNDEF(&_39$$44);
-	ZVAL_UNDEF(&_40$$44);
-	ZVAL_UNDEF(&_35$$46);
-	ZVAL_UNDEF(&_36$$46);
-	ZVAL_UNDEF(&_37$$49);
-	ZVAL_UNDEF(&_38$$49);
-	ZVAL_UNDEF(&_41$$51);
-	ZVAL_UNDEF(&_42$$51);
-	ZVAL_UNDEF(&_44$$52);
-	ZVAL_UNDEF(&_45$$54);
+	ZVAL_UNDEF(&_28$$42);
+	ZVAL_UNDEF(&_29$$42);
+	ZVAL_UNDEF(&_31$$43);
+	ZVAL_UNDEF(&_38$$43);
+	ZVAL_UNDEF(&_39$$43);
+	ZVAL_UNDEF(&_34$$45);
+	ZVAL_UNDEF(&_35$$45);
+	ZVAL_UNDEF(&_36$$48);
+	ZVAL_UNDEF(&_37$$48);
+	ZVAL_UNDEF(&_40$$50);
+	ZVAL_UNDEF(&_41$$50);
+	ZVAL_UNDEF(&_43$$51);
+	ZVAL_UNDEF(&_44$$53);
+	ZVAL_UNDEF(&_45$$53);
 	ZVAL_UNDEF(&_46$$54);
-	ZVAL_UNDEF(&_47$$55);
+	ZVAL_UNDEF(&_47$$54);
 	ZVAL_UNDEF(&_48$$55);
-	ZVAL_UNDEF(&_49$$56);
+	ZVAL_UNDEF(&_49$$55);
 	ZVAL_UNDEF(&_50$$56);
-	ZVAL_UNDEF(&_51$$57);
-	ZVAL_UNDEF(&_52$$59);
+	ZVAL_UNDEF(&_51$$58);
+	ZVAL_UNDEF(&_52$$58);
 	ZVAL_UNDEF(&_53$$59);
-	ZVAL_UNDEF(&_54$$60);
+	ZVAL_UNDEF(&_54$$59);
 	ZVAL_UNDEF(&_55$$60);
-	ZVAL_UNDEF(&_56$$61);
+	ZVAL_UNDEF(&_56$$60);
 	ZVAL_UNDEF(&_57$$61);
-	ZVAL_UNDEF(&_58$$62);
-	ZVAL_UNDEF(&_59$$64);
+	ZVAL_UNDEF(&_58$$63);
+	ZVAL_UNDEF(&_60$$64);
+	ZVAL_UNDEF(&_63$$64);
+	ZVAL_UNDEF(&_64$$64);
 	ZVAL_UNDEF(&_61$$65);
-	ZVAL_UNDEF(&_64$$65);
-	ZVAL_UNDEF(&_65$$65);
 	ZVAL_UNDEF(&_62$$66);
-	ZVAL_UNDEF(&_63$$67);
-	ZVAL_UNDEF(&_66$$69);
-	ZVAL_UNDEF(&_68$$71);
-	ZVAL_UNDEF(&_79$$71);
-	ZVAL_UNDEF(&_80$$71);
-	ZVAL_UNDEF(&itemExplode$$74);
-	ZVAL_UNDEF(&_69$$74);
-	ZVAL_UNDEF(&_70$$74);
-	ZVAL_UNDEF(&_71$$74);
-	ZVAL_UNDEF(&_72$$74);
-	ZVAL_UNDEF(&_73$$72);
-	ZVAL_UNDEF(&itemExplode$$77);
-	ZVAL_UNDEF(&_74$$77);
-	ZVAL_UNDEF(&_75$$77);
-	ZVAL_UNDEF(&_76$$77);
-	ZVAL_UNDEF(&_77$$77);
-	ZVAL_UNDEF(&_78$$75);
-	ZVAL_UNDEF(&_81$$78);
-	ZVAL_UNDEF(&_82$$84);
-	ZVAL_UNDEF(&_83$$87);
-	ZVAL_UNDEF(&_84$$87);
-	ZVAL_UNDEF(&_85$$87);
-	ZVAL_UNDEF(&_86$$87);
-	ZVAL_UNDEF(&_87$$87);
-	ZVAL_UNDEF(&_89$$88);
-	ZVAL_UNDEF(&_90$$88);
-	ZVAL_UNDEF(&_91$$88);
-	ZVAL_UNDEF(&_92$$88);
-	ZVAL_UNDEF(&_93$$88);
+	ZVAL_UNDEF(&_65$$68);
+	ZVAL_UNDEF(&_67$$70);
+	ZVAL_UNDEF(&_78$$70);
+	ZVAL_UNDEF(&_79$$70);
+	ZVAL_UNDEF(&itemExplode$$73);
+	ZVAL_UNDEF(&_68$$73);
+	ZVAL_UNDEF(&_69$$73);
+	ZVAL_UNDEF(&_70$$73);
+	ZVAL_UNDEF(&_71$$73);
+	ZVAL_UNDEF(&_72$$71);
+	ZVAL_UNDEF(&itemExplode$$76);
+	ZVAL_UNDEF(&_73$$76);
+	ZVAL_UNDEF(&_74$$76);
+	ZVAL_UNDEF(&_75$$76);
+	ZVAL_UNDEF(&_76$$76);
+	ZVAL_UNDEF(&_77$$74);
+	ZVAL_UNDEF(&_80$$77);
+	ZVAL_UNDEF(&_81$$83);
+	ZVAL_UNDEF(&_82$$86);
+	ZVAL_UNDEF(&_83$$86);
+	ZVAL_UNDEF(&_84$$86);
+	ZVAL_UNDEF(&_85$$86);
+	ZVAL_UNDEF(&_86$$86);
+	ZVAL_UNDEF(&_88$$87);
+	ZVAL_UNDEF(&_89$$87);
+	ZVAL_UNDEF(&_90$$87);
+	ZVAL_UNDEF(&_91$$87);
+	ZVAL_UNDEF(&_92$$87);
 	ZVAL_UNDEF(&_3$$8);
 
 	ZEPHIR_MM_GROW();
@@ -1172,12 +1168,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	ZEPHIR_CPY_WRT(&models, &_0);
 	if (Z_TYPE_P(&models) == IS_ARRAY) {
 		if (UNEXPECTED(!(zephir_fast_count_int(&models)))) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 625);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 624);
 			return;
 		}
 	} else {
 		if (UNEXPECTED(!zephir_is_true(&models))) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 631);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "At least one model is required to build the query", "phalcon/Mvc/Model/Query/Builder.zep", 630);
 			return;
 		}
 	}
@@ -1186,11 +1182,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	if (zephir_is_numeric(&conditions)) {
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
 			if (UNEXPECTED(zephir_fast_count_int(&models) > 1)) {
-				ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Cannot build the query. Invalid condition", "phalcon/Mvc/Model/Query/Builder.zep", 646);
+				ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Cannot build the query. Invalid condition", "phalcon/Mvc/Model/Query/Builder.zep", 645);
 				return;
 			}
 			ZEPHIR_OBS_VAR(&model);
-			zephir_array_fetch_long(&model, &models, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 649);
+			zephir_array_fetch_long(&model, &models, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 648);
 		} else {
 			ZEPHIR_CPY_WRT(&model, &models);
 		}
@@ -1227,55 +1223,30 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 						ZEPHIR_CONCAT_SVS(&_5$$17, "Column '", &firstPrimaryKey, "' isn't part of the column map");
 						ZEPHIR_CALL_METHOD(NULL, &_4$$17, "__construct", NULL, 6, &_5$$17);
 						zephir_check_call_status();
-						zephir_throw_exception_debug(&_4$$17, "phalcon/Mvc/Model/Query/Builder.zep", 685);
+						zephir_throw_exception_debug(&_4$$17, "phalcon/Mvc/Model/Query/Builder.zep", 684);
 						ZEPHIR_MM_RESTORE();
 						return;
 					}
 				} else {
 					ZEPHIR_CPY_WRT(&attributeField, &firstPrimaryKey);
 				}
-				ZEPHIR_CALL_METHOD(&columnType, &metaData, "getdatatypes", NULL, 0, &modelInstance);
-				zephir_check_call_status();
-				ZEPHIR_OBS_VAR(&primaryKeyType);
-				if (zephir_array_isset_fetch(&primaryKeyType, &columnType, &firstPrimaryKey, 0)) {
-					ZEPHIR_INIT_VAR(&textTypes);
-					zephir_create_array(&textTypes, 6, 0);
+				if (Z_TYPE_P(&conditions) == IS_STRING) {
 					ZEPHIR_INIT_VAR(&_6$$19);
-					ZVAL_LONG(&_6$$19, 5);
-					zephir_array_fast_append(&textTypes, &_6$$19);
-					ZEPHIR_INIT_NVAR(&_6$$19);
-					ZVAL_LONG(&_6$$19, 24);
-					zephir_array_fast_append(&textTypes, &_6$$19);
-					ZEPHIR_INIT_NVAR(&_6$$19);
-					ZVAL_LONG(&_6$$19, 23);
-					zephir_array_fast_append(&textTypes, &_6$$19);
-					ZEPHIR_INIT_NVAR(&_6$$19);
-					ZVAL_LONG(&_6$$19, 6);
-					zephir_array_fast_append(&textTypes, &_6$$19);
-					ZEPHIR_INIT_NVAR(&_6$$19);
-					ZVAL_LONG(&_6$$19, 25);
-					zephir_array_fast_append(&textTypes, &_6$$19);
-					ZEPHIR_INIT_NVAR(&_6$$19);
-					ZVAL_LONG(&_6$$19, 2);
-					zephir_array_fast_append(&textTypes, &_6$$19);
-					if (1 == zephir_fast_in_array(&primaryKeyType, &textTypes)) {
-						ZEPHIR_INIT_VAR(&_7$$20);
-						ZEPHIR_CONCAT_SVS(&_7$$20, "'", &conditions, "'");
-						ZEPHIR_CPY_WRT(&conditions, &_7$$20);
-					}
+					ZEPHIR_CONCAT_SVS(&_6$$19, "'", &conditions, "'");
+					ZEPHIR_CPY_WRT(&conditions, &_6$$19);
 				}
-				ZEPHIR_CALL_METHOD(&_8$$13, this_ptr, "autoescape", NULL, 487, &model);
+				ZEPHIR_CALL_METHOD(&_7$$13, this_ptr, "autoescape", NULL, 487, &model);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&_9$$13, this_ptr, "autoescape", NULL, 487, &attributeField);
+				ZEPHIR_CALL_METHOD(&_8$$13, this_ptr, "autoescape", NULL, 487, &attributeField);
 				zephir_check_call_status();
-				ZEPHIR_INIT_VAR(&_10$$13);
-				ZEPHIR_CONCAT_VSVSV(&_10$$13, &_8$$13, ".", &_9$$13, " = ", &conditions);
-				ZEPHIR_CPY_WRT(&conditions, &_10$$13);
+				ZEPHIR_INIT_VAR(&_9$$13);
+				ZEPHIR_CONCAT_VSVSV(&_9$$13, &_7$$13, ".", &_8$$13, " = ", &conditions);
+				ZEPHIR_CPY_WRT(&conditions, &_9$$13);
 				noPrimary = 0;
 			}
 		}
 		if (UNEXPECTED(noPrimary)) {
-			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Source related to this model does not have a primary key defined", "phalcon/Mvc/Model/Query/Builder.zep", 717);
+			ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_mvc_model_exception_ce, "Source related to this model does not have a primary key defined", "phalcon/Mvc/Model/Query/Builder.zep", 707);
 			return;
 		}
 	}
@@ -1298,35 +1269,35 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		if (Z_TYPE_P(&columns) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&selectedColumns);
 			array_init(&selectedColumns);
-			zephir_is_iterable(&columns, 0, "phalcon/Mvc/Model/Query/Builder.zep", 750);
+			zephir_is_iterable(&columns, 0, "phalcon/Mvc/Model/Query/Builder.zep", 740);
 			if (Z_TYPE_P(&columns) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&columns), _13$$27, _14$$27, _11$$27)
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&columns), _12$$26, _13$$26, _10$$26)
 				{
 					ZEPHIR_INIT_NVAR(&columnAlias);
-					if (_14$$27 != NULL) { 
-						ZVAL_STR_COPY(&columnAlias, _14$$27);
+					if (_13$$26 != NULL) { 
+						ZVAL_STR_COPY(&columnAlias, _13$$26);
 					} else {
-						ZVAL_LONG(&columnAlias, _13$$27);
+						ZVAL_LONG(&columnAlias, _12$$26);
 					}
 					ZEPHIR_INIT_NVAR(&column);
-					ZVAL_COPY(&column, _11$$27);
+					ZVAL_COPY(&column, _10$$26);
 					if (Z_TYPE_P(&columnAlias) == IS_LONG) {
-						zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 744);
+						zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 734);
 					} else {
-						ZEPHIR_CALL_METHOD(&_15$$30, this_ptr, "autoescape", NULL, 487, &columnAlias);
+						ZEPHIR_CALL_METHOD(&_14$$29, this_ptr, "autoescape", NULL, 487, &columnAlias);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_16$$30);
-						ZEPHIR_CONCAT_VSV(&_16$$30, &column, " AS ", &_15$$30);
-						zephir_array_append(&selectedColumns, &_16$$30, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 746);
+						ZEPHIR_INIT_NVAR(&_15$$29);
+						ZEPHIR_CONCAT_VSV(&_15$$29, &column, " AS ", &_14$$29);
+						zephir_array_append(&selectedColumns, &_15$$29, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 736);
 					}
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &columns, "rewind", NULL, 0);
 				zephir_check_call_status();
 				while (1) {
-					ZEPHIR_CALL_METHOD(&_12$$27, &columns, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_11$$26, &columns, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_12$$27)) {
+					if (!zend_is_true(&_11$$26)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&columnAlias, &columns, "key", NULL, 0);
@@ -1334,13 +1305,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 					ZEPHIR_CALL_METHOD(&column, &columns, "current", NULL, 0);
 					zephir_check_call_status();
 						if (Z_TYPE_P(&columnAlias) == IS_LONG) {
-							zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 744);
+							zephir_array_append(&selectedColumns, &column, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 734);
 						} else {
-							ZEPHIR_CALL_METHOD(&_17$$33, this_ptr, "autoescape", NULL, 487, &columnAlias);
+							ZEPHIR_CALL_METHOD(&_16$$32, this_ptr, "autoescape", NULL, 487, &columnAlias);
 							zephir_check_call_status();
-							ZEPHIR_INIT_NVAR(&_18$$33);
-							ZEPHIR_CONCAT_VSV(&_18$$33, &column, " AS ", &_17$$33);
-							zephir_array_append(&selectedColumns, &_18$$33, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 746);
+							ZEPHIR_INIT_NVAR(&_17$$32);
+							ZEPHIR_CONCAT_VSV(&_17$$32, &column, " AS ", &_16$$32);
+							zephir_array_append(&selectedColumns, &_17$$32, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 736);
 						}
 					ZEPHIR_CALL_METHOD(NULL, &columns, "next", NULL, 0);
 					zephir_check_call_status();
@@ -1348,9 +1319,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 			}
 			ZEPHIR_INIT_NVAR(&column);
 			ZEPHIR_INIT_NVAR(&columnAlias);
-			ZEPHIR_INIT_VAR(&_19$$27);
-			zephir_fast_join_str(&_19$$27, SL(", "), &selectedColumns);
-			zephir_concat_self(&phql, &_19$$27);
+			ZEPHIR_INIT_VAR(&_18$$26);
+			zephir_fast_join_str(&_18$$26, SL(", "), &selectedColumns);
+			zephir_concat_self(&phql, &_18$$26);
 		} else {
 			zephir_concat_self(&phql, &columns);
 		}
@@ -1358,37 +1329,37 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
 			ZEPHIR_INIT_NVAR(&selectedColumns);
 			array_init(&selectedColumns);
-			zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 771);
+			zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 761);
 			if (Z_TYPE_P(&models) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _22$$36, _23$$36, _20$$36)
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _21$$35, _22$$35, _19$$35)
 				{
 					ZEPHIR_INIT_NVAR(&modelColumnAlias);
-					if (_23$$36 != NULL) { 
-						ZVAL_STR_COPY(&modelColumnAlias, _23$$36);
+					if (_22$$35 != NULL) { 
+						ZVAL_STR_COPY(&modelColumnAlias, _22$$35);
 					} else {
-						ZVAL_LONG(&modelColumnAlias, _22$$36);
+						ZVAL_LONG(&modelColumnAlias, _21$$35);
 					}
 					ZEPHIR_INIT_NVAR(&model);
-					ZVAL_COPY(&model, _20$$36);
+					ZVAL_COPY(&model, _19$$35);
 					ZEPHIR_INIT_NVAR(&selectedColumn);
 					if (Z_TYPE_P(&modelColumnAlias) == IS_LONG) {
-						ZEPHIR_CALL_METHOD(&_24$$38, this_ptr, "autoescape", NULL, 487, &model);
+						ZEPHIR_CALL_METHOD(&_23$$37, this_ptr, "autoescape", NULL, 487, &model);
+						zephir_check_call_status();
+						ZEPHIR_CONCAT_VS(&selectedColumn, &_23$$37, ".*");
+					} else {
+						ZEPHIR_CALL_METHOD(&_24$$38, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
 						zephir_check_call_status();
 						ZEPHIR_CONCAT_VS(&selectedColumn, &_24$$38, ".*");
-					} else {
-						ZEPHIR_CALL_METHOD(&_25$$39, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
-						zephir_check_call_status();
-						ZEPHIR_CONCAT_VS(&selectedColumn, &_25$$39, ".*");
 					}
-					zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 768);
+					zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 758);
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &models, "rewind", NULL, 0);
 				zephir_check_call_status();
 				while (1) {
-					ZEPHIR_CALL_METHOD(&_21$$36, &models, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_20$$35, &models, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_21$$36)) {
+					if (!zend_is_true(&_20$$35)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&modelColumnAlias, &models, "key", NULL, 0);
@@ -1397,67 +1368,67 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 					zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&selectedColumn);
 						if (Z_TYPE_P(&modelColumnAlias) == IS_LONG) {
-							ZEPHIR_CALL_METHOD(&_26$$41, this_ptr, "autoescape", NULL, 487, &model);
+							ZEPHIR_CALL_METHOD(&_25$$40, this_ptr, "autoescape", NULL, 487, &model);
+							zephir_check_call_status();
+							ZEPHIR_CONCAT_VS(&selectedColumn, &_25$$40, ".*");
+						} else {
+							ZEPHIR_CALL_METHOD(&_26$$41, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
 							zephir_check_call_status();
 							ZEPHIR_CONCAT_VS(&selectedColumn, &_26$$41, ".*");
-						} else {
-							ZEPHIR_CALL_METHOD(&_27$$42, this_ptr, "autoescape", NULL, 487, &modelColumnAlias);
-							zephir_check_call_status();
-							ZEPHIR_CONCAT_VS(&selectedColumn, &_27$$42, ".*");
 						}
-						zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 768);
+						zephir_array_append(&selectedColumns, &selectedColumn, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 758);
 					ZEPHIR_CALL_METHOD(NULL, &models, "next", NULL, 0);
 					zephir_check_call_status();
 				}
 			}
 			ZEPHIR_INIT_NVAR(&model);
 			ZEPHIR_INIT_NVAR(&modelColumnAlias);
-			ZEPHIR_INIT_VAR(&_28$$36);
-			zephir_fast_join_str(&_28$$36, SL(", "), &selectedColumns);
-			zephir_concat_self(&phql, &_28$$36);
+			ZEPHIR_INIT_VAR(&_27$$35);
+			zephir_fast_join_str(&_27$$35, SL(", "), &selectedColumns);
+			zephir_concat_self(&phql, &_27$$35);
 		} else {
-			ZEPHIR_CALL_METHOD(&_29$$43, this_ptr, "autoescape", NULL, 487, &models);
+			ZEPHIR_CALL_METHOD(&_28$$42, this_ptr, "autoescape", NULL, 487, &models);
 			zephir_check_call_status();
-			ZEPHIR_INIT_VAR(&_30$$43);
-			ZEPHIR_CONCAT_VS(&_30$$43, &_29$$43, ".*");
-			zephir_concat_self(&phql, &_30$$43);
+			ZEPHIR_INIT_VAR(&_29$$42);
+			ZEPHIR_CONCAT_VS(&_29$$42, &_28$$42, ".*");
+			zephir_concat_self(&phql, &_29$$42);
 		}
 	}
 	if (Z_TYPE_P(&models) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&selectedModels);
 		array_init(&selectedModels);
-		zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 793);
+		zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query/Builder.zep", 783);
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _33$$44, _34$$44, _31$$44)
+			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _32$$43, _33$$43, _30$$43)
 			{
 				ZEPHIR_INIT_NVAR(&modelAlias);
-				if (_34$$44 != NULL) { 
-					ZVAL_STR_COPY(&modelAlias, _34$$44);
+				if (_33$$43 != NULL) { 
+					ZVAL_STR_COPY(&modelAlias, _33$$43);
 				} else {
-					ZVAL_LONG(&modelAlias, _33$$44);
+					ZVAL_LONG(&modelAlias, _32$$43);
 				}
 				ZEPHIR_INIT_NVAR(&model);
-				ZVAL_COPY(&model, _31$$44);
+				ZVAL_COPY(&model, _30$$43);
 				if (Z_TYPE_P(&modelAlias) == IS_STRING) {
-					ZEPHIR_CALL_METHOD(&_35$$46, this_ptr, "autoescape", NULL, 487, &model);
+					ZEPHIR_CALL_METHOD(&_34$$45, this_ptr, "autoescape", NULL, 487, &model);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&_36$$46, this_ptr, "autoescape", NULL, 487, &modelAlias);
+					ZEPHIR_CALL_METHOD(&_35$$45, this_ptr, "autoescape", NULL, 487, &modelAlias);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&selectedModel);
-					ZEPHIR_CONCAT_VSV(&selectedModel, &_35$$46, " AS ", &_36$$46);
+					ZEPHIR_CONCAT_VSV(&selectedModel, &_34$$45, " AS ", &_35$$45);
 				} else {
 					ZEPHIR_CALL_METHOD(&selectedModel, this_ptr, "autoescape", NULL, 487, &model);
 					zephir_check_call_status();
 				}
-				zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 790);
+				zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 780);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &models, "rewind", NULL, 0);
 			zephir_check_call_status();
 			while (1) {
-				ZEPHIR_CALL_METHOD(&_32$$44, &models, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_31$$43, &models, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_32$$44)) {
+				if (!zend_is_true(&_31$$43)) {
 					break;
 				}
 				ZEPHIR_CALL_METHOD(&modelAlias, &models, "key", NULL, 0);
@@ -1465,121 +1436,121 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 				ZEPHIR_CALL_METHOD(&model, &models, "current", NULL, 0);
 				zephir_check_call_status();
 					if (Z_TYPE_P(&modelAlias) == IS_STRING) {
-						ZEPHIR_CALL_METHOD(&_37$$49, this_ptr, "autoescape", NULL, 487, &model);
+						ZEPHIR_CALL_METHOD(&_36$$48, this_ptr, "autoescape", NULL, 487, &model);
 						zephir_check_call_status();
-						ZEPHIR_CALL_METHOD(&_38$$49, this_ptr, "autoescape", NULL, 487, &modelAlias);
+						ZEPHIR_CALL_METHOD(&_37$$48, this_ptr, "autoescape", NULL, 487, &modelAlias);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&selectedModel);
-						ZEPHIR_CONCAT_VSV(&selectedModel, &_37$$49, " AS ", &_38$$49);
+						ZEPHIR_CONCAT_VSV(&selectedModel, &_36$$48, " AS ", &_37$$48);
 					} else {
 						ZEPHIR_CALL_METHOD(&selectedModel, this_ptr, "autoescape", NULL, 487, &model);
 						zephir_check_call_status();
 					}
-					zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 790);
+					zephir_array_append(&selectedModels, &selectedModel, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 780);
 				ZEPHIR_CALL_METHOD(NULL, &models, "next", NULL, 0);
 				zephir_check_call_status();
 			}
 		}
 		ZEPHIR_INIT_NVAR(&model);
 		ZEPHIR_INIT_NVAR(&modelAlias);
-		ZEPHIR_INIT_VAR(&_39$$44);
-		zephir_fast_join_str(&_39$$44, SL(", "), &selectedModels);
-		ZEPHIR_INIT_VAR(&_40$$44);
-		ZEPHIR_CONCAT_SV(&_40$$44, " FROM ", &_39$$44);
-		zephir_concat_self(&phql, &_40$$44);
+		ZEPHIR_INIT_VAR(&_38$$43);
+		zephir_fast_join_str(&_38$$43, SL(", "), &selectedModels);
+		ZEPHIR_INIT_VAR(&_39$$43);
+		ZEPHIR_CONCAT_SV(&_39$$43, " FROM ", &_38$$43);
+		zephir_concat_self(&phql, &_39$$43);
 	} else {
-		ZEPHIR_CALL_METHOD(&_41$$51, this_ptr, "autoescape", NULL, 487, &models);
+		ZEPHIR_CALL_METHOD(&_40$$50, this_ptr, "autoescape", NULL, 487, &models);
 		zephir_check_call_status();
-		ZEPHIR_INIT_VAR(&_42$$51);
-		ZEPHIR_CONCAT_SV(&_42$$51, " FROM ", &_41$$51);
-		zephir_concat_self(&phql, &_42$$51);
+		ZEPHIR_INIT_VAR(&_41$$50);
+		ZEPHIR_CONCAT_SV(&_41$$50, " FROM ", &_40$$50);
+		zephir_concat_self(&phql, &_41$$50);
 	}
 	zephir_read_property(&_0, this_ptr, SL("joins"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&joins, &_0);
 	if (Z_TYPE_P(&joins) == IS_ARRAY) {
-		zephir_is_iterable(&joins, 0, "phalcon/Mvc/Model/Query/Builder.zep", 848);
+		zephir_is_iterable(&joins, 0, "phalcon/Mvc/Model/Query/Builder.zep", 838);
 		if (Z_TYPE_P(&joins) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&joins), _43$$52)
+			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&joins), _42$$51)
 			{
 				ZEPHIR_INIT_NVAR(&join);
-				ZVAL_COPY(&join, _43$$52);
+				ZVAL_COPY(&join, _42$$51);
 				ZEPHIR_OBS_NVAR(&joinModel);
-				zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 808);
+				zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 798);
 				ZEPHIR_OBS_NVAR(&joinConditions);
-				zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 813);
+				zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 803);
 				ZEPHIR_OBS_NVAR(&joinAlias);
-				zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 818);
+				zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 808);
 				ZEPHIR_OBS_NVAR(&joinType);
-				zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 823);
+				zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 813);
 				if (zephir_is_true(&joinType)) {
-					ZEPHIR_CALL_METHOD(&_45$$54, this_ptr, "autoescape", NULL, 487, &joinModel);
+					ZEPHIR_CALL_METHOD(&_44$$53, this_ptr, "autoescape", NULL, 487, &joinModel);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_46$$54);
-					ZEPHIR_CONCAT_SVSV(&_46$$54, " ", &joinType, " JOIN ", &_45$$54);
-					zephir_concat_self(&phql, &_46$$54);
+					ZEPHIR_INIT_NVAR(&_45$$53);
+					ZEPHIR_CONCAT_SVSV(&_45$$53, " ", &joinType, " JOIN ", &_44$$53);
+					zephir_concat_self(&phql, &_45$$53);
 				} else {
-					ZEPHIR_CALL_METHOD(&_47$$55, this_ptr, "autoescape", NULL, 487, &joinModel);
+					ZEPHIR_CALL_METHOD(&_46$$54, this_ptr, "autoescape", NULL, 487, &joinModel);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_48$$55);
-					ZEPHIR_CONCAT_SV(&_48$$55, " JOIN ", &_47$$55);
-					zephir_concat_self(&phql, &_48$$55);
+					ZEPHIR_INIT_NVAR(&_47$$54);
+					ZEPHIR_CONCAT_SV(&_47$$54, " JOIN ", &_46$$54);
+					zephir_concat_self(&phql, &_47$$54);
 				}
 				if (zephir_is_true(&joinAlias)) {
-					ZEPHIR_CALL_METHOD(&_49$$56, this_ptr, "autoescape", NULL, 487, &joinAlias);
+					ZEPHIR_CALL_METHOD(&_48$$55, this_ptr, "autoescape", NULL, 487, &joinAlias);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_50$$56);
-					ZEPHIR_CONCAT_SV(&_50$$56, " AS ", &_49$$56);
-					zephir_concat_self(&phql, &_50$$56);
+					ZEPHIR_INIT_NVAR(&_49$$55);
+					ZEPHIR_CONCAT_SV(&_49$$55, " AS ", &_48$$55);
+					zephir_concat_self(&phql, &_49$$55);
 				}
 				if (zephir_is_true(&joinConditions)) {
-					ZEPHIR_INIT_NVAR(&_51$$57);
-					ZEPHIR_CONCAT_SV(&_51$$57, " ON ", &joinConditions);
-					zephir_concat_self(&phql, &_51$$57);
+					ZEPHIR_INIT_NVAR(&_50$$56);
+					ZEPHIR_CONCAT_SV(&_50$$56, " ON ", &joinConditions);
+					zephir_concat_self(&phql, &_50$$56);
 				}
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &joins, "rewind", NULL, 0);
 			zephir_check_call_status();
 			while (1) {
-				ZEPHIR_CALL_METHOD(&_44$$52, &joins, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_43$$51, &joins, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_44$$52)) {
+				if (!zend_is_true(&_43$$51)) {
 					break;
 				}
 				ZEPHIR_CALL_METHOD(&join, &joins, "current", NULL, 0);
 				zephir_check_call_status();
 					ZEPHIR_OBS_NVAR(&joinModel);
-					zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 808);
+					zephir_array_fetch_long(&joinModel, &join, 0, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 798);
 					ZEPHIR_OBS_NVAR(&joinConditions);
-					zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 813);
+					zephir_array_fetch_long(&joinConditions, &join, 1, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 803);
 					ZEPHIR_OBS_NVAR(&joinAlias);
-					zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 818);
+					zephir_array_fetch_long(&joinAlias, &join, 2, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 808);
 					ZEPHIR_OBS_NVAR(&joinType);
-					zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 823);
+					zephir_array_fetch_long(&joinType, &join, 3, PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 813);
 					if (zephir_is_true(&joinType)) {
-						ZEPHIR_CALL_METHOD(&_52$$59, this_ptr, "autoescape", NULL, 487, &joinModel);
+						ZEPHIR_CALL_METHOD(&_51$$58, this_ptr, "autoescape", NULL, 487, &joinModel);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_53$$59);
-						ZEPHIR_CONCAT_SVSV(&_53$$59, " ", &joinType, " JOIN ", &_52$$59);
-						zephir_concat_self(&phql, &_53$$59);
+						ZEPHIR_INIT_NVAR(&_52$$58);
+						ZEPHIR_CONCAT_SVSV(&_52$$58, " ", &joinType, " JOIN ", &_51$$58);
+						zephir_concat_self(&phql, &_52$$58);
 					} else {
-						ZEPHIR_CALL_METHOD(&_54$$60, this_ptr, "autoescape", NULL, 487, &joinModel);
+						ZEPHIR_CALL_METHOD(&_53$$59, this_ptr, "autoescape", NULL, 487, &joinModel);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_55$$60);
-						ZEPHIR_CONCAT_SV(&_55$$60, " JOIN ", &_54$$60);
-						zephir_concat_self(&phql, &_55$$60);
+						ZEPHIR_INIT_NVAR(&_54$$59);
+						ZEPHIR_CONCAT_SV(&_54$$59, " JOIN ", &_53$$59);
+						zephir_concat_self(&phql, &_54$$59);
 					}
 					if (zephir_is_true(&joinAlias)) {
-						ZEPHIR_CALL_METHOD(&_56$$61, this_ptr, "autoescape", NULL, 487, &joinAlias);
+						ZEPHIR_CALL_METHOD(&_55$$60, this_ptr, "autoescape", NULL, 487, &joinAlias);
 						zephir_check_call_status();
-						ZEPHIR_INIT_NVAR(&_57$$61);
-						ZEPHIR_CONCAT_SV(&_57$$61, " AS ", &_56$$61);
-						zephir_concat_self(&phql, &_57$$61);
+						ZEPHIR_INIT_NVAR(&_56$$60);
+						ZEPHIR_CONCAT_SV(&_56$$60, " AS ", &_55$$60);
+						zephir_concat_self(&phql, &_56$$60);
 					}
 					if (zephir_is_true(&joinConditions)) {
-						ZEPHIR_INIT_NVAR(&_58$$62);
-						ZEPHIR_CONCAT_SV(&_58$$62, " ON ", &joinConditions);
-						zephir_concat_self(&phql, &_58$$62);
+						ZEPHIR_INIT_NVAR(&_57$$61);
+						ZEPHIR_CONCAT_SV(&_57$$61, " ON ", &joinConditions);
+						zephir_concat_self(&phql, &_57$$61);
 					}
 				ZEPHIR_CALL_METHOD(NULL, &joins, "next", NULL, 0);
 				zephir_check_call_status();
@@ -1589,9 +1560,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	}
 	if (Z_TYPE_P(&conditions) == IS_STRING) {
 		if (!(ZEPHIR_IS_EMPTY(&conditions))) {
-			ZEPHIR_INIT_VAR(&_59$$64);
-			ZEPHIR_CONCAT_SV(&_59$$64, " WHERE ", &conditions);
-			zephir_concat_self(&phql, &_59$$64);
+			ZEPHIR_INIT_VAR(&_58$$63);
+			ZEPHIR_CONCAT_SV(&_58$$63, " WHERE ", &conditions);
+			zephir_concat_self(&phql, &_58$$63);
 		}
 	}
 	zephir_read_property(&_0, this_ptr, SL("group"), PH_NOISY_CC | PH_READONLY);
@@ -1599,48 +1570,48 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 	if (Z_TYPE_P(&group) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&groupItems);
 		array_init(&groupItems);
-		zephir_is_iterable(&group, 0, "phalcon/Mvc/Model/Query/Builder.zep", 868);
+		zephir_is_iterable(&group, 0, "phalcon/Mvc/Model/Query/Builder.zep", 858);
 		if (Z_TYPE_P(&group) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&group), _60$$65)
+			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&group), _59$$64)
 			{
 				ZEPHIR_INIT_NVAR(&groupItem);
-				ZVAL_COPY(&groupItem, _60$$65);
-				ZEPHIR_CALL_METHOD(&_62$$66, this_ptr, "autoescape", NULL, 487, &groupItem);
+				ZVAL_COPY(&groupItem, _59$$64);
+				ZEPHIR_CALL_METHOD(&_61$$65, this_ptr, "autoescape", NULL, 487, &groupItem);
 				zephir_check_call_status();
-				zephir_array_append(&groupItems, &_62$$66, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 865);
+				zephir_array_append(&groupItems, &_61$$65, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 855);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &group, "rewind", NULL, 0);
 			zephir_check_call_status();
 			while (1) {
-				ZEPHIR_CALL_METHOD(&_61$$65, &group, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_60$$64, &group, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_61$$65)) {
+				if (!zend_is_true(&_60$$64)) {
 					break;
 				}
 				ZEPHIR_CALL_METHOD(&groupItem, &group, "current", NULL, 0);
 				zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&_63$$67, this_ptr, "autoescape", NULL, 487, &groupItem);
+					ZEPHIR_CALL_METHOD(&_62$$66, this_ptr, "autoescape", NULL, 487, &groupItem);
 					zephir_check_call_status();
-					zephir_array_append(&groupItems, &_63$$67, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 865);
+					zephir_array_append(&groupItems, &_62$$66, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 855);
 				ZEPHIR_CALL_METHOD(NULL, &group, "next", NULL, 0);
 				zephir_check_call_status();
 			}
 		}
 		ZEPHIR_INIT_NVAR(&groupItem);
-		ZEPHIR_INIT_VAR(&_64$$65);
-		zephir_fast_join_str(&_64$$65, SL(", "), &groupItems);
-		ZEPHIR_INIT_VAR(&_65$$65);
-		ZEPHIR_CONCAT_SV(&_65$$65, " GROUP BY ", &_64$$65);
-		zephir_concat_self(&phql, &_65$$65);
+		ZEPHIR_INIT_VAR(&_63$$64);
+		zephir_fast_join_str(&_63$$64, SL(", "), &groupItems);
+		ZEPHIR_INIT_VAR(&_64$$64);
+		ZEPHIR_CONCAT_SV(&_64$$64, " GROUP BY ", &_63$$64);
+		zephir_concat_self(&phql, &_64$$64);
 	}
 	zephir_read_property(&_0, this_ptr, SL("having"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&having, &_0);
 	if (Z_TYPE_P(&having) != IS_NULL) {
 		if (!(ZEPHIR_IS_EMPTY(&having))) {
-			ZEPHIR_INIT_VAR(&_66$$69);
-			ZEPHIR_CONCAT_SV(&_66$$69, " HAVING ", &having);
-			zephir_concat_self(&phql, &_66$$69);
+			ZEPHIR_INIT_VAR(&_65$$68);
+			ZEPHIR_CONCAT_SV(&_65$$68, " HAVING ", &having);
+			zephir_concat_self(&phql, &_65$$68);
 		}
 	}
 	zephir_read_property(&_0, this_ptr, SL("order"), PH_NOISY_CC | PH_READONLY);
@@ -1649,76 +1620,76 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		if (Z_TYPE_P(&order) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&orderItems);
 			array_init(&orderItems);
-			zephir_is_iterable(&order, 0, "phalcon/Mvc/Model/Query/Builder.zep", 912);
+			zephir_is_iterable(&order, 0, "phalcon/Mvc/Model/Query/Builder.zep", 902);
 			if (Z_TYPE_P(&order) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&order), _67$$71)
+				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&order), _66$$70)
 				{
 					ZEPHIR_INIT_NVAR(&orderItem);
-					ZVAL_COPY(&orderItem, _67$$71);
+					ZVAL_COPY(&orderItem, _66$$70);
 					if (Z_TYPE_P(&orderItem) == IS_LONG) {
-						zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 895);
+						zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 885);
 						continue;
 					}
-					if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 900) != 0) {
-						ZEPHIR_INIT_NVAR(&itemExplode$$74);
-						zephir_fast_explode_str(&itemExplode$$74, SL(" "), &orderItem, LONG_MAX);
-						zephir_array_fetch_long(&_70$$74, &itemExplode$$74, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
-						ZEPHIR_CALL_METHOD(&_69$$74, this_ptr, "autoescape", NULL, 487, &_70$$74);
+					if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 890) != 0) {
+						ZEPHIR_INIT_NVAR(&itemExplode$$73);
+						zephir_fast_explode_str(&itemExplode$$73, SL(" "), &orderItem, LONG_MAX);
+						zephir_array_fetch_long(&_69$$73, &itemExplode$$73, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 894);
+						ZEPHIR_CALL_METHOD(&_68$$73, this_ptr, "autoescape", NULL, 487, &_69$$73);
 						zephir_check_call_status();
-						zephir_array_fetch_long(&_71$$74, &itemExplode$$74, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
-						ZEPHIR_INIT_NVAR(&_72$$74);
-						ZEPHIR_CONCAT_VSV(&_72$$74, &_69$$74, " ", &_71$$74);
-						zephir_array_append(&orderItems, &_72$$74, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 904);
+						zephir_array_fetch_long(&_70$$73, &itemExplode$$73, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 894);
+						ZEPHIR_INIT_NVAR(&_71$$73);
+						ZEPHIR_CONCAT_VSV(&_71$$73, &_68$$73, " ", &_70$$73);
+						zephir_array_append(&orderItems, &_71$$73, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 894);
 						continue;
 					}
-					ZEPHIR_CALL_METHOD(&_73$$72, this_ptr, "autoescape", NULL, 487, &orderItem);
+					ZEPHIR_CALL_METHOD(&_72$$71, this_ptr, "autoescape", NULL, 487, &orderItem);
 					zephir_check_call_status();
-					zephir_array_append(&orderItems, &_73$$72, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 909);
+					zephir_array_append(&orderItems, &_72$$71, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 899);
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &order, "rewind", NULL, 0);
 				zephir_check_call_status();
 				while (1) {
-					ZEPHIR_CALL_METHOD(&_68$$71, &order, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_67$$70, &order, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_68$$71)) {
+					if (!zend_is_true(&_67$$70)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&orderItem, &order, "current", NULL, 0);
 					zephir_check_call_status();
 						if (Z_TYPE_P(&orderItem) == IS_LONG) {
-							zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 895);
+							zephir_array_append(&orderItems, &orderItem, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 885);
 							continue;
 						}
-						if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 900) != 0) {
-							ZEPHIR_INIT_NVAR(&itemExplode$$77);
-							zephir_fast_explode_str(&itemExplode$$77, SL(" "), &orderItem, LONG_MAX);
-							zephir_array_fetch_long(&_75$$77, &itemExplode$$77, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
-							ZEPHIR_CALL_METHOD(&_74$$77, this_ptr, "autoescape", NULL, 487, &_75$$77);
+						if (zephir_memnstr_str(&orderItem, SL(" "), "phalcon/Mvc/Model/Query/Builder.zep", 890) != 0) {
+							ZEPHIR_INIT_NVAR(&itemExplode$$76);
+							zephir_fast_explode_str(&itemExplode$$76, SL(" "), &orderItem, LONG_MAX);
+							zephir_array_fetch_long(&_74$$76, &itemExplode$$76, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 894);
+							ZEPHIR_CALL_METHOD(&_73$$76, this_ptr, "autoescape", NULL, 487, &_74$$76);
 							zephir_check_call_status();
-							zephir_array_fetch_long(&_76$$77, &itemExplode$$77, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 904);
-							ZEPHIR_INIT_NVAR(&_77$$77);
-							ZEPHIR_CONCAT_VSV(&_77$$77, &_74$$77, " ", &_76$$77);
-							zephir_array_append(&orderItems, &_77$$77, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 904);
+							zephir_array_fetch_long(&_75$$76, &itemExplode$$76, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query/Builder.zep", 894);
+							ZEPHIR_INIT_NVAR(&_76$$76);
+							ZEPHIR_CONCAT_VSV(&_76$$76, &_73$$76, " ", &_75$$76);
+							zephir_array_append(&orderItems, &_76$$76, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 894);
 							continue;
 						}
-						ZEPHIR_CALL_METHOD(&_78$$75, this_ptr, "autoescape", NULL, 487, &orderItem);
+						ZEPHIR_CALL_METHOD(&_77$$74, this_ptr, "autoescape", NULL, 487, &orderItem);
 						zephir_check_call_status();
-						zephir_array_append(&orderItems, &_78$$75, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 909);
+						zephir_array_append(&orderItems, &_77$$74, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 899);
 					ZEPHIR_CALL_METHOD(NULL, &order, "next", NULL, 0);
 					zephir_check_call_status();
 				}
 			}
 			ZEPHIR_INIT_NVAR(&orderItem);
-			ZEPHIR_INIT_VAR(&_79$$71);
-			zephir_fast_join_str(&_79$$71, SL(", "), &orderItems);
-			ZEPHIR_INIT_VAR(&_80$$71);
-			ZEPHIR_CONCAT_SV(&_80$$71, " ORDER BY ", &_79$$71);
-			zephir_concat_self(&phql, &_80$$71);
+			ZEPHIR_INIT_VAR(&_78$$70);
+			zephir_fast_join_str(&_78$$70, SL(", "), &orderItems);
+			ZEPHIR_INIT_VAR(&_79$$70);
+			ZEPHIR_CONCAT_SV(&_79$$70, " ORDER BY ", &_78$$70);
+			zephir_concat_self(&phql, &_79$$70);
 		} else {
-			ZEPHIR_INIT_VAR(&_81$$78);
-			ZEPHIR_CONCAT_SV(&_81$$78, " ORDER BY ", &order);
-			zephir_concat_self(&phql, &_81$$78);
+			ZEPHIR_INIT_VAR(&_80$$77);
+			ZEPHIR_CONCAT_SV(&_80$$77, " ORDER BY ", &order);
+			zephir_concat_self(&phql, &_80$$77);
 		}
 	}
 	zephir_read_property(&_0, this_ptr, SL("limit"), PH_NOISY_CC | PH_READONLY);
@@ -1728,7 +1699,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		ZVAL_NULL(&number);
 		if (Z_TYPE_P(&limit) == IS_ARRAY) {
 			ZEPHIR_OBS_NVAR(&number);
-			zephir_array_fetch_string(&number, &limit, SL("number"), PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 926);
+			zephir_array_fetch_string(&number, &limit, SL("number"), PH_NOISY, "phalcon/Mvc/Model/Query/Builder.zep", 916);
 			ZEPHIR_OBS_VAR(&offset);
 			if (zephir_array_isset_string_fetch(&offset, &limit, SL("offset"), 0)) {
 				if (!(zephir_is_numeric(&offset))) {
@@ -1739,8 +1710,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		} else {
 			if (zephir_is_numeric(&limit)) {
 				ZEPHIR_CPY_WRT(&number, &limit);
-				zephir_read_property(&_82$$84, this_ptr, SL("offset"), PH_NOISY_CC | PH_READONLY);
-				ZEPHIR_CPY_WRT(&offset, &_82$$84);
+				zephir_read_property(&_81$$83, this_ptr, SL("offset"), PH_NOISY_CC | PH_READONLY);
+				ZEPHIR_CPY_WRT(&offset, &_81$$83);
 				if (Z_TYPE_P(&offset) != IS_NULL) {
 					if (!(zephir_is_numeric(&offset))) {
 						ZEPHIR_INIT_NVAR(&offset);
@@ -1751,34 +1722,34 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql) {
 		}
 		if (zephir_is_numeric(&number)) {
 			zephir_concat_self_str(&phql, SL(" LIMIT :APL0:"));
-			ZVAL_LONG(&_83$$87, 10);
-			ZEPHIR_CALL_FUNCTION(&_84$$87, "intval", NULL, 49, &number, &_83$$87);
+			ZVAL_LONG(&_82$$86, 10);
+			ZEPHIR_CALL_FUNCTION(&_83$$86, "intval", NULL, 49, &number, &_82$$86);
 			zephir_check_call_status();
-			ZEPHIR_INIT_VAR(&_85$$87);
-			ZVAL_STRING(&_85$$87, "APL0");
-			zephir_update_property_array(this_ptr, SL("bindParams"), &_85$$87, &_84$$87);
-			ZEPHIR_INIT_VAR(&_86$$87);
-			ZVAL_STRING(&_86$$87, "APL0");
-			ZEPHIR_INIT_VAR(&_87$$87);
-			ZVAL_LONG(&_87$$87, 1);
-			zephir_update_property_array(this_ptr, SL("bindTypes"), &_86$$87, &_87$$87);
-			_88$$87 = zephir_is_numeric(&offset);
-			if (_88$$87) {
-				_88$$87 = !ZEPHIR_IS_LONG_IDENTICAL(&offset, 0);
+			ZEPHIR_INIT_VAR(&_84$$86);
+			ZVAL_STRING(&_84$$86, "APL0");
+			zephir_update_property_array(this_ptr, SL("bindParams"), &_84$$86, &_83$$86);
+			ZEPHIR_INIT_VAR(&_85$$86);
+			ZVAL_STRING(&_85$$86, "APL0");
+			ZEPHIR_INIT_VAR(&_86$$86);
+			ZVAL_LONG(&_86$$86, 1);
+			zephir_update_property_array(this_ptr, SL("bindTypes"), &_85$$86, &_86$$86);
+			_87$$86 = zephir_is_numeric(&offset);
+			if (_87$$86) {
+				_87$$86 = !ZEPHIR_IS_LONG_IDENTICAL(&offset, 0);
 			}
-			if (_88$$87) {
+			if (_87$$86) {
 				zephir_concat_self_str(&phql, SL(" OFFSET :APL1:"));
-				ZVAL_LONG(&_89$$88, 10);
-				ZEPHIR_CALL_FUNCTION(&_90$$88, "intval", NULL, 49, &offset, &_89$$88);
+				ZVAL_LONG(&_88$$87, 10);
+				ZEPHIR_CALL_FUNCTION(&_89$$87, "intval", NULL, 49, &offset, &_88$$87);
 				zephir_check_call_status();
-				ZEPHIR_INIT_VAR(&_91$$88);
-				ZVAL_STRING(&_91$$88, "APL1");
-				zephir_update_property_array(this_ptr, SL("bindParams"), &_91$$88, &_90$$88);
-				ZEPHIR_INIT_VAR(&_92$$88);
-				ZVAL_STRING(&_92$$88, "APL1");
-				ZEPHIR_INIT_VAR(&_93$$88);
-				ZVAL_LONG(&_93$$88, 1);
-				zephir_update_property_array(this_ptr, SL("bindTypes"), &_92$$88, &_93$$88);
+				ZEPHIR_INIT_VAR(&_90$$87);
+				ZVAL_STRING(&_90$$87, "APL1");
+				zephir_update_property_array(this_ptr, SL("bindParams"), &_90$$87, &_89$$87);
+				ZEPHIR_INIT_VAR(&_91$$87);
+				ZVAL_STRING(&_91$$87, "APL1");
+				ZEPHIR_INIT_VAR(&_92$$87);
+				ZVAL_LONG(&_92$$87, 1);
+				zephir_update_property_array(this_ptr, SL("bindTypes"), &_91$$87, &_92$$87);
 			}
 		}
 	}
@@ -1835,7 +1806,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getQuery) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_2$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 985);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 975);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -1917,7 +1888,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, groupBy) {
 
 
 	if (Z_TYPE_P(group) == IS_STRING) {
-		if (zephir_memnstr_str(group, SL(","), "phalcon/Mvc/Model/Query/Builder.zep", 1041)) {
+		if (zephir_memnstr_str(group, SL(","), "phalcon/Mvc/Model/Query/Builder.zep", 1031)) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			ZEPHIR_INIT_VAR(&_1$$4);
 			ZVAL_STRING(&_1$$4, " ");
@@ -3162,7 +3133,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionBetween) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1524);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1514);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3279,7 +3250,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1572);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1562);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3300,7 +3271,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 	array_init(&bindParams);
 	ZEPHIR_INIT_VAR(&bindKeys);
 	array_init(&bindKeys);
-	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1603);
+	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1593);
 	if (Z_TYPE_P(&values) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&values), _7)
 		{
@@ -3313,7 +3284,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 			ZEPHIR_CPY_WRT(&key, &_10$$5);
 			ZEPHIR_INIT_NVAR(&queryKey);
 			ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1594);
+			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1584);
 			zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 			hiddenParam++;
 		} ZEND_HASH_FOREACH_END();
@@ -3335,7 +3306,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn) {
 				ZEPHIR_CPY_WRT(&key, &_12$$6);
 				ZEPHIR_INIT_NVAR(&queryKey);
 				ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1594);
+				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1584);
 				zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 				hiddenParam++;
 			ZEPHIR_CALL_METHOD(NULL, &values, "next", NULL, 0);
@@ -3434,7 +3405,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotBetween) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1626);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1616);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3551,7 +3522,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 6, &_3$$3);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1673);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Model/Query/Builder.zep", 1663);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3572,7 +3543,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 	array_init(&bindParams);
 	ZEPHIR_INIT_VAR(&bindKeys);
 	array_init(&bindKeys);
-	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1704);
+	zephir_is_iterable(&values, 0, "phalcon/Mvc/Model/Query/Builder.zep", 1694);
 	if (Z_TYPE_P(&values) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&values), _7)
 		{
@@ -3585,7 +3556,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 			ZEPHIR_CPY_WRT(&key, &_10$$5);
 			ZEPHIR_INIT_NVAR(&queryKey);
 			ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1695);
+			zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1685);
 			zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 			hiddenParam++;
 		} ZEND_HASH_FOREACH_END();
@@ -3607,7 +3578,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn) {
 				ZEPHIR_CPY_WRT(&key, &_12$$6);
 				ZEPHIR_INIT_NVAR(&queryKey);
 				ZEPHIR_CONCAT_SVS(&queryKey, ":", &key, ":");
-				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1695);
+				zephir_array_append(&bindKeys, &queryKey, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 1685);
 				zephir_array_update_zval(&bindParams, &key, &value, PH_COPY | PH_SEPARATE);
 				hiddenParam++;
 			ZEPHIR_CALL_METHOD(NULL, &values, "next", NULL, 0);

--- a/ext/php_phalcon.h
+++ b/ext/php_phalcon.h
@@ -14,7 +14,7 @@
 #define PHP_PHALCON_VERSION     "4.0.5"
 #define PHP_PHALCON_EXTNAME     "phalcon"
 #define PHP_PHALCON_AUTHOR      "Phalcon Team and contributors"
-#define PHP_PHALCON_ZEPVERSION  "0.12.16-12256a1"
+#define PHP_PHALCON_ZEPVERSION  "0.12.17-6724dbf"
 #define PHP_PHALCON_DESCRIPTION "Phalcon is a full stack PHP framework, delivered as a PHP extension, offering lower resource consumption and high performance."
 
 typedef struct _zephir_struct_db { 

--- a/ext/php_phalcon.h
+++ b/ext/php_phalcon.h
@@ -14,7 +14,7 @@
 #define PHP_PHALCON_VERSION     "4.0.5"
 #define PHP_PHALCON_EXTNAME     "phalcon"
 #define PHP_PHALCON_AUTHOR      "Phalcon Team and contributors"
-#define PHP_PHALCON_ZEPVERSION  "0.12.17-6724dbf"
+#define PHP_PHALCON_ZEPVERSION  "0.12.16-12256a1"
 #define PHP_PHALCON_DESCRIPTION "Phalcon is a full stack PHP framework, delivered as a PHP extension, offering lower resource consumption and high performance."
 
 typedef struct _zephir_struct_db { 

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -687,9 +687,13 @@ class Builder implements BuilderInterface, InjectionAwareInterface
                         let attributeField = firstPrimaryKey;
                     }
 
-                    //check the type of the primary key, if it's a string put single quote between the value
+                    // check the type of the condition, if it's a string put single quotes around the value
                     if is_string(conditions) {
-                        // put single quote arround the value - make trouble with PostgreSQL
+                        /*
+                         * Example : if the developer writes findFirstBy('135'), Phalcon will generate where uuid = 135.
+                         * But the column's type is text so Postgres needs to have single quotes such as ;
+                         * where uuid = '135'.
+                         */
                         let conditions = "'" . conditions . "'";
                     }
 

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -607,7 +607,8 @@ class Builder implements BuilderInterface, InjectionAwareInterface
             selectedColumn, selectedModel, selectedModels, columnAlias,
             modelColumnAlias, joins, join, joinModel, joinConditions,
             joinAlias, joinType, group, groupItems, groupItem, having, order,
-            orderItems, orderItem, limit, number, offset, forUpdate, distinct;
+            orderItems, orderItem, limit, number, offset, forUpdate, distinct,
+            columnType, primaryKeyType, textTypes;
         bool noPrimary;
 
         let container = this->container;
@@ -685,6 +686,21 @@ class Builder implements BuilderInterface, InjectionAwareInterface
                         }
                     } else {
                         let attributeField = firstPrimaryKey;
+                    }
+
+                    //check the type of the primary key, if it's a string put single quote between the value
+                    let columnType = metaData->getDataTypes(modelInstance);
+
+                    if fetch primaryKeyType, columnType[firstPrimaryKey] {
+                           let textTypes = [
+                                Column::TYPE_CHAR, Column::TYPE_LONGTEXT,
+                                Column::TYPE_MEDIUMTEXT, Column::TYPE_TEXT,
+                                Column::TYPE_TINYTEXT, Column::TYPE_VARCHAR
+                           ];
+                           if true === in_array(primaryKeyType, textTypes) {
+                                // put single quote arround the value - make trouble with PostgreSQL
+                                let conditions = "'" . conditions . "'";
+                           }
                     }
 
                     let conditions = this->autoescape(model) . "." . this->autoescape(attributeField) . " = " . conditions,

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -607,8 +607,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
             selectedColumn, selectedModel, selectedModels, columnAlias,
             modelColumnAlias, joins, join, joinModel, joinConditions,
             joinAlias, joinType, group, groupItems, groupItem, having, order,
-            orderItems, orderItem, limit, number, offset, forUpdate, distinct,
-            columnType, primaryKeyType, textTypes;
+            orderItems, orderItem, limit, number, offset, forUpdate, distinct;
         bool noPrimary;
 
         let container = this->container;
@@ -689,18 +688,9 @@ class Builder implements BuilderInterface, InjectionAwareInterface
                     }
 
                     //check the type of the primary key, if it's a string put single quote between the value
-                    let columnType = metaData->getDataTypes(modelInstance);
-
-                    if fetch primaryKeyType, columnType[firstPrimaryKey] {
-                           let textTypes = [
-                                Column::TYPE_CHAR, Column::TYPE_LONGTEXT,
-                                Column::TYPE_MEDIUMTEXT, Column::TYPE_TEXT,
-                                Column::TYPE_TINYTEXT, Column::TYPE_VARCHAR
-                           ];
-                           if true === in_array(primaryKeyType, textTypes) {
-                                // put single quote arround the value - make trouble with PostgreSQL
-                                let conditions = "'" . conditions . "'";
-                           }
+                    if is_string(conditions) {
+                        // put single quote arround the value - make trouble with PostgreSQL
+                        let conditions = "'" . conditions . "'";
                     }
 
                     let conditions = this->autoescape(model) . "." . this->autoescape(attributeField) . " = " . conditions,

--- a/tests/_data/assets/schemas/pgsql.sql
+++ b/tests/_data/assets/schemas/pgsql.sql
@@ -1,5 +1,28 @@
 
 
+drop table if exists complex_default;
+            
+create table complex_default
+(
+    id           SERIAL PRIMARY KEY,
+    created      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_null TIMESTAMP NULL DEFAULT NULL
+);
+            
+CREATE OR REPLACE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+   NEW.updated = NOW(); 
+   NEW.updated_null = NOW();
+   RETURN NEW;
+END;
+$$ language 'plpgsql';
+            
+CREATE TRIGGER update_timestamp BEFORE UPDATE
+ON complex_default FOR EACH ROW EXECUTE PROCEDURE 
+update_timestamp();
+            
 
 
 drop table if exists co_customers;
@@ -27,7 +50,7 @@ drop table if exists co_invoices;
             
 create table co_invoices
 (
-    inv_id          serial not null constraint co_invoices_pk primary key,
+    inv_id          serial constraint co_invoices_pk primary key,
     inv_cst_id      integer,
     inv_status_flag smallint,
     inv_title       varchar(100),
@@ -46,9 +69,18 @@ create index co_invoices_inv_status_flag_index
             
 
 
+drop table if exists objects;
+            
+create table objects
+(
+    obj_id serial not null constraint objects_pk primary key,
+    obj_name varchar(100) not null,
+    obj_type smallint not null
+);
+            
 
 
-drop table if exists co_orders;            
+drop table if exists co_orders;
             
 create table co_orders
 (
@@ -71,7 +103,7 @@ create table private.co_orders_x_products
             
 
 
-drop table if exists co_products;            
+drop table if exists co_products;
             
 create table co_products
 (
@@ -85,5 +117,13 @@ create table co_products
 
 
 
+drop table if exists table_with_uuid_primary;
+            
+create table table_with_uuid_primary
+(
+    uuid char(36) not null primary key,
+    int_field int null
+);
+            
 
 

--- a/tests/_data/fixtures/Migrations/ComplexDefaultMigration.php
+++ b/tests/_data/fixtures/Migrations/ComplexDefaultMigration.php
@@ -33,7 +33,7 @@ class ComplexDefaultMigration extends AbstractMigration
 insert into complex_default (
     id, created, updated
 ) values (
-    {$id}, "{$created}", "{$updated}"
+    {$id}, '{$created}', '{$updated}'
 )
 SQL;
 
@@ -65,7 +65,35 @@ create table complex_default
 
     protected function getSqlPgsql(): array
     {
-        return [];
+        return [
+            "
+drop table if exists complex_default;
+            ",
+            "
+create table complex_default
+(
+    id           SERIAL PRIMARY KEY,
+    created      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_null TIMESTAMP NULL DEFAULT NULL
+);
+            ",
+            "
+CREATE OR REPLACE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+   NEW.updated = NOW(); 
+   NEW.updated_null = NOW();
+   RETURN NEW;
+END;
+$$ language 'plpgsql';
+            ",
+            "
+CREATE TRIGGER update_timestamp BEFORE UPDATE
+ON complex_default FOR EACH ROW EXECUTE PROCEDURE 
+update_timestamp();
+            "
+        ];
     }
 
     protected function getSqlSqlsrv(): array

--- a/tests/_data/fixtures/Migrations/InvoicesMigration.php
+++ b/tests/_data/fixtures/Migrations/InvoicesMigration.php
@@ -125,7 +125,7 @@ drop table if exists co_invoices;
             "
 create table co_invoices
 (
-    inv_id          serial not null constraint co_invoices_pk primary key,
+    inv_id          serial constraint co_invoices_pk primary key,
     inv_cst_id      integer,
     inv_status_flag smallint,
     inv_title       varchar(100),

--- a/tests/_data/fixtures/Migrations/ObjectsMigration.php
+++ b/tests/_data/fixtures/Migrations/ObjectsMigration.php
@@ -36,7 +36,7 @@ class ObjectsMigration extends AbstractMigration
 
         $sql = <<<SQL
 insert into objects (obj_id, obj_name, obj_type)
-values ({$id}, "{$name}", "{$type}");
+values ({$id}, '{$name}', '{$type}');
 SQL;
 
         $this->connection->exec($sql);
@@ -79,7 +79,19 @@ create table objects
 
     protected function getSqlPgsql(): array
     {
-        return [];
+        return [
+            "
+drop table if exists objects;
+            ",
+            "
+create table objects
+(
+    obj_id serial not null constraint objects_pk primary key,
+    obj_name varchar(100) not null,
+    obj_type smallint not null
+);
+            "
+        ];
     }
 
     protected function getSqlSqlsrv(): array

--- a/tests/_data/fixtures/Migrations/StringPrimaryMigration.php
+++ b/tests/_data/fixtures/Migrations/StringPrimaryMigration.php
@@ -72,7 +72,18 @@ create table table_with_uuid_primary
 
     protected function getSqlPgsql(): array
     {
-        return [];
+        return [
+            "
+drop table if exists table_with_uuid_primary;
+            ",
+            "
+create table table_with_uuid_primary
+(
+    uuid char(36) not null primary key,
+    int_field int null
+);
+            "
+        ];
     }
 
     protected function getSqlSqlsrv(): array

--- a/tests/_data/fixtures/Traits/RecordsTrait.php
+++ b/tests/_data/fixtures/Traits/RecordsTrait.php
@@ -79,7 +79,7 @@ trait RecordsTrait
         $title = uniqid($prefix . '-');
         for ($counter = 1; $counter <= $count; $counter++) {
             $migration->insert(
-                'default',
+                null,
                 $custId,
                 1,
                 $title,

--- a/tests/_data/fixtures/Traits/RecordsTrait.php
+++ b/tests/_data/fixtures/Traits/RecordsTrait.php
@@ -65,6 +65,7 @@ trait RecordsTrait
     /**
      * @param InvoicesMigration $migration
      * @param int               $count
+     * @param string            $invId
      * @param int               $custId
      * @param string            $prefix
      * @param int               $pad
@@ -72,6 +73,7 @@ trait RecordsTrait
     private function insertDataInvoices(
         InvoicesMigration $migration,
         int $count,
+        string $invId = null,
         int $custId,
         string $prefix,
         int $pad = 0
@@ -79,7 +81,7 @@ trait RecordsTrait
         $title = uniqid($prefix . '-');
         for ($counter = 1; $counter <= $count; $counter++) {
             $migration->insert(
-                null,
+                $invId,
                 $custId,
                 1,
                 $title,

--- a/tests/_data/fixtures/Traits/RecordsTrait.php
+++ b/tests/_data/fixtures/Traits/RecordsTrait.php
@@ -79,7 +79,7 @@ trait RecordsTrait
         $title = uniqid($prefix . '-');
         for ($counter = 1; $counter <= $count; $counter++) {
             $migration->insert(
-                null,
+                'default',
                 $custId,
                 1,
                 $title,

--- a/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
+++ b/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
@@ -56,4 +56,29 @@ final class DescribeColumnsCest
         $I->assertSame('CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP', $columns[2]->getDefault());
         $I->assertSame('NULL on update CURRENT_TIMESTAMP', $columns[3]->getDefault());
     }
+
+    /**
+     * Tests Phalcon\Db\Adapter\Pdo :: describeColumns()
+     *
+     * @author Jeremy PASTOURET <https://github.com/jenovateurs>
+     * @since  2019-12-07
+     *
+     * @group pgsql
+     */
+    public function dbAdapterPdoDescribeColumnsDefaultPostgres(DatabaseTester $I)
+    {
+        $I->wantToTest('Db\Adapter\Pdo - describeColumns() - CheckPostgres Default value');
+
+        $connection = $I->getConnection();
+        $db = $this->container->get('db');
+
+        $now = date('Y-m-d H:i:s');
+        $migration = new ComplexDefaultMigration($connection);
+        $migration->insert(1, $now, $now);
+
+        $columns = $db->describeColumns($migration->getTable());
+
+        $I->assertSame('now()', $columns[1]->getDefault());
+        $I->assertSame('now()', $columns[2]->getDefault());
+    }
 }

--- a/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
+++ b/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
@@ -61,7 +61,7 @@ final class DescribeColumnsCest
      * Tests Phalcon\Db\Adapter\Pdo :: describeColumns()
      *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
-     * @since  2019-12-07
+     * @since  2020-03-09
      *
      * @group pgsql
      */

--- a/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
+++ b/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
@@ -78,7 +78,7 @@ final class DescribeColumnsCest
 
         $columns = $db->describeColumns($migration->getTable());
 
-        $I->assertSame('now()', $columns[1]->getDefault());
+        $I->assertSame('CURRENT_TIMESTAMP', $columns[1]->getDefault());
         $I->assertSame('now()', $columns[2]->getDefault());
     }
 }

--- a/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
+++ b/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
@@ -79,6 +79,6 @@ final class DescribeColumnsCest
         $columns = $db->describeColumns($migration->getTable());
 
         $I->assertSame('CURRENT_TIMESTAMP', $columns[1]->getDefault());
-        $I->assertSame('now()', $columns[2]->getDefault());
+        $I->assertSame('CURRENT_TIMESTAMP', $columns[2]->getDefault());
     }
 }

--- a/tests/database/Mvc/Model/AssignCest.php
+++ b/tests/database/Mvc/Model/AssignCest.php
@@ -41,8 +41,7 @@ class AssignCest
      * @author Sid Roberts <https://github.com/SidRoberts>
      * @since  2019-04-18
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelAssign(DatabaseTester $I)
     {
@@ -99,8 +98,7 @@ class AssignCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-29
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelAssignIncomplete(DatabaseTester $I)
     {
@@ -141,8 +139,7 @@ class AssignCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-13
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelAssignAutoPrimary(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/AssignCest.php
+++ b/tests/database/Mvc/Model/AssignCest.php
@@ -43,7 +43,7 @@ class AssignCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelAssign(DatabaseTester $I)
     {
@@ -102,7 +102,7 @@ class AssignCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelAssignIncomplete(DatabaseTester $I)
     {
@@ -145,7 +145,7 @@ class AssignCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelAssignAutoPrimary(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/AssignCest.php
+++ b/tests/database/Mvc/Model/AssignCest.php
@@ -41,7 +41,9 @@ class AssignCest
      * @author Sid Roberts <https://github.com/SidRoberts>
      * @since  2019-04-18
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelAssign(DatabaseTester $I)
     {
@@ -98,7 +100,9 @@ class AssignCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-29
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelAssignIncomplete(DatabaseTester $I)
     {
@@ -139,7 +143,9 @@ class AssignCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-13
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelAssignAutoPrimary(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/AssignCest.php
+++ b/tests/database/Mvc/Model/AssignCest.php
@@ -43,7 +43,7 @@ class AssignCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelAssign(DatabaseTester $I)
     {
@@ -102,7 +102,7 @@ class AssignCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelAssignIncomplete(DatabaseTester $I)
     {
@@ -145,7 +145,7 @@ class AssignCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelAssignAutoPrimary(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/AverageCest.php
+++ b/tests/database/Mvc/Model/AverageCest.php
@@ -34,11 +34,10 @@ class AverageCest
      * @since  2020-01-30
      *
      * @group mysql
+     * @group pgsql
      */
     public function mvcModelAverage(DatabaseTester $I)
     {
-        $driver = $I->getDriver();
-
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
@@ -67,7 +66,8 @@ class AverageCest
                 'inv_cst_id = 2',
             ]
         );
-        $I->assertEquals('4.714286', $total);
+        //Handle Postgres need round because Postgres send (4.7142857142857143) and mysql (4.714286)
+        $I->assertEquals('4.714286', round($total, 6));
 
         $total = Invoices::average(
             [
@@ -86,12 +86,14 @@ class AverageCest
                 ],
             ]
         );
-        $I->assertEquals('4.714286', $total);
+        //Handle Postgres need round because Postgres send (4.7142857142857143) and mysql (4.714286)
+        $I->assertEquals('4.714286', round($total, 6));
 
         $results = Invoices::average(
             [
                 'column' => 'inv_total',
                 'group'  => 'inv_cst_id',
+                'order'  => 'inv_cst_id'
             ]
         );
         $I->assertInstanceOf(Simple::class, $results);

--- a/tests/database/Mvc/Model/AverageCest.php
+++ b/tests/database/Mvc/Model/AverageCest.php
@@ -35,15 +35,19 @@ class AverageCest
      *
      * @group mysql
      * @group pgsql
+     * @group sqlite
      */
     public function mvcModelAverage(DatabaseTester $I)
     {
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 7, 2, 'ccc');
-        $this->insertDataInvoices($migration, 1, 3, 'aaa');
-        $this->insertDataInvoices($migration, 11, 1, 'aaa');
+
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa');
 
         $total = Invoices::average(
             [

--- a/tests/database/Mvc/Model/AverageCest.php
+++ b/tests/database/Mvc/Model/AverageCest.php
@@ -35,7 +35,7 @@ class AverageCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelAverage(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/AverageCest.php
+++ b/tests/database/Mvc/Model/AverageCest.php
@@ -35,7 +35,7 @@ class AverageCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelAverage(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ConstructCest.php
+++ b/tests/database/Mvc/Model/ConstructCest.php
@@ -38,7 +38,9 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ConstructCest.php
+++ b/tests/database/Mvc/Model/ConstructCest.php
@@ -40,7 +40,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ConstructCest.php
+++ b/tests/database/Mvc/Model/ConstructCest.php
@@ -38,8 +38,7 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ConstructCest.php
+++ b/tests/database/Mvc/Model/ConstructCest.php
@@ -40,7 +40,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/CountCest.php
+++ b/tests/database/Mvc/Model/CountCest.php
@@ -135,8 +135,8 @@ class CountCest
         $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc');
         $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa');
         $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa');
-        $this->insertDataInvoices($migration, 9, $invId,1, 'bbb');
-        $this->insertDataInvoices($migration, 5, $invId,2, 'aaa');
+        $this->insertDataInvoices($migration, 9, $invId, 1, 'bbb');
+        $this->insertDataInvoices($migration, 5, $invId, 2, 'aaa');
 
         $total = InvoicesMap::count();
         $I->assertEquals(33, $total);

--- a/tests/database/Mvc/Model/CountCest.php
+++ b/tests/database/Mvc/Model/CountCest.php
@@ -57,11 +57,13 @@ class CountCest
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
 
-        $this->insertDataInvoices($migration, 7, 2, 'ccc');
-        $this->insertDataInvoices($migration, 1, 3, 'aaa');
-        $this->insertDataInvoices($migration, 11, 1, 'aaa');
-        $this->insertDataInvoices($migration, 9, 1, 'bbb');
-        $this->insertDataInvoices($migration, 5, 2, 'aaa');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 9, $invId, 1, 'bbb');
+        $this->insertDataInvoices($migration, 5, $invId, 2, 'aaa');
 
         $total = Invoices::count();
         $I->assertEquals(33, $total);
@@ -128,11 +130,13 @@ class CountCest
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
 
-        $this->insertDataInvoices($migration, 7, 2, 'ccc');
-        $this->insertDataInvoices($migration, 1, 3, 'aaa');
-        $this->insertDataInvoices($migration, 11, 1, 'aaa');
-        $this->insertDataInvoices($migration, 9, 1, 'bbb');
-        $this->insertDataInvoices($migration, 5, 2, 'aaa');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 9, $invId,1, 'bbb');
+        $this->insertDataInvoices($migration, 5, $invId,2, 'aaa');
 
         $total = InvoicesMap::count();
         $I->assertEquals(33, $total);

--- a/tests/database/Mvc/Model/CountCest.php
+++ b/tests/database/Mvc/Model/CountCest.php
@@ -44,69 +44,67 @@ class CountCest
      * @since  2020-01-29
      *
      * @group mysql
-     * @group sqlite
+     * @group pgsql
      */
     public function mvcModelCount(DatabaseTester $I)
     {
-        $driver = $I->getDriver();
-
         /**
          * The following tests need to skip sqlite because we will get
          * a General Error 5 database is locked error
          */
-        if ('sqlite' !== $driver) {
-            /** @var PDO $connection */
-            $connection = $I->getConnection();
-            $migration  = new InvoicesMigration($connection);
 
-            $this->insertDataInvoices($migration, 7, 2, 'ccc');
-            $this->insertDataInvoices($migration, 1, 3, 'aaa');
-            $this->insertDataInvoices($migration, 11, 1, 'aaa');
-            $this->insertDataInvoices($migration, 9, 1, 'bbb');
-            $this->insertDataInvoices($migration, 5, 2, 'aaa');
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $migration  = new InvoicesMigration($connection);
 
-            $total = Invoices::count();
-            $I->assertEquals(33, $total);
+        $this->insertDataInvoices($migration, 7, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, 1, 'aaa');
+        $this->insertDataInvoices($migration, 9, 1, 'bbb');
+        $this->insertDataInvoices($migration, 5, 2, 'aaa');
 
-            $total = Invoices::count(
-                [
-                    'distinct' => 'inv_cst_id',
-                ]
-            );
-            $I->assertEquals(3, $total);
+        $total = Invoices::count();
+        $I->assertEquals(33, $total);
 
-            $total = Invoices::count(
-                'inv_cst_id = 2'
-            );
-            $I->assertEquals(12, $total);
+        $total = Invoices::count(
+            [
+                'distinct' => 'inv_cst_id',
+            ]
+        );
+        $I->assertEquals(3, $total);
 
-            $results = Invoices::count(
-                [
-                    'group' => 'inv_cst_id',
-                ]
-            );
-            $I->assertInstanceOf(Simple::class, $results);
-            $I->assertEquals(1, (int) $results[0]->inv_cst_id);
-            $I->assertEquals(20, (int) $results[0]->rowcount);
-            $I->assertEquals(2, (int) $results[1]->inv_cst_id);
-            $I->assertEquals(12, (int) $results[1]->rowcount);
-            $I->assertEquals(3, (int) $results[2]->inv_cst_id);
-            $I->assertEquals(1, (int) $results[2]->rowcount);
+        $total = Invoices::count(
+            'inv_cst_id = 2'
+        );
+        $I->assertEquals(12, $total);
 
-            $results = Invoices::count(
-                [
-                    'group' => 'inv_cst_id',
-                    'order' => 'inv_cst_id DESC',
-                ]
-            );
-            $I->assertInstanceOf(Simple::class, $results);
-            $I->assertEquals(3, (int) $results[0]->inv_cst_id);
-            $I->assertEquals(1, (int) $results[0]->rowcount);
-            $I->assertEquals(2, (int) $results[1]->inv_cst_id);
-            $I->assertEquals(12, (int) $results[1]->rowcount);
-            $I->assertEquals(1, (int) $results[2]->inv_cst_id);
-            $I->assertEquals(20, (int) $results[2]->rowcount);
-        }
+        $results = Invoices::count(
+            [
+                'group' => 'inv_cst_id',
+                'order' => 'inv_cst_id',
+            ]
+        );
+        $I->assertInstanceOf(Simple::class, $results);
+        $I->assertEquals(1, (int) $results[0]->inv_cst_id);
+        $I->assertEquals(20, (int) $results[0]->rowcount);
+        $I->assertEquals(2, (int) $results[1]->inv_cst_id);
+        $I->assertEquals(12, (int) $results[1]->rowcount);
+        $I->assertEquals(3, (int) $results[2]->inv_cst_id);
+        $I->assertEquals(1, (int) $results[2]->rowcount);
+
+        $results = Invoices::count(
+            [
+                'group' => 'inv_cst_id',
+                'order' => 'inv_cst_id DESC',
+            ]
+        );
+        $I->assertInstanceOf(Simple::class, $results);
+        $I->assertEquals(3, (int) $results[0]->inv_cst_id);
+        $I->assertEquals(1, (int) $results[0]->rowcount);
+        $I->assertEquals(2, (int) $results[1]->inv_cst_id);
+        $I->assertEquals(12, (int) $results[1]->rowcount);
+        $I->assertEquals(1, (int) $results[2]->inv_cst_id);
+        $I->assertEquals(20, (int) $results[2]->rowcount);
     }
 
     /**
@@ -116,10 +114,10 @@ class CountCest
      * @since  2020-01-29
      *
      * @group mysql
+     * @group pgsql
      */
     public function mvcModelCountColumnMap(DatabaseTester $I)
     {
-        $driver = $I->getDriver();
 
         /**
          * The following tests need to skip sqlite because we will get
@@ -154,6 +152,7 @@ class CountCest
         $results = InvoicesMap::count(
             [
                 'group' => 'cst_id',
+                'order' => 'cst_id',
             ]
         );
         $I->assertInstanceOf(Simple::class, $results);

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -39,8 +39,7 @@ class DeleteCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelDelete(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -47,27 +47,23 @@ class DeleteCest
     {
         $I->wantToTest('Mvc\Model - delete()');
 
-        $driver = $I->getDriver();
-
         /**
          * The following tests need to skip sqlite because we will get
          * a General Error 5 database is locked error
          */
-        if ('sqlite' !== $driver) {
-            $title                    = uniqid('inv-');
-            $date                     = date('Y-m-d H:i:s');
-            $invoice                  = new Invoices();
-            $invoice->inv_cst_id      = 2;
-            $invoice->inv_status_flag = 3;
-            $invoice->inv_title       = $title;
-            $invoice->inv_total       = 100.12;
-            $invoice->inv_created_at  = $date;
+        $title                    = uniqid('inv-');
+        $date                     = date('Y-m-d H:i:s');
+        $invoice                  = new Invoices();
+        $invoice->inv_cst_id      = 2;
+        $invoice->inv_status_flag = 3;
+        $invoice->inv_title       = $title;
+        $invoice->inv_total       = 100.12;
+        $invoice->inv_created_at  = $date;
 
-            $result = $invoice->create();
-            $I->assertNotFalse($result);
+        $result = $invoice->create();
+        $I->assertNotFalse($result);
 
-            $result = $invoice->delete();
-            $I->assertTrue($result);
-        }
+        $result = $invoice->delete();
+        $I->assertTrue($result);
     }
 }

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -41,7 +41,7 @@ class DeleteCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelDelete(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -41,7 +41,7 @@ class DeleteCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelDelete(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -39,7 +39,9 @@ class DeleteCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelDelete(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/FindCest.php
+++ b/tests/database/Mvc/Model/FindCest.php
@@ -48,8 +48,7 @@ class FindCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFind(DatabaseTester $I)
     {
@@ -75,8 +74,7 @@ class FindCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindWithCache(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/FindCest.php
+++ b/tests/database/Mvc/Model/FindCest.php
@@ -50,7 +50,7 @@ class FindCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelFind(DatabaseTester $I)
     {
@@ -78,7 +78,7 @@ class FindCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelFindWithCache(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/FindCest.php
+++ b/tests/database/Mvc/Model/FindCest.php
@@ -50,7 +50,7 @@ class FindCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelFind(DatabaseTester $I)
     {
@@ -78,7 +78,7 @@ class FindCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelFindWithCache(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/FindCest.php
+++ b/tests/database/Mvc/Model/FindCest.php
@@ -48,7 +48,9 @@ class FindCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFind(DatabaseTester $I)
     {
@@ -74,7 +76,9 @@ class FindCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindWithCache(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -200,7 +200,6 @@ class FindFirstCest
      * @since        2020-01-27
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function mvcModelFindFirstStringPrimaryKey(DatabaseTester $I, Example $example)

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -50,7 +50,9 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindFirst(DatabaseTester $I)
     {
@@ -93,7 +95,9 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindFirstNotFound(DatabaseTester $I)
     {
@@ -114,7 +118,9 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindFirstByNotFound(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -251,7 +251,7 @@ class FindFirstCest
                 'found'  => false,
             ],
             [
-                'params' => 134,
+                'params' => '134',
                 'found'  => false,
             ],
             [

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -50,8 +50,7 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindFirst(DatabaseTester $I)
     {
@@ -94,8 +93,7 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindFirstNotFound(DatabaseTester $I)
     {
@@ -116,8 +114,7 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindFirstByNotFound(DatabaseTester $I)
     {
@@ -134,8 +131,7 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindFirstExtended(DatabaseTester $I)
     {
@@ -166,8 +162,7 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindFirstException(DatabaseTester $I)
     {
@@ -194,8 +189,7 @@ class FindFirstCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-01-27
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelFindFirstStringPrimaryKey(DatabaseTester $I, Example $example)
     {
@@ -245,11 +239,11 @@ class FindFirstCest
                 'found'  => false,
             ],
             [
-                'params' => 134,
+                'params' => '134',
                 'found'  => false,
             ],
             [
-                'params' => 'uuid = 134',
+                'params' => 'uuid = \'134\'',
                 'found'  => false,
             ],
         ];

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -200,6 +200,7 @@ class FindFirstCest
      * @since        2020-01-27
      *
      * @group mysql
+     * @group pgsql
      * @group sqlite
      */
     public function mvcModelFindFirstStringPrimaryKey(DatabaseTester $I, Example $example)
@@ -250,11 +251,11 @@ class FindFirstCest
                 'found'  => false,
             ],
             [
-                'params' => '134',
+                'params' => 134,
                 'found'  => false,
             ],
             [
-                'params' => 'uuid = \'134\'',
+                'params' => "uuid = '134'",
                 'found'  => false,
             ],
         ];

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -131,7 +131,9 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindFirstExtended(DatabaseTester $I)
     {
@@ -162,7 +164,9 @@ class FindFirstCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindFirstException(DatabaseTester $I)
     {
@@ -189,7 +193,9 @@ class FindFirstCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-01-27
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelFindFirstStringPrimaryKey(DatabaseTester $I, Example $example)
     {

--- a/tests/database/Mvc/Model/GetMessagesCest.php
+++ b/tests/database/Mvc/Model/GetMessagesCest.php
@@ -42,7 +42,9 @@ class GetMessagesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelGetMessages(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetMessagesCest.php
+++ b/tests/database/Mvc/Model/GetMessagesCest.php
@@ -44,7 +44,7 @@ class GetMessagesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelGetMessages(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetMessagesCest.php
+++ b/tests/database/Mvc/Model/GetMessagesCest.php
@@ -44,7 +44,7 @@ class GetMessagesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelGetMessages(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetMessagesCest.php
+++ b/tests/database/Mvc/Model/GetMessagesCest.php
@@ -42,8 +42,7 @@ class GetMessagesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelGetMessages(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetReadConnectionCest.php
+++ b/tests/database/Mvc/Model/GetReadConnectionCest.php
@@ -38,7 +38,7 @@ class GetReadConnectionCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelGetReadConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetReadConnectionCest.php
+++ b/tests/database/Mvc/Model/GetReadConnectionCest.php
@@ -36,8 +36,7 @@ class GetReadConnectionCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelGetReadConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetReadConnectionCest.php
+++ b/tests/database/Mvc/Model/GetReadConnectionCest.php
@@ -38,7 +38,7 @@ class GetReadConnectionCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelGetReadConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetReadConnectionCest.php
+++ b/tests/database/Mvc/Model/GetReadConnectionCest.php
@@ -36,7 +36,9 @@ class GetReadConnectionCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelGetReadConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetEventsManagerCest.php
+++ b/tests/database/Mvc/Model/GetSetEventsManagerCest.php
@@ -47,7 +47,7 @@ class GetSetEventsManagerCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelGetEventsManager(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetEventsManagerCest.php
+++ b/tests/database/Mvc/Model/GetSetEventsManagerCest.php
@@ -45,7 +45,9 @@ class GetSetEventsManagerCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelGetEventsManager(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetEventsManagerCest.php
+++ b/tests/database/Mvc/Model/GetSetEventsManagerCest.php
@@ -45,8 +45,7 @@ class GetSetEventsManagerCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelGetEventsManager(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetEventsManagerCest.php
+++ b/tests/database/Mvc/Model/GetSetEventsManagerCest.php
@@ -47,7 +47,7 @@ class GetSetEventsManagerCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelGetEventsManager(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
@@ -39,7 +39,7 @@ class GetSetReadConnectionServiceCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelGetSetReadConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
@@ -37,7 +37,9 @@ class GetSetReadConnectionServiceCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelGetSetReadConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
@@ -37,8 +37,7 @@ class GetSetReadConnectionServiceCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelGetSetReadConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetReadConnectionServiceCest.php
@@ -39,7 +39,7 @@ class GetSetReadConnectionServiceCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelGetSetReadConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
@@ -37,8 +37,7 @@ class GetSetWriteConnectionServiceCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelGetSetWriteConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
@@ -37,7 +37,9 @@ class GetSetWriteConnectionServiceCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelGetSetWriteConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
@@ -39,7 +39,7 @@ class GetSetWriteConnectionServiceCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelGetSetWriteConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
+++ b/tests/database/Mvc/Model/GetSetWriteConnectionServiceCest.php
@@ -39,7 +39,7 @@ class GetSetWriteConnectionServiceCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelGetSetWriteConnectionService(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetWriteConnectionCest.php
+++ b/tests/database/Mvc/Model/GetWriteConnectionCest.php
@@ -36,8 +36,7 @@ class GetWriteConnectionCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelGetWriteConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetWriteConnectionCest.php
+++ b/tests/database/Mvc/Model/GetWriteConnectionCest.php
@@ -36,7 +36,9 @@ class GetWriteConnectionCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelGetWriteConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetWriteConnectionCest.php
+++ b/tests/database/Mvc/Model/GetWriteConnectionCest.php
@@ -38,7 +38,7 @@ class GetWriteConnectionCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelGetWriteConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/GetWriteConnectionCest.php
+++ b/tests/database/Mvc/Model/GetWriteConnectionCest.php
@@ -38,7 +38,7 @@ class GetWriteConnectionCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelGetWriteConnection(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MaximumCest.php
+++ b/tests/database/Mvc/Model/MaximumCest.php
@@ -34,6 +34,7 @@ class MaximumCest
      * @since  2020-01-30
      *
      * @group mysql
+     * @group pgsql
      */
     public function mvcModelMaximum(DatabaseTester $I)
     {
@@ -92,6 +93,7 @@ class MaximumCest
             [
                 'column' => 'inv_total',
                 'group'  => 'inv_cst_id',
+                'order'  => 'inv_cst_id'
             ]
         );
         $I->assertInstanceOf(Simple::class, $results);

--- a/tests/database/Mvc/Model/MaximumCest.php
+++ b/tests/database/Mvc/Model/MaximumCest.php
@@ -38,14 +38,15 @@ class MaximumCest
      */
     public function mvcModelMaximum(DatabaseTester $I)
     {
-        $driver = $I->getDriver();
-
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 7, 2, 'ccc');
-        $this->insertDataInvoices($migration, 1, 3, 'aaa');
-        $this->insertDataInvoices($migration, 11, 1, 'aaa');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa');
+
 
         $total = Invoices::maximum(
             [

--- a/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
@@ -37,7 +37,9 @@ class GetAttributesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataGetAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
@@ -40,7 +40,7 @@ class GetAttributesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataGetAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
@@ -17,6 +17,7 @@ use DatabaseTester;
 use Phalcon\Mvc\Model\MetaData;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use Phalcon\Test\Models\Invoices;
+use Phalcon\Test\Models\Customers;
 
 /**
  * Class GetAttributesCest

--- a/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
@@ -40,7 +40,7 @@ class GetAttributesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataGetAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetAttributesCest.php
@@ -37,8 +37,7 @@ class GetAttributesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataGetAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
@@ -38,8 +38,7 @@ class GetColumnMapCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataGetColumnMap(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
@@ -40,7 +40,7 @@ class GetColumnMapCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataGetColumnMap(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
@@ -40,7 +40,7 @@ class GetColumnMapCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataGetColumnMap(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
@@ -38,7 +38,9 @@ class GetColumnMapCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataGetColumnMap(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
@@ -39,7 +39,7 @@ class GetDataTypesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataGetDataTypes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
@@ -39,7 +39,7 @@ class GetDataTypesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataGetDataTypes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
@@ -37,7 +37,9 @@ class GetDataTypesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataGetDataTypes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetDataTypesCest.php
@@ -37,8 +37,7 @@ class GetDataTypesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataGetDataTypes(DatabaseTester $I)
     {
@@ -76,7 +75,14 @@ class GetDataTypesCest
                     'inv_created_at'  => 6,
                 ];
             default:
-                return [];
+                return [
+                    'inv_id'          => 0,
+                    'inv_cst_id'      => 0,
+                    'inv_status_flag' => 22,
+                    'inv_title'       => 2,
+                    'inv_total'       => 3,
+                    'inv_created_at'  => 17,
+                ];
         }
     }
 }

--- a/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
@@ -39,7 +39,7 @@ class GetIdentityFieldCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataGetIdentityField(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
@@ -37,7 +37,9 @@ class GetIdentityFieldCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataGetIdentityField(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
@@ -37,8 +37,7 @@ class GetIdentityFieldCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataGetIdentityField(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetIdentityFieldCest.php
@@ -39,7 +39,7 @@ class GetIdentityFieldCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataGetIdentityField(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
@@ -39,7 +39,7 @@ class GetNonPrimaryKeyAttributesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataGetNonPrimaryKeyAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
@@ -37,7 +37,9 @@ class GetNonPrimaryKeyAttributesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataGetNonPrimaryKeyAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
@@ -39,7 +39,7 @@ class GetNonPrimaryKeyAttributesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataGetNonPrimaryKeyAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
@@ -57,7 +57,7 @@ class GetNonPrimaryKeyAttributesCest
             'inv_created_at',
         ];
         $actual   = $metadata->getNonPrimaryKeyAttributes($model);
-        var_dump($actual);
+
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
@@ -57,6 +57,7 @@ class GetNonPrimaryKeyAttributesCest
             'inv_created_at',
         ];
         $actual   = $metadata->getNonPrimaryKeyAttributes($model);
+        var_dump($actual);
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNonPrimaryKeyAttributesCest.php
@@ -37,8 +37,7 @@ class GetNonPrimaryKeyAttributesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataGetNonPrimaryKeyAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
@@ -37,7 +37,9 @@ class GetNotNullAttributesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataGetNotNullAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
@@ -39,7 +39,7 @@ class GetNotNullAttributesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataGetNotNullAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
@@ -37,8 +37,7 @@ class GetNotNullAttributesCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataGetNotNullAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
@@ -38,6 +38,7 @@ class GetNotNullAttributesCest
      * @since  2020-02-01
      *
      * @group mysql
+     * @group pgsql
      * @group sqlite
      */
     public function mvcModelMetadataGetNotNullAttributes(DatabaseTester $I)

--- a/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
@@ -38,7 +38,6 @@ class GetNotNullAttributesCest
      * @since  2020-02-01
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function mvcModelMetadataGetNotNullAttributes(DatabaseTester $I)

--- a/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetNotNullAttributesCest.php
@@ -39,7 +39,7 @@ class GetNotNullAttributesCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataGetNotNullAttributes(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
+++ b/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
@@ -37,8 +37,7 @@ class HasAttributeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelMetadataHasAttribute(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
+++ b/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
@@ -39,7 +39,7 @@ class HasAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelMetadataHasAttribute(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
+++ b/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
@@ -37,7 +37,9 @@ class HasAttributeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelMetadataHasAttribute(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
+++ b/tests/database/Mvc/Model/MetaData/HasAttributeCest.php
@@ -39,7 +39,7 @@ class HasAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelMetadataHasAttribute(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/MinimumCest.php
+++ b/tests/database/Mvc/Model/MinimumCest.php
@@ -38,14 +38,14 @@ class MinimumCest
      */
     public function mvcModelMinimum(DatabaseTester $I)
     {
-        $driver = $I->getDriver();
-
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 7, 2, 'ccc', 11);
-        $this->insertDataInvoices($migration, 1, 3, 'aaa', 13);
-        $this->insertDataInvoices($migration, 11, 1, 'aaa', 7);
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc', 11);
+        $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa', 13);
+        $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa', 7);
 
         $total = Invoices::minimum(
             [

--- a/tests/database/Mvc/Model/MinimumCest.php
+++ b/tests/database/Mvc/Model/MinimumCest.php
@@ -34,6 +34,7 @@ class MinimumCest
      * @since  2020-01-30
      *
      * @group mysql
+     * @group pgsql
      */
     public function mvcModelMinimum(DatabaseTester $I)
     {
@@ -92,6 +93,7 @@ class MinimumCest
             [
                 'column' => 'inv_total',
                 'group'  => 'inv_cst_id',
+                'order'  => 'inv_cst_id'
             ]
         );
         $I->assertInstanceOf(Simple::class, $results);

--- a/tests/database/Mvc/Model/QueryCest.php
+++ b/tests/database/Mvc/Model/QueryCest.php
@@ -47,8 +47,7 @@ class QueryCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelQuery(DatabaseTester $I)
     {
@@ -71,8 +70,7 @@ class QueryCest
      * @since  2018-11-13
      * @issue  14783
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelQueryIssue14783(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/QueryCest.php
+++ b/tests/database/Mvc/Model/QueryCest.php
@@ -47,7 +47,9 @@ class QueryCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelQuery(DatabaseTester $I)
     {
@@ -70,7 +72,9 @@ class QueryCest
      * @since  2018-11-13
      * @issue  14783
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelQueryIssue14783(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/QueryCest.php
+++ b/tests/database/Mvc/Model/QueryCest.php
@@ -49,7 +49,7 @@ class QueryCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelQuery(DatabaseTester $I)
     {
@@ -74,7 +74,7 @@ class QueryCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelQueryIssue14783(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/QueryCest.php
+++ b/tests/database/Mvc/Model/QueryCest.php
@@ -49,7 +49,7 @@ class QueryCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelQuery(DatabaseTester $I)
     {
@@ -74,7 +74,7 @@ class QueryCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelQueryIssue14783(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ReadWriteAttributeCest.php
+++ b/tests/database/Mvc/Model/ReadWriteAttributeCest.php
@@ -43,7 +43,7 @@ class ReadWriteAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelWriteAttribute(DatabaseTester $I)
     {
@@ -78,7 +78,7 @@ class ReadWriteAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelWriteAttributeWithAssociativeArray(DatabaseTester $I)
     {
@@ -121,7 +121,7 @@ class ReadWriteAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelWriteAttributeUndefinedPropertyWithAssociativeArray(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ReadWriteAttributeCest.php
+++ b/tests/database/Mvc/Model/ReadWriteAttributeCest.php
@@ -41,7 +41,9 @@ class ReadWriteAttributeCest
      * @author Sid Roberts <https://github.com/SidRoberts>
      * @since  2019-04-18
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelWriteAttribute(DatabaseTester $I)
     {
@@ -74,7 +76,9 @@ class ReadWriteAttributeCest
      * @author Balázs Németh <https://github.com/zsilbi>
      * @since  2019-04-30
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelWriteAttributeWithAssociativeArray(DatabaseTester $I)
     {
@@ -115,7 +119,9 @@ class ReadWriteAttributeCest
      * @author Balázs Németh <https://github.com/zsilbi>
      * @since  2019-04-30
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelWriteAttributeUndefinedPropertyWithAssociativeArray(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ReadWriteAttributeCest.php
+++ b/tests/database/Mvc/Model/ReadWriteAttributeCest.php
@@ -41,8 +41,7 @@ class ReadWriteAttributeCest
      * @author Sid Roberts <https://github.com/SidRoberts>
      * @since  2019-04-18
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelWriteAttribute(DatabaseTester $I)
     {
@@ -75,8 +74,7 @@ class ReadWriteAttributeCest
      * @author Balázs Németh <https://github.com/zsilbi>
      * @since  2019-04-30
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelWriteAttributeWithAssociativeArray(DatabaseTester $I)
     {
@@ -117,8 +115,7 @@ class ReadWriteAttributeCest
      * @author Balázs Németh <https://github.com/zsilbi>
      * @since  2019-04-30
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelWriteAttributeUndefinedPropertyWithAssociativeArray(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ReadWriteAttributeCest.php
+++ b/tests/database/Mvc/Model/ReadWriteAttributeCest.php
@@ -43,7 +43,7 @@ class ReadWriteAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelWriteAttribute(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ReadWriteAttributeCest.php
+++ b/tests/database/Mvc/Model/ReadWriteAttributeCest.php
@@ -78,7 +78,7 @@ class ReadWriteAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelWriteAttributeWithAssociativeArray(DatabaseTester $I)
     {
@@ -121,7 +121,7 @@ class ReadWriteAttributeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelWriteAttributeUndefinedPropertyWithAssociativeArray(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/RefreshCest.php
+++ b/tests/database/Mvc/Model/RefreshCest.php
@@ -38,7 +38,9 @@ class RefreshCest
     /**
      * Tests Phalcon\Mvc\Model :: refresh()
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelRefresh(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/RefreshCest.php
+++ b/tests/database/Mvc/Model/RefreshCest.php
@@ -38,8 +38,7 @@ class RefreshCest
     /**
      * Tests Phalcon\Mvc\Model :: refresh()
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelRefresh(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/RefreshCest.php
+++ b/tests/database/Mvc/Model/RefreshCest.php
@@ -40,7 +40,7 @@ class RefreshCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelRefresh(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/RefreshCest.php
+++ b/tests/database/Mvc/Model/RefreshCest.php
@@ -40,7 +40,7 @@ class RefreshCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelRefresh(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/SerializeCest.php
+++ b/tests/database/Mvc/Model/SerializeCest.php
@@ -47,8 +47,7 @@ class SerializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelSerialize(DatabaseTester $I)
     {
@@ -57,7 +56,6 @@ class SerializeCest
         $title = uniqid('inv-');
         $date  = date('Y-m-d H:i:s');
         $data  = [
-            'inv_id'          => 1,
             'inv_cst_id'      => 2,
             'inv_status_flag' => 3,
             'inv_title'       => $title,
@@ -75,7 +73,6 @@ class SerializeCest
 
         $newObject = unserialize($serialized);
 
-        $I->assertEquals(1, $newObject->inv_id);
         $I->assertEquals(2, $newObject->inv_cst_id);
         $I->assertEquals(3, $newObject->inv_status_flag);
         $I->assertEquals($title, $newObject->inv_title);

--- a/tests/database/Mvc/Model/SerializeCest.php
+++ b/tests/database/Mvc/Model/SerializeCest.php
@@ -47,7 +47,9 @@ class SerializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelSerialize(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/SerializeCest.php
+++ b/tests/database/Mvc/Model/SerializeCest.php
@@ -49,7 +49,7 @@ class SerializeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelSerialize(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/SerializeCest.php
+++ b/tests/database/Mvc/Model/SerializeCest.php
@@ -49,7 +49,7 @@ class SerializeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelSerialize(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/SumCest.php
+++ b/tests/database/Mvc/Model/SumCest.php
@@ -34,94 +34,92 @@ class SumCest
      * @since  2020-01-30
      *
      * @group mysql
-     * @group sqlite
+     * @group pgsql
      */
     public function mvcModelSum(DatabaseTester $I)
     {
-        $driver = $I->getDriver();
 
         /**
          * The following tests need to skip sqlite because we will get
          * a General Error 5 database is locked error
          */
-        if ('sqlite' !== $driver) {
-            /** @var PDO $connection */
-            $connection = $I->getConnection();
-            $migration  = new InvoicesMigration($connection);
-            $this->insertDataInvoices($migration, 7, 2, 'ccc');
-            $this->insertDataInvoices($migration, 1, 3, 'aaa');
-            $this->insertDataInvoices($migration, 11, 1, 'aaa');
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $this->insertDataInvoices($migration, 7, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, 1, 'aaa');
 
-            $total = Invoices::sum(
-                [
-                    'column' => 'inv_total',
-                ]
-            );
-            $I->assertEquals(266.00, $total);
+        $total = Invoices::sum(
+            [
+                'column' => 'inv_total',
+            ]
+        );
+        $I->assertEquals(266.00, $total);
 
-            $total = Invoices::sum(
-                [
-                    'column'   => 'inv_total',
-                    'distinct' => 'inv_cst_id',
-                ]
-            );
-            $I->assertEquals(6, $total);
+        $total = Invoices::sum(
+            [
+                'column'   => 'inv_total',
+                'distinct' => 'inv_cst_id',
+            ]
+        );
+        $I->assertEquals(6, $total);
 
-            $total = Invoices::sum(
-                [
-                    'column' => 'inv_total',
-                    'inv_cst_id = 2',
-                ]
-            );
-            $I->assertEquals(33.00, $total);
+        $total = Invoices::sum(
+            [
+                'column' => 'inv_total',
+                'inv_cst_id = 2',
+            ]
+        );
+        $I->assertEquals(33.00, $total);
 
-            $total = Invoices::sum(
-                [
-                    'column' => 'inv_total',
-                    'where'  => 'inv_cst_id = 2',
-                ]
-            );
-            $I->assertEquals(266.00, $total);
+        $total = Invoices::sum(
+            [
+                'column' => 'inv_total',
+                'where'  => 'inv_cst_id = 2',
+            ]
+        );
+        $I->assertEquals(266.00, $total);
 
-            $total = Invoices::sum(
-                [
-                    'column'     => 'inv_total',
-                    'conditions' => 'inv_cst_id = :custId:',
-                    'bind'       => [
-                        'custId' => 2,
-                    ],
-                ]
-            );
-            $I->assertEquals(33.00, $total);
+        $total = Invoices::sum(
+            [
+                'column'     => 'inv_total',
+                'conditions' => 'inv_cst_id = :custId:',
+                'bind'       => [
+                    'custId' => 2,
+                ],
+            ]
+        );
+        $I->assertEquals(33.00, $total);
 
-            $results = Invoices::sum(
-                [
-                    'column' => 'inv_total',
-                    'group'  => 'inv_cst_id',
-                ]
-            );
-            $I->assertInstanceOf(Simple::class, $results);
-            $I->assertEquals(1, (int) $results[0]->inv_cst_id);
-            $I->assertEquals(232, (int) $results[0]->sumatory);
-            $I->assertEquals(2, (int) $results[1]->inv_cst_id);
-            $I->assertEquals(33, (int) $results[1]->sumatory);
-            $I->assertEquals(3, (int) $results[2]->inv_cst_id);
-            $I->assertEquals(1, (int) $results[2]->sumatory);
+        $results = Invoices::sum(
+            [
+                'column' => 'inv_total',
+                'group'  => 'inv_cst_id',
+                'order'  => 'inv_cst_id'
+            ]
+        );
+        $I->assertInstanceOf(Simple::class, $results);
+        $I->assertEquals(1, (int) $results[0]->inv_cst_id);
+        $I->assertEquals(232, (int) $results[0]->sumatory);
+        $I->assertEquals(2, (int) $results[1]->inv_cst_id);
+        $I->assertEquals(33, (int) $results[1]->sumatory);
+        $I->assertEquals(3, (int) $results[2]->inv_cst_id);
+        $I->assertEquals(1, (int) $results[2]->sumatory);
 
-            $results = Invoices::sum(
-                [
-                    'column' => 'inv_total',
-                    'group'  => 'inv_cst_id',
-                    'order'  => 'inv_cst_id DESC',
-                ]
-            );
-            $I->assertInstanceOf(Simple::class, $results);
-            $I->assertEquals(3, (int) $results[0]->inv_cst_id);
-            $I->assertEquals(1, (int) $results[0]->sumatory);
-            $I->assertEquals(2, (int) $results[1]->inv_cst_id);
-            $I->assertEquals(33, (int) $results[1]->sumatory);
-            $I->assertEquals(1, (int) $results[2]->inv_cst_id);
-            $I->assertEquals(232, (int) $results[2]->sumatory);
-        }
+        $results = Invoices::sum(
+            [
+                'column' => 'inv_total',
+                'group'  => 'inv_cst_id',
+                'order'  => 'inv_cst_id DESC',
+            ]
+        );
+        $I->assertInstanceOf(Simple::class, $results);
+        $I->assertEquals(3, (int) $results[0]->inv_cst_id);
+        $I->assertEquals(1, (int) $results[0]->sumatory);
+        $I->assertEquals(2, (int) $results[1]->inv_cst_id);
+        $I->assertEquals(33, (int) $results[1]->sumatory);
+        $I->assertEquals(1, (int) $results[2]->inv_cst_id);
+        $I->assertEquals(232, (int) $results[2]->sumatory);
     }
 }

--- a/tests/database/Mvc/Model/SumCest.php
+++ b/tests/database/Mvc/Model/SumCest.php
@@ -46,9 +46,12 @@ class SumCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 7, 2, 'ccc');
-        $this->insertDataInvoices($migration, 1, 3, 'aaa');
-        $this->insertDataInvoices($migration, 11, 1, 'aaa');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 7, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 1, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 11, $invId, 1, 'aaa');
+
 
         $total = Invoices::sum(
             [

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -41,7 +41,7 @@ class ToArrayCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelToArray(DatabaseTester $I)
     {
@@ -89,7 +89,7 @@ class ToArrayCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelToArrayColumnMap(DatabaseTester $I)
     {
@@ -138,55 +138,11 @@ class ToArrayCest
      * @issue 1701
      *
      * @group mysql
-     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelToArrayFindFirstColumns(DatabaseTester $I)
     {
         $I->wantToTest('Mvc\Model - toArray() - find first columns');
-
-        $title = uniqid('inv-');
-        $date  = date('Y-m-d H:i:s');
-
-        $data = [
-            'inv_id'          => null,
-            'inv_cst_id'      => 5,
-            'inv_status_flag' => 2,
-            'inv_title'       => $title,
-            'inv_total'       => 100.12,
-            'inv_created_at'  => $date,
-        ];
-
-        $invoice = new Invoices();
-        $invoice->assign($data);
-        $result = $invoice->save();
-        $I->assertNotFalse($result);
-
-        $invoice = Invoices::findFirst(
-            [
-                'columns' => 'inv_id, inv_cst_id, inv_title',
-                'inv_title = "' . $title . '"',
-            ]
-        );
-
-        $expected = [
-            'inv_id'     => 1,
-            'inv_cst_id' => 5,
-            'inv_title'  => $title,
-        ];
-        $actual   = $invoice->toArray();
-        $I->assertEquals($expected, $actual);
-    }
-
-    /**
-     * Tests Phalcon\Mvc\Model :: toArray() - find first columns
-     *
-     * @issue 1701
-     *
-     * @group sqlite
-     */
-    public function mvcModelToArrayFindFirstColumnsSQLite(DatabaseTester $I)
-    {
-        $I->wantToTest('Mvc\Model - toArray() - find first columns - sqlite');
 
         $title = uniqid('inv-');
         $date  = date('Y-m-d H:i:s');

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -138,7 +138,6 @@ class ToArrayCest
      * @issue 1701
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function mvcModelToArrayFindFirstColumns(DatabaseTester $I)
@@ -170,7 +169,7 @@ class ToArrayCest
         );
 
         $expected = [
-            'inv_id'     => 1,
+            'inv_id'     => 52,
             'inv_cst_id' => 5,
             'inv_title'  => $title,
         ];

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -138,11 +138,55 @@ class ToArrayCest
      * @issue 1701
      *
      * @group mysql
-     * @group sqlite
+     * @group pgsql
      */
     public function mvcModelToArrayFindFirstColumns(DatabaseTester $I)
     {
         $I->wantToTest('Mvc\Model - toArray() - find first columns');
+
+        $title = uniqid('inv-');
+        $date  = date('Y-m-d H:i:s');
+
+        $data = [
+            'inv_id'          => null,
+            'inv_cst_id'      => 5,
+            'inv_status_flag' => 2,
+            'inv_title'       => $title,
+            'inv_total'       => 100.12,
+            'inv_created_at'  => $date,
+        ];
+
+        $invoice = new Invoices();
+        $invoice->assign($data);
+        $result = $invoice->save();
+        $I->assertNotFalse($result);
+
+        $invoice = Invoices::findFirst(
+            [
+                'columns' => 'inv_id, inv_cst_id, inv_title',
+                'inv_title = "' . $title . '"',
+            ]
+        );
+
+        $expected = [
+            'inv_id'     => 1,
+            'inv_cst_id' => 5,
+            'inv_title'  => $title,
+        ];
+        $actual   = $invoice->toArray();
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: toArray() - find first columns
+     *
+     * @issue 1701
+     *
+     * @group sqlite
+     */
+    public function mvcModelToArrayFindFirstColumnsSQLite(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - toArray() - find first columns - sqlite');
 
         $title = uniqid('inv-');
         $date  = date('Y-m-d H:i:s');

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -39,8 +39,7 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray()
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelToArray(DatabaseTester $I)
     {
@@ -50,7 +49,7 @@ class ToArrayCest
         $date  = date('Y-m-d H:i:s');
 
         $data = [
-            'inv_id'          => 4,
+            'inv_id'          => 1,
             'inv_cst_id'      => 5,
             'inv_status_flag' => 2,
             'inv_title'       => $title,
@@ -86,8 +85,7 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray() - column map
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelToArrayColumnMap(DatabaseTester $I)
     {
@@ -135,8 +133,7 @@ class ToArrayCest
      *
      * @issue 1701
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelToArrayFindFirstColumns(DatabaseTester $I)
     {
@@ -146,7 +143,7 @@ class ToArrayCest
         $date  = date('Y-m-d H:i:s');
 
         $data = [
-            'inv_id'          => 4,
+            'inv_id'          => null,
             'inv_cst_id'      => 5,
             'inv_status_flag' => 2,
             'inv_title'       => $title,
@@ -167,7 +164,7 @@ class ToArrayCest
         );
 
         $expected = [
-            'inv_id'     => 4,
+            'inv_id'     => 1,
             'inv_cst_id' => 5,
             'inv_title'  => $title,
         ];

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -39,7 +39,9 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray()
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelToArray(DatabaseTester $I)
     {
@@ -85,7 +87,9 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray() - column map
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelToArrayColumnMap(DatabaseTester $I)
     {
@@ -133,7 +137,9 @@ class ToArrayCest
      *
      * @issue 1701
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelToArrayFindFirstColumns(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -213,7 +213,7 @@ class ToArrayCest
         );
 
         $expected = [
-            'inv_id'     => 52,
+            'inv_id'     => 12,
             'inv_cst_id' => 5,
             'inv_title'  => $title,
         ];

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -41,7 +41,7 @@ class ToArrayCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelToArray(DatabaseTester $I)
     {
@@ -89,7 +89,7 @@ class ToArrayCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelToArrayColumnMap(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -192,7 +192,7 @@ class ToArrayCest
         $date  = date('Y-m-d H:i:s');
 
         $data = [
-            'inv_id'          => null,
+            'inv_id'          => 4,
             'inv_cst_id'      => 5,
             'inv_status_flag' => 2,
             'inv_title'       => $title,
@@ -213,7 +213,7 @@ class ToArrayCest
         );
 
         $expected = [
-            'inv_id'     => 12,
+            'inv_id'     => 4,
             'inv_cst_id' => 5,
             'inv_title'  => $title,
         ];

--- a/tests/database/Mvc/Model/UnserializeCest.php
+++ b/tests/database/Mvc/Model/UnserializeCest.php
@@ -45,8 +45,7 @@ class UnserializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function mvcModelUnserialize(DatabaseTester $I)
     {
@@ -56,7 +55,7 @@ class UnserializeCest
         $date  = date('Y-m-d H:i:s');
 
         $data = [
-            'inv_id'          => 4,
+            'inv_id'          => null,
             'inv_cst_id'      => 5,
             'inv_status_flag' => 2,
             'inv_title'       => $title,

--- a/tests/database/Mvc/Model/UnserializeCest.php
+++ b/tests/database/Mvc/Model/UnserializeCest.php
@@ -47,7 +47,7 @@ class UnserializeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function mvcModelUnserialize(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/UnserializeCest.php
+++ b/tests/database/Mvc/Model/UnserializeCest.php
@@ -47,7 +47,7 @@ class UnserializeCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function mvcModelUnserialize(DatabaseTester $I)
     {

--- a/tests/database/Mvc/Model/UnserializeCest.php
+++ b/tests/database/Mvc/Model/UnserializeCest.php
@@ -45,7 +45,9 @@ class UnserializeCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-31
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function mvcModelUnserialize(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/Model/ConstructCest.php
@@ -47,7 +47,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function paginatorAdapterModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/Model/ConstructCest.php
@@ -47,7 +47,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function paginatorAdapterModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/Model/ConstructCest.php
@@ -45,8 +45,7 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-11-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/Model/ConstructCest.php
@@ -45,7 +45,9 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-11-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterModelConstruct(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/Model/PaginateCest.php
@@ -48,10 +48,12 @@ class PaginateCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 11, 3, 'aaa');
-        $this->insertDataInvoices($migration, 31, 1, 'aaa');
-        $this->insertDataInvoices($migration, 15, 2, 'bbb');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 31, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 15, $invId, 2, 'bbb');
 
         $paginator = new Model(
             [
@@ -107,10 +109,13 @@ class PaginateCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 11, 3, 'aaa');
-        $this->insertDataInvoices($migration, 31, 1, 'aaa');
-        $this->insertDataInvoices($migration, 15, 2, 'bbb');
+
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 31, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 15, $invId, 2, 'bbb');
 
         $parameters = [
             'columns' => 'inv_cst_id',
@@ -155,10 +160,12 @@ class PaginateCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 11, 3, 'aaa');
-        $this->insertDataInvoices($migration, 31, 1, 'aaa');
-        $this->insertDataInvoices($migration, 15, 2, 'bbb');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 31, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 15, $invId, 2, 'bbb');
 
         $paginator = new Model(
             [
@@ -193,10 +200,12 @@ class PaginateCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 11, 3, 'aaa');
-        $this->insertDataInvoices($migration, 31, 1, 'aaa');
-        $this->insertDataInvoices($migration, 15, 2, 'bbb');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 31, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 15, $invId, 2, 'bbb');
 
         $paginator = new Model(
             [

--- a/tests/database/Paginator/Adapter/Model/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/Model/PaginateCest.php
@@ -40,7 +40,9 @@ class PaginateCest
     /**
      * @param DatabaseTester $I
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterModelPaginate(DatabaseTester $I)
     {
@@ -146,7 +148,9 @@ class PaginateCest
     /**
      * @param DatabaseTester $I
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterModelPaginateParametersString(DatabaseTester $I): void
     {
@@ -183,7 +187,9 @@ class PaginateCest
     /**
      * @param DatabaseTester $I
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterModelPaginateParametersArrayString(DatabaseTester $I): void
     {

--- a/tests/database/Paginator/Adapter/Model/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/Model/PaginateCest.php
@@ -41,7 +41,6 @@ class PaginateCest
      * @param DatabaseTester $I
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function paginatorAdapterModelPaginate(DatabaseTester $I)
@@ -149,7 +148,6 @@ class PaginateCest
      * @param DatabaseTester $I
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function paginatorAdapterModelPaginateParametersString(DatabaseTester $I): void
@@ -188,7 +186,6 @@ class PaginateCest
      * @param DatabaseTester $I
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function paginatorAdapterModelPaginateParametersArrayString(DatabaseTester $I): void

--- a/tests/database/Paginator/Adapter/Model/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/Model/PaginateCest.php
@@ -40,8 +40,7 @@ class PaginateCest
     /**
      * @param DatabaseTester $I
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterModelPaginate(DatabaseTester $I)
     {
@@ -113,6 +112,7 @@ class PaginateCest
         $this->insertDataInvoices($migration, 15, 2, 'bbb');
 
         $parameters = [
+            'columns' => 'inv_cst_id',
             'conditions' => 'inv_cst_id >= :d1:',
             'bind'       => [
                 'd1' => '2',
@@ -146,8 +146,7 @@ class PaginateCest
     /**
      * @param DatabaseTester $I
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterModelPaginateParametersString(DatabaseTester $I): void
     {
@@ -184,8 +183,7 @@ class PaginateCest
     /**
      * @param DatabaseTester $I
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterModelPaginateParametersArrayString(DatabaseTester $I): void
     {

--- a/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
+++ b/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
@@ -45,8 +45,7 @@ class SetGetLimitCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-11-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterModelGetLimit(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
+++ b/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
@@ -46,7 +46,6 @@ class SetGetLimitCest
      * @since  2019-11-01
      *
      * @group mysql
-     * @group pgsql
      * @group sqlite
      */
     public function paginatorAdapterModelGetLimit(DatabaseTester $I)

--- a/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
+++ b/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
@@ -45,7 +45,9 @@ class SetGetLimitCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-11-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterModelGetLimit(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
+++ b/tests/database/Paginator/Adapter/Model/SetGetLimitCest.php
@@ -55,10 +55,13 @@ class SetGetLimitCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 11, 3, 'aaa');
-        $this->insertDataInvoices($migration, 31, 1, 'aaa');
-        $this->insertDataInvoices($migration, 15, 2, 'bbb');
+
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, $invId, 3, 'aaa');
+        $this->insertDataInvoices($migration, 31, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 15, $invId, 2, 'bbb');
 
         $paginator = new Model(
             [

--- a/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
@@ -46,7 +46,9 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderConstruct(DatabaseTester $I)
     {
@@ -77,7 +79,9 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderConstructException(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
@@ -46,8 +46,7 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterQuerybuilderConstruct(DatabaseTester $I)
     {
@@ -78,8 +77,7 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterQuerybuilderConstructException(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
@@ -48,7 +48,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderConstruct(DatabaseTester $I)
     {
@@ -81,7 +81,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderConstructException(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/ConstructCest.php
@@ -48,7 +48,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function paginatorAdapterQuerybuilderConstruct(DatabaseTester $I)
     {
@@ -81,7 +81,7 @@ class ConstructCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function paginatorAdapterQuerybuilderConstructException(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
@@ -41,7 +41,7 @@ class GetSetLimitCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlites
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderGetSetLimit(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
@@ -41,7 +41,7 @@ class GetSetLimitCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
+     * @group sqlites
      */
     public function paginatorAdapterQuerybuilderGetSetLimit(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
@@ -50,7 +50,9 @@ class GetSetLimitCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
 
         $manager = $this->getService('modelsManager');
         $builder = $manager

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
@@ -39,7 +39,9 @@ class GetSetLimitCest
     /**
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: getLimit() / setLimit()
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderGetSetLimit(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
@@ -39,8 +39,7 @@ class GetSetLimitCest
     /**
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: getLimit() / setLimit()
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterQuerybuilderGetSetLimit(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
@@ -41,6 +41,7 @@ class GetSetQueryBuilderCest
      * setQueryBuilder()
      *
      * @group mysql
+     * @group sqlite
      * @group pgsql
      */
     public function paginatorAdapterQuerybuilderGetSetQueryBuilder(DatabaseTester $I)

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
@@ -40,45 +40,44 @@ class GetSetQueryBuilderCest
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: getQueryBuilder() /
      * setQueryBuilder()
      *
-     * @group common
+     * @group mysql
+     * @group pgsql
      */
     public function paginatorAdapterQuerybuilderGetSetQueryBuilder(DatabaseTester $I)
     {
         $I->wantToTest('Paginator\Adapter\QueryBuilder - getQueryBuilder() / setQueryBuilder()');
 
-        if ('sqlite' !== $I->getDriver()) {
-            /** @var PDO $connection */
-            $connection = $I->getConnection();
-            $migration  = new InvoicesMigration($connection);
-            $this->insertDataInvoices($migration, 17, 2, 'ccc');
-            $this->insertDataInvoices($migration, 15, 2, 'bbb');
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $this->insertDataInvoices($migration, 17, 2, 'ccc');
+        $this->insertDataInvoices($migration, 15, 2, 'bbb');
 
-            $manager  = $this->getService('modelsManager');
-            $builder1 = $manager
-                ->createBuilder()
-                ->from(Invoices::class)
-            ;
+        $manager  = $this->getService('modelsManager');
+        $builder1 = $manager
+            ->createBuilder()
+            ->from(Invoices::class)
+        ;
 
-            $paginator = new QueryBuilder(
-                [
-                    'builder' => $builder1,
-                    'limit'   => 5,
-                    'page'    => 1,
-                ]
-            );
+        $paginator = new QueryBuilder(
+            [
+                'builder' => $builder1,
+                'limit'   => 5,
+                'page'    => 1,
+            ]
+        );
 
-            $I->assertEquals($builder1, $paginator->getQueryBuilder());
+        $I->assertEquals($builder1, $paginator->getQueryBuilder());
 
-            $builder2 = $manager
-                ->createBuilder()
-                ->from(Invoices::class)
-                ->where('inv_cst_id = :custId:', ['custId' => 2])
-            ;
+        $builder2 = $manager
+            ->createBuilder()
+            ->from(Invoices::class)
+            ->where('inv_cst_id = :custId:', ['custId' => 2])
+        ;
 
-            $result = $paginator->setQueryBuilder($builder2);
+        $result = $paginator->setQueryBuilder($builder2);
 
-            $I->assertEquals($builder2, $paginator->getQueryBuilder());
-            $I->assertEquals($paginator, $result);
-        }
+        $I->assertEquals($builder2, $paginator->getQueryBuilder());
+        $I->assertEquals($paginator, $result);
     }
 }

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
@@ -40,8 +40,7 @@ class GetSetQueryBuilderCest
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: getQueryBuilder() /
      * setQueryBuilder()
      *
-     * @group mysql
-     * @group sqlite
+     * @group common
      */
     public function paginatorAdapterQuerybuilderGetSetQueryBuilder(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetQueryBuilderCest.php
@@ -50,8 +50,10 @@ class GetSetQueryBuilderCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 15, 2, 'bbb');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 15, $invId, 2, 'bbb');
 
         $manager  = $this->getService('modelsManager');
         $builder1 = $manager

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
@@ -44,6 +44,7 @@ class PaginateCest
      * @since  2020-02-01
      *
      * @group mysql
+     * @group sqlite
      * @group pgsql
      */
     public function paginatorAdapterQuerybuilderPaginate(DatabaseTester $I)
@@ -96,6 +97,7 @@ class PaginateCest
      *
      * @group mysql
      * @group pgsql
+     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderPaginateGroupBy(DatabaseTester $I)
     {

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
@@ -44,7 +44,7 @@ class PaginateCest
      * @since  2020-02-01
      *
      * @group mysql
-     * @group sqlite
+     * @group pgsql
      */
     public function paginatorAdapterQuerybuilderPaginate(DatabaseTester $I)
     {
@@ -53,40 +53,37 @@ class PaginateCest
         /**
          * Sqlite does not like `where` that much and locks the database
          */
-        if ('sqlite' !== $I->getDriver()) {
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $this->insertDataInvoices($migration, 17, 2, 'ccc');
 
-            /** @var PDO $connection */
-            $connection = $I->getConnection();
-            $migration  = new InvoicesMigration($connection);
-            $this->insertDataInvoices($migration, 17, 2, 'ccc');
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->from(Invoices::class)
+        ;
 
-            $manager = $this->getService('modelsManager');
-            $builder = $manager
-                ->createBuilder()
-                ->from(Invoices::class)
-            ;
+        $paginator = new QueryBuilder(
+            [
+                'builder' => $builder,
+                'limit'   => 5,
+                'page'    => 1,
+            ]
+        );
 
-            $paginator = new QueryBuilder(
-                [
-                    'builder' => $builder,
-                    'limit'   => 5,
-                    'page'    => 1,
-                ]
-            );
+        $page = $paginator->paginate();
 
-            $page = $paginator->paginate();
-
-            $I->assertInstanceOf(Repository::class, $page);
-            $I->assertCount(5, $page->getItems());
-            $I->assertEquals(1, $page->getPrevious());
-            $I->assertEquals(2, $page->getNext());
-            $I->assertEquals(4, $page->getLast());
-            $I->assertEquals(5, $page->getLimit());
-            $I->assertEquals(1, $page->getCurrent());
-            $I->assertEquals(5, $page->limit);
-            $I->assertEquals(17, $page->getTotalItems());
-            $I->assertInternalType('int', $page->getTotalItems());
-        }
+        $I->assertInstanceOf(Repository::class, $page);
+        $I->assertCount(5, $page->getItems());
+        $I->assertEquals(1, $page->getPrevious());
+        $I->assertEquals(2, $page->getNext());
+        $I->assertEquals(4, $page->getLast());
+        $I->assertEquals(5, $page->getLimit());
+        $I->assertEquals(1, $page->getCurrent());
+        $I->assertEquals(5, $page->limit);
+        $I->assertEquals(17, $page->getTotalItems());
+        $I->assertInternalType('int', $page->getTotalItems());
     }
 
     /**
@@ -96,7 +93,7 @@ class PaginateCest
      * @since  2020-01-29
      *
      * @group mysql
-     * @group sqlite
+     * @group pgsql
      */
     public function paginatorAdapterQuerybuilderPaginateGroupBy(DatabaseTester $I)
     {
@@ -105,60 +102,59 @@ class PaginateCest
         /**
          * Sqlite does not like `where` that much and locks the database
          */
-        if ('sqlite' !== $I->getDriver()) {
-            /** @var PDO $connection */
-            $connection = $I->getConnection();
-            $migration  = new InvoicesMigration($connection);
-            $this->insertDataInvoices($migration, 17, 2, 'ccc');
-            $this->insertDataInvoices($migration, 11, 3, 'aaa');
 
-            $manager = $this->getService('modelsManager');
-            $builder = $manager
-                ->createBuilder()
-                ->from(Invoices::class)
-            ;
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $this->insertDataInvoices($migration, 17, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, 3, 'aaa');
 
-            $paginator = new QueryBuilder(
-                [
-                    'builder' => $builder,
-                    'limit'   => 5,
-                    'page'    => 1,
-                ]
-            );
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->from(Invoices::class)
+        ;
 
-            $page = $paginator->paginate();
+        $paginator = new QueryBuilder(
+            [
+                'builder' => $builder,
+                'limit'   => 5,
+                'page'    => 1,
+            ]
+        );
 
-            $I->assertInstanceOf(Repository::class, $page);
-            $I->assertCount(5, $page->getItems());
-            $I->assertEquals(1, $page->getPrevious());
-            $I->assertEquals(2, $page->getNext());
-            $I->assertEquals(6, $page->getLast());
-            $I->assertEquals(5, $page->getLimit());
-            $I->assertEquals(1, $page->getCurrent());
-            $I->assertEquals(5, $page->limit);
-            $I->assertEquals(28, $page->getTotalItems());
-            $I->assertInternalType('int', $page->getTotalItems());
+        $page = $paginator->paginate();
 
-            $builder = $manager
-                ->createBuilder()
-                ->from(Invoices::class)
-                ->where('inv_cst_id = :custId:', ['custId' => 2])
-            ;
+        $I->assertInstanceOf(Repository::class, $page);
+        $I->assertCount(5, $page->getItems());
+        $I->assertEquals(1, $page->getPrevious());
+        $I->assertEquals(2, $page->getNext());
+        $I->assertEquals(6, $page->getLast());
+        $I->assertEquals(5, $page->getLimit());
+        $I->assertEquals(1, $page->getCurrent());
+        $I->assertEquals(5, $page->limit);
+        $I->assertEquals(28, $page->getTotalItems());
+        $I->assertInternalType('int', $page->getTotalItems());
 
-            $paginator->setQueryBuilder($builder);
+        $builder = $manager
+            ->createBuilder()
+            ->from(Invoices::class)
+            ->where('inv_cst_id = :custId:', ['custId' => 2])
+        ;
 
-            $page = $paginator->paginate();
+        $paginator->setQueryBuilder($builder);
 
-            $I->assertInstanceOf(Repository::class, $page);
-            $I->assertCount(5, $page->getItems());
-            $I->assertEquals(1, $page->getPrevious());
-            $I->assertEquals(2, $page->getNext());
-            $I->assertEquals(4, $page->getLast());
-            $I->assertEquals(5, $page->getLimit());
-            $I->assertEquals(1, $page->getCurrent());
-            $I->assertEquals(5, $page->limit);
-            $I->assertEquals(17, $page->getTotalItems());
-            $I->assertInternalType('int', $page->getTotalItems());
-        }
+        $page = $paginator->paginate();
+
+        $I->assertInstanceOf(Repository::class, $page);
+        $I->assertCount(5, $page->getItems());
+        $I->assertEquals(1, $page->getPrevious());
+        $I->assertEquals(2, $page->getNext());
+        $I->assertEquals(4, $page->getLast());
+        $I->assertEquals(5, $page->getLimit());
+        $I->assertEquals(1, $page->getCurrent());
+        $I->assertEquals(5, $page->limit);
+        $I->assertEquals(17, $page->getTotalItems());
+        $I->assertInternalType('int', $page->getTotalItems());
     }
 }

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
@@ -56,7 +56,9 @@ class PaginateCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
 
         $manager = $this->getService('modelsManager');
         $builder = $manager
@@ -106,8 +108,10 @@ class PaginateCest
         /** @var PDO $connection */
         $connection = $I->getConnection();
         $migration  = new InvoicesMigration($connection);
-        $this->insertDataInvoices($migration, 17, 2, 'ccc');
-        $this->insertDataInvoices($migration, 11, 3, 'aaa');
+        $invId = ('sqlite' === $I->getDriver()) ? 'null' : 'default';
+
+        $this->insertDataInvoices($migration, 17, $invId, 2, 'ccc');
+        $this->insertDataInvoices($migration, 11, $invId, 3, 'aaa');
 
         $manager = $this->getService('modelsManager');
         $builder = $manager

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateCest.php
@@ -97,7 +97,6 @@ class PaginateCest
      *
      * @group mysql
      * @group pgsql
-     * @group sqlite
      */
     public function paginatorAdapterQuerybuilderPaginateGroupBy(DatabaseTester $I)
     {


### PR DESCRIPTION
Hello team!

A lot of things in this PR : 
- I updated some tests to handle PostgreSQL.
- I updated some Migration classes to create tables in the PostgreSQL database.
- I found one bug with the function getPhql and I hope I have fixed it correctly.

I discovered the bug by doing the tests 
`mvcModelFindFirstStringPrimaryKey (database/Mvc/Model/FindFirstCest.php).`

The error was triggered with PostgreSQL.
When we do a:
`ModelWithStringPrimary::findFirst('135');`

The primary key of ModelWithStringPrimary is a string.
And the function findFirst writes the condition like that:
`... where uuid = 135`

PostgreSQL triggers an error like character varying = integer (there is an error...).

So I updated getPhSQL and checked if the type of the simple condition is a string, I put single quotes around the condition.

The updated file is phalcon/Mvc/Model/Query/Builder.zep

Thanks for your review/help 🧙.

* Type: bug fix | code quality
* Link to issue: #14874

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

