### PR TITLE
Fixed return type hint for Di::getInternalEventsManager

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -37,6 +37,7 @@
   - `Phalcon\Validation::getEntity`
   - `Phalcon\Validation\ValidationInterface::getEntity`
 - Fixed default value of `Phalcon\Crypt::$key` to satisfy the interface [#14989](https://github.com/phalcon/cphalcon/issues/14989)
+- Fixed return type hint for `Phalcon\Di::getInternalEventsManager` [#14992](https://github.com/phalcon/cphalcon/issues/14992)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/phalcon/Di.zep
+++ b/phalcon/Di.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon;
@@ -63,23 +63,27 @@ class Di implements DiInterface
 {
     /**
      * List of registered services
+     *
+     * @var ServiceInterface[]
      */
-    protected services;
+    protected services = [];
 
     /**
      * List of shared instances
      */
-    protected sharedInstances;
+    protected sharedInstances = [];
 
     /**
      * Events Manager
      *
-     * @var ManagerInterface
+     * @var ManagerInterface | null
      */
     protected eventsManager;
 
     /**
      * Latest DI build
+     *
+     * @var DiInterface | null
      */
     protected static _default;
 
@@ -265,7 +269,7 @@ class Di implements DiInterface
     /**
      * Returns the internal event manager
      */
-    public function getInternalEventsManager() -> <ManagerInterface>
+    public function getInternalEventsManager() -> <ManagerInterface> | null
     {
         return this->eventsManager;
     }

--- a/tests/unit/Di/GetInternalEventsManagerCest.php
+++ b/tests/unit/Di/GetInternalEventsManagerCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -22,6 +22,8 @@ class GetInternalEventsManagerCest
 {
     /**
      * Unit Tests Phalcon\Di :: getInternalEventsManager()
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-06-13

--- a/tests/unit/Di/GetServicesCest.php
+++ b/tests/unit/Di/GetServicesCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -14,13 +14,14 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Di;
 
 use Phalcon\Di;
-use Phalcon\Escaper;
 use UnitTester;
 
 class GetServicesCest
 {
     /**
      * Unit Tests Phalcon\Di :: getServices()
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-06-13
@@ -30,18 +31,13 @@ class GetServicesCest
         $I->wantToTest('Di - getServices()');
 
         $di = new Di();
+        $I->assertEquals([], $di->getServices());
 
-        $I->assertNull($di->getServices());
-
-        $di->set('escaper', Escaper::class);
-
+        $di->set('service', \stdClass::class);
         $I->assertCount(1, $di->getServices());
 
-        $di->remove('escaper');
-        $I->assertFalse($di->has('escaper'));
+        $di->remove('service');
+        $I->assertFalse($di->has('service'));
         $I->assertEquals([], $di->getServices());
-        $I->assertEmpty($di->getServices());
-        $I->assertTrue(is_array($di->getServices()));
-        $I->assertCount(0, $di->getServices());
     }
 }

--- a/tests/unit/Di/SetInternalEventsManagerCest.php
+++ b/tests/unit/Di/SetInternalEventsManagerCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -22,6 +22,8 @@ class SetInternalEventsManagerCest
 {
     /**
      * Unit Tests Phalcon\Di :: setInternalEventsManager()
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-06-13


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14992

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

- Fixed return type hint for `Phalcon\Di::getInternalEventsManager`
- Changed default value for `Phalcon\Di::getInternalEventsManager:$services` to empty array
- Changed default value for `Phalcon\Di::getInternalEventsManager:$sharedInstances` to empty array
- Adjusted tests

Thanks

