### PR TITLE
Fixed recognizing language operators inside Volt's echo mode

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
           git config --global advice.detachedHead false
 
           # Will be used before as a cache key
-          export CPUHASH="$(cat /proc/cpuinfo | grep "model name" | head -n 1 | cut -d':' -f2 | md5sum)"
+          export CPUHASH="$(cat /proc/cpuinfo | grep 'model name' | head -n 1 | cut -d':' -f2 | md5sum)"
 
       - name: Git checkout
         uses: actions/checkout@v2-beta

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)
 - Fixed schema manipulation in `Phalcon\Db\Dialect\Mysql`, remove unnecessary `NULL` in column definition, unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
+- Fixed recognizing language operators inside Volt's echo mode (`{{ ... }}`) [#14476](https://github.com/phalcon/cphalcon/issues/14476)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added
@@ -91,7 +92,7 @@
 - Fixed `Phalcon\Mvc\Model` to ignore internal setters if properties have the same name as the setter [#14538](https://github.com/phalcon/cphalcon/issues/14538)
 - Fixed `Phalcon\Logger\Formatter\Line` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream` [#14547](https://github.com/phalcon/cphalcon/issues/14547)
 - Fixed `Phalcon\Mvc\Model\MetaData\Apcu` and `Phalcon\Mvc\Model\MetaData\Redis` to allow setting the `prefix` and `lifetime` using the options or use the default. [#14549](https://github.com/phalcon/cphalcon/issues/14549)
-- Fixed `Phalcon\Storage\Adapter\AbstractAdapter`, `Phalcon\Storage\Adapter\AbstractInterface` getters to contain a default value 
+- Fixed `Phalcon\Storage\Adapter\AbstractAdapter`, `Phalcon\Storage\Adapter\AbstractInterface` getters to contain a default value
 - Fixed `Phalcon\Storage\Adapter\Memory` initializing the array store correctly [#14551](https://github.com/phalcon/cphalcon/issues/14551)
 - Fixed `Phalcon\Storage\Adapter\Stream` to capture notice if the stream is not opened properly [#14551](https://github.com/phalcon/cphalcon/issues/14551)
 - Fixed `Phalcon\Security::getRandomBytes` to return `int` [#14551](https://github.com/phalcon/cphalcon/issues/14551)
@@ -167,8 +168,8 @@
 - Fixed `Phalcon\Annotations\Adapter\Stream::read` and `Phalcon\Annotations\Adapter\Stream::write` to use `serialize`/`unserialize` vs. `var_export` [#14515](https://github.com/phalcon/cphalcon/issues/14515)
 - Fixed `Phalcon\Http\Request::hasFiles` to return boolean and `true` if files are present [#14519](https://github.com/phalcon/cphalcon/issues/14519)
 - Fixed `Phalcon\Logger\Adapter\Syslog` to correctly log Syslog messages [#14522](https://github.com/phalcon/cphalcon/issues/14522)
-- Fixed `Phalcon\Mvc\Model\MetaDataInterface::getIdentityField` and `Phalcon\Mvc\Model\MetaData::getIdentityField` to also return `null` if the identity field is not present [#14523](https://github.com/phalcon/cphalcon/issues/14523) 
-- Fixed `Phalcon\Storage\Serializer\Json` to serialize objects that implement the `JsonSerializable` interface [#14528](https://github.com/phalcon/cphalcon/issues/14528) 
+- Fixed `Phalcon\Mvc\Model\MetaDataInterface::getIdentityField` and `Phalcon\Mvc\Model\MetaData::getIdentityField` to also return `null` if the identity field is not present [#14523](https://github.com/phalcon/cphalcon/issues/14523)
+- Fixed `Phalcon\Storage\Serializer\Json` to serialize objects that implement the `JsonSerializable` interface [#14528](https://github.com/phalcon/cphalcon/issues/14528)
 - Fixed `Phalcon\Collection` to correctly return one level nested objects that implement `JsonSerializable` [#14528](https://github.com/phalcon/cphalcon/issues/14528)
 - Fixed `Phalcon\Mvc\View` to only include first found instance of view when using multiple view directories [#12977](https://github.com/phalcon/cphalcon/issues/12977)
 
@@ -200,9 +201,9 @@
 - Fixed `Phalcon\Filter\FilterFactory::newInstance()` to return `FilterInterface` instead of non existing `LocatorInterface` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
 - Fixed `Phalcon\Forms\Element\Select::addOption()` and `Phalcon\Forms\Element\Select::setOption()` to return `ElementInterface` instead of non existing Element [#14414](https://github.com/phalcon/cphalcon/pull/14414)
 - Fixed `Phalcon\Forms\Manager::set()` to return `Manager` instead of non existing `FormManager` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
-- Fixed 
- - `Phalcon\Paginator\Adapter\AbstractAdapter::setCurrentPage()` 
- - `Phalcon\Paginator\Adapter\AbstractAdapter::setLimit()` 
+- Fixed
+ - `Phalcon\Paginator\Adapter\AbstractAdapter::setCurrentPage()`
+ - `Phalcon\Paginator\Adapter\AbstractAdapter::setLimit()`
  - `Phalcon\Paginator\Adapter\AbstractAdapter::setRepository()` to return `AdapterInterface` instead of non existing `Adapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
 - Fixed `Phalcon\Translate\TranslateFactory::set()` to return `AdapterInterface` instead of non existing `AbstractAdapter` [#14414](https://github.com/phalcon/cphalcon/pull/14414)
 - Fixed `Phalcon\Filter` to properly work with closures [#14417](https://github.com/phalcon/cphalcon/issues/14417)

--- a/ext/phalcon/annotations/parser.php7.c
+++ b/ext/phalcon/annotations/parser.php7.c
@@ -12,10 +12,10 @@
 /* Next is all token values, in a form suitable for use by makeheaders.
 ** This section will be null unless lemon is run with the -m switch.
 */
-/*
+/* 
 ** These constants (all generated automatically by the parser generator)
 ** specify the various kinds of tokens (terminals) that the parser
-** understands.
+** understands. 
 **
 ** Each symbol here is a terminal symbol in the grammar.
 */
@@ -32,7 +32,7 @@
 **                       and nonterminals.  "int" is used otherwise.
 **    YYNOCODE           is a number of type YYCODETYPE which corresponds
 **                       to no legal terminal or nonterminal number.  This
-**                       number is used to fill in empty slots of the hash
+**                       number is used to fill in empty slots of the hash 
 **                       table.
 **    YYFALLBACK         If defined, this indicates that one or more tokens
 **                       have fall-back values which should be used if the
@@ -41,7 +41,7 @@
 **                       and nonterminal numbers.  "unsigned char" is
 **                       used if there are fewer than 250 rules and
 **                       states combined.  "int" is used otherwise.
-**    phannot_TOKENTYPE     is the data type used for minor tokens given
+**    phannot_TOKENTYPE     is the data type used for minor tokens given 
 **                       directly to the parser from the tokenizer.
 **    YYMINORTYPE        is the data type used for all minor tokens.
 **                       This is typically a union of many types, one of
@@ -82,7 +82,7 @@ typedef union {
 /* Next are that tables used to determine what action to take based on the
 ** current state and lookahead token.  These tables are used to implement
 ** functions that take a state number and lookahead value and return an
-** action integer.
+** action integer.  
 **
 ** Suppose the action integer is N.  Then the action is determined as
 ** follows
@@ -107,7 +107,7 @@ typedef union {
 ** If the index value yy_shift_ofst[S]+X is out of range or if the value
 ** yy_lookahead[yy_shift_ofst[S]+X] is not equal to X or if yy_shift_ofst[S]
 ** is equal to YY_SHIFT_USE_DFLT, it means that the action is not in the table
-** and that yy_default[S] should be used instead.
+** and that yy_default[S] should be used instead.  
 **
 ** The formula above is for computing the action when the lookahead is
 ** a terminal symbol.  If the lookahead is a non-terminal (as occurs after
@@ -174,7 +174,7 @@ static YYACTIONTYPE yy_default[] = {
 
 /* The next table maps tokens into fallback tokens.  If a construct
 ** like the following:
-**
+** 
 **      %fallback ID X Y Z.
 **
 ** appears in the grammer, then ID becomes a fallback token for X, Y,
@@ -225,10 +225,10 @@ static char *yyTracePrompt = 0;
 #endif /* NDEBUG */
 
 #ifndef NDEBUG
-/*
+/* 
 ** Turn parser tracing on by giving a stream to which to write the trace
 ** and a prompt to preface each trace message.  Tracing is turned off
-** by making either argument NULL
+** by making either argument NULL 
 **
 ** Inputs:
 ** <ul>
@@ -253,14 +253,14 @@ void phannot_Trace(FILE *TraceFILE, char *zTracePrompt){
 #ifndef NDEBUG
 /* For tracing shifts, the names of all terminals and nonterminals
 ** are required.  The following table supplies these names */
-static const char *yyTokenName[] = {
-  "$",             "COMMA",         "AT",            "IDENTIFIER",
-  "PARENTHESES_OPEN",  "PARENTHESES_CLOSE",  "STRING",        "EQUALS",
-  "COLON",         "INTEGER",       "DOUBLE",        "NULL",
+static const char *yyTokenName[] = { 
+  "$",             "COMMA",         "AT",            "IDENTIFIER",  
+  "PARENTHESES_OPEN",  "PARENTHESES_CLOSE",  "STRING",        "EQUALS",      
+  "COLON",         "INTEGER",       "DOUBLE",        "NULL",        
   "FALSE",         "TRUE",          "BRACKET_OPEN",  "BRACKET_CLOSE",
-  "SBRACKET_OPEN",  "SBRACKET_CLOSE",  "error",         "program",
+  "SBRACKET_OPEN",  "SBRACKET_CLOSE",  "error",         "program",     
   "annotation_language",  "annotation_list",  "annotation",    "argument_list",
-  "argument_item",  "expr",          "array",
+  "argument_item",  "expr",          "array",       
 };
 #endif /* NDEBUG */
 
@@ -312,7 +312,7 @@ const char *phannot_TokenName(int tokenType){
 #endif
 }
 
-/*
+/* 
 ** This function allocates a new parser.
 ** The only argument is a pointer to a function which works like
 ** malloc.
@@ -343,7 +343,7 @@ static void yy_destructor(YYCODETYPE yymajor, YYMINORTYPE *yypminor){
     /* Here is inserted the actions which take place when a
     ** terminal or non-terminal is destroyed.  This can happen
     ** when the symbol is popped from the stack during a
-    ** reduce or during error processing or when a parser is
+    ** reduce or during error processing or when a parser is 
     ** being destroyed before it is finished parsing.
     **
     ** Note: during a reduce, the only symbols destroyed are those
@@ -420,7 +420,7 @@ static int yy_pop_parser_stack(yyParser *pParser){
   return yymajor;
 }
 
-/*
+/* 
 ** Deallocate and destroy a parser.  Destructors are all called for
 ** all stack elements before shutting the parser down.
 **
@@ -456,7 +456,7 @@ static int yy_find_shift_action(
 ){
   int i;
   int stateno = pParser->yystack[pParser->yyidx].stateno;
-
+ 
   /* if( pParser->yyidx<0 ) return YY_NO_ACTION;  */
   i = yy_shift_ofst[stateno];
   if( i==YY_SHIFT_USE_DFLT ){
@@ -500,7 +500,7 @@ static int yy_find_reduce_action(
 ){
   int i;
   int stateno = pParser->yystack[pParser->yyidx].stateno;
-
+ 
   i = yy_reduce_ofst[stateno];
   if( i==YY_REDUCE_USE_DFLT ){
     return yy_default[stateno];
@@ -609,7 +609,7 @@ static void yy_reduce(
   phannot_ARG_FETCH;
   yymsp = &yypParser->yystack[yypParser->yyidx];
 #ifndef NDEBUG
-  if( yyTraceFILE && yyruleno>=0
+  if( yyTraceFILE && yyruleno>=0 
         && yyruleno<sizeof(yyRuleName)/sizeof(yyRuleName[0]) ){
     fprintf(yyTraceFILE, "%sReduce [%s].\n", yyTracePrompt,
       yyRuleName[yyruleno]);
@@ -832,8 +832,8 @@ static void yy_syntax_error(
 	if (status->scanner_state->start_length) {
 		char *token_name = NULL;
 		const phannot_token_names *tokens = phannot_tokens;
-		zend_uint active_token = status->scanner_state->active_token;
-		uint near_length = status->scanner_state->start_length;
+		int active_token = status->scanner_state->active_token;
+		unsigned int near_length = status->scanner_state->start_length;
 
 		if (active_token) {
 			do {
@@ -966,7 +966,7 @@ void phannot_(
 #ifdef YYERRORSYMBOL
       /* A syntax error has occurred.
       ** The response to an error depends upon whether or not the
-      ** grammar defines an error token "ERROR".
+      ** grammar defines an error token "ERROR".  
       **
       ** This is what we do if the grammar does define ERROR:
       **

--- a/ext/phalcon/mvc/view/engine/volt/scanner.c
+++ b/ext/phalcon/mvc/view/engine/volt/scanner.c
@@ -1358,7 +1358,7 @@ vv135:
 			}
 vv136:
 			{
-			if (s->mode == PHVOLT_MODE_ECHO) {
+			if (s->active_token == PHVOLT_T_DOT) {
 				token->opcode = PHVOLT_T_IDENTIFIER;
 				token->value = estrndup(start, VVCURSOR - start);
 				token->len = VVCURSOR - start;
@@ -1620,7 +1620,6 @@ vv154:
 			}
 vv155:
 			{
-			s->mode = PHVOLT_MODE_ECHO;
 			s->whitespace_control = 0;
 			s->statement_position++;
 			token->opcode = PHVOLT_T_OPEN_EDELIMITER;
@@ -2298,7 +2297,7 @@ vv201:
 			}
 vv202:
 			{
-			if (s->mode == PHVOLT_MODE_ECHO) {
+			if (s->active_token == PHVOLT_T_DOT) {
 				token->opcode = PHVOLT_T_IDENTIFIER;
 				token->value = estrndup(start, VVCURSOR - start);
 				token->len = VVCURSOR - start;
@@ -2346,7 +2345,6 @@ vv207:
 vv209:
 			++VVCURSOR;
 			{
-			s->mode = PHVOLT_MODE_ECHO;
 			s->whitespace_control = 0;
 			s->statement_position++;
 			token->opcode = PHVOLT_T_OPEN_EDELIMITER;

--- a/ext/phalcon/mvc/view/engine/volt/scanner.h
+++ b/ext/phalcon/mvc/view/engine/volt/scanner.h
@@ -23,7 +23,6 @@
 #define PHVOLT_MODE_RAW 0
 #define PHVOLT_MODE_CODE 1
 #define PHVOLT_MODE_COMMENT 2
-#define PHVOLT_MODE_ECHO 4 /* To indicates we're in {{ }} */
 
 #define PHVOLT_T_IGNORE 257
 

--- a/ext/phalcon/mvc/view/engine/volt/scanner.re
+++ b/ext/phalcon/mvc/view/engine/volt/scanner.re
@@ -241,7 +241,7 @@ int phvolt_get_token(phvolt_scanner_state *s, phvolt_scanner_token *token) {
 		}
 
 		'set' {
-			if (s->mode == PHVOLT_MODE_ECHO) {
+			if (s->active_token == PHVOLT_T_DOT) {
 				token->opcode = PHVOLT_T_IDENTIFIER;
 				token->value = estrndup(start, YYCURSOR - start);
 				token->len = YYCURSOR - start;
@@ -339,7 +339,7 @@ int phvolt_get_token(phvolt_scanner_state *s, phvolt_scanner_token *token) {
 		}
 
 		'is' {
-			if (s->mode == PHVOLT_MODE_ECHO) {
+			if (s->active_token == PHVOLT_T_DOT) {
 				token->opcode = PHVOLT_T_IDENTIFIER;
 				token->value = estrndup(start, YYCURSOR - start);
 				token->len = YYCURSOR - start;
@@ -484,7 +484,6 @@ int phvolt_get_token(phvolt_scanner_state *s, phvolt_scanner_token *token) {
 		}
 
 		"{{" {
-			s->mode = PHVOLT_MODE_ECHO;
 			s->whitespace_control = 0;
 			s->statement_position++;
 			token->opcode = PHVOLT_T_OPEN_EDELIMITER;
@@ -498,7 +497,6 @@ int phvolt_get_token(phvolt_scanner_state *s, phvolt_scanner_token *token) {
 		}
 
 		"{{-" {
-			s->mode = PHVOLT_MODE_ECHO;
 			s->whitespace_control = 0;
 			s->statement_position++;
 			token->opcode = PHVOLT_T_OPEN_EDELIMITER;

--- a/tests/syntax/volt/operators/bug14476.phpt
+++ b/tests/syntax/volt/operators/bug14476.phpt
@@ -1,5 +1,5 @@
 --TEST--
-is - Perform test for equals
+ternary - Use with {{ }}
 --SKIPIF--
 <?php if (!extension_loaded("phalcon")) print "skip extension not loaded"; ?>
 --FILE--
@@ -7,24 +7,44 @@ is - Perform test for equals
 use Phalcon\Mvc\View\Engine\Volt\Compiler;
 
 $compiler = new Compiler();
-var_dump($compiler->parse("{% if a is b %}c{% endif %}"));
+var_dump($compiler->parse("{{ someVar is defined ? 'yes' : 'no' }}"));
 ?>
 --EXPECT--
 array(1) {
   [0]=>
-  array(5) {
+  array(4) {
     ["type"]=>
-    int(300)
+    int(359)
     ["expr"]=>
-    array(5) {
+    array(6) {
       ["type"]=>
-      int(311)
+      int(366)
+      ["ternary"]=>
+      array(4) {
+        ["type"]=>
+        int(363)
+        ["left"]=>
+        array(4) {
+          ["type"]=>
+          int(265)
+          ["value"]=>
+          string(7) "someVar"
+          ["file"]=>
+          string(9) "eval code"
+          ["line"]=>
+          int(1)
+        }
+        ["file"]=>
+        string(9) "eval code"
+        ["line"]=>
+        int(1)
+      }
       ["left"]=>
       array(4) {
         ["type"]=>
-        int(265)
+        int(260)
         ["value"]=>
-        string(1) "a"
+        string(3) "yes"
         ["file"]=>
         string(9) "eval code"
         ["line"]=>
@@ -33,9 +53,9 @@ array(1) {
       ["right"]=>
       array(4) {
         ["type"]=>
-        int(265)
+        int(260)
         ["value"]=>
-        string(1) "b"
+        string(2) "no"
         ["file"]=>
         string(9) "eval code"
         ["line"]=>
@@ -45,20 +65,6 @@ array(1) {
       string(9) "eval code"
       ["line"]=>
       int(1)
-    }
-    ["true_statements"]=>
-    array(1) {
-      [0]=>
-      array(4) {
-        ["type"]=>
-        int(357)
-        ["value"]=>
-        string(1) "c"
-        ["file"]=>
-        string(9) "eval code"
-        ["line"]=>
-        int(1)
-      }
     }
     ["file"]=>
     string(9) "eval code"

--- a/tests/syntax/volt/statements/is/003.phpt
+++ b/tests/syntax/volt/statements/is/003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-is - Perform test for equals
+is - Using as a object property and {{ }}
 --SKIPIF--
 <?php if (!extension_loaded("phalcon")) print "skip extension not loaded"; ?>
 --FILE--
@@ -7,24 +7,24 @@ is - Perform test for equals
 use Phalcon\Mvc\View\Engine\Volt\Compiler;
 
 $compiler = new Compiler();
-var_dump($compiler->parse("{% if a is b %}c{% endif %}"));
+var_dump($compiler->parse("{{ object.is }}"));
 ?>
 --EXPECT--
 array(1) {
   [0]=>
-  array(5) {
+  array(4) {
     ["type"]=>
-    int(300)
+    int(359)
     ["expr"]=>
     array(5) {
       ["type"]=>
-      int(311)
+      int(46)
       ["left"]=>
       array(4) {
         ["type"]=>
         int(265)
         ["value"]=>
-        string(1) "a"
+        string(6) "object"
         ["file"]=>
         string(9) "eval code"
         ["line"]=>
@@ -35,7 +35,7 @@ array(1) {
         ["type"]=>
         int(265)
         ["value"]=>
-        string(1) "b"
+        string(2) "is"
         ["file"]=>
         string(9) "eval code"
         ["line"]=>
@@ -45,20 +45,6 @@ array(1) {
       string(9) "eval code"
       ["line"]=>
       int(1)
-    }
-    ["true_statements"]=>
-    array(1) {
-      [0]=>
-      array(4) {
-        ["type"]=>
-        int(357)
-        ["value"]=>
-        string(1) "c"
-        ["file"]=>
-        string(9) "eval code"
-        ["line"]=>
-        int(1)
-      }
     }
     ["file"]=>
     string(9) "eval code"

--- a/tests/syntax/volt/statements/is/003.phpt
+++ b/tests/syntax/volt/statements/is/003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-is - Using as a object property and {{ }}
+is - Using as an object property and {{ }}
 --SKIPIF--
 <?php if (!extension_loaded("phalcon")) print "skip extension not loaded"; ?>
 --FILE--

--- a/tests/syntax/volt/statements/is/bug14288.phpt
+++ b/tests/syntax/volt/statements/is/bug14288.phpt
@@ -1,5 +1,5 @@
 --TEST--
-set - Tests for false-positive matching
+is - Tests for false-positive matching
 --SKIPIF--
 <?php if (!extension_loaded("phalcon")) print "skip extension not loaded"; ?>
 --FILE--

--- a/tests/syntax/volt/statements/set/002.phpt
+++ b/tests/syntax/volt/statements/set/002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-set - Using as a object property and {{ }}
+set - Using as an object property and {{ }}
 --SKIPIF--
 <?php if (!extension_loaded("phalcon")) print "skip extension not loaded"; ?>
 --FILE--

--- a/tests/syntax/volt/statements/set/002.phpt
+++ b/tests/syntax/volt/statements/set/002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-is - Perform test for equals
+set - Using as a object property and {{ }}
 --SKIPIF--
 <?php if (!extension_loaded("phalcon")) print "skip extension not loaded"; ?>
 --FILE--
@@ -7,24 +7,33 @@ is - Perform test for equals
 use Phalcon\Mvc\View\Engine\Volt\Compiler;
 
 $compiler = new Compiler();
-var_dump($compiler->parse("{% if a is b %}c{% endif %}"));
+var_dump($compiler->parse("{{ factory().set }}"));
 ?>
 --EXPECT--
 array(1) {
   [0]=>
-  array(5) {
+  array(4) {
     ["type"]=>
-    int(300)
+    int(359)
     ["expr"]=>
     array(5) {
       ["type"]=>
-      int(311)
+      int(46)
       ["left"]=>
       array(4) {
         ["type"]=>
-        int(265)
-        ["value"]=>
-        string(1) "a"
+        int(350)
+        ["name"]=>
+        array(4) {
+          ["type"]=>
+          int(265)
+          ["value"]=>
+          string(7) "factory"
+          ["file"]=>
+          string(9) "eval code"
+          ["line"]=>
+          int(1)
+        }
         ["file"]=>
         string(9) "eval code"
         ["line"]=>
@@ -35,7 +44,7 @@ array(1) {
         ["type"]=>
         int(265)
         ["value"]=>
-        string(1) "b"
+        string(3) "set"
         ["file"]=>
         string(9) "eval code"
         ["line"]=>
@@ -45,20 +54,6 @@ array(1) {
       string(9) "eval code"
       ["line"]=>
       int(1)
-    }
-    ["true_statements"]=>
-    array(1) {
-      [0]=>
-      array(4) {
-        ["type"]=>
-        int(357)
-        ["value"]=>
-        string(1) "c"
-        ["file"]=>
-        string(9) "eval code"
-        ["line"]=>
-        int(1)
-      }
     }
     ["file"]=>
     string(9) "eval code"


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14476

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

This fix will return the possibility to use Volt's operators inside echo mode (`{{ ... }}`):

```volt
{{ foo is defined ? 'yes' : 'no' }}
```
Thanks

