### PR TITLE
Fixed return type hint for Column::getAfterPosition

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -54,6 +54,7 @@
 - Fixed return type hint for `Phalcon\Mvc\Model\MetaDataInterface::getColumnMap` and `Phalcon\Mvc\Model\MetaDataInterface::getReverseColumnMap` to reflect original behavior [#15015](https://github.com/phalcon/cphalcon/issues/15015)
 - Fixed return type hint for `Phalcon\Mvc\Model\CriteriaInterface::getColumns` and `Phalcon\Mvc\Model\Criteria::getColumns` to reflect original behavior [#15017](https://github.com/phalcon/cphalcon/issues/15017)
 - Fixed return type hint for `Phalcon\Db\Column::getSize` and `Phalcon\Db\ColumnInterface::getSize` to reflect original behavior [#15019](https://github.com/phalcon/cphalcon/issues/15019)
+- Fixed return type hint for `Phalcon\Db\Column::getAfterPosition` and `Phalcon\Db\ColumnInterface::getAfterPosition` to reflect original behavior [#15021](https://github.com/phalcon/cphalcon/issues/15021)
 
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added

--- a/ext/phalcon/db/column.zep.c
+++ b/ext/phalcon/db/column.zep.c
@@ -59,7 +59,7 @@ ZEPHIR_INIT_CLASS(Phalcon_Db_Column) {
 	/**
 	 * Column Position
 	 *
-	 * @var string
+	 * @var string|null
 	 */
 	zend_declare_property_null(phalcon_db_column_ce, SL("after"), ZEND_ACC_PROTECTED);
 

--- a/ext/phalcon/db/column.zep.h
+++ b/ext/phalcon/db/column.zep.h
@@ -59,9 +59,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_db_column___construct, 0, 0, 2)
 ZEND_END_ARG_INFO()
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_column_getafterposition, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_column_getafterposition, 0, 0, IS_STRING, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_column_getafterposition, 0, 0, IS_STRING, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_column_getafterposition, 0, 0, IS_STRING, NULL, 1)
 #endif
 ZEND_END_ARG_INFO()
 

--- a/ext/phalcon/db/columninterface.zep.h
+++ b/ext/phalcon/db/columninterface.zep.h
@@ -4,9 +4,9 @@ extern zend_class_entry *phalcon_db_columninterface_ce;
 ZEPHIR_INIT_CLASS(Phalcon_Db_ColumnInterface);
 
 #if PHP_VERSION_ID >= 70200
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_columninterface_getafterposition, 0, 0, IS_STRING, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_columninterface_getafterposition, 0, 0, IS_STRING, 1)
 #else
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_columninterface_getafterposition, 0, 0, IS_STRING, NULL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_db_columninterface_getafterposition, 0, 0, IS_STRING, NULL, 1)
 #endif
 ZEND_END_ARG_INFO()
 

--- a/phalcon/Db/Column.zep
+++ b/phalcon/Db/Column.zep
@@ -208,7 +208,7 @@ class Column implements ColumnInterface
     /**
      * Column Position
      *
-     * @var string
+     * @var string|null
      */
     protected after;
 
@@ -443,7 +443,7 @@ class Column implements ColumnInterface
     /**
      * Check whether field absolute to position in table
      */
-    public function getAfterPosition() -> string
+    public function getAfterPosition() -> string | null
     {
         return this->after;
     }

--- a/phalcon/Db/ColumnInterface.zep
+++ b/phalcon/Db/ColumnInterface.zep
@@ -18,7 +18,7 @@ interface ColumnInterface
     /**
      * Check whether field absolute to position in table
      */
-    public function getAfterPosition() -> string;
+    public function getAfterPosition() -> string | null;
 
     /**
      * Returns the type of bind handling

--- a/tests/database/Db/Column/GetAfterPositionCest.php
+++ b/tests/database/Db/Column/GetAfterPositionCest.php
@@ -5,8 +5,8 @@
  *
  * (c) Phalcon Team <team@phalcon.io>
  *
- * For the full copyright and license information, please view the LICENSE.txt
- * file that was distributed with this source code.
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
  */
 
 declare(strict_types=1);
@@ -23,6 +23,7 @@ class GetAfterPositionCest
     /**
      * Tests Phalcon\Db\Column :: getAfterPosition()
      *
+     * @param  DatabaseTester $I
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-02-01
      *


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/cphalcon/issues/15021

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed return type hint for `Phalcon\Db\Column::getAfterPosition` and `Phalcon\Db\ColumnInterface::getAfterPosition` to reflect original behavior

Thanks

