### PR TITLE
Changed return type hint for Model::getEventsManager

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -9,6 +9,7 @@
 - Changed return type hints of the following `Phalcon\Flash\FlashInterface`'s methods: `error`, `message`, `notice`, `success` and `warning` [#14994](https://github.com/phalcon/cphalcon/issues/14994)
 - Changed return type hint for `Phalcon\Mvc\ModelInterface::sum` [#15000](https://github.com/phalcon/cphalcon/issues/15000)
 - Changed return type for `Phalcon\Mvc\Model\Criteria::getLimit` so that integer, NULL or array will be returned [#15004](https://github.com/phalcon/cphalcon/issues/15004)
+- Changed return type hint for `Phalcon\Mvc\Model\Manager::getCustomEventsManager` to return NULL instead of boolean FALSE if there is no special events manager [#15008](https://github.com/phalcon/cphalcon/issues/15008)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql` to add single quote between string value on a simple condition [#14874](https://github.com/phalcon/cphalcon/issues/14874)
@@ -46,6 +47,7 @@
 - Fixed return type hint for `Phalcon\Mvc\Model::sum` [#15000](https://github.com/phalcon/cphalcon/issues/15000)
 - Fixed return type hint for `Phalcon\Mvc\Model\CriteriaInterface::getLimit` and `Phalcon\Mvc\Model\Criteria::getLimit` to follow documentation and original purpose [#15004](https://github.com/phalcon/cphalcon/issues/15004)
 - Fixed return type hint for `Phalcon\Mvc\Model::count` and `Phalcon\Mvc\ModelInterface::count` to reflect original behavior [#15006](https://github.com/phalcon/cphalcon/issues/15006)
+- Fixed return type hint for `Phalcon\Mvc\Model::getEventsManager` to reflect original behavior [#15008](https://github.com/phalcon/cphalcon/issues/15008)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/ext/phalcon/mvc/model.zep.h
+++ b/ext/phalcon/mvc/model.zep.h
@@ -316,9 +316,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_getdirtystate,
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_mvc_model_geteventsmanager, 0, 0, Phalcon\\Events\\ManagerInterface, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_mvc_model_geteventsmanager, 0, 0, Phalcon\\Events\\ManagerInterface, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_geteventsmanager, 0, 0, IS_OBJECT, "Phalcon\\Events\\ManagerInterface", 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_geteventsmanager, 0, 0, IS_OBJECT, "Phalcon\\Events\\ManagerInterface", 1)
 #endif
 ZEND_END_ARG_INFO()
 

--- a/ext/phalcon/mvc/model/manager.zep.c
+++ b/ext/phalcon/mvc/model/manager.zep.c
@@ -258,7 +258,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, setCustomEventsManager) {
 }
 
 /**
- * Returns a custom events manager related to a model
+ * Returns a custom events manager related to a model a null otherwise
  */
 PHP_METHOD(Phalcon_Mvc_Model_Manager, getCustomEventsManager) {
 
@@ -279,10 +279,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getCustomEventsManager) {
 	zephir_read_property(&_0, this_ptr, SL("customEventsManager"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
-	if (!(zephir_array_isset_fetch(&eventsManager, &_0, &_1, 1))) {
-		RETURN_MM_BOOL(0);
+	if (zephir_array_isset_fetch(&eventsManager, &_0, &_1, 1)) {
+		RETURN_CTOR(&eventsManager);
 	}
-	RETURN_CTOR(&eventsManager);
+	RETURN_MM_NULL();
 
 }
 

--- a/ext/phalcon/mvc/model/manager.zep.h
+++ b/ext/phalcon/mvc/model/manager.zep.h
@@ -127,7 +127,11 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_model_manager_setcustomeventsmanager,
 	ZEND_ARG_OBJ_INFO(0, eventsManager, Phalcon\\Events\\ManagerInterface, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_mvc_model_manager_getcustomeventsmanager, 0, 0, 1)
+#if PHP_VERSION_ID >= 70200
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_mvc_model_manager_getcustomeventsmanager, 0, 1, Phalcon\\Events\\ManagerInterface, 1)
+#else
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_manager_getcustomeventsmanager, 0, 1, IS_OBJECT, "Phalcon\\Events\\ManagerInterface", 1)
+#endif
 	ZEND_ARG_OBJ_INFO(0, model, Phalcon\\Mvc\\ModelInterface, 0)
 ZEND_END_ARG_INFO()
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1702,7 +1702,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Returns the custom events manager or null if there is no custom events manager
      */
-    public function getEventsManager() ->  <EventsManagerInterface> | null
+    public function getEventsManager() -> <EventsManagerInterface> | null
     {
         return this->modelsManager->getCustomEventsManager(this);
     }

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1700,9 +1700,9 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     }
 
     /**
-     * Returns the custom events manager
+     * Returns the custom events manager or null if there is no custom events manager
      */
-    public function getEventsManager() -> <EventsManagerInterface>
+    public function getEventsManager() ->  <EventsManagerInterface> | null
     {
         return this->modelsManager->getCustomEventsManager(this);
     }

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -194,17 +194,17 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Returns a custom events manager related to a model
+     * Returns a custom events manager related to a model or null if there is no related events manager
      */
-    public function getCustomEventsManager(<ModelInterface> model) -> <EventsManagerInterface> | bool
+    public function getCustomEventsManager(<ModelInterface> model) -> <EventsManagerInterface> | null
     {
         var eventsManager;
 
-        if !fetch eventsManager, this->customEventsManager[get_class_lower(model)] {
-            return false;
+        if fetch eventsManager, this->customEventsManager[get_class_lower(model)] {
+            return eventsManager;
         }
 
-        return eventsManager;
+        return null;
     }
 
     /**

--- a/tests/_data/fixtures/models/Invoices.php
+++ b/tests/_data/fixtures/models/Invoices.php
@@ -24,6 +24,9 @@ use Phalcon\Mvc\Model;
  * @property string $inv_title
  * @property float  $inv_total
  * @property string $inv_created_at
+ *
+ * @method static Invoices findFirst($parameters = null)
+ * @method static Model\Resultset\Simple|Invoices[] find($parameters = null)
  */
 class Invoices extends Model
 {

--- a/tests/_data/fixtures/models/Invoices.php
+++ b/tests/_data/fixtures/models/Invoices.php
@@ -25,8 +25,8 @@ use Phalcon\Mvc\Model;
  * @property float  $inv_total
  * @property string $inv_created_at
  *
- * @method static Invoices findFirst($parameters = null)
- * @method static Model\Resultset\Simple|Invoices[] find($parameters = null)
+ * @method static static findFirst($parameters = null)
+ * @method static Model\Resultset\Simple|static[] find($parameters = null)
  */
 class Invoices extends Model
 {

--- a/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
+++ b/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
@@ -47,19 +47,6 @@ final class DescribeColumnsCest
     }
 
     /**
-     * Executed after each test
-     *
-     * @param  DatabaseTester $I
-     * @return void
-     */
-    public function _after(DatabaseTester $I): void
-    {
-        if ($this->migration) {
-            $this->migration->clear();
-        }
-    }
-
-    /**
      * Tests Phalcon\Db\Adapter\Pdo :: describeColumns()
      *
      * @param  DatabaseTester $I

--- a/tests/database/Mvc/Model/CountCest.php
+++ b/tests/database/Mvc/Model/CountCest.php
@@ -52,19 +52,6 @@ class CountCest
     }
 
     /**
-     * Executed after each test
-     *
-     * @param  DatabaseTester $I
-     * @return void
-     */
-    public function _after(DatabaseTester $I): void
-    {
-        if ($this->invoiceMigration) {
-            $this->invoiceMigration->clear();
-        }
-    }
-
-    /**
      * Tests Phalcon\Mvc\Model :: count()
      *
      * @param  DatabaseTester $I

--- a/tests/database/Mvc/Model/GetSetEventsManagerCest.php
+++ b/tests/database/Mvc/Model/GetSetEventsManagerCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -15,6 +15,7 @@ namespace Phalcon\Test\Database\Mvc\Model;
 
 use DatabaseTester;
 use Phalcon\Events\Manager;
+use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use Phalcon\Test\Models\Invoices;
@@ -28,19 +29,47 @@ class GetSetEventsManagerCest
 {
     use DiTrait;
 
-    public function _before(DatabaseTester $I)
+    /**
+     * @var InvoicesMigration
+     */
+    private $invoiceMigration;
+
+    /**
+     * Executed before each test
+     *
+     * @param  DatabaseTester $I
+     * @return void
+     */
+    public function _before(DatabaseTester $I): void
     {
-        $this->setNewFactoryDefault();
+        try {
+            $this->setNewFactoryDefault();
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
+
         $this->setDatabase($I);
 
-        /** @var PDO $connection */
-        $connection = $I->getConnection();
-        $migration  = new InvoicesMigration($connection);
-        $migration->clear();
+        $this->invoiceMigration = new InvoicesMigration($I->getConnection());
+    }
+
+    /**
+     * Executed after each test
+     *
+     * @param  DatabaseTester $I
+     * @return void
+     */
+    public function _after(DatabaseTester $I): void
+    {
+        if ($this->invoiceMigration) {
+            $this->invoiceMigration->clear();
+        }
     }
 
     /**
      * Tests Phalcon\Mvc\Model :: getEventsManager()
+     *
+     * @param  DatabaseTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
@@ -53,19 +82,15 @@ class GetSetEventsManagerCest
     {
         $I->wantToTest('Mvc\Model - getEventsManager()');
 
-        $title = uniqid('inv-');
-        /** @var PDO $connection */
-        $connection = $I->getConnection();
-        $migration  = new InvoicesMigration($connection);
-        $migration->insert(4, null, 0, $title);
+        $this->invoiceMigration->insert(4, null, 0, uniqid('inv-', true));
 
         $invoice = Invoices::findFirst();
-        $manager = new Manager();
 
-        $I->assertFalse(
+        $I->assertNull(
             $invoice->getEventsManager()
         );
 
+        $manager = new Manager();
         $invoice->setEventsManager($manager);
 
         $I->assertEquals(

--- a/tests/database/Mvc/Model/GetSetEventsManagerCest.php
+++ b/tests/database/Mvc/Model/GetSetEventsManagerCest.php
@@ -44,26 +44,13 @@ class GetSetEventsManagerCest
     {
         try {
             $this->setNewFactoryDefault();
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             $I->fail($e->getMessage());
         }
 
         $this->setDatabase($I);
 
         $this->invoiceMigration = new InvoicesMigration($I->getConnection());
-    }
-
-    /**
-     * Executed after each test
-     *
-     * @param  DatabaseTester $I
-     * @return void
-     */
-    public function _after(DatabaseTester $I): void
-    {
-        if ($this->invoiceMigration) {
-            $this->invoiceMigration->clear();
-        }
     }
 
     /**

--- a/tests/database/Mvc/Model/QueryCest.php
+++ b/tests/database/Mvc/Model/QueryCest.php
@@ -66,23 +66,6 @@ class QueryCest
     }
 
     /**
-     * Executed after each test
-     *
-     * @param  DatabaseTester $I
-     * @return void
-     */
-    public function _after(DatabaseTester $I): void
-    {
-        if ($this->invoiceMigration) {
-            $this->invoiceMigration->clear();
-        }
-
-        if ($this->customerMigration) {
-            $this->customerMigration->clear();
-        }
-    }
-
-    /**
      * Tests Phalcon\Mvc\Model :: query()
      *
      * @param  DatabaseTester $I

--- a/tests/database/Mvc/Model/SumCest.php
+++ b/tests/database/Mvc/Model/SumCest.php
@@ -51,19 +51,6 @@ class SumCest
     }
 
     /**
-     * Executed after each test
-     *
-     * @param  DatabaseTester $I
-     * @return void
-     */
-    public function _after(DatabaseTester $I): void
-    {
-        if ($this->invoiceMigration) {
-            $this->invoiceMigration->clear();
-        }
-    }
-
-    /**
      * Tests Phalcon\Mvc\Model :: sum()
      *
      * @param  DatabaseTester $I


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15008

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

- Changed return type hint for `Phalcon\Mvc\Model\Manager::getCustomEventsManager` to return NULL instead of boolean FALSE if there is no special events manager
- Fixed return type hint for `Phalcon\Mvc\Model::getEventsManager` to reflect original behavior

Thanks

