### PR TITLE
Remove UTF-8 charset from Phalcon\Http\Request::setJsonContent to comply with RFC

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -39,6 +39,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - PHQL now supports the use of any printable characters from the extended ASCII
   table for escaped identifiers. The exception characters are `[` and `]`. To
   use `[` and `]` escape they (`\[`, `\]`) [#14535](https://github.com/phalcon/cphalcon/issues/14535)
+- Removed UTF-8 charset when using `Phalcon\Http\Response::setJsonContent` to apply with rfc7159
 
 ## Fixed
 - Fixed `Phalcon\Db\Dialect\Mysql::getColumnDefinition` to recognize `size` for `DATETIME`, `TIME` and `TIMESTAMP` columns [#13297](https://github.com/phalcon/cphalcon/issues/13297)

--- a/phalcon/Http/Response.zep
+++ b/phalcon/Http/Response.zep
@@ -643,7 +643,7 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
      */
     public function setJsonContent(var content, int jsonOptions = 0, int depth = 512) -> <ResponseInterface>
     {
-        this->setContentType("application/json", "UTF-8");
+        this->setContentType("application/json");
 
         this->setContent(
             Json::encode(content, jsonOptions, depth)

--- a/tests/unit/Http/Response/SetJsonContentCest.php
+++ b/tests/unit/Http/Response/SetJsonContentCest.php
@@ -45,7 +45,7 @@ class SetJsonContentCest
         //Check Header
         $I->assertSame(
             $oResponse->getHeaders()->get('Content-Type'),
-            "application/json; charset=UTF-8"
+            "application/json"
         );
 
         //With option


### PR DESCRIPTION
Hello!

* Type:  code quality
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Reading this discussion I think we shouldn't be sending the UTF-8 charset.

https://stackoverflow.com/questions/13096259/can-charset-parameter-be-used-with-application-json-content-type-in-http-1-1

And this note: https://tools.ietf.org/html/rfc7159#page-11

