### PR TITLE
Fixed default value of Crypt::$key

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -36,6 +36,7 @@
   - `Phalcon\Mvc\Model\Binder::findBoundModel`
   - `Phalcon\Validation::getEntity`
   - `Phalcon\Validation\ValidationInterface::getEntity`
+- Fixed default value of `Phalcon\Crypt::$key` to satisfy the interface [#14989](https://github.com/phalcon/cphalcon/issues/14989)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/phalcon/Crypt.zep
+++ b/phalcon/Crypt.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon;
@@ -46,18 +46,21 @@ class Crypt implements CryptInterface
      * @var string
      */
     protected authTag { get };
+
     /**
      * @var string
      */
     protected authData = "" { get };
+
     /**
      * @var int
      */
     protected authTagLength = 16 { get };
+
     /**
      * @var string
      */
-    protected key;
+    protected key = "";
 
     /**
      * @var int

--- a/tests/unit/Crypt/GetSetKeyCest.php
+++ b/tests/unit/Crypt/GetSetKeyCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -21,6 +21,8 @@ class GetSetKeyCest
     /**
      * Tests Phalcon\Crypt :: getKey()/setKey()
      *
+     * @param  UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-16
      */
@@ -30,7 +32,7 @@ class GetSetKeyCest
 
         $crypt = new Crypt();
 
-        $I->assertEmpty($crypt->getKey());
+        $I->assertEquals('', $crypt->getKey());
 
         $crypt->setKey('123456');
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14989

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

