### PR TITLE
Fixed default type of the Annotation properties and return type hints of the Annotation methods

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -13,7 +13,8 @@
 - Fixed the Volt compiler to no longer parse `cache` fragments and thus searching for the `viewCache` service (deprecated for v4) [#14907](https://github.com/phalcon/cphalcon/issues/14907)
 - Fixed `IN` operator precedence in Volt [#14816](https://github.com/phalcon/cphalcon/issues/14816)
 - Fixed testing suite to work with PHPUnit 9 when we upgrade [#14837](https://github.com/phalcon/cphalcon/issues/14837)
-- Fixed return type hints of the following `Phalcon\Acl\AbstractAdapter`'s methods: `getActiveAccess`, `getActiveRole`, `getActiveComponent` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
+- Fixed return type hints of the following `Phalcon\Acl\AbstractAdapter`'s methods: `getActiveAccess`, `getActiveRole` and `getActiveComponent` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
+- Fixed default value of the following `Phalcon\Annotations\Annotation`'s properties: `$arguments` and `$exprArguments` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -15,6 +15,7 @@
 - Fixed testing suite to work with PHPUnit 9 when we upgrade [#14837](https://github.com/phalcon/cphalcon/issues/14837)
 - Fixed return type hints of the following `Phalcon\Acl\AbstractAdapter`'s methods: `getActiveAccess`, `getActiveRole` and `getActiveComponent` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Fixed default value of the following `Phalcon\Annotations\Annotation`'s properties: `$arguments` and `$exprArguments` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
+- Fixed return type hints of the following `Phalcon\Annotations\Annotation`'s methods: `getArgument`, `getName` and `getNamedArgument` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/phalcon/Acl/Adapter/AbstractAdapter.zep
+++ b/phalcon/Acl/Adapter/AbstractAdapter.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Acl\Adapter;

--- a/phalcon/Annotations/Annotation.zep
+++ b/phalcon/Annotations/Annotation.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Annotations;
@@ -20,14 +20,14 @@ class Annotation
      *
      * @var array
      */
-    protected arguments;
+    protected arguments = [];
 
     /**
      * Annotation ExprArguments
      *
-     * @var string
+     * @var array
      */
-    protected exprArguments;
+    protected exprArguments = [];
 
     /**
      * Annotation Name
@@ -44,7 +44,11 @@ class Annotation
         var name, exprArguments, argument, resolvedArgument;
         array arguments;
 
-        let this->name = reflectionData["name"];
+        if fetch name, reflectionData["name"] {
+            let this->name = reflectionData["name"];
+        } else {
+            let this->name = "";
+        }
 
         /**
          * Process annotation arguments

--- a/phalcon/Annotations/Annotation.zep
+++ b/phalcon/Annotations/Annotation.zep
@@ -32,7 +32,7 @@ class Annotation
     /**
      * Annotation Name
      *
-     * @var string
+     * @var string|null
      */
     protected name;
 
@@ -46,8 +46,6 @@ class Annotation
 
         if fetch name, reflectionData["name"] {
             let this->name = reflectionData["name"];
-        } else {
-            let this->name = "";
         }
 
         /**
@@ -76,13 +74,15 @@ class Annotation
     /**
      * Returns an argument in a specific position
      */
-    public function getArgument(var position)
+    public function getArgument(var position) -> var | null
     {
         var argument;
 
         if fetch argument, this->arguments[position] {
             return argument;
         }
+
+        return null;
     }
 
     /**
@@ -160,7 +160,7 @@ class Annotation
     /**
      * Returns the annotation's name
      */
-    public function getName() -> string
+    public function getName() -> null | string
     {
         return this->name;
     }
@@ -168,13 +168,15 @@ class Annotation
     /**
      * Returns a named argument
      */
-    public function getNamedArgument(string! name)
+    public function getNamedArgument(string! name) -> var | null
     {
         var argument;
 
         if fetch argument, this->arguments[name] {
             return argument;
         }
+
+        return null;
     }
 
     /**

--- a/tests/unit/Acl/Adapter/Memory/GetActiveAccessCest.php
+++ b/tests/unit/Acl/Adapter/Memory/GetActiveAccessCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);

--- a/tests/unit/Annotations/ReflectionCest.php
+++ b/tests/unit/Annotations/ReflectionCest.php
@@ -20,7 +20,9 @@ use UnitTester;
 class ReflectionCest
 {
     /**
-     * executed before each test
+     * Executed before each test.
+     *
+     * @param  UnitTester $I
      */
     protected function _before(UnitTester $I)
     {
@@ -29,6 +31,8 @@ class ReflectionCest
 
     /**
      * Tests parsing class annotations
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2016-01-26
@@ -43,7 +47,7 @@ class ReflectionCest
 
         $methodsAnnotations = $reflection->getMethodsAnnotations();
 
-        $I->assertTrue(is_array($methodsAnnotations));
+        $I->assertIsArray($methodsAnnotations);
 
         $I->assertInstanceOf(
             Collection::class,
@@ -53,7 +57,7 @@ class ReflectionCest
         $total = 0;
 
         foreach ($methodsAnnotations as $method => $annotations) {
-            $I->assertTrue(is_string($method));
+            $I->assertIsString($method);
 
             $number = 0;
 
@@ -80,7 +84,7 @@ class ReflectionCest
 
         $annotation = $annotations->get('Simple');
         $I->assertEquals('Simple', $annotation->getName());
-        $I->assertEquals(null, $annotation->getArguments());
+        $I->assertEquals([], $annotation->getArguments());
         $I->assertEquals(0, $annotation->numberArguments());
         $I->assertFalse($annotation->hasArgument('none'));
 
@@ -93,7 +97,7 @@ class ReflectionCest
         $I->assertFalse($annotation->hasArgument('none'));
 
         $propertiesAnnotations = $reflection->getPropertiesAnnotations();
-        $I->assertTrue(is_array($propertiesAnnotations));
+        $I->assertIsArray($propertiesAnnotations);
         $I->assertInstanceOf(
             Collection::class,
             $propertiesAnnotations['testProp1']


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14977

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Fixed default value of the following `Phalcon\Annotations\Annotation`'s properties:

- `Phalcon\Annotations\Annotation::$arguments`
- `Phalcon\Annotations\Annotation::$exprArguments`

Thanks

