### PR TITLE
Fixed incorrect return type hints for ConfigFactory

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -18,6 +18,7 @@
 - Fixed default value of the following `Phalcon\Annotations\Annotation`'s properties: `$arguments` and `$exprArguments` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
 - Fixed return type hints of the following `Phalcon\Annotations\Annotation`'s methods: `getArgument`, `getName` and `getNamedArgument` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
 - Fixed incorrect return type hint for `Phalcon\Http\Response\Cookies::setSignKey` [#14982](https://github.com/phalcon/cphalcon/issues/14982)
+- Fixed return type hints for `Phalcon\Config\ConfigFactory::load` and `Phalcon\Config\ConfigFactory::newInstance` to explicitly indicate the return type as `Phalcon\Config` instance [#14978](https://github.com/phalcon/cphalcon/issues/14978)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -4,20 +4,14 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Config;
 
 use Phalcon\Config;
-use Phalcon\Config\Adapter\Grouped;
-use Phalcon\Config\Adapter\Ini;
-use Phalcon\Config\Adapter\Json;
-use Phalcon\Config\Adapter\Php;
-use Phalcon\Config\Adapter\Yaml;
 use Phalcon\Factory\AbstractFactory;
-use Phalcon\Factory\Exception as FactoryException;
 use Phalcon\Helper\Arr;
 
 /**

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -55,7 +55,7 @@ class ConfigFactory extends AbstractFactory
      *      'callbacks' => null
      * ]
      */
-    public function load(config) -> object
+    public function load(config) -> <Config>
     {
         var adapter, extension, first, oldConfig, second;
 
@@ -117,7 +117,7 @@ class ConfigFactory extends AbstractFactory
     /**
      * Returns a new Config instance
      */
-    public function newInstance(string name, string fileName, var params = null) -> object
+    public function newInstance(string name, string fileName, var params = null) -> <Config>
     {
         var definition, options;
 

--- a/tests/_data/fixtures/Traits/FactoryTrait.php
+++ b/tests/_data/fixtures/Traits/FactoryTrait.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -15,6 +15,7 @@ namespace Phalcon\Test\Fixtures\Traits;
 
 use Phalcon\Config;
 use Phalcon\Config\Adapter\Ini;
+
 use function dataDir;
 use function outputDir;
 
@@ -35,8 +36,10 @@ trait FactoryTrait
 
     /**
      * Initializes the main config
+     *
+     * @return void
      */
-    protected function init()
+    protected function init(): void
     {
         $configFile = dataDir('assets/config/factory.ini');
 
@@ -47,8 +50,10 @@ trait FactoryTrait
 
     /**
      * Initializes the logger config - this is special because it is nested
+     *
+     * @return void
      */
-    protected function initLogger()
+    protected function initLogger(): void
     {
         $options = [
             'logger' => [

--- a/tests/unit/Config/ConfigFactory/LoadCest.php
+++ b/tests/unit/Config/ConfigFactory/LoadCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -29,13 +29,21 @@ class LoadCest
 {
     use FactoryTrait;
 
-    public function _before(UnitTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param UnitTester $I
+     * @return void
+     */
+    public function _before(UnitTester $I): void
     {
         $this->init();
     }
 
     /**
      * Tests Phalcon\Config\ConfigFactory :: load() - Config
+     *
+     * @param UnitTester $I
      *
      * @author Wojciech Ślawski <jurigag@gmail.com>
      * @since  2017-03-02
@@ -44,7 +52,7 @@ class LoadCest
     {
         $I->wantToTest('Config\ConfigFactory - load() - Config');
 
-        $options = $this->config->config;
+        $options = $this->config->get('config');
 
         /** @var Ini $ini */
         $ini = (new ConfigFactory())->load($options);
@@ -63,7 +71,7 @@ class LoadCest
         );
 
         /** @var Ini $ini */
-        $ini = (new ConfigFactory())->load($ini->config->toArray());
+        $ini = (new ConfigFactory())->load($ini->get('config')->toArray());
 
         $I->assertInstanceOf(
             Ini::class,
@@ -73,6 +81,8 @@ class LoadCest
 
     /**
      * Tests Phalcon\Config\ConfigFactory :: load() - array
+     *
+     * @param UnitTester $I
      *
      * @author Wojciech Ślawski <jurigag@gmail.com>
      * @since  2017-03-02
@@ -95,6 +105,8 @@ class LoadCest
     /**
      * Tests Phalcon\Config\ConfigFactory :: load() - string
      *
+     * @param UnitTester $I
+     *
      * @author Wojciech Ślawski <jurigag@gmail.com>
      * @since  2017-11-24
      */
@@ -115,6 +127,8 @@ class LoadCest
 
     /**
      * Tests Phalcon\Config\ConfigFactory :: load() -  exception
+     *
+     * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-06-19
@@ -169,6 +183,8 @@ class LoadCest
     /**
      * Tests Phalcon\Config\ConfigFactory :: load() -  yaml callback
      *
+     * @param UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-06-19
      */
@@ -198,6 +214,8 @@ class LoadCest
     /**
      * Tests Phalcon\Config\ConfigFactory :: load() -  two calls new instances
      *
+     * @param UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-12-07
      * @issue  14584
@@ -211,11 +229,11 @@ class LoadCest
         $configFile1 = dataDir('assets/config/config.php');
         $config      = $factory->load($configFile1);
 
-        $I->assertEquals("/phalcon/", $config->phalcon->baseUri);
+        $I->assertEquals("/phalcon/", $config->get('phalcon')->baseUri);
 
         $configFile2 = dataDir('assets/config/config-2.php');
         $config2     = $factory->load($configFile2);
 
-        $I->assertEquals("/phalcon4/", $config2->phalcon->baseUri);
+        $I->assertEquals("/phalcon4/", $config2->get('phalcon')->baseUri);
     }
 }

--- a/tests/unit/Config/ConfigFactory/NewInstanceCest.php
+++ b/tests/unit/Config/ConfigFactory/NewInstanceCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -26,6 +26,8 @@ class NewInstanceCest
 {
     /**
      * Tests Phalcon\Logger\LoggerFactory :: newInstance()
+     *
+     * @param UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-05-03


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14978

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Fixed return type hints for the following methods:
- `Phalcon\Config\ConfigFactory::load`
- `Phalcon\Config\ConfigFactory::newInstance`

to explicitly indicate the return type as `Phalcon\Config`.

Thanks

