### PR TITLE
Correct return type Item::getContext()

### DIFF
--- a/phalcon/Logger/Item.zep
+++ b/phalcon/Logger/Item.zep
@@ -20,7 +20,8 @@ class Item
 {
     /**
      * Log Context
-     * @return mixed
+     *      
+     * @var mixed
      */
     protected context { get };
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/ide-stubs/pull/53

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Correct return type Item::getContext()

Thanks

