### PR TITLE
Added archive download fallback

### DIFF
--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -45,12 +45,17 @@ Function DownloadPhpSrc {
     Write-Output "Download PHP Src: ${env:PHP_VERSION}"
 
     $RemoteUrl = "http://windows.php.net/downloads/releases/php-${env:PHP_VERSION}-src.zip"
+    $RemoteArchiveUrl = "http://windows.php.net/downloads/releases/archives/php-${env:PHP_VERSION}-src.zip"
     $DestinationPath = "C:\Downloads\php-${env:PHP_VERSION}-src.zip"
 
     If (-not (Test-Path $env:PHP_SRC_PATH)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
             DownloadFile $RemoteUrl $DestinationPath
+        }
+        If (-not [System.IO.File]::Exists($DestinationPath)) {
+            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
+            DownloadFile ${RemoteArchiveUrl} $DestinationPath
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-src"
@@ -67,12 +72,17 @@ Function InstallPhpDevPack {
     Write-Output "Install PHP Dev pack: ${env:PHP_VERSION}"
 
     $RemoteUrl = "http://windows.php.net/downloads/releases/php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-vc${env:VC_VERSION}-${env:PHP_ARCH}.zip"
+    $RemoteArchiveUrl = "http://windows.php.net/downloads/releases/archives/php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-vc${env:VC_VERSION}-${env:PHP_ARCH}.zip"
     $DestinationPath = "C:\Downloads\php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-VC${env:VC_VERSION}-${env:PHP_ARCH}.zip"
 
     If (-not (Test-Path $env:PHP_DEVPACK)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
             DownloadFile $RemoteUrl $DestinationPath
+        }
+        If (-not [System.IO.File]::Exists($DestinationPath)) {
+            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
+            DownloadFile $RemoteArchiveUrl $DestinationPath
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-devel-VC${env:VC_VERSION}-${env:PHP_ARCH}"

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -50,19 +50,21 @@ Function DownloadPhpSrc {
 
     If (-not (Test-Path $env:PHP_SRC_PATH)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
-            Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
+            Write-Output "Downloading PHP pack: ${RemoteUrl} ..."
             DownloadFile $RemoteUrl $DestinationPath
-        }
-
-        If (-not (Get-Item $DestinationPath).length -gt 500kb) {
-            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
-            DownloadFile $RemoteArchiveUrl $DestinationPath
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-src"
 
         If (-not (Test-Path "$DestinationUnzipPath")) {
-            Expand-Item7zip $DestinationPath $env:Temp
+            Try {
+                Expand-Item7zip $DestinationPath $env:Temp
+            } Catch {
+                # if expand fails try alternative download
+                Write-Output "Downloading PHP pack from archive: ${RemoteArchiveUrl} ..."
+                DownloadFile $RemoteArchiveUrl $DestinationPath
+                Expand-Item7zip $DestinationPath $env:Temp
+            }
         }
 
         Move-Item -Path $DestinationUnzipPath -Destination $env:PHP_SRC_PATH
@@ -82,15 +84,17 @@ Function InstallPhpDevPack {
             DownloadFile $RemoteUrl $DestinationPath
         }
 
-        If (-not (Get-Item $DestinationPath).length -gt 500kb) {
-            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
-            DownloadFile $RemoteArchiveUrl $DestinationPath
-        }
-
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-devel-VC${env:VC_VERSION}-${env:PHP_ARCH}"
 
         If (-not (Test-Path "$DestinationUnzipPath")) {
-            Expand-Item7zip $DestinationPath $env:Temp
+            Try {
+                Expand-Item7zip $DestinationPath $env:Temp
+            } Catch {
+                # if expand fails try alternative download
+                Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
+                DownloadFile $RemoteArchiveUrl $DestinationPath
+                Expand-Item7zip $DestinationPath $env:Temp
+            }
         }
 
         Move-Item -Path $DestinationUnzipPath -Destination $env:PHP_DEVPACK

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -54,7 +54,7 @@ Function DownloadPhpSrc {
             DownloadFile $RemoteUrl $DestinationPath
         }
 
-        If (-not [System.IO.File]::Exists($DestinationPath)) {
+        If (-not (Get-Item $DestinationPath).length -gt 0kb) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
             DownloadFile $RemoteArchiveUrl $DestinationPath
         }
@@ -82,7 +82,7 @@ Function InstallPhpDevPack {
             DownloadFile $RemoteUrl $DestinationPath
         }
 
-        If (-not [System.IO.File]::Exists($DestinationPath)) {
+        If (-not (Get-Item $DestinationPath).length -gt 0kb) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
             DownloadFile $RemoteArchiveUrl $DestinationPath
         }

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -54,7 +54,7 @@ Function DownloadPhpSrc {
             DownloadFile $RemoteUrl $DestinationPath
         }
 
-        If (-not (Get-Item $DestinationPath).length -gt 0kb) {
+        If (-not (Get-Item $DestinationPath).length -gt 500kb) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
             DownloadFile $RemoteArchiveUrl $DestinationPath
         }
@@ -82,7 +82,7 @@ Function InstallPhpDevPack {
             DownloadFile $RemoteUrl $DestinationPath
         }
 
-        If (-not (Get-Item $DestinationPath).length -gt 0kb) {
+        If (-not (Get-Item $DestinationPath).length -gt 500kb) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
             DownloadFile $RemoteArchiveUrl $DestinationPath
         }

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -55,7 +55,7 @@ Function DownloadPhpSrc {
         }
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
-            DownloadFile ${RemoteArchiveUrl} $DestinationPath
+            DownloadFile $RemoteArchiveUrl $DestinationPath
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-src"

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -53,6 +53,7 @@ Function DownloadPhpSrc {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
             DownloadFile $RemoteUrl $DestinationPath
         }
+
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
             DownloadFile $RemoteArchiveUrl $DestinationPath
@@ -80,6 +81,7 @@ Function InstallPhpDevPack {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
             DownloadFile $RemoteUrl $DestinationPath
         }
+        
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
             DownloadFile $RemoteArchiveUrl $DestinationPath

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -51,11 +51,12 @@ Function DownloadPhpSrc {
     If (-not (Test-Path $env:PHP_SRC_PATH)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
-            Try {
-                DownloadFile $RemoteUrl $DestinationPath
-            } Catch {
-                DownloadFile $RemoteArchiveUrl $DestinationPath
-            }
+            DownloadFile $RemoteUrl $DestinationPath
+        }
+
+        If (-not [System.IO.File]::Exists($DestinationPath)) {
+            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
+            DownloadFile $RemoteArchiveUrl $DestinationPath
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-src"
@@ -78,11 +79,12 @@ Function InstallPhpDevPack {
     If (-not (Test-Path $env:PHP_DEVPACK)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
-            Try {
-                DownloadFile $RemoteUrl $DestinationPath
-            } Catch {
-                DownloadFile $RemoteArchiveUrl $DestinationPath
-            }
+            DownloadFile $RemoteUrl $DestinationPath
+        }
+
+        If (-not [System.IO.File]::Exists($DestinationPath)) {
+            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
+            DownloadFile $RemoteArchiveUrl $DestinationPath
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-devel-VC${env:VC_VERSION}-${env:PHP_ARCH}"

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -44,8 +44,8 @@ Function InstallPhpSdk {
 Function DownloadPhpSrc {
     Write-Output "Download PHP Src: ${env:PHP_VERSION}"
 
-    $RemoteUrl = "http://windows.php.net/downloads/releases/php-${env:PHP_VERSION}-src.zip"
-    $RemoteArchiveUrl = "http://windows.php.net/downloads/releases/archives/php-${env:PHP_VERSION}-src.zip"
+    $RemoteUrl = "https://windows.php.net/downloads/releases/php-${env:PHP_VERSION}-src.zip"
+    $RemoteArchiveUrl = "https://windows.php.net/downloads/releases/archives/php-${env:PHP_VERSION}-src.zip"
     $DestinationPath = "C:\Downloads\php-${env:PHP_VERSION}-src.zip"
 
     If (-not (Test-Path $env:PHP_SRC_PATH)) {
@@ -74,8 +74,8 @@ Function DownloadPhpSrc {
 Function InstallPhpDevPack {
     Write-Output "Install PHP Dev pack: ${env:PHP_VERSION}"
 
-    $RemoteUrl = "http://windows.php.net/downloads/releases/php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-vc${env:VC_VERSION}-${env:PHP_ARCH}.zip"
-    $RemoteArchiveUrl = "http://windows.php.net/downloads/releases/archives/php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-vc${env:VC_VERSION}-${env:PHP_ARCH}.zip"
+    $RemoteUrl = "https://windows.php.net/downloads/releases/php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-vc${env:VC_VERSION}-${env:PHP_ARCH}.zip"
+    $RemoteArchiveUrl = "https://windows.php.net/downloads/releases/archives/php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-vc${env:VC_VERSION}-${env:PHP_ARCH}.zip"
     $DestinationPath = "C:\Downloads\php-devel-pack-${env:PHP_VERSION}-${env:BUILD_TYPE}-VC${env:VC_VERSION}-${env:PHP_ARCH}.zip"
 
     If (-not (Test-Path $env:PHP_DEVPACK)) {
@@ -141,10 +141,14 @@ Function DownloadFile {
         Try {
             $WebClient.DownloadFile($RemoteUrl, $DestinationPath)
             $Completed = $true
-        } Catch {
+        } Catch (WebException wex) {
+            If (((HttpWebResponse) wex.Response).StatusCode == HttpStatusCode.NotFound)
+            {
+            // error 404, do what you need to do
+            }
             If ($RetryCount -ge $RetryMax) {
                 $ErrorMessage = $_.Exception.Message
-                Write-Output "Error downloadingig ${RemoteUrl}: $ErrorMessage"
+                Write-Output "Error downloading ${RemoteUrl}: $ErrorMessage"
                 $Completed = $true
             } Else {
                 $RetryCount++

--- a/.ci/win-ci-tools.psm1
+++ b/.ci/win-ci-tools.psm1
@@ -51,12 +51,11 @@ Function DownloadPhpSrc {
     If (-not (Test-Path $env:PHP_SRC_PATH)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
-            DownloadFile $RemoteUrl $DestinationPath
-        }
-
-        If (-not [System.IO.File]::Exists($DestinationPath)) {
-            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
-            DownloadFile $RemoteArchiveUrl $DestinationPath
+            Try {
+                DownloadFile $RemoteUrl $DestinationPath
+            } Catch {
+                DownloadFile $RemoteArchiveUrl $DestinationPath
+            }
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-src"
@@ -79,12 +78,11 @@ Function InstallPhpDevPack {
     If (-not (Test-Path $env:PHP_DEVPACK)) {
         If (-not [System.IO.File]::Exists($DestinationPath)) {
             Write-Output "Downloading PHP Dev pack: ${RemoteUrl} ..."
-            DownloadFile $RemoteUrl $DestinationPath
-        }
-        
-        If (-not [System.IO.File]::Exists($DestinationPath)) {
-            Write-Output "Downloading PHP Dev pack from archive: ${RemoteArchiveUrl} ..."
-            DownloadFile $RemoteArchiveUrl $DestinationPath
+            Try {
+                DownloadFile $RemoteUrl $DestinationPath
+            } Catch {
+                DownloadFile $RemoteArchiveUrl $DestinationPath
+            }
         }
 
         $DestinationUnzipPath = "${env:Temp}\php-${env:PHP_VERSION}-devel-VC${env:VC_VERSION}-${env:PHP_ARCH}"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -386,7 +386,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2.1.2
+        uses: shivammathur/setup-php@2.1.2
         with:
           php-version: ${{ matrix.php-versions }}
           ini-values: apc.enable_cli=on, session.save_path=C:\temp

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -386,7 +386,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2.1.2
         with:
           php-version: ${{ matrix.php-versions }}
           ini-values: apc.enable_cli=on, session.save_path=C:\temp

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -386,7 +386,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           ini-values: apc.enable_cli=on, session.save_path=C:\temp

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -386,7 +386,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@2.1.2
+        uses: shivammathur/setup-php@2
         with:
           php-version: ${{ matrix.php-versions }}
           ini-values: apc.enable_cli=on, session.save_path=C:\temp


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: https://github.com/phalcon/cphalcon/pull/14921

When a new PHP is released and our upstream php Github action isn't updated yet we should fetch the windows downloads from the archive instead of the latest.
Added a fallback to check the archive when first download fails.


