### PR TITLE
Let result item still in an object

### DIFF
--- a/phalcon/Paginator/Adapter/Model.zep
+++ b/phalcon/Paginator/Adapter/Model.zep
@@ -122,7 +122,6 @@ class Model extends AbstractAdapter
                 [modelClass, "find"],
                 parameters
             );
-            let pageItems = items->toArray();
         }
 
         //Fix next
@@ -140,7 +139,7 @@ class Model extends AbstractAdapter
 
         return this->getRepository(
             [
-                RepositoryInterface::PROPERTY_ITEMS         : pageItems,
+                RepositoryInterface::PROPERTY_ITEMS         : items,
                 RepositoryInterface::PROPERTY_TOTAL_ITEMS   : rowcount,
                 RepositoryInterface::PROPERTY_LIMIT         : this->limitRows,
                 RepositoryInterface::PROPERTY_FIRST_PAGE    : 1,


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: [#15074 ](https://github.com/phalcon/cphalcon/issues/15074)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Item object result can give us ORM compatibility after make paging results.

Thanks

