### PR TITLE
Events manager fix

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -42,6 +42,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 
 ## Fixed
 - Fixed `Phalcon\Db\Dialect\Mysql::getColumnDefinition` to recognize `size` for `DATETIME`, `TIME` and `TIMESTAMP` columns [#13297](https://github.com/phalcon/cphalcon/issues/13297)
+- Fixed `Phalcon\Events\Manager` to provide callable support [#13322](https://github.com/phalcon/cphalcon/issues/13322), [#15045](https://github.com/phalcon/cphalcon/pull/15045)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Events/Manager.zep
+++ b/phalcon/Events/Manager.zep
@@ -48,9 +48,7 @@ class Manager implements ManagerInterface
     {
         var priorityQueue;
 
-        if unlikely typeof handler != "object" {
-            throw new Exception("Event handler must be an Object");
-        }
+        this->isValidHandler(handler);
 
         if !fetch priorityQueue, this->events[eventType] {
             // Create a SplPriorityQueue to store the events with priorities
@@ -99,9 +97,7 @@ class Manager implements ManagerInterface
     {
         var priorityQueue, newPriorityQueue, data;
 
-        if unlikely typeof handler != "object" {
-            throw new Exception("Event handler must be an Object");
-        }
+        this->isValidHandler(handler);
 
         if fetch priorityQueue, this->events[eventType] {
             /**
@@ -263,12 +259,12 @@ class Manager implements ManagerInterface
             iterator->next();
 
             // Only handler objects are valid
-            if unlikely typeof handler != "object" {
+            if unlikely false === this->isValidHandler(handler, true) {
                 continue;
             }
 
             // Check if the event is a closure
-            if handler instanceof Closure {
+            if handler instanceof Closure || is_callable(handler) {
                 // Call the function in the PHP userland
                 let status = call_user_func_array(
                     handler,
@@ -350,5 +346,18 @@ class Manager implements ManagerInterface
     public function isCollecting() -> bool
     {
         return this->collect;
+    }
+
+    protected function isValidHandler(handler, bool silent = false) -> bool
+    {
+        if unlikely typeof handler != "object" && !is_callable(handler) {
+            if likely silent {
+                return false;
+            }
+
+            throw new Exception("Event handler must be an Object or Callable");
+        }
+
+        return true;
     }
 }

--- a/phalcon/Events/Manager.zep
+++ b/phalcon/Events/Manager.zep
@@ -48,7 +48,9 @@ class Manager implements ManagerInterface
     {
         var priorityQueue;
 
-        this->isValidHandler(handler);
+        if unlikely false === this->isValidHandler(handler) {
+            throw new Exception("Event handler must be an Object or Callable");
+        }
 
         if !fetch priorityQueue, this->events[eventType] {
             // Create a SplPriorityQueue to store the events with priorities
@@ -97,7 +99,9 @@ class Manager implements ManagerInterface
     {
         var priorityQueue, newPriorityQueue, data;
 
-        this->isValidHandler(handler);
+        if unlikely false === this->isValidHandler(handler) {
+            throw new Exception("Event handler must be an Object or Callable");
+        }
 
         if fetch priorityQueue, this->events[eventType] {
             /**
@@ -259,7 +263,7 @@ class Manager implements ManagerInterface
             iterator->next();
 
             // Only handler objects are valid
-            if unlikely false === this->isValidHandler(handler, true) {
+            if unlikely false === this->isValidHandler(handler) {
                 continue;
             }
 
@@ -348,13 +352,10 @@ class Manager implements ManagerInterface
         return this->collect;
     }
 
-    public function isValidHandler(handler, bool silent = false) -> bool
+    public function isValidHandler(handler) -> bool
     {
         if unlikely typeof handler != "object" && !is_callable(handler) {
-            if likely silent {
-                return false;
-            }
-            throw new Exception("Event handler must be an Object or Callable");
+            return false;
         }
 
         return true;

--- a/phalcon/Events/Manager.zep
+++ b/phalcon/Events/Manager.zep
@@ -348,13 +348,12 @@ class Manager implements ManagerInterface
         return this->collect;
     }
 
-    protected function isValidHandler(handler, bool silent = false) -> bool
+    public function isValidHandler(handler, bool silent = false) -> bool
     {
         if unlikely typeof handler != "object" && !is_callable(handler) {
             if likely silent {
                 return false;
             }
-
             throw new Exception("Event handler must be an Object or Callable");
         }
 

--- a/tests/unit/Events/Manager/IsValidHandlerCest.php
+++ b/tests/unit/Events/Manager/IsValidHandlerCest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Events\Manager;
+
+use Phalcon\Events\Manager;
+use UnitTester;
+
+class IsValidHandlerCest
+{
+    /**
+     * Tests Phalcon\Events\Manager :: isValidHandler()
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2018-11-13
+     */
+    public function eventsManagerIsValidHandler(UnitTester $I)
+    {
+        $I->wantToTest('Events\Manager - isValidHandler()');
+
+        $silent = true;
+        $manager = new Manager();
+
+        $stringHandler = 'handler';
+        $I->assertFalse(
+            $manager->isValidHandler($stringHandler, $silent)
+        );
+
+        $integerHandler = 666;
+        $I->assertFalse(
+            $manager->isValidHandler($integerHandler, $silent)
+        );
+
+        $objectHandler = new Manager();
+        $I->assertTrue(
+            $manager->isValidHandler($objectHandler, $silent)
+        );
+
+        $callableHandler = [$objectHandler, 'hasListeners'];
+        $I->assertTrue(
+            $manager->isValidHandler($callableHandler, $silent)
+        );
+
+        $closureHandler = function () {
+            return true;
+        };
+        $I->assertTrue(
+            $manager->isValidHandler($closureHandler, $silent)
+        );
+    }
+}

--- a/tests/unit/Events/Manager/IsValidHandlerCest.php
+++ b/tests/unit/Events/Manager/IsValidHandlerCest.php
@@ -28,34 +28,33 @@ class IsValidHandlerCest
     {
         $I->wantToTest('Events\Manager - isValidHandler()');
 
-        $silent = true;
         $manager = new Manager();
 
         $stringHandler = 'handler';
         $I->assertFalse(
-            $manager->isValidHandler($stringHandler, $silent)
+            $manager->isValidHandler($stringHandler)
         );
 
         $integerHandler = 666;
         $I->assertFalse(
-            $manager->isValidHandler($integerHandler, $silent)
+            $manager->isValidHandler($integerHandler)
         );
 
         $objectHandler = new Manager();
         $I->assertTrue(
-            $manager->isValidHandler($objectHandler, $silent)
+            $manager->isValidHandler($objectHandler)
         );
 
         $callableHandler = [$objectHandler, 'hasListeners'];
         $I->assertTrue(
-            $manager->isValidHandler($callableHandler, $silent)
+            $manager->isValidHandler($callableHandler)
         );
 
         $closureHandler = function () {
             return true;
         };
         $I->assertTrue(
-            $manager->isValidHandler($closureHandler, $silent)
+            $manager->isValidHandler($closureHandler)
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: [#13322](https://github.com/phalcon/cphalcon/issues/13322)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
There is a note in [docs](https://docs.phalcon.io/4.0/en/events), saying that you can attach callable to events manager as event handler, but that doesn't works properly. [Issue](https://github.com/phalcon/cphalcon/issues/13322) describing it.
Fixed in this PR. Now you can pass callable as event handler.

Thanks

