### PR TITLE
Changed return type hints for FlashInterface methods

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,7 +6,7 @@
 - Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults [#14888](https://github.com/phalcon/cphalcon/pull/14888), [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Changed the default ACL access level from boolean `FALSE` to `Enum::DENY` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Changed the way `Phalcon\Http\Response::__construct` checks `content` data type. Now a `TypeError` will be thrown if incompatible data type was passed [#14983](https://github.com/phalcon/cphalcon/issues/14983)
-- Changed return type hints of the following `Phalcon\Flash\FlashInterface`'s: `error`, `message`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
+- Changed return type hints of the following `Phalcon\Flash\FlashInterface`'s methods: `error`, `message`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition [#14874](https://github.com/phalcon/cphalcon/issues/14874)
@@ -39,7 +39,7 @@
   - `Phalcon\Validation\ValidationInterface::getEntity`
 - Fixed default value of `Phalcon\Crypt::$key` to satisfy the interface [#14989](https://github.com/phalcon/cphalcon/issues/14989)
 - Fixed return type hint for `Phalcon\Di::getInternalEventsManager` [#14992](https://github.com/phalcon/cphalcon/issues/14992)
-- Fixed return type hints of the following `Phalcon\Flash\AbstractFlash`'s: `error`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
+- Fixed return type hints of the following `Phalcon\Flash\AbstractFlash`'s methods: `error`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -6,6 +6,7 @@
 - Changed schema manipulation in `Phalcon\Db\Dialect\Mysql` - unquote numerical defaults [#14888](https://github.com/phalcon/cphalcon/pull/14888), [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Changed the default ACL access level from boolean `FALSE` to `Enum::DENY` [#14974](https://github.com/phalcon/cphalcon/pull/14974)
 - Changed the way `Phalcon\Http\Response::__construct` checks `content` data type. Now a `TypeError` will be thrown if incompatible data type was passed [#14983](https://github.com/phalcon/cphalcon/issues/14983)
+- Changed return type hints of the following `Phalcon\Flash\FlashInterface`'s: `error`, `message`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition [#14874](https://github.com/phalcon/cphalcon/issues/14874)
@@ -38,6 +39,7 @@
   - `Phalcon\Validation\ValidationInterface::getEntity`
 - Fixed default value of `Phalcon\Crypt::$key` to satisfy the interface [#14989](https://github.com/phalcon/cphalcon/issues/14989)
 - Fixed return type hint for `Phalcon\Di::getInternalEventsManager` [#14992](https://github.com/phalcon/cphalcon/issues/14992)
+- Fixed return type hints of the following `Phalcon\Flash\AbstractFlash`'s: `error`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Flash;
@@ -97,8 +97,10 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *```php
      * $flash->error("This is an error");
      *```
+     *
+     * @return null|string|void
      */
-    public function error(string message) -> string
+    public function error(string message) -> string | null
     {
         return this->{"message"}("error", message);
     }
@@ -136,8 +138,10 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *```php
      * $flash->notice("This is an information");
      *```
+     *
+     * @return null|string|void
      */
-    public function notice(string message) -> string
+    public function notice(string message) -> string | null
     {
         return this->{"message"}("notice", message);
     }
@@ -209,8 +213,10 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *```php
      * $flash->success("The process was finished successfully");
      *```
+     *
+     * @return null|string|void
      */
-    public function success(string message) -> string
+    public function success(string message) -> string | null
     {
         return this->{"message"}("success", message);
     }
@@ -223,7 +229,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *```
      *
      * @param string|array message
-     * @return string|void
+     * @return null|string|void
      */
     public function outputMessage(string type, var message)
     {
@@ -300,8 +306,10 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *```php
      * $flash->warning("Hey, this is important");
      *```
+     *
+     * @return null|string|void
      */
-    public function warning(string message) -> string
+    public function warning(string message) -> null | string
     {
         return this->{"message"}("warning", message);
     }

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -309,7 +309,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *
      * @return null|string|void
      */
-    public function warning(string message) -> null | string
+    public function warning(string message) -> string | null
     {
         return this->{"message"}("warning", message);
     }

--- a/phalcon/Flash/Direct.zep
+++ b/phalcon/Flash/Direct.zep
@@ -4,20 +4,22 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Flash;
 
 /**
- * This is a variant of the Phalcon\Flash that immediately outputs any message
- * passed to it
+ * This is an implementation of the Phalcon\Flash\FlashInterface that
+ * immediately outputs any message passed to it.
  */
 class Direct extends AbstractFlash
 {
     /**
      * Outputs a message
+     *
+     * @return null|string|void
      */
     public function message(string type, var message) -> string | null
     {

--- a/phalcon/Flash/Exception.zep
+++ b/phalcon/Flash/Exception.zep
@@ -4,14 +4,14 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Flash;
 
 /**
- * Exceptions thrown in Phalcon\Flash will use this class
+ * Exceptions thrown in Phalcon\Flash calsses will use this class
  */
 class Exception extends \Phalcon\Exception
 {

--- a/phalcon/Flash/FlashInterface.zep
+++ b/phalcon/Flash/FlashInterface.zep
@@ -13,7 +13,7 @@ namespace Phalcon\Flash;
 /**
  * Phalcon\Flash\FlashInterface
  *
- * Interface for Phalcon\Flash clases
+ * Interface for Phalcon\Flash classes
  */
 interface FlashInterface
 {
@@ -22,33 +22,33 @@ interface FlashInterface
      *
      * @return null|string|void
      */
-    public function error(string message) -> null | string;
+    public function error(string message) -> string | null;
 
     /**
      * Outputs a message
      *
      * @return null|string|void
      */
-    public function message(string type, string message) -> null | string;
+    public function message(string type, string message) -> string | null;
 
     /**
      * Shows a HTML notice/information message
      *
      * @return null|string|void
      */
-    public function notice(string message) -> null | string;
+    public function notice(string message) -> string | null;
 
     /**
      * Shows a HTML success message
      *
      * @return null|string|void
      */
-    public function success(string message) -> null | string;
+    public function success(string message) -> string | null;
 
     /**
      * Shows a HTML warning message
      *
      * @return null|string|void
      */
-    public function warning(string message) -> null | string;
+    public function warning(string message) -> string | null;
 }

--- a/phalcon/Flash/FlashInterface.zep
+++ b/phalcon/Flash/FlashInterface.zep
@@ -4,41 +4,51 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Flash;
 
 /**
- * Phalcon\FlashInterface
+ * Phalcon\Flash\FlashInterface
  *
- * Interface for Phalcon\Flash
+ * Interface for Phalcon\Flash clases
  */
 interface FlashInterface
 {
     /**
      * Shows a HTML error message
+     *
+     * @return null|string|void
      */
-    public function error(string message) -> string;
+    public function error(string message) -> null | string;
 
     /**
      * Outputs a message
+     *
+     * @return null|string|void
      */
-    public function message(string type, string message) -> string | null;
+    public function message(string type, string message) -> null | string;
 
     /**
      * Shows a HTML notice/information message
+     *
+     * @return null|string|void
      */
-    public function notice(string message) -> string;
+    public function notice(string message) -> null | string;
 
     /**
      * Shows a HTML success message
+     *
+     * @return null|string|void
      */
-    public function success(string message) -> string;
+    public function success(string message) -> null | string;
 
     /**
      * Shows a HTML warning message
+     *
+     * @return null|string|void
      */
-    public function warning(string message) -> string;
+    public function warning(string message) -> null | string;
 }

--- a/phalcon/Flash/Session.zep
+++ b/phalcon/Flash/Session.zep
@@ -14,8 +14,9 @@ use Phalcon\Di\DiInterface;
 use Phalcon\Session\ManagerInterface;
 
 /**
- * Temporarily stores the messages in session, then messages can be printed in
- * the next request
+ * This is an implementation of the Phalcon\Flash\FlashInterface that
+ * temporarily stores the messages in session, then messages can be printed in
+ * the next request.
  */
 class Session extends AbstractFlash
 {
@@ -160,7 +161,7 @@ class Session extends AbstractFlash
         }
 
         if likely container->has("session") {
-            return <RequestInterface> container->getShared("session");
+            return <ManagerInterface> container->getShared("session");
         } else {
             throw new Exception(
                 Exception::containerServiceNotFound("the 'session' service")

--- a/phalcon/Flash/Session.zep
+++ b/phalcon/Flash/Session.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Flash;
@@ -54,6 +54,8 @@ class Session extends AbstractFlash
 
     /**
      * Adds a message to the session flasher
+     *
+     * @return null|string|void
      */
     public function message(string type, string message) -> string | null
     {

--- a/tests/unit/Filter/Filter/CustomCest.php
+++ b/tests/unit/Filter/Filter/CustomCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -22,6 +22,8 @@ class CustomCest
     /**
      * Tests Phalcon\Filter :: custom has()
      *
+     * @param  UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-01-19
      */
@@ -29,19 +31,15 @@ class CustomCest
     {
         $I->wantToTest('Filter\Filter - custom has()');
 
-        $services = [
-            'ipv4' => IPv4::class,
-        ];
-
-        $locator = new Filter($services);
-
         $I->assertTrue(
-            $locator->has('ipv4')
+            (new Filter(['ipv4' => IPv4::class]))->has('ipv4')
         );
     }
 
     /**
      * Tests Phalcon\Filter :: custom sanitizer
+     *
+     * @param  UnitTester $I
      *
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2019-01-19
@@ -50,14 +48,8 @@ class CustomCest
     {
         $I->wantToTest('Filter\Filter - custom sanitizer');
 
-        $services = [
-            'ipv4' => IPv4::class,
-        ];
-
-        $locator = new Filter($services);
-
         /** @var IPv4 $sanitizer */
-        $sanitizer = $locator->get('ipv4');
+        $sanitizer = (new Filter(['ipv4' => IPv4::class]))->get('ipv4');
 
         $I->assertInstanceOf(
             IPv4::class,

--- a/tests/unit/Filter/Filter/GetSetHasCest.php
+++ b/tests/unit/Filter/Filter/GetSetHasCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -22,6 +22,8 @@ class GetSetHasCest
 {
     /**
      * Tests Phalcon\Filter :: get()/set()/has() - has()
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-01-19
@@ -43,6 +45,8 @@ class GetSetHasCest
 
     /**
      * Tests Phalcon\Filter :: get()/set()/has() - get()
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
@@ -68,17 +72,16 @@ class GetSetHasCest
     /**
      * Tests Phalcon\Filter :: get()/set()/has() - get() same
      *
+     * @param  UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
     public function filterFilterGetSetHasGetSame(UnitTester $I)
     {
         $I->wantToTest('Filter\Filter - get()/set()/has() - get() - same');
-        $services = [
-            'helloFilter' => HelloService::class,
-        ];
 
-        $locator = new Filter($services);
+        $locator = new Filter(['helloFilter' => HelloService::class]);
         $actual  = $locator->has('helloFilter');
         $I->assertTrue($actual);
 
@@ -94,6 +97,8 @@ class GetSetHasCest
 
     /**
      * Tests Phalcon\Filter :: get()/set()/has() - set()
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
@@ -118,6 +123,8 @@ class GetSetHasCest
 
     /**
      * Tests Phalcon\Filter :: get()/set()/has() - set() closure
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-09-25

--- a/tests/unit/Filter/FilterFactory/NewInstanceCest.php
+++ b/tests/unit/Filter/FilterFactory/NewInstanceCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -45,6 +45,8 @@ class NewInstanceCest
     /**
      * Tests Phalcon\Filter\FilterFactory :: newInstance()
      *
+     * @param  UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
@@ -52,15 +54,15 @@ class NewInstanceCest
     {
         $I->wantToTest('Filter\FilterFactory - newInstance()');
         $factory  = new FilterFactory();
-        $instance = $factory->newInstance();
 
-        $class = FilterInterface::class;
-        $I->assertInstanceOf($class, $instance);
+        $I->assertInstanceOf(FilterInterface::class, $factory->newInstance());
     }
 
     /**
      * Tests Phalcon\Filter\FilterFactory :: newInstance() - services
      *
+     * @param        UnitTester $I
+     * @param        Example $example
      * @dataProvider getData
      *
      * @author       Phalcon Team <team@phalcon.io>

--- a/tests/unit/Flash/Direct/FlashDirectCustomCSSCest.php
+++ b/tests/unit/Flash/Direct/FlashDirectCustomCSSCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Test\Unit\Flash\Direct;
@@ -16,17 +16,21 @@ use UnitTester;
 
 class FlashDirectCustomCSSCest extends FlashBase
 {
-    public function _before(UnitTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _before(UnitTester $I): void
     {
         parent::_before($I);
 
-        $classes = [
+        $this->setClasses([
             'error'   => 'alert alert-error',
             'success' => 'alert alert-success',
             'notice'  => 'alert alert-notice',
             'warning' => 'alert alert-warning',
-        ];
-
-        $this->setClasses($classes);
+        ]);
     }
 }

--- a/tests/unit/Flash/Direct/FlashDirectEmptyCSSCest.php
+++ b/tests/unit/Flash/Direct/FlashDirectEmptyCSSCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Test\Unit\Flash\Direct;
@@ -16,7 +16,13 @@ use UnitTester;
 
 class FlashDirectEmptyCSSCest extends FlashBase
 {
-    public function _before(UnitTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _before(UnitTester $I): void
     {
         parent::_before($I);
 

--- a/tests/unit/Flash/Direct/Helper/FlashBase.php
+++ b/tests/unit/Flash/Direct/Helper/FlashBase.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace Phalcon\Test\Unit\Flash\Direct\Helper;
 
 use Phalcon\Escaper;
+use Phalcon\Flash\AbstractFlash;
 use Phalcon\Flash\Direct;
 use UnitTester;
 
 class FlashBase
 {
-    private $classes     = null;
+    private $classes     = [];
     private $notHtml     = false;
     private $notImplicit = false;
 
@@ -30,12 +31,20 @@ class FlashBase
         'error'   => 'errorMessage',
     ];
 
-    public function _before(UnitTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _before(UnitTester $I): void
     {
     }
 
     /**
      * Tests warning (implicit flush)
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
@@ -56,6 +65,9 @@ class FlashBase
 
     /**
      * Tests a string with implicit flush Html
+     *
+     * @param  UnitTester $I
+     * @param  string     $function
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
@@ -94,10 +106,13 @@ class FlashBase
      * Private function to get the class of the message depending on the classes
      * set
      *
+     * @param  string $key
+     * @return string
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
      */
-    private function getClass($key): string
+    private function getClass(string $key): string
     {
         $template = ' class="%s"';
 
@@ -117,10 +132,15 @@ class FlashBase
      * Private function to start the ob, call the function, get the
      * contents and clean the ob
      *
+     * @param  AbstractFlash $flash
+     * @param  string        $function
+     * @param  string        $message
+     * @return string
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
      */
-    private function getObResponse($flash, $function, $message): string
+    private function getObResponse(AbstractFlash $flash, string $function, string $message): string
     {
         ob_start();
         $flash->$function($message);
@@ -132,6 +152,8 @@ class FlashBase
 
     /**
      * Tests warning (no implicit flush)
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
@@ -157,6 +179,8 @@ class FlashBase
     /**
      * Tests warning (implicit flush no html)
      *
+     * @param  UnitTester $I
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
      */
@@ -180,6 +204,8 @@ class FlashBase
 
     /**
      * Tests error (no implicit flush no html)
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
@@ -206,6 +232,8 @@ class FlashBase
 
     /**
      * Tests auto escaping
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @issue  https://github.com/phalcon/cphalcon/issues/11448
@@ -235,10 +263,13 @@ class FlashBase
     /**
      * Sets the custom classes for the tests
      *
+     * @param  array $classes
+     * @return void
+     *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2014-10-04
      */
-    protected function setClasses($classes)
+    protected function setClasses(array $classes): void
     {
         $this->classes = $classes;
     }

--- a/tests/unit/Flash/DirectCest.php
+++ b/tests/unit/Flash/DirectCest.php
@@ -5,14 +5,15 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Test\Unit\Flash;
 
 use Codeception\Example;
 use Phalcon\Flash\Direct;
+use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use UnitTester;
 
@@ -30,18 +31,32 @@ class DirectCest
         'error'   => 'errorMessage',
     ];
 
-    public function _before(UnitTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _before(UnitTester $I): void
     {
         $this->newDi();
-        $this->setDiService('escaper');
+
+        try {
+            $this->setDiService('escaper');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
     }
 
     /**
      * Tests auto escaping
      *
-     * @author       Phalcon Team <team@phalcon.io>
+     * @param  UnitTester $I
+     * @param  Example $example
+     *
+     * @author Phalcon Team <team@phalcon.io>
      * @issue  https://github.com/phalcon/cphalcon/issues/11448
-     * @since        2016-06-15
+     * @since  2016-06-15
      *
      * @dataProvider testShouldAutoEscapeHtmlProvider
      */
@@ -114,6 +129,9 @@ class DirectCest
     /**
      * Test output formatted messages
      *
+     * @param  UnitTester $I
+     * @param  Example $example
+     *
      * @author       Iván Guillén <zeopix@gmail.com>
      * @since        2015-10-26
      *
@@ -158,6 +176,8 @@ class DirectCest
 
     /**
      * Test custom message
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @issue  https://github.com/phalcon/cphalcon/issues/13445

--- a/tests/unit/Flash/SessionCest.php
+++ b/tests/unit/Flash/SessionCest.php
@@ -5,14 +5,15 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Test\Unit\Flash;
 
 use Codeception\Example;
 use Phalcon\Flash\Session;
+use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use UnitTester;
 
@@ -30,11 +31,22 @@ class SessionCest
         'error'   => 'errorMessage',
     ];
 
-    public function _before(UnitTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _before(UnitTester $I): void
     {
         $this->newDi();
-        $this->setDiService('escaper');
-        $this->setDiService('sessionStream');
+
+        try {
+            $this->setDiService('escaper');
+            $this->setDiService('sessionStream');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
 
         if (PHP_SESSION_ACTIVE !== session_status()) {
             session_start();
@@ -45,7 +57,13 @@ class SessionCest
         }
     }
 
-    public function _after(UnitTester $I)
+    /**
+     * Executed after each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _after(UnitTester $I): void
     {
         session_destroy();
     }
@@ -54,9 +72,12 @@ class SessionCest
     /**
      * Tests auto escaping
      *
-     * @author       Phalcon Team <team@phalcon.io>
+     * @param  UnitTester $I
+     * @param  Example $example
+     *
+     * @author Phalcon Team <team@phalcon.io>
      * @issue  https://github.com/phalcon/cphalcon/issues/11448
-     * @since        2016-06-15
+     * @since  2016-06-15
      *
      * @dataProvider testShouldAutoEscapeHtmlProvider
      */
@@ -154,6 +175,8 @@ class SessionCest
      * Test getMessages with specified type and removal
      * activated, only removes the received messages.
      *
+     * @param  UnitTester $I
+     *
      * @author Iván Guillén <zeopix@gmail.com>
      * @since  2015-10-26
      */
@@ -186,6 +209,8 @@ class SessionCest
     /**
      * Tests getMessages in case of non existent type request
      *
+     * @param  UnitTester $I
+     *
      * @issue  https://github.com/phalcon/cphalcon/issues/11941
      * @author Phalcon Team <team@phalcon.io>
      * @since  2016-07-03
@@ -210,6 +235,8 @@ class SessionCest
     /**
      * Tests clear method
      *
+     * @param  UnitTester $I
+     *
      * @author Iván Guillén <zeopix@gmail.com>
      * @since  2015-10-26
      */
@@ -232,6 +259,9 @@ class SessionCest
 
     /**
      * Test output formatted messages
+     *
+     * @param  UnitTester $I
+     * @param  Example $example
      *
      * @author       Iván Guillén <zeopix@gmail.com>
      * @since        2015-10-26
@@ -277,6 +307,8 @@ class SessionCest
 
     /**
      * Test custom message
+     *
+     * @param  UnitTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @issue  https://github.com/phalcon/cphalcon/issues/13445


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14994

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Changed return type hints of the following `Phalcon\Flash\FlashInterface`'s methods: 
- `Phalcon\Flash\FlashInterface::error`
- `Phalcon\Flash\FlashInterface::message`
- `Phalcon\Flash\FlashInterface::notice`
- `Phalcon\Flash\FlashInterface::success`
- `Phalcon\Flash\FlashInterface::warning`

Fixed return type hints of the following `Phalcon\Flash\AbstractFlash`'s methods:
- `Phalcon\Flash\AbstractFlash::error`
- `Phalcon\Flash\AbstractFlash::notice`
- `Phalcon\Flash\AbstractFlash::success`
- `Phalcon\Flash\AbstractFlash::warning`


Thanks

