### PR TITLE
Removed InterpolatorFactory::${mapper,services}

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -61,6 +61,9 @@
 - Rollback the regression changes for `Phalcon\Mvc\Model\Query::_prepareSelect` to properly prepare a SQL `SELECT` statement from a PHQL one [#14657](https://github.com/phalcon/cphalcon/issues/14657)
 - Fixed `SerializerInterface` usage for `Phalcon\Mvc\Model\Resultset\Complex::unserialize` as well as `Phalcon\Mvc\Model\Resultset\Complex::unserialize` [#14942](https://github.com/phalcon/cphalcon/issues/14942)
 
+## Removed
+- Removed `Phalcon\Translate\InterpolatorFactory::$mapper` as well as `Phalcon\Translate\InterpolatorFactory::$services` in favor of `Phalcon\Factory\AbstractFactory` ones [#15036](https://github.com/phalcon/cphalcon/issues/15036)
+
 # [4.0.5](https://github.com/phalcon/cphalcon/releases/tag/v4.0.5) (2020-03-07)
 ## Added
 

--- a/ext/phalcon/translate/interpolatorfactory.zep.c
+++ b/ext/phalcon/translate/interpolatorfactory.zep.c
@@ -33,17 +33,6 @@ ZEPHIR_INIT_CLASS(Phalcon_Translate_InterpolatorFactory) {
 
 	ZEPHIR_REGISTER_CLASS_EX(Phalcon\\Translate, InterpolatorFactory, phalcon, translate_interpolatorfactory, phalcon_factory_abstractfactory_ce, phalcon_translate_interpolatorfactory_method_entry, 0);
 
-	/**
-	 * @var array
-	 */
-	zend_declare_property_null(phalcon_translate_interpolatorfactory_ce, SL("mapper"), ZEND_ACC_PRIVATE);
-
-	/**
-	 * @var array
-	 */
-	zend_declare_property_null(phalcon_translate_interpolatorfactory_ce, SL("services"), ZEND_ACC_PRIVATE);
-
-	phalcon_translate_interpolatorfactory_ce->create_object = zephir_init_properties_Phalcon_Translate_InterpolatorFactory;
 	return SUCCESS;
 
 }
@@ -112,7 +101,7 @@ PHP_METHOD(Phalcon_Translate_InterpolatorFactory, newInstance) {
 	zephir_check_call_status();
 	zephir_read_property(&_0, this_ptr, SL("mapper"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_OBS_VAR(&definition);
-	zephir_array_fetch(&definition, &_0, &name, PH_NOISY, "phalcon/Translate/InterpolatorFactory.zep", 45);
+	zephir_array_fetch(&definition, &_0, &name, PH_NOISY, "phalcon/Translate/InterpolatorFactory.zep", 35);
 	ZEPHIR_LAST_CALL_STATUS = zephir_create_instance(return_value, &definition);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -128,38 +117,6 @@ PHP_METHOD(Phalcon_Translate_InterpolatorFactory, getAdapters) {
 	add_assoc_stringl_ex(return_value, SL("associativeArray"), SL("Phalcon\\Translate\\Interpolator\\AssociativeArray"));
 	add_assoc_stringl_ex(return_value, SL("indexedArray"), SL("Phalcon\\Translate\\Interpolator\\IndexedArray"));
 	return;
-
-}
-
-zend_object *zephir_init_properties_Phalcon_Translate_InterpolatorFactory(zend_class_entry *class_type TSRMLS_DC) {
-
-		zval _0, _2, _1$$3, _3$$4;
-	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-		ZVAL_UNDEF(&_0);
-	ZVAL_UNDEF(&_2);
-	ZVAL_UNDEF(&_1$$3);
-	ZVAL_UNDEF(&_3$$4);
-
-		ZEPHIR_MM_GROW();
-	
-	{
-		zval local_this_ptr, *this_ptr = &local_this_ptr;
-		ZEPHIR_CREATE_OBJECT(this_ptr, class_type);
-		zephir_read_property(&_0, this_ptr, SL("services"), PH_NOISY_CC | PH_READONLY);
-		if (Z_TYPE_P(&_0) == IS_NULL) {
-			ZEPHIR_INIT_VAR(&_1$$3);
-			array_init(&_1$$3);
-			zephir_update_property_zval(this_ptr, SL("services"), &_1$$3);
-		}
-		zephir_read_property(&_2, this_ptr, SL("mapper"), PH_NOISY_CC | PH_READONLY);
-		if (Z_TYPE_P(&_2) == IS_NULL) {
-			ZEPHIR_INIT_VAR(&_3$$4);
-			array_init(&_3$$4);
-			zephir_update_property_zval(this_ptr, SL("mapper"), &_3$$4);
-		}
-		ZEPHIR_MM_RESTORE();
-		return Z_OBJ_P(this_ptr);
-	}
 
 }
 

--- a/ext/phalcon/translate/interpolatorfactory.zep.h
+++ b/ext/phalcon/translate/interpolatorfactory.zep.h
@@ -6,7 +6,6 @@ ZEPHIR_INIT_CLASS(Phalcon_Translate_InterpolatorFactory);
 PHP_METHOD(Phalcon_Translate_InterpolatorFactory, __construct);
 PHP_METHOD(Phalcon_Translate_InterpolatorFactory, newInstance);
 PHP_METHOD(Phalcon_Translate_InterpolatorFactory, getAdapters);
-zend_object *zephir_init_properties_Phalcon_Translate_InterpolatorFactory(zend_class_entry *class_type TSRMLS_DC);
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_translate_interpolatorfactory___construct, 0, 0, 0)
 	ZEND_ARG_ARRAY_INFO(0, services, 0)

--- a/phalcon/Translate/InterpolatorFactory.zep
+++ b/phalcon/Translate/InterpolatorFactory.zep
@@ -16,16 +16,6 @@ use Phalcon\Translate\Interpolator\InterpolatorInterface;
 class InterpolatorFactory extends AbstractFactory
 {
     /**
-     * @var array
-     */
-    private mapper   = [];
-
-    /**
-     * @var array
-     */
-    private services = [];
-
-    /**
      * AdapterFactory constructor.
      */
     public function __construct(array! services = [])


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15036

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Removed `Phalcon\Translate\InterpolatorFactory::$mapper` as well as `Phalcon\Translate\InterpolatorFactory::$services` in favor of `Phalcon\Factory\AbstractFactory` ones.

Thanks

