### PR TITLE
di support custom adapter

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -31,6 +31,7 @@ This component will be used in the Data Mapper implementation but can be used as
   - `Phalcon\DataMapper\Query\QueryFactory`
 This component can be used to create SQL statements using a fluent interface. Optionally the statements can be executed from the builder itself using the `DataMapper\Pdo` connection. [#14734](https://github.com/phalcon/cphalcon/issues/14734)
 - Added `Phalcon\Mvc\Micro\LazyLoader::getHandler()` to return real handler when using lazy loaded controllers for `Phalcon\Mvc\Micro` [#14871](https://github.com/phalcon/cphalcon/issues/14871) [@Jurigag](https://github.com/Jurigag)
+- Added `Phalcon\Di` support custom adapter
 
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)

--- a/phalcon/Di.zep
+++ b/phalcon/Di.zep
@@ -13,6 +13,8 @@ namespace Phalcon;
 use Phalcon\Di\Service;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Exception;
+use Phalcon\Di\AdapterInterface
+use Phalcon\Di\Adapter\Memory;
 use Phalcon\Di\Exception\ServiceResolutionException;
 use Phalcon\Config\Adapter\Php;
 use Phalcon\Config\Adapter\Yaml;
@@ -90,12 +92,36 @@ class Di implements DiInterface
     /**
      * Phalcon\Di constructor
      */
-    public function __construct()
+    public function __construct(<AdapterInterface> adapter = null)
     {
-        if !self::_default {
-            let self::_default = this;
+        var adapter;
+        if !self::_default && adapter {
+            self::setAdapter(adapter);
+        }
+        let adapter = self::getAdapter(adapter);
+        if !adapter->has(){
+            adapter->set(this)
         }
     }
+
+    /**
+     * get adapter
+     */
+     public static function getAdapter() -> <AdapterInterface>
+     {
+        if !self::_default {
+            let self::_default = new Memory();
+        }
+        return self::_default;
+     }
+
+     /**
+     * get adapter
+     */
+     public static function setAdapter(<AdapterInterface> adapter) -> void
+     {
+        let self::_default = adapter;
+     }
 
     /**
      * Magic method to get or set services using setters/getters
@@ -263,7 +289,7 @@ class Di implements DiInterface
      */
     public static function getDefault() -> <DiInterface> | null
     {
-        return self::_default;
+        return this->getAdapter()->get();
     }
 
     /**
@@ -531,7 +557,7 @@ class Di implements DiInterface
      */
     public static function reset() -> void
     {
-        let self::_default = null;
+        let this->getAdapter->set(null);
     }
 
     /**
@@ -550,7 +576,7 @@ class Di implements DiInterface
      */
     public static function setDefault(<DiInterface> container) -> void
     {
-        let self::_default = container;
+        let this->getAdapter()->set(container);
     }
 
     /**

--- a/phalcon/Di.zep
+++ b/phalcon/Di.zep
@@ -13,7 +13,7 @@ namespace Phalcon;
 use Phalcon\Di\Service;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Exception;
-use Phalcon\Di\AdapterInterface
+use Phalcon\Di\AdapterInterface;
 use Phalcon\Di\Adapter\Memory;
 use Phalcon\Di\Exception\ServiceResolutionException;
 use Phalcon\Config\Adapter\Php;

--- a/phalcon/Di.zep
+++ b/phalcon/Di.zep
@@ -92,15 +92,12 @@ class Di implements DiInterface
     /**
      * Phalcon\Di constructor
      */
-    public function __construct(<AdapterInterface> adapter = null)
+    public function __construct()
     {
         var adapter;
-        if !self::_default && adapter {
-            self::setAdapter(adapter);
-        }
-        let adapter = self::getAdapter(adapter);
-        if !adapter->has(){
-            adapter->set(this)
+        let adapter = self::getAdapter();
+        if !adapter->has() {
+            adapter->set(this);
         }
     }
 
@@ -289,7 +286,7 @@ class Di implements DiInterface
      */
     public static function getDefault() -> <DiInterface> | null
     {
-        return this->getAdapter()->get();
+        return self::getAdapter()->get();
     }
 
     /**
@@ -557,7 +554,7 @@ class Di implements DiInterface
      */
     public static function reset() -> void
     {
-        let this->getAdapter->set(null);
+        self::getAdapter()->set(null);
     }
 
     /**
@@ -576,7 +573,7 @@ class Di implements DiInterface
      */
     public static function setDefault(<DiInterface> container) -> void
     {
-        let this->getAdapter()->set(container);
+        self::getAdapter()->set(container);
     }
 
     /**

--- a/phalcon/Di/Adapter/Memory.zep
+++ b/phalcon/Di/Adapter/Memory.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Di\Adapter;
 
 use Phalcon\Di\DiInterface;
+use Phalcon\Di\AdapterInterface;
 
 /**
  * This interface must be implemented in those classes that uses internally the
@@ -27,7 +28,7 @@ class Memory implements AdapterInterface
     /**
      * get the dependency injector
      */
-    public function has(<DiInterface> container) -> bool
+    public function has() -> bool
     {
         if !this->_default {
             return false;
@@ -47,7 +48,7 @@ class Memory implements AdapterInterface
      * Set a default dependency injection container to be obtained into static
      * methods
      */
-     public function setDefault(<DiInterface> container) -> void
+     public function set(<DiInterface> container = null) -> void
      {
          let this->_default = container;
      }

--- a/phalcon/Di/Adapter/Memory.zep
+++ b/phalcon/Di/Adapter/Memory.zep
@@ -1,0 +1,54 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Di\Adapter;
+
+use Phalcon\Di\DiInterface;
+
+/**
+ * This interface must be implemented in those classes that uses internally the
+ */
+class Memory implements AdapterInterface
+{
+    /**
+     * Latest DI build
+     *
+     * @var DiInterface | null
+     */
+     protected _default;
+
+    /**
+     * get the dependency injector
+     */
+    public function has(<DiInterface> container) -> bool
+    {
+        if !this->_default {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns the internal dependency injector
+     */
+    public function get() -> <DiInterface> | null
+    {
+        return this->_default;
+    }
+
+    /**
+     * Set a default dependency injection container to be obtained into static
+     * methods
+     */
+     public function setDefault(<DiInterface> container) -> void
+     {
+         let this->_default = container;
+     }
+}

--- a/phalcon/Di/AdapterInterface.zep
+++ b/phalcon/Di/AdapterInterface.zep
@@ -18,15 +18,15 @@ interface AdapterInterface
     /**
      * get the dependency injector
      */
-    public static function has() -> bool;
+    public  function has() -> bool;
 
     /**
      * Returns the internal dependency injector
      */
-    public static function get() -> <DiInterface> | null;
+    public  function get() -> <DiInterface> | null;
 
     /**
      * set the dependency injector
      */
-     public static function set(<DiInterface> container = null ) -> void;
+     public function set(<DiInterface> container = null ) -> void;
 }

--- a/phalcon/Di/AdapterInterface.zep
+++ b/phalcon/Di/AdapterInterface.zep
@@ -1,0 +1,32 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Di;
+
+/**
+ * This interface must be implemented in those classes that uses internally the
+ */
+interface AdapterInterface
+{
+    /**
+     * get the dependency injector
+     */
+    public static function has(<DiInterface> container) -> bool;
+
+    /**
+     * Returns the internal dependency injector
+     */
+    public static function get() -> <DiInterface> | null;
+
+    /**
+     * set the dependency injector
+     */
+     public static function set(<DiInterface> container) -> void;
+}

--- a/phalcon/Di/AdapterInterface.zep
+++ b/phalcon/Di/AdapterInterface.zep
@@ -18,7 +18,7 @@ interface AdapterInterface
     /**
      * get the dependency injector
      */
-    public static function has(<DiInterface> container) -> bool;
+    public static function has() -> bool;
 
     /**
      * Returns the internal dependency injector
@@ -28,5 +28,5 @@ interface AdapterInterface
     /**
      * set the dependency injector
      */
-     public static function set(<DiInterface> container) -> void;
+     public static function set(<DiInterface> container = null ) -> void;
 }

--- a/tests/unit/Di/Adapter/MemoryCest.php
+++ b/tests/unit/Di/Adapter/MemoryCest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Di;
+
+use Phalcon\Di;
+use Phalcon\Di\Exception;
+use Phalcon\Di\Service;
+use Phalcon\Escaper;
+use UnitTester;
+use Phalcon\Di\Adapter\Memory;
+
+class MemoryCest
+{
+    /**
+     * Unit Tests Phalcon\Adapter\Memory :: set()
+     *
+     * @author cq-z <64899484@qq.com>
+     * @since  2020-08-01
+     */
+    public function adapterSet(UnitTester $I)
+    {
+        $I->wantToTest('Adapter\Memory - set()');
+
+        // setup
+        $di = new Di();
+
+        $memory = new Memory();
+        // check has di
+        $I->assertFalse($memory->has());
+        // get di and  it to check
+        $I->assertEquals(null, $memory->get());
+        $memory->set($di);
+        // get di and  it to check
+        $I->assertEquals($di, $memory->get());
+        // check has di
+        $I->assertTrue($memory->has());
+        
+    }
+}

--- a/tests/unit/Di/Adapter/MemoryCest.php
+++ b/tests/unit/Di/Adapter/MemoryCest.php
@@ -45,6 +45,5 @@ class MemoryCest
         $I->assertEquals($di, $memory->get());
         // check has di
         $I->assertTrue($memory->has());
-        
     }
 }


### PR DESCRIPTION
Hello!

Type: new feature
Link to issue:
di support custom adapter ，compatibly to swoole context of coroutine or recover context

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

di support custom adapter ，compatibly to swoole context of coroutine or recover context


