### PR TITLE
Fixed return type hint for InterpolatorFactory::newInstance

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -40,6 +40,7 @@
 - Fixed default value of `Phalcon\Crypt::$key` to satisfy the interface [#14989](https://github.com/phalcon/cphalcon/issues/14989)
 - Fixed return type hint for `Phalcon\Di::getInternalEventsManager` [#14992](https://github.com/phalcon/cphalcon/issues/14992)
 - Fixed return type hints of the following `Phalcon\Flash\AbstractFlash`'s methods: `error`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
+- Fixed return type hint for `Phalcon\Translate\InterpolatorFactory::newInstance` [#14996](https://github.com/phalcon/cphalcon/issues/14996)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/phalcon/Translate/InterpolatorFactory.zep
+++ b/phalcon/Translate/InterpolatorFactory.zep
@@ -4,14 +4,14 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Translate;
 
 use Phalcon\Factory\AbstractFactory;
-use Phalcon\Translate\Adapter\AdapterInterface;
+use Phalcon\Translate\Interpolator\InterpolatorInterface;
 
 class InterpolatorFactory extends AbstractFactory
 {
@@ -36,7 +36,7 @@ class InterpolatorFactory extends AbstractFactory
     /**
      * Create a new instance of the adapter
      */
-    public function newInstance(string! name) -> <AdapterInterface>
+    public function newInstance(string! name) -> <InterpolatorInterface>
     {
         var definition;
 

--- a/tests/unit/Translate/InterpolatorFactory/NewInstanceCest.php
+++ b/tests/unit/Translate/InterpolatorFactory/NewInstanceCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -25,6 +25,8 @@ class NewInstanceCest
     /**
      * Tests Phalcon\Translate\InterpolatorFactory :: newInstance()
      *
+     * @param        UnitTester $I
+     * @param        Example $example
      * @dataProvider getExamples
      *
      * @author       Phalcon Team <team@phalcon.io>
@@ -44,6 +46,7 @@ class NewInstanceCest
     /**
      * Tests Phalcon\Translate\InterpolatorFactory :: newInstance() - exception
      *
+     * @param        UnitTester $I
      * @dataProvider getExamples
      *
      * @author       Phalcon Team <team@phalcon.io>
@@ -57,8 +60,7 @@ class NewInstanceCest
             new Exception('Service unknown is not registered'),
             function () {
                 $adapter = new InterpolatorFactory();
-
-                $service = $adapter->newInstance('unknown');
+                $adapter->newInstance('unknown');
             }
         );
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/14996

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed return type hint for `Phalcon\Translate\InterpolatorFactory::newInstance`

Thanks

