### PR TITLE
Fixed incorrect return type hint for setSignKey

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -16,6 +16,7 @@
 - Fixed return type hints of the following `Phalcon\Acl\AbstractAdapter`'s methods: `getActiveAccess`, `getActiveRole` and `getActiveComponent` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Fixed default value of the following `Phalcon\Annotations\Annotation`'s properties: `$arguments` and `$exprArguments` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
 - Fixed return type hints of the following `Phalcon\Annotations\Annotation`'s methods: `getArgument`, `getName` and `getNamedArgument` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
+- Fixed incorrect return type hint for `Phalcon\Http\Response\Cookies::setSignKey` [#14982](https://github.com/phalcon/cphalcon/issues/14982)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/phalcon/Http/Response/Cookies.zep
+++ b/phalcon/Http/Response/Cookies.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Http\Response;
@@ -312,7 +312,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
      *
      * @see \Phalcon\Security\Random
      */
-    public function setSignKey(string signKey = null) -> <CookieInterface>
+    public function setSignKey(string signKey = null) -> <CookiesInterface>
     {
         let this->signKey = signKey;
 

--- a/tests/unit/Http/Response/Cookies/DeleteCest.php
+++ b/tests/unit/Http/Response/Cookies/DeleteCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Http\Response\Cookies;
 
 use Phalcon\Http\Response\Cookies;
+use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Traits\CookieTrait;
 use Phalcon\Test\Unit\Http\Helper\HttpBase;
 use UnitTester;
@@ -23,16 +24,26 @@ class DeleteCest extends HttpBase
     use CookieTrait;
 
     /**
-     * executed before each test
+     * Executed before each test
+     *
+     * @param UnitTester $I
+     * @return void
      */
-    public function _before(UnitTester $I)
+    public function _before(UnitTester $I): void
     {
         parent::_before($I);
-        $this->setDiService('sessionStream');
+
+        try {
+            $this->setDiService('sessionStream');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
     }
 
     /**
      * Tests Phalcon\Http\Response\Cookies :: delete()
+     *
+     * @param UnitTester $I
      *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2020-01-06
@@ -44,7 +55,12 @@ class DeleteCest extends HttpBase
         $sName  = 'framework';
         $sValue = 'phalcon';
 
-        $this->setDiService('crypt');
+        try {
+            $this->setDiService('crypt');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
+
         $container = $this->getDi();
 
         $oCookie = new Cookies();

--- a/tests/unit/Http/Response/Cookies/SetSignKeyCest.php
+++ b/tests/unit/Http/Response/Cookies/SetSignKeyCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Http\Response\Cookies;
 
 use Phalcon\Http\Response\Cookies;
+use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Traits\CookieTrait;
 use Phalcon\Test\Unit\Http\Helper\HttpBase;
 use UnitTester;
@@ -23,16 +24,26 @@ class SetSignKeyCest extends HttpBase
     use CookieTrait;
 
     /**
-     * executed before each test
+     * Executed before each test
+     *
+     * @param UnitTester $I
+     * @return void
      */
-    public function _before(UnitTester $I)
+    public function _before(UnitTester $I): void
     {
         parent::_before($I);
-        $this->setDiService('sessionStream');
+
+        try {
+            $this->setDiService('sessionStream');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
     }
 
     /**
      * Tests Phalcon\Http\Response\Cookies :: setSignKey()
+     *
+     * @param UnitTester $I
      *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2020-01-06
@@ -41,10 +52,12 @@ class SetSignKeyCest extends HttpBase
     {
         $I->wantToTest('Http\Response\Cookies - setSignKey()');
 
-        $sName  = 'framework';
-        $sValue = 'phalcon';
+        try {
+            $this->setDiService('crypt');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
 
-        $this->setDiService('crypt');
         $container = $this->getDi();
 
         $oCookie = new Cookies();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14982

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Fixed incorrect return type hint for `Phalcon\Http\Response\Cookies::setSignKey`

Thanks

