### PR TITLE
Fixed return type hint for MetaData

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -50,6 +50,7 @@
 - Fixed return type hint for `Phalcon\Mvc\Model::count` and `Phalcon\Mvc\ModelInterface::count` to reflect original behavior [#15006](https://github.com/phalcon/cphalcon/issues/15006)
 - Fixed return type hint for `Phalcon\Mvc\Model::getEventsManager` to reflect original behavior [#15008](https://github.com/phalcon/cphalcon/issues/15008)
 - Fixed return type hint for `Phalcon\Mvc\Model::average` and `Phalcon\Mvc\ModelInterface::average` to reflect original behavior [#15013](https://github.com/phalcon/cphalcon/issues/15013)
+- Fixed return type hint for `Phalcon\Mvc\Model\MetaData::getColumnMap` and `Phalcon\Mvc\Model\MetaData::getReverseColumnMap` to reflect original behavior [#15015](https://github.com/phalcon/cphalcon/issues/15015)
 
 [#14987](https://github.com/phalcon/cphalcon/issues/14987)
 

--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -51,8 +51,7 @@
 - Fixed return type hint for `Phalcon\Mvc\Model::getEventsManager` to reflect original behavior [#15008](https://github.com/phalcon/cphalcon/issues/15008)
 - Fixed return type hint for `Phalcon\Mvc\Model::average` and `Phalcon\Mvc\ModelInterface::average` to reflect original behavior [#15013](https://github.com/phalcon/cphalcon/issues/15013)
 - Fixed return type hint for `Phalcon\Mvc\Model\MetaData::getColumnMap` and `Phalcon\Mvc\Model\MetaData::getReverseColumnMap` to reflect original behavior [#15015](https://github.com/phalcon/cphalcon/issues/15015)
-
-[#14987](https://github.com/phalcon/cphalcon/issues/14987)
+- Fixed return type hint for `Phalcon\Mvc\Model\MetaDataInterface::getColumnMap` and `Phalcon\Mvc\Model\MetaDataInterface::getReverseColumnMap` to reflect original behavior [#15015](https://github.com/phalcon/cphalcon/issues/15015)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/ext/phalcon/mvc/model/metadata.zep.c
+++ b/ext/phalcon/mvc/model/metadata.zep.c
@@ -1500,10 +1500,12 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData, throwWriteException) {
 
 zend_object *zephir_init_properties_Phalcon_Mvc_Model_MetaData(zend_class_entry *class_type TSRMLS_DC) {
 
-		zval _0, _1$$3;
+		zval _0, _2, _1$$3, _3$$4;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 		ZVAL_UNDEF(&_0);
+	ZVAL_UNDEF(&_2);
 	ZVAL_UNDEF(&_1$$3);
+	ZVAL_UNDEF(&_3$$4);
 
 		ZEPHIR_MM_GROW();
 	
@@ -1515,6 +1517,12 @@ zend_object *zephir_init_properties_Phalcon_Mvc_Model_MetaData(zend_class_entry 
 			ZEPHIR_INIT_VAR(&_1$$3);
 			array_init(&_1$$3);
 			zephir_update_property_zval(this_ptr, SL("metaData"), &_1$$3);
+		}
+		zephir_read_property(&_2, this_ptr, SL("columnMap"), PH_NOISY_CC | PH_READONLY);
+		if (Z_TYPE_P(&_2) == IS_NULL) {
+			ZEPHIR_INIT_VAR(&_3$$4);
+			array_init(&_3$$4);
+			zephir_update_property_zval(this_ptr, SL("columnMap"), &_3$$4);
 		}
 		ZEPHIR_MM_RESTORE();
 		return Z_OBJ_P(this_ptr);

--- a/ext/phalcon/mvc/model/metadata.zep.h
+++ b/ext/phalcon/mvc/model/metadata.zep.h
@@ -71,9 +71,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getbi
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getcolumnmap, 0, 1, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getcolumnmap, 0, 1, IS_ARRAY, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getcolumnmap, 0, 1, IS_ARRAY, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getcolumnmap, 0, 1, IS_ARRAY, NULL, 1)
 #endif
 	ZEND_ARG_OBJ_INFO(0, model, Phalcon\\Mvc\\ModelInterface, 0)
 ZEND_END_ARG_INFO()
@@ -150,9 +150,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getpr
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getreversecolumnmap, 0, 1, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getreversecolumnmap, 0, 1, IS_ARRAY, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getreversecolumnmap, 0, 1, IS_ARRAY, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadata_getreversecolumnmap, 0, 1, IS_ARRAY, NULL, 1)
 #endif
 	ZEND_ARG_OBJ_INFO(0, model, Phalcon\\Mvc\\ModelInterface, 0)
 ZEND_END_ARG_INFO()

--- a/ext/phalcon/mvc/model/metadatainterface.zep.h
+++ b/ext/phalcon/mvc/model/metadatainterface.zep.h
@@ -36,9 +36,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterf
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getcolumnmap, 0, 1, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getcolumnmap, 0, 1, IS_ARRAY, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getcolumnmap, 0, 1, IS_ARRAY, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getcolumnmap, 0, 1, IS_ARRAY, NULL, 1)
 #endif
 	ZEND_ARG_OBJ_INFO(0, model, Phalcon\\Mvc\\ModelInterface, 0)
 ZEND_END_ARG_INFO()
@@ -108,9 +108,9 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterf
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getreversecolumnmap, 0, 1, IS_ARRAY, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getreversecolumnmap, 0, 1, IS_ARRAY, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getreversecolumnmap, 0, 1, IS_ARRAY, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_metadatainterface_getreversecolumnmap, 0, 1, IS_ARRAY, NULL, 1)
 #endif
 	ZEND_ARG_OBJ_INFO(0, model, Phalcon\\Mvc\\ModelInterface, 0)
 ZEND_END_ARG_INFO()

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -61,7 +61,7 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      */
     protected adapter;
 
-    protected columnMap;
+    protected columnMap = [];
 
     protected container;
 
@@ -185,7 +185,7 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      * );
      *```
      */
-    public function getColumnMap(<ModelInterface> model) -> array
+    public function getColumnMap(<ModelInterface> model) -> array | null
     {
         var data;
 
@@ -417,7 +417,7 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      * );
      *```
      */
-    public function getReverseColumnMap(<ModelInterface> model) -> array
+    public function getReverseColumnMap(<ModelInterface> model) -> array | null
     {
         var data;
 

--- a/phalcon/Mvc/Model/MetaDataInterface.zep
+++ b/phalcon/Mvc/Model/MetaDataInterface.zep
@@ -43,7 +43,7 @@ interface MetaDataInterface
     /**
      * Returns the column map if any
      */
-    public function getColumnMap(<ModelInterface> model) -> array;
+    public function getColumnMap(<ModelInterface> model) -> array | null;
 
     /**
      * Returns attributes (which have default values) and their default values
@@ -88,7 +88,7 @@ interface MetaDataInterface
     /**
      * Returns the reverse column map if any
      */
-    public function getReverseColumnMap(<ModelInterface> model) -> array;
+    public function getReverseColumnMap(<ModelInterface> model) -> array | null;
 
     /**
      * Return the strategy to obtain the meta-data

--- a/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
+++ b/tests/database/Mvc/Model/MetaData/GetColumnMapCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -15,6 +15,7 @@ namespace Phalcon\Test\Database\Mvc\Model\MetaData;
 
 use DatabaseTester;
 use Phalcon\Mvc\Model\MetaData;
+use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
 use Phalcon\Test\Models\Invoices;
 use Phalcon\Test\Models\InvoicesMap;
@@ -26,14 +27,27 @@ class GetColumnMapCest
 {
     use DiTrait;
 
-    public function _before(DatabaseTester $I)
+    /**
+     * Executed before each test
+     *
+     * @param  DatabaseTester $I
+     * @return void
+     */
+    public function _before(DatabaseTester $I): void
     {
-        $this->setNewFactoryDefault();
+        try {
+            $this->setNewFactoryDefault();
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
+
         $this->setDatabase($I);
     }
 
     /**
      * Tests Phalcon\Mvc\Model\MetaData :: getColumnMap()
+     *
+     * @param  DatabaseTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
@@ -48,11 +62,9 @@ class GetColumnMapCest
 
         /** @var MetaData $metadata */
         $metadata = $this->container->get('modelsMetadata');
-
         $model    = new Invoices();
-        $expected = null;
-        $actual   = $metadata->getColumnMap($model);
-        $I->assertEquals($expected, $actual);
+
+        $I->assertNull($metadata->getColumnMap($model));
 
         $model    = new InvoicesMap();
         $expected = [
@@ -63,7 +75,7 @@ class GetColumnMapCest
             'inv_total'       => 'total',
             'inv_created_at'  => 'created_at',
         ];
-        $actual   = $metadata->getColumnMap($model);
-        $I->assertEquals($expected, $actual);
+
+        $I->assertEquals($expected, $metadata->getColumnMap($model));
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15015

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

- Fixed return type hint for `Phalcon\Mvc\Model\MetaData::getColumnMap` and `Phalcon\Mvc\Model\MetaData::getReverseColumnMap` to reflect original behavior

- Fixed return type hint for `Phalcon\Mvc\Model\MetaDataInterface::getColumnMap`  and `Phalcon\Mvc\Model\MetaDataInterface::getReverseColumnMap` to reflect original behavior

Thanks