### PR TITLE
Correct PhpDoc for Phalcon\Db\Adapter\AbstractAdapter

### DIFF
--- a/phalcon/Db/Adapter/AbstractAdapter.zep
+++ b/phalcon/Db/Adapter/AbstractAdapter.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.com>
  *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
  */
 
 namespace Phalcon\Db\Adapter;
@@ -23,7 +23,7 @@ use Phalcon\Events\EventsAwareInterface;
 use Phalcon\Events\ManagerInterface;
 
 /**
- * Base class for Phalcon\Db adapters
+ * Base class for Phalcon\Db\Adapter adapters
  */
 abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
 {
@@ -59,7 +59,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Event Manager
      *
-     * @var Phalcon\Events\Manager
+     * @var ManagerInterface
      */
     protected eventsManager;
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/ide-stubs/pull/44

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Correct PhpDoc for `Phalcon\Db\Adapter\AbstractAdapter`.
`Phalcon\Db\Adapter\AdapterInterface` issue related to Zephir.

Thanks

