### PR TITLE
Review MySQL default null and nullable column definition

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,10 +3,10 @@
 
 ## Changed
 - Changed `Volt::convertEncoding` to no longer using `iconv` for a fallback since it causes issues with macOS [#14912](https://github.com/phalcon/cphalcon/issues/14912)
+- Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)
-- Fixed schema manipulation in `Phalcon\Db\Dialect\Mysql`, unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
 - Fixed recognizing language operators inside Volt's echo mode (`{{ ... }}`) [#14476](https://github.com/phalcon/cphalcon/issues/14476)
 - Fixed `Tag::friendlyTitle` to correctly convert titles under MacOS and Windows [#14866](https://github.com/phalcon/cphalcon/issues/14866)
 - Fixed the Volt compiler to no longer parse `cache` fragments and thus searching for the `viewCache` service (deprecated for v4) [#14907](https://github.com/phalcon/cphalcon/issues/14907)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,7 +6,7 @@
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)
-- Fixed schema manipulation in `Phalcon\Db\Dialect\Mysql`, remove unnecessary `NULL` in column definition, unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
+- Fixed schema manipulation in `Phalcon\Db\Dialect\Mysql`, unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
 - Fixed recognizing language operators inside Volt's echo mode (`{{ ... }}`) [#14476](https://github.com/phalcon/cphalcon/issues/14476)
 - Fixed `Tag::friendlyTitle` to correctly convert titles under MacOS and Windows [#14866](https://github.com/phalcon/cphalcon/issues/14866)
 - Fixed the Volt compiler to no longer parse `cache` fragments and thus searching for the `viewCache` service (deprecated for v4) [#14907](https://github.com/phalcon/cphalcon/issues/14907)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,10 +3,10 @@
 
 ## Changed
 - Changed `Volt::convertEncoding` to no longer using `iconv` for a fallback since it causes issues with macOS [#14912](https://github.com/phalcon/cphalcon/issues/14912)
-- Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [#14974](https://github.com/phalcon/cphalcon/pull/14974)
+- Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults [#14888](https://github.com/phalcon/cphalcon/pull/14888) [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 
 ## Fixed
-- Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)
+- Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition [#14874](https://github.com/phalcon/cphalcon/issues/14874)
 - Fixed recognizing language operators inside Volt's echo mode (`{{ ... }}`) [#14476](https://github.com/phalcon/cphalcon/issues/14476)
 - Fixed `Tag::friendlyTitle` to correctly convert titles under MacOS and Windows [#14866](https://github.com/phalcon/cphalcon/issues/14866)
 - Fixed the Volt compiler to no longer parse `cache` fragments and thus searching for the `viewCache` service (deprecated for v4) [#14907](https://github.com/phalcon/cphalcon/issues/14907)
@@ -19,7 +19,7 @@
 ## Changed
 
 ## Fixed
-- Fixed `Phalcon\Db::fetchAll` to correctly return data when `Enum::FETCH_COLUMN` is supplied. [#13321](https://github.com/phalcon/cphalcon/issues/13321)
+- Fixed `Phalcon\Db::fetchAll` to correctly return data when `Enum::FETCH_COLUMN` is supplied [#13321](https://github.com/phalcon/cphalcon/issues/13321)
 - Fixed Postgres NULL values to not be required during model update. [#14862](https://github.com/phalcon/cphalcon/issues/14862)
 - Fixed MySQL alter column when default value contains not only CURRENT_TIMESTAMP [#14880](https://github.com/phalcon/cphalcon/issues/14880)
 - Fixed MySQL default value with ON UPDATE expression [#14887](https://github.com/phalcon/cphalcon/pull/14887)

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -3,7 +3,7 @@
 
 ## Changed
 - Changed `Volt::convertEncoding` to no longer using `iconv` for a fallback since it causes issues with macOS [#14912](https://github.com/phalcon/cphalcon/issues/14912)
-- Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [@pfz](https://github.com/pfz)
+- Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults. [#14888](https://github.com/phalcon/cphalcon/pull/14888) [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition. [#14874](https://github.com/phalcon/cphalcon/issues/14874) [@jenovateurs](https://github.com/jenovateurs)

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -456,10 +456,6 @@ class Mysql extends Dialect
                     let columnSql .= "DATETIME";
                 }
 
-                if column->getSize() > 0 {
-                    let columnSql .= this->getColumnSize(column);
-                }
-
                 break;
 
             case Column::TYPE_DECIMAL:
@@ -572,19 +568,11 @@ class Mysql extends Dialect
                     let columnSql .= "TIME";
                 }
 
-                if column->getSize() > 0 {
-                    let columnSql .= this->getColumnSize(column);
-                }
-
                 break;
 
             case Column::TYPE_TIMESTAMP:
                 if empty columnSql {
                     let columnSql .= "TIMESTAMP";
-                }
-
-                if column->getSize() > 0 {
-                    let columnSql .= this->getColumnSize(column);
                 }
 
                 break;

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -33,23 +33,29 @@ class Mysql extends Dialect
      */
     public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> string
     {
-        var afterPosition, defaultValue;
+        var afterPosition, defaultValue, upperDefaultValue;
         string sql;
 
         let sql = "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD `" . column->getName() . "` " . this->getColumnDefinition(column);
 
+        if column->isNotNull() {
+            let sql .= " NOT NULL";
+        } else {
+            // This is required for some types like TIMESTAMP
+            // Query won't be executed if NULL wasn't specified
+            // Even if DEFAULT NULL was specified
+            let sql .= " NULL";
+        }
+
         if column->hasDefault() {
             let defaultValue = column->getDefault();
+            let upperDefaultValue = strtoupper(defaultValue);
 
-            if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") || is_int(defaultValue) || is_float(defaultValue) {
+            if memstr(upperDefaultValue, "CURRENT_TIMESTAMP") || memstr(upperDefaultValue, "NULL") || is_int(defaultValue) || is_float(defaultValue) {
                 let sql .= " DEFAULT " . defaultValue;
             } else {
                 let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
             }
-        }
-
-        if column->isNotNull() {
-            let sql .= " NOT NULL";
         }
 
         if column->isAutoIncrement() {
@@ -135,7 +141,7 @@ class Mysql extends Dialect
     {
         var temporary, options, table, columns, column, indexes, index,
             reference, references, indexName, columnLine, indexType, onDelete,
-            onUpdate, defaultValue;
+            onUpdate, defaultValue, upperDefaultValue;
         array createLines;
         string indexSql, referenceSql, sql;
 
@@ -167,27 +173,29 @@ class Mysql extends Dialect
             let columnLine = "`" . column->getName() . "` " . this->getColumnDefinition(column);
 
             /**
-             * Add a Default clause
-             */
-            if column->hasDefault() {
-                let defaultValue = column->getDefault();
-
-                if (defaultValue === null) {
-                    let columnLine .= " DEFAULT NULL";
-                } else {
-                    if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") || is_int(defaultValue) || is_float(defaultValue) {
-                        let columnLine .= " DEFAULT " . defaultValue;
-                    } else {
-                        let columnLine .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
-                    }
-                }
-            }
-
-            /**
              * Add a NOT NULL clause
              */
             if column->isNotNull() {
                 let columnLine .= " NOT NULL";
+            } else {
+                // This is required for some types like TIMESTAMP
+                // Query won't be executed if NULL wasn't specified
+                // Even if DEFAULT NULL was specified
+                let columnLine .= " NULL";
+            }
+
+            /**
+             * Add a Default clause
+             */
+            if column->hasDefault() {
+                let defaultValue = column->getDefault();
+                let upperDefaultValue = strtoupper(defaultValue);
+
+                if memstr(upperDefaultValue, "CURRENT_TIMESTAMP") || memstr(upperDefaultValue, "NULL") || is_int(defaultValue) || is_float(defaultValue) {
+                    let columnLine .= " DEFAULT " . defaultValue;
+                } else {
+                    let columnLine .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
+                }
             }
 
             /**
@@ -448,6 +456,10 @@ class Mysql extends Dialect
                     let columnSql .= "DATETIME";
                 }
 
+                if column->getSize() > 0 {
+                    let columnSql .= this->getColumnSize(column);
+                }
+
                 break;
 
             case Column::TYPE_DECIMAL:
@@ -560,11 +572,19 @@ class Mysql extends Dialect
                     let columnSql .= "TIME";
                 }
 
+                if column->getSize() > 0 {
+                    let columnSql .= this->getColumnSize(column);
+                }
+
                 break;
 
             case Column::TYPE_TIMESTAMP:
                 if empty columnSql {
                     let columnSql .= "TIMESTAMP";
+                }
+
+                if column->getSize() > 0 {
+                    let columnSql .= this->getColumnSize(column);
                 }
 
                 break;
@@ -672,7 +692,7 @@ class Mysql extends Dialect
      */
     public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
     {
-        var afterPosition, defaultValue, columnDefinition;
+        var afterPosition, defaultValue, upperDefaultValue, columnDefinition;
         string sql;
 
         let columnDefinition = this->getColumnDefinition(column),
@@ -688,19 +708,25 @@ class Mysql extends Dialect
             let sql .= " MODIFY `" . column->getName() . "` " . columnDefinition;
         }
 
+        if column->isNotNull() {
+            let sql .= " NOT NULL";
+        } else {
+            // This is required for some types like TIMESTAMP
+            // Query won't be executed if NULL wasn't specified
+            // Even if DEFAULT NULL was specified
+            let sql .= " NULL";
+        }
+
         if column->hasDefault() {
             let defaultValue = column->getDefault();
+            let upperDefaultValue = strtoupper(defaultValue);
 
-            if memstr(strtoupper(defaultValue), "CURRENT_TIMESTAMP") || is_int(defaultValue) || is_float(defaultValue) {
+            if memstr(upperDefaultValue, "CURRENT_TIMESTAMP") || memstr(upperDefaultValue, "NULL") || is_int(defaultValue) || is_float(defaultValue) {
                 let sql .= " DEFAULT " . defaultValue;
             }  else {
                 let sql .= " DEFAULT \"" . addcslashes(defaultValue, "\"") . "\"";
             }
         }
-
-        if column->isNotNull() {
-            let sql .= " NOT NULL";
-        } 
 
         if column->isAutoIncrement() {
             let sql .= " AUTO_INCREMENT";

--- a/tests/integration/Db/Dialect/Mysql/AddColumnCest.php
+++ b/tests/integration/Db/Dialect/Mysql/AddColumnCest.php
@@ -23,7 +23,8 @@ class AddColumnCest
      * Tests Phalcon\Db\Adapter\Pdo\Mysql :: addColumn()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-05-02
+     * @since  2020-02-27
+     * @since  2020-05-02 Changed default null and nullable column definition
      */
     public function dbAdapterPdoMysqlAddColumn(IntegrationTester $I)
     {

--- a/tests/integration/Db/Dialect/Mysql/AddColumnCest.php
+++ b/tests/integration/Db/Dialect/Mysql/AddColumnCest.php
@@ -23,7 +23,7 @@ class AddColumnCest
      * Tests Phalcon\Db\Adapter\Pdo\Mysql :: addColumn()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-02-27
+     * @since  2020-05-02
      */
     public function dbAdapterPdoMysqlAddColumn(IntegrationTester $I)
     {
@@ -32,28 +32,63 @@ class AddColumnCest
         $additions = [
             [
                 new Column(
-                    'updated_at',
-                    [
-                        'type'    => Column::TYPE_TIMESTAMP,
-                        'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
-                        'notNull' => false,
-                        'after'   => 'created_at',
-                    ]
-                ),
-                'ALTER TABLE `test` ADD `updated_at` TIMESTAMP ' .
-                'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created_at`',
-            ],
-            [
-                new Column(
                     'numeric_val',
                     [
                         'type'    => Column::TYPE_FLOAT,
                         'default' => 21.42,
                         'notNull' => true,
+                    ]
+                ),
+                'ALTER TABLE `test` ADD `numeric_val` FLOAT NOT NULL DEFAULT 21.42',
+            ],
+            [
+                new Column(
+                    'null_int',
+                    [
+                        'type'    => Column::TYPE_INTEGER,
+                        'size'    => 11,
+                        'notNull' => false,
+                        'after'   => 'numeric_val',
+                    ]
+                ),
+                'ALTER TABLE `test` ADD `null_int` INT(11) NULL AFTER `numeric_val`',
+            ],
+            [
+                new Column(
+                    'created_at',
+                    [
+                        'type'    => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP",
+                        'notNull' => true,
+                        'after'   => 'null_int',
+                    ]
+                ),
+                'ALTER TABLE `test` ADD `created_at` TIMESTAMP NOT NULL ' .
+                'DEFAULT CURRENT_TIMESTAMP AFTER `null_int`',
+            ],
+            [
+                new Column(
+                    'updated_at',
+                    [
+                        'type'    => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+                        'notNull' => true,
+                        'after'   => 'created_at',
+                    ]
+                ),
+                'ALTER TABLE `test` ADD `updated_at` TIMESTAMP NOT NULL ' .
+                'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created_at`',
+            ],
+            [
+                new Column(
+                    'deleted_at',
+                    [
+                        'type'    => Column::TYPE_TIMESTAMP,
+                        'notNull' => false,
                         'after'   => 'updated_at',
                     ]
                 ),
-                'ALTER TABLE `test` ADD `numeric_val` FLOAT DEFAULT 21.42 NOT NULL AFTER `updated_at`',
+                'ALTER TABLE `test` ADD `deleted_at` TIMESTAMP NULL AFTER `updated_at`',
             ],
         ];
 

--- a/tests/integration/Db/Dialect/Mysql/CreateTableCest.php
+++ b/tests/integration/Db/Dialect/Mysql/CreateTableCest.php
@@ -24,7 +24,8 @@ class CreateTableCest
      * Tests Phalcon\Db\Adapter\Pdo\Mysql :: createTable()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-05-02
+     * @since  2020-02-27
+     * @since  2020-05-02 Changed default null and nullable column definition
      */
     public function dbAdapterPdoMysqlCreateTable(IntegrationTester $I)
     {

--- a/tests/integration/Db/Dialect/Mysql/CreateTableCest.php
+++ b/tests/integration/Db/Dialect/Mysql/CreateTableCest.php
@@ -24,7 +24,7 @@ class CreateTableCest
      * Tests Phalcon\Db\Adapter\Pdo\Mysql :: createTable()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-02-27
+     * @since  2020-05-02
      */
     public function dbAdapterPdoMysqlCreateTable(IntegrationTester $I)
     {
@@ -43,20 +43,46 @@ class CreateTableCest
                     ]
                 ),
                 new Column(
-                    'updated_at',
+                    'numeric_val',
+                    [
+                        'type'    => Column::TYPE_FLOAT,
+                        'default' => 21.42,
+                        'notNull' => true,
+                    ]
+                ),
+                new Column(
+                    'null_int',
+                    [
+                        'type'    => Column::TYPE_INTEGER,
+                        'size'    => 11,
+                        'notNull' => false,
+                        'after'   => 'numeric_val',
+                    ]
+                ),
+                new Column(
+                    'created_at',
                     [
                         'type'    => Column::TYPE_TIMESTAMP,
-                        'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
-                        'notNull' => false,
+                        'default' => "CURRENT_TIMESTAMP",
+                        'notNull' => true,
                         'after'   => 'created_at',
                     ]
                 ),
                 new Column(
-                    'numeric_val',
+                    'updated_at',
                     [
-                        'type'    => Column::TYPE_FLOAT,
+                        'type'    => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
+                        'notNull' => true,
+                        'after'   => 'created_at',
+                    ]
+                ),
+                new Column(
+                    'deleted_at',
+                    [
+                        'type'    => Column::TYPE_TIMESTAMP,
                         'notNull' => false,
-                        'after'   => 'updated_at',
+                        'after'   => 'created_at',
                     ]
                 ),
             ],
@@ -70,8 +96,11 @@ class CreateTableCest
         $expected = <<<SQL
 CREATE TABLE `test` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
-	`updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-	`numeric_val` FLOAT,
+	`numeric_val` FLOAT NOT NULL DEFAULT 21.42,
+	`null_int` INT(11) NULL,
+	`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+	`deleted_at` TIMESTAMP NULL,
 	PRIMARY KEY (`id`)
 )
 SQL;

--- a/tests/integration/Db/Dialect/Mysql/ModifyColumnCest.php
+++ b/tests/integration/Db/Dialect/Mysql/ModifyColumnCest.php
@@ -23,7 +23,7 @@ class ModifyColumnCest
      * Tests Phalcon\Db\Adapter\Pdo\Mysql :: modifyColumn()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-02-27
+     * @since  2020-05-02
      */
     public function dbAdapterPdoMysqlModifyColumn(IntegrationTester $I)
     {
@@ -36,20 +36,42 @@ class ModifyColumnCest
                     [
                         'type'    => Column::TYPE_TIMESTAMP,
                         'default' => "CURRENT_TIMESTAMP",
-                        'notNull' => false,
+                        'notNull' => true,
                         'after'   => 'created_at',
                     ]
-                ), new Column(
+                ),
+                new Column(
                     'updated_at',
                     [
                         'type'    => Column::TYPE_TIMESTAMP,
                         'default' => "CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP",
-                        'notNull' => false,
+                        'notNull' => true,
                         'after'   => 'created_at',
                     ]
                 ),
-                'ALTER TABLE `test` MODIFY `updated_at` TIMESTAMP ' .
+                'ALTER TABLE `test` MODIFY `updated_at` TIMESTAMP NOT NULL ' .
                 'DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP AFTER `created_at`',
+            ],
+            [
+                new Column(
+                    'deleted_at',
+                    [
+                        'type'    => Column::TYPE_TIMESTAMP,
+                        'default' => "CURRENT_TIMESTAMP",
+                        'notNull' => false,
+                        'after'   => 'updated_at',
+                    ]
+                ),
+                new Column(
+                    'deleted_at',
+                    [
+                        'type'    => Column::TYPE_TIMESTAMP,
+                        'default' => "NULL",
+                        'notNull' => false,
+                        'after'   => 'updated_at',
+                    ]
+                ),
+                'ALTER TABLE `test` MODIFY `deleted_at` TIMESTAMP NULL DEFAULT NULL AFTER `updated_at`',
             ],
             [
                 new Column(
@@ -59,7 +81,8 @@ class ModifyColumnCest
                         'notNull' => true,
                         'after'   => 'updated_at',
                     ]
-                ), new Column(
+                ),
+                new Column(
                     'numeric_val',
                     [
                         'type'    => Column::TYPE_FLOAT,
@@ -68,7 +91,7 @@ class ModifyColumnCest
                         'after'   => 'updated_at',
                     ]
                 ),
-                'ALTER TABLE `test` MODIFY `numeric_val` FLOAT DEFAULT 21.42 AFTER `updated_at`',
+                'ALTER TABLE `test` MODIFY `numeric_val` FLOAT NULL DEFAULT 21.42 AFTER `updated_at`',
             ],
         ];
 

--- a/tests/integration/Db/Dialect/Mysql/ModifyColumnCest.php
+++ b/tests/integration/Db/Dialect/Mysql/ModifyColumnCest.php
@@ -23,7 +23,8 @@ class ModifyColumnCest
      * Tests Phalcon\Db\Adapter\Pdo\Mysql :: modifyColumn()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-05-02
+     * @since  2020-02-27
+     * @since  2020-05-02 Changed default null and nullable column definition
      */
     public function dbAdapterPdoMysqlModifyColumn(IntegrationTester $I)
     {


### PR DESCRIPTION
Hello!

* Type: bug fix | code quality
* Link to issue: #14888

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Current PR fixes previous PRs (#14888) behavior, when it wasn't possible to specify `NULL` in column definition, as some of types requires it, if column need to be nullable.
For example:
This is NOT NULL
```
updated_at TIMESTAMP
```

This is NULL, with default NULL
```
updated_at TIMESTAMP NULL
```

This is also NULL, with default NULL
```
updated_at TIMESTAMP NULL DEFAULT NULL
```

Two last examples was not possible to generate before this PR.

<hr/>

Also, moved `NULL/NOT NULL` before `DEFAULT`.

Before:
```
updated_at` TIMESTAMP DEFAULT NULL NULL
```

After
```
updated_at` TIMESTAMP NULL DEFAULT NULL
```


Previous branch - #14973

Thanks

