### PR TITLE
Do not use `object` return type hint

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -19,6 +19,25 @@
 - Fixed return type hints of the following `Phalcon\Annotations\Annotation`'s methods: `getArgument`, `getName` and `getNamedArgument` [#14977](https://github.com/phalcon/cphalcon/issues/14977)
 - Fixed incorrect return type hint for `Phalcon\Http\Response\Cookies::setSignKey` [#14982](https://github.com/phalcon/cphalcon/issues/14982)
 - Fixed return type hints for `Phalcon\Config\ConfigFactory::load` and `Phalcon\Config\ConfigFactory::newInstance` to explicitly indicate the return type as `Phalcon\Config` instance [#14978](https://github.com/phalcon/cphalcon/issues/14978)
+- Fixed return type hints for the following methods [#14987](https://github.com/phalcon/cphalcon/issues/14987):
+  - `Phalcon\Dispatcher\AbstractDispatcher::dispatch`
+  - `Phalcon\Dispatcher\DispatcherInterface::dispatch`
+  - `Phalcon\Filter::get`
+  - `Phalcon\Http\Message\AbstractCommon::cloneInstance`
+  - `Phalcon\Http\Message\AbstractCommon::processWith`
+  - `Phalcon\Http\Message\AbstractMessage::withAddedHeader`
+  - `Phalcon\Http\Message\AbstractMessage::withBody`
+  - `Phalcon\Http\Message\AbstractMessage::withHeader`
+  - `Phalcon\Http\Message\AbstractMessage::withProtocolVersion`
+  - `Phalcon\Http\Message\AbstractMessage::withoutHeader`
+  - `Phalcon\Http\Message\AbstractRequest::withMethod`
+  - `Phalcon\Http\Message\AbstractRequest::withRequestTarget`
+  - `Phalcon\Http\Message\AbstractRequest::withUri`
+  - `Phalcon\Mvc\Model\Binder::findBoundModel`
+  - `Phalcon\Validation::getEntity`
+  - `Phalcon\Validation\ValidationInterface::getEntity`
+
+[#14987](https://github.com/phalcon/cphalcon/issues/14987)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/phalcon/Dispatcher/AbstractDispatcher.zep
+++ b/phalcon/Dispatcher/AbstractDispatcher.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Dispatcher;
@@ -120,7 +120,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
      *
      * @throws \Exception if any uncaught or unhandled exception occurs during the dispatcher process.
      */
-    public function dispatch() -> object | bool
+    public function dispatch() -> var | bool
     {
         bool hasService, hasEventsManager;
         int numberDispatches;

--- a/phalcon/Dispatcher/DispatcherInterface.zep
+++ b/phalcon/Dispatcher/DispatcherInterface.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Dispatcher;
@@ -17,8 +17,10 @@ interface DispatcherInterface
 {
     /**
      * Dispatches a handle action taking into account the routing parameters
+     *
+     * @return object|false
      */
-    public function dispatch()  -> object | bool;
+    public function dispatch()  -> var | bool;
 
     /**
      * Forwards the execution flow to another controller/action

--- a/phalcon/Filter.zep
+++ b/phalcon/Filter.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon;
@@ -63,8 +63,10 @@ class Filter implements FilterInterface
     /**
      * Get a service. If it is not in the mapper array, create a new object,
      * set it and then return it.
+     *
+     * @return object
      */
-    public function get(string! name) -> object
+    public function get(string! name) -> var
     {
         var definition;
 

--- a/phalcon/Http/Message/AbstractCommon.zep
+++ b/phalcon/Http/Message/AbstractCommon.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  *
  * Implementation of this file has been influenced by Zend Diactoros
  * @link    https://github.com/zendframework/zend-diactoros
@@ -27,9 +27,9 @@ abstract class AbstractCommon
      * @param mixed  $element
      * @param string $property
      *
-     * @return mixed
+     * @return static
      */
-    final protected function cloneInstance(var element, string property) -> object
+    final protected function cloneInstance(var element, string property) -> var
     {
         var newInstance;
 
@@ -60,9 +60,9 @@ abstract class AbstractCommon
      * @param mixed  $element
      * @param string $property
      *
-     * @return mixed
+     * @return static
      */
-    final protected function processWith(var element, string property) -> object
+    final protected function processWith(var element, string property) -> var
     {
         this->checkStringParameter(element);
 

--- a/phalcon/Http/Message/AbstractMessage.zep
+++ b/phalcon/Http/Message/AbstractMessage.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  *
  * Implementation of this file has been influenced by Zend Diactoros
  * @link    https://github.com/zendframework/zend-diactoros
@@ -161,9 +161,9 @@ abstract class AbstractMessage extends AbstractCommon
      * @param string          $name
      * @param string|string[] $value
      *
-     * @return self
+     * @return static
      */
-    public function withAddedHeader(var name, var value) -> object
+    public function withAddedHeader(var name, var value) -> var
     {
         var existing, headers;
 
@@ -190,11 +190,11 @@ abstract class AbstractMessage extends AbstractCommon
      *
      * @param StreamInterface $body
      *
-     * @return self
+     * @return static
      * @throws InvalidArgumentException When the body is not valid.
      *
      */
-    public function withBody(<StreamInterface> body) -> object
+    public function withBody(<StreamInterface> body) -> var
     {
         var newBody;
 
@@ -217,11 +217,11 @@ abstract class AbstractMessage extends AbstractCommon
      * @param string          $name
      * @param string|string[] $value
      *
-     * @return self
+     * @return static
      * @throws InvalidArgumentException for invalid header names or values.
      *
      */
-    public function withHeader(var name, var value) -> object
+    public function withHeader(var name, var value) -> var
     {
         var headers;
 
@@ -247,9 +247,9 @@ abstract class AbstractMessage extends AbstractCommon
      *
      * @param string $version
      *
-     * @return self
+     * @return static
      */
-    public function withProtocolVersion(var version) -> object
+    public function withProtocolVersion(var version) -> var
     {
         this->processProtocol(version);
 
@@ -267,9 +267,9 @@ abstract class AbstractMessage extends AbstractCommon
      *
      * @param string $name
      *
-     * @return self
+     * @return static
      */
-    public function withoutHeader(var name) -> object
+    public function withoutHeader(var name) -> var
     {
         var headers;
 

--- a/phalcon/Http/Message/AbstractRequest.zep
+++ b/phalcon/Http/Message/AbstractRequest.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  *
  * Implementation of this file has been influenced by Zend Diactoros
  * @link    https://github.com/zendframework/zend-diactoros
@@ -95,11 +95,10 @@ abstract class AbstractRequest extends AbstractMessage
      *
      * @param string $method
      *
-     * @return object
+     * @return static
      * @throws InvalidArgumentException for invalid HTTP methods.
-     *
      */
-    public function withMethod(var method) -> object
+    public function withMethod(var method) -> var
     {
         this->processMethod(method);
 
@@ -123,9 +122,9 @@ abstract class AbstractRequest extends AbstractMessage
      *
      * @param mixed $requestTarget
      *
-     * @return object
+     * @return static
      */
-    public function withRequestTarget(var requestTarget) -> object
+    public function withRequestTarget(var requestTarget) -> var
     {
         if unlikely preg_match("/\s/", requestTarget) {
             throw new InvalidArgumentException(
@@ -167,9 +166,9 @@ abstract class AbstractRequest extends AbstractMessage
      * @param UriInterface $uri
      * @param bool         $preserveHost
      *
-     * @return object
+     * @return static
      */
-    public function withUri(<UriInterface> uri, var preserveHost = false) -> object
+    public function withUri(<UriInterface> uri, var preserveHost = false) -> var
     {
         var headers, newInstance;
 

--- a/phalcon/Mvc/Model/Binder.zep
+++ b/phalcon/Mvc/Model/Binder.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Mvc\Model;
@@ -18,7 +18,7 @@ use ReflectionFunction;
 use ReflectionMethod;
 
 /**
- * Phalcon\Mvc\Model\Binding
+ * Phalcon\Mvc\Model\Binder
  *
  * This is an class for binding models into params for handler
  */
@@ -94,8 +94,10 @@ class Binder implements BinderInterface
 
     /**
      * Find the model by param value.
+     *
+     * @return object|false
      */
-    protected function findBoundModel(var paramValue, string className) -> object | bool
+    protected function findBoundModel(var paramValue, string className) -> var | bool
     {
         return {className}::findFirst(paramValue);
     }

--- a/phalcon/Validation.zep
+++ b/phalcon/Validation.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon;
@@ -130,8 +130,10 @@ class Validation extends Injectable implements ValidationInterface
 
     /**
      * Returns the bound entity
+     *
+     * @return object
      */
-    public function getEntity() -> object
+    public function getEntity() -> var
     {
         return this->entity;
     }

--- a/phalcon/Validation/ValidationInterface.zep
+++ b/phalcon/Validation/ValidationInterface.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Validation;
@@ -40,8 +40,10 @@ interface ValidationInterface
 
     /**
      * Returns the bound entity
+     *
+     * @return object
      */
-    public function getEntity() -> object;
+    public function getEntity() -> var;
 
     /**
      * Returns all the filters or a specific one


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14987

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed return type hints for the following methods:
  - `Phalcon\Dispatcher\AbstractDispatcher::dispatch`
  - `Phalcon\Dispatcher\DispatcherInterface::dispatch`
  - `Phalcon\Filter::get`
  - `Phalcon\Http\Message\AbstractCommon::cloneInstance`
  - `Phalcon\Http\Message\AbstractCommon::processWith`
  - `Phalcon\Http\Message\AbstractMessage::withAddedHeader`
  - `Phalcon\Http\Message\AbstractMessage::withBody`
  - `Phalcon\Http\Message\AbstractMessage::withHeader`
  - `Phalcon\Http\Message\AbstractMessage::withProtocolVersion`
  - `Phalcon\Http\Message\AbstractMessage::withoutHeader`
  - `Phalcon\Http\Message\AbstractRequest::withMethod`
  - `Phalcon\Http\Message\AbstractRequest::withRequestTarget`
  - `Phalcon\Http\Message\AbstractRequest::withUri`
  - `Phalcon\Mvc\Model\Binder::findBoundModel`
  - `Phalcon\Validation::getEntity`
  - `Phalcon\Validation\ValidationInterface::getEntity`

Thanks

