### PR TITLE
Fixed return type for CriteriaInterface::getColumns

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -52,6 +52,7 @@
 - Fixed return type hint for `Phalcon\Mvc\Model::average` and `Phalcon\Mvc\ModelInterface::average` to reflect original behavior [#15013](https://github.com/phalcon/cphalcon/issues/15013)
 - Fixed return type hint for `Phalcon\Mvc\Model\MetaData::getColumnMap` and `Phalcon\Mvc\Model\MetaData::getReverseColumnMap` to reflect original behavior [#15015](https://github.com/phalcon/cphalcon/issues/15015)
 - Fixed return type hint for `Phalcon\Mvc\Model\MetaDataInterface::getColumnMap` and `Phalcon\Mvc\Model\MetaDataInterface::getReverseColumnMap` to reflect original behavior [#15015](https://github.com/phalcon/cphalcon/issues/15015)
+- Fixed return type hint for `Phalcon\Mvc\Model\CriteriaInterface::getColumns` and `Phalcon\Mvc\Model\Criteria::getColumns` to reflect original behavior [#15017](https://github.com/phalcon/cphalcon/issues/15017)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/ext/phalcon/mvc/model/criteria.zep.c
+++ b/ext/phalcon/mvc/model/criteria.zep.c
@@ -28,8 +28,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 /**
  * Phalcon\Mvc\Model\Criteria

--- a/ext/phalcon/mvc/model/criteria.zep.h
+++ b/ext/phalcon/mvc/model/criteria.zep.h
@@ -174,13 +174,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteria_fromi
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteria_getcolumns, 0, 0, IS_STRING, 1)
-#else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteria_getcolumns, 0, 0, IS_STRING, NULL, 1)
-#endif
-ZEND_END_ARG_INFO()
-
-#if PHP_VERSION_ID >= 70200
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteria_getconditions, 0, 0, IS_STRING, 1)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteria_getconditions, 0, 0, IS_STRING, NULL, 1)
@@ -443,7 +436,7 @@ ZEPHIR_INIT_FUNCS(phalcon_mvc_model_criteria_method_entry) {
 	PHP_ME(Phalcon_Mvc_Model_Criteria, execute, arginfo_phalcon_mvc_model_criteria_execute, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, forUpdate, arginfo_phalcon_mvc_model_criteria_forupdate, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, fromInput, arginfo_phalcon_mvc_model_criteria_frominput, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
-	PHP_ME(Phalcon_Mvc_Model_Criteria, getColumns, arginfo_phalcon_mvc_model_criteria_getcolumns, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Mvc_Model_Criteria, getColumns, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, getConditions, arginfo_phalcon_mvc_model_criteria_getconditions, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, getDI, arginfo_phalcon_mvc_model_criteria_getdi, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Mvc_Model_Criteria, getGroupBy, NULL, ZEND_ACC_PUBLIC)

--- a/ext/phalcon/mvc/model/criteriainterface.zep.h
+++ b/ext/phalcon/mvc/model/criteriainterface.zep.h
@@ -95,13 +95,6 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteriainterf
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteriainterface_getcolumns, 0, 0, IS_STRING, 1)
-#else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteriainterface_getcolumns, 0, 0, IS_STRING, NULL, 1)
-#endif
-ZEND_END_ARG_INFO()
-
-#if PHP_VERSION_ID >= 70200
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteriainterface_getconditions, 0, 0, IS_STRING, 1)
 #else
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_mvc_model_criteriainterface_getconditions, 0, 0, IS_STRING, NULL, 1)
@@ -323,7 +316,7 @@ ZEPHIR_INIT_FUNCS(phalcon_mvc_model_criteriainterface_method_entry) {
 	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, distinct, arginfo_phalcon_mvc_model_criteriainterface_distinct)
 	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, execute, arginfo_phalcon_mvc_model_criteriainterface_execute)
 	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, forUpdate, arginfo_phalcon_mvc_model_criteriainterface_forupdate)
-	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, getColumns, arginfo_phalcon_mvc_model_criteriainterface_getcolumns)
+	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, getColumns, NULL)
 	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, getConditions, arginfo_phalcon_mvc_model_criteriainterface_getconditions)
 	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, getGroupBy, NULL)
 	PHP_ABSTRACT_ME(Phalcon_Mvc_Model_CriteriaInterface, getHaving, NULL)

--- a/phalcon/Mvc/Model/Criteria.zep
+++ b/phalcon/Mvc/Model/Criteria.zep
@@ -4,8 +4,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 namespace Phalcon\Mvc\Model;
@@ -331,7 +331,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Returns the columns to be queried
      */
-    public function getColumns() -> string | null
+    public function getColumns() -> string | array | null
     {
         var columns;
 

--- a/phalcon/Mvc/Model/CriteriaInterface.zep
+++ b/phalcon/Mvc/Model/CriteriaInterface.zep
@@ -80,7 +80,7 @@ interface CriteriaInterface
     /**
      * Returns the columns to be queried
      */
-    public function getColumns() -> string | null;
+    public function getColumns() -> string | array | null;
 
     /**
      * Returns the conditions parameter in the criteria

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,6 @@ following resources:
 The container based environment contains all the services you need to write
 and run your tests. These services are:
 
-- Beanstalkd
 - Memcached
 - Mongodb
 - Mysql

--- a/tests/_ci/.env.default
+++ b/tests/_ci/.env.default
@@ -31,10 +31,6 @@ DATA_REDIS_HOST="127.0.0.1"
 DATA_REDIS_PORT=6379
 DATA_REDIS_NAME="0"
 
-# Beanstalk
-DATA_BEANSTALKD_HOST="127.0.0.1"
-DATA_BEANSTALKD_PORT=11300
-
 # SQLite
 DATA_SQLITE_NAME="tests/_data/phalcon_test.sqlite"
 DATA_SQLITE_I18N_NAME="tests/_data/translations.sqlite"

--- a/tests/_ci/.env.travis
+++ b/tests/_ci/.env.travis
@@ -38,10 +38,6 @@ DATA_REDIS_HOST="127.0.0.1"
 DATA_REDIS_PORT=6379
 DATA_REDIS_NAME="0"
 
-# Beanstalk
-DATA_BEANSTALKD_HOST="127.0.0.1"
-DATA_BEANSTALKD_PORT=11300
-
 # SQLite
 DATA_SQLITE_NAME="tests/_data/phalcon_test.sqlite"
 DATA_SQLITE_I18N_NAME="tests/_data/translations.sqlite"

--- a/tests/_ci/nanobox/.env.example
+++ b/tests/_ci/nanobox/.env.example
@@ -29,9 +29,6 @@ DATA_MONGODB_NAME="phalcon_test"
 DATA_REDIS_PORT="6379"
 DATA_REDIS_NAME="0"
 
-# Beanstalk
-DATA_BEANSTALKD_PORT="11300"
-
 # SQLite
 DATA_SQLITE_NAME="/app/tests/_output/phalcon_test.sqlite"
 DATA_SQLITE_I18N_NAME="/app/tests/_output/translations.sqlite"

--- a/tests/database/Mvc/Model/Criteria/GetColumnsCest.php
+++ b/tests/database/Mvc/Model/Criteria/GetColumnsCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -16,13 +16,12 @@ namespace Phalcon\Test\Database\Mvc\Model\Criteria;
 use DatabaseTester;
 use Phalcon\Mvc\Model\Criteria;
 
-/**
- * Class GetColumnsCest
- */
 class GetColumnsCest
 {
     /**
      * Tests Phalcon\Mvc\Model\Criteria :: getColumns()
+     *
+     * @param  DatabaseTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
@@ -44,6 +43,8 @@ class GetColumnsCest
 
     /**
      * Tests Phalcon\Mvc\Model\Criteria :: getColumns() - array
+     *
+     * @param  DatabaseTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15017

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed return type hint for `Phalcon\Mvc\Model\CriteriaInterface::getColumns` and `Phalcon\Mvc\Model\Criteria::getColumns` to reflect original behavior

Thanks

