### PR TITLE
Improved content type check for Response::__construct

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -5,6 +5,7 @@
 - Changed `Volt::convertEncoding` to no longer using `iconv` for a fallback since it causes issues with macOS [#14912](https://github.com/phalcon/cphalcon/issues/14912)
 - Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults [#14888](https://github.com/phalcon/cphalcon/pull/14888), [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Changed the default ACL access level from boolean `FALSE` to `Enum::DENY` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
+- Changed the way `Phalcon\Http\Response::__construct` checks `content` data type. Now a `TypeError` will be thrown if incompatible data type was passed [#14983](https://github.com/phalcon/cphalcon/issues/14983)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition [#14874](https://github.com/phalcon/cphalcon/issues/14874)

--- a/phalcon/Http/Response.zep
+++ b/phalcon/Http/Response.zep
@@ -64,14 +64,17 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
     /**
      * Phalcon\Http\Response constructor
      */
-    public function __construct(content = null, code = null, status = null)
+    public function __construct(string! content = null, code = null, status = null)
     {
-        /**
-         * A Phalcon\Http\Response\Headers bag is temporary used to manage the headers before sent them to the client
-         */
+        // Note: Don't remove exclamation mark above otherwise NULL will be coerced.
+
+        // A Phalcon\Http\Response\Headers bag is temporary used to manage
+        // the headers before sent them to the client
         let this->headers = new Headers();
 
-        let this->content = content;
+        if content !== null {
+            this->setContent(content);
+        }
 
         if code !== null {
             this->setStatusCode(code, status);
@@ -93,7 +96,8 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
      */
     public function getContent() -> string
     {
-        return this->content;
+        // Type cast is required here to satisfy the interface
+        return (string) this->content;
     }
 
     /**

--- a/tests/unit/Http/Response/ConstructCest.php
+++ b/tests/unit/Http/Response/ConstructCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -15,11 +15,14 @@ namespace Phalcon\Test\Unit\Http\Response;
 
 use Phalcon\Http\Response;
 use UnitTester;
+use TypeError;
 
 class ConstructCest
 {
     /**
      * Tests Phalcon\Http\Response :: __construct()
+     *
+     * @param  UnitTester $I
      *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2019-12-08
@@ -37,7 +40,34 @@ class ConstructCest
     }
 
     /**
+     * Tests Phalcon\Http\Response :: __construct(content = [array])
+     *
+     * @param  UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-05-02
+     */
+    public function httpResponseConstructWithIncorrectDataType(UnitTester $I)
+    {
+        $I->wantToTest('Http\Response - __construct(content = [array])');
+
+        /** @noinspection PhpUndefinedClassInspection */
+        $throwable = new TypeError(
+            sprintf(
+                'Argument 1 passed to %s::__construct() must be of the type string or null, array given',
+                Response::class
+            )
+        );
+
+        $I->expectThrowable($throwable, function () {
+            new Response(['Put a Sock In It']);
+        });
+    }
+
+    /**
      * Tests Phalcon\Http\Response :: __construct(content = null)
+     *
+     * @param  UnitTester $I
      *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2019-12-08
@@ -46,20 +76,20 @@ class ConstructCest
     {
         $I->wantToTest('Http\Response - __construct(content = null)');
 
-        $aData = [
-            'user' => 'jeremy',
-        ];
+        $content = '<h1>Money Doesn\'t Grow On Trees</h1>';
 
-        $oResponse = new Response($aData);
+        $oResponse = new Response($content);
 
         $I->assertSame(
-            $aData,
+            $content,
             $oResponse->getContent()
         );
     }
 
     /**
      * Tests Phalcon\Http\Response :: __construct(content = null, code = null)
+     *
+     * @param  UnitTester $I
      *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2019-12-08
@@ -68,16 +98,14 @@ class ConstructCest
     {
         $I->wantToTest('Http\Response - __construct(content = null, code = null)');
 
-        $aData = [
-            'user' => 'jeremy',
-        ];
+        $content = '<h1>Elephant in the Room</h1>';
 
         $nCodeSuccess = 200;
 
-        $oResponse = new Response($aData, $nCodeSuccess);
+        $oResponse = new Response($content, $nCodeSuccess);
 
         $I->assertSame(
-            $aData,
+            $content,
             $oResponse->getContent()
         );
 
@@ -97,6 +125,8 @@ class ConstructCest
      * Tests Phalcon\Http\Response :: __construct(content = null, code = null,
      * status = null)
      *
+     * @param  UnitTester $I
+     *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2019-12-08
      */
@@ -104,16 +134,14 @@ class ConstructCest
     {
         $I->wantToTest('Http\Response - __construct(content = null, code = null, status = null)');
 
-        $aData = [
-            'user' => 'jeremy',
-        ];
+        $content = '<h1>Fight Fire With Fire</h1>';
 
         $nCodeSuccess = 200;
 
-        $oResponse = new Response($aData, $nCodeSuccess, 'Success');
+        $oResponse = new Response($content, $nCodeSuccess, 'Success');
 
         $I->assertSame(
-            $aData,
+            $content,
             $oResponse->getContent()
         );
 

--- a/tests/unit/Http/Response/GetSetContentCest.php
+++ b/tests/unit/Http/Response/GetSetContentCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -21,6 +21,8 @@ class GetSetContentCest
     /**
      * Tests Phalcon\Http\Response :: getContent() / setContent()
      *
+     * @param  UnitTester $I
+     *
      * @author Jeremy PASTOURET <https://github.com/jenovateurs>
      * @since  2019-12-08
      */
@@ -31,8 +33,9 @@ class GetSetContentCest
         $sData = '<h1>Phalcon book 2020</h1>';
 
         $oResponse = new Response();
-        $oResponse->setContent($sData);
+        $I->assertEquals('', $oResponse->getContent());
 
+        $oResponse->setContent($sData);
         $I->assertSame(
             $sData,
             $oResponse->getContent()


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14983

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Changed the way `Phalcon\Http\Response::__construct` checks `content` data type.
Now a `TypeError` will be thrown if incompatible data type was passed.

Thanks

