### PR TITLE
Collection and Config Interfaces

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -31,6 +31,7 @@ This component will be used in the Data Mapper implementation but can be used as
   - `Phalcon\DataMapper\Query\QueryFactory`
 This component can be used to create SQL statements using a fluent interface. Optionally the statements can be executed from the builder itself using the `DataMapper\Pdo` connection. [#14734](https://github.com/phalcon/cphalcon/issues/14734)
 - Added `Phalcon\Mvc\Micro\LazyLoader::getHandler()` to return real handler when using lazy loaded controllers for `Phalcon\Mvc\Micro` [#14871](https://github.com/phalcon/cphalcon/issues/14871) [@Jurigag](https://github.com/Jurigag)
+- Added `Phalcon\Collection\CollectionInterface` and `Phalcon\Config\ConfigInterface` to use as typehints when extending or implementing custom classes [#15106](https://github.com/phalcon/cphalcon/issues/15106) [@BeMySlaveDarlin](https://github.com/BeMySlaveDarlin)
 
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)

--- a/phalcon/Cache/CacheFactory.zep
+++ b/phalcon/Cache/CacheFactory.zep
@@ -15,6 +15,7 @@ use Phalcon\Cache;
 use Psr\SimpleCache\CacheInterface;
 use Phalcon\Cache\Exception\Exception;
 use Phalcon\Config;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Helper\Arr;
 
 /**
@@ -67,7 +68,7 @@ class CacheFactory
     {
         var name, options;
 
-        if typeof config == "object" && config instanceof Config {
+        if typeof config == "object" && config instanceof ConfigInterface {
             let config = config->toArray();
         }
 

--- a/phalcon/Collection.zep
+++ b/phalcon/Collection.zep
@@ -15,6 +15,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use JsonSerializable;
+use Phalcon\Collection\CollectionInterface;
 use Phalcon\Helper\Json;
 use Serializable;
 use Traversable;
@@ -33,6 +34,7 @@ use Traversable;
  */
 class Collection implements
     ArrayAccess,
+    CollectionInterface,
     Countable,
     IteratorAggregate,
     JsonSerializable,

--- a/phalcon/Collection/CollectionInterface.zep
+++ b/phalcon/Collection/CollectionInterface.zep
@@ -1,0 +1,47 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Collection;
+
+/**
+ * Phalcon\Collection\CollectionInterface
+ *
+ * Interface for Phalcon\Collection class
+ */
+interface CollectionInterface
+{
+    public function __get(string element) -> var;
+
+    public function __isset(string element) -> bool;
+
+    public function __set(string element, value) -> void;
+
+    public function __unset(string element) -> void;
+
+    public function clear() -> void;
+
+    public function get(string element, var defaultValue = null, string! cast = null) -> var;
+
+    public function getKeys(bool insensitive = true) -> array;
+
+    public function getValues() -> array;
+
+    public function has(string element) -> bool;
+
+    public function init(array data = []) -> void;
+
+    public function remove(string element) -> void;
+
+    public function set(string element, var value) -> void;
+
+    public function toArray() -> array;
+
+    public function toJson(int options = 79) -> string;
+}

--- a/phalcon/Config.zep
+++ b/phalcon/Config.zep
@@ -11,6 +11,7 @@
 namespace Phalcon;
 
 use Phalcon\Collection;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Config\Exception;
 
 /**
@@ -38,7 +39,7 @@ use Phalcon\Config\Exception;
  * );
  *```
  */
-class Config extends Collection
+class Config extends Collection implements ConfigInterface
 {
     const DEFAULT_PATH_DELIMITER = ".";
 
@@ -76,13 +77,13 @@ class Config extends Collection
      * $globalConfig->merge($appConfig);
      *```
      */
-    public function merge(var toMerge) -> <Config>
+    public function merge(var toMerge) -> <ConfigInterface>
     {
         var config, result, source, target;
 
         if typeof toMerge === "array" {
             let config = new Config(toMerge);
-        } elseif typeof toMerge === "object" && toMerge instanceof Config {
+        } elseif typeof toMerge === "object" && toMerge instanceof ConfigInterface {
             let config = toMerge;
         } else {
             throw new Exception("Invalid data type for merge.");
@@ -143,7 +144,7 @@ class Config extends Collection
     /**
      * Sets the default path delimiter
      */
-    public function setPathDelimiter(string delimiter = null) -> <Config>
+    public function setPathDelimiter(string delimiter = null) -> <ConfigInterface>
     {
         let this->pathDelimiter = delimiter;
 

--- a/phalcon/Config/Adapter/Grouped.zep
+++ b/phalcon/Config/Adapter/Grouped.zep
@@ -11,9 +11,10 @@
 namespace Phalcon\Config\Adapter;
 
 use Phalcon\Config;
+use Phalcon\Config\ConfigFactory;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Config\Exception;
 use Phalcon\Factory\Exception as FactoryException;
-use Phalcon\Config\ConfigFactory;
 
 /**
  * Reads multiple files (or arrays) and merges them all together.
@@ -81,7 +82,7 @@ class Grouped extends Config
             let configInstance = configName;
 
             // Set to default adapter if passed as string
-            if configName instanceof "Phalcon\\Config" {
+            if typeof configName === "object" && configName instanceof ConfigInterface {
                 this->merge(configInstance);
                 continue;
             } elseif typeof configName === "string" {

--- a/phalcon/Config/ConfigFactory.zep
+++ b/phalcon/Config/ConfigFactory.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Config;
 
 use Phalcon\Config;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Factory\AbstractFactory;
 use Phalcon\Helper\Arr;
 
@@ -49,7 +50,7 @@ class ConfigFactory extends AbstractFactory
      *      'callbacks' => null
      * ]
      */
-    public function load(config) -> <Config>
+    public function load(config) -> <ConfigInterface>
     {
         var adapter, extension, first, oldConfig, second;
 
@@ -69,7 +70,7 @@ class ConfigFactory extends AbstractFactory
             ];
         }
 
-        if typeof config === "object" && config instanceof Config {
+        if typeof config === "object" && config instanceof ConfigInterface {
             let config = config->toArray();
         }
 
@@ -111,7 +112,7 @@ class ConfigFactory extends AbstractFactory
     /**
      * Returns a new Config instance
      */
-    public function newInstance(string name, string fileName, var params = null) -> <Config>
+    public function newInstance(string name, string fileName, var params = null) -> <ConfigInterface>
     {
         var definition, options;
 

--- a/phalcon/Config/ConfigInterface.zep
+++ b/phalcon/Config/ConfigInterface.zep
@@ -1,0 +1,29 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Config;
+
+use Phalcon\Collection\CollectionInterface;
+
+/**
+ * Phalcon\Config\ConfigInterface
+ *
+ * Interface for Phalcon\Config class
+ */
+interface ConfigInterface extends CollectionInterface
+{
+    public function getPathDelimiter() -> string;
+
+    public function merge(var toMerge) -> <ConfigInterface>;
+
+    public function path(string path, defaultValue = null, var delimiter = null) -> var | null;
+
+    public function setPathDelimiter(string delimiter = null) -> <ConfigInterface>;
+}

--- a/phalcon/Di.zep
+++ b/phalcon/Di.zep
@@ -16,6 +16,7 @@ use Phalcon\Di\Exception;
 use Phalcon\Di\Exception\ServiceResolutionException;
 use Phalcon\Config\Adapter\Php;
 use Phalcon\Config\Adapter\Yaml;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Events\ManagerInterface;
 use Phalcon\Di\InjectionAwareInterface;
@@ -337,7 +338,7 @@ class Di implements DiInterface
     /**
      * Loads services from a Config object.
      */
-    protected function loadFromConfig(<Config> config) -> void
+    protected function loadFromConfig(<ConfigInterface> config) -> void
     {
         var services, name, service;
 

--- a/phalcon/Factory/AbstractFactory.zep
+++ b/phalcon/Factory/AbstractFactory.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Factory;
 
 use Phalcon\Config;
+use Phalcon\Config\ConfigInterface;
 
 abstract class AbstractFactory
 {
@@ -29,7 +30,7 @@ abstract class AbstractFactory
      */
     protected function checkConfig(var config) -> array
     {
-        if typeof config == "object" && config instanceof Config {
+        if typeof config == "object" && config instanceof ConfigInterface {
             let config = config->toArray();
         }
 

--- a/phalcon/Html/Link/Link.zep
+++ b/phalcon/Html/Link/Link.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Html\Link;
 
 use Phalcon\Collection;
+use Phalcon\Collection\CollectionInterface;
 use Psr\Link\LinkInterface;
 
 /**
@@ -24,7 +25,7 @@ use Psr\Link\LinkInterface;
 class Link implements LinkInterface
 {
     /**
-     * @var Collection
+     * @var Collection|CollectionInterface
      */
     protected attributes;
 
@@ -34,7 +35,7 @@ class Link implements LinkInterface
     protected href = "";
 
     /**
-     * @var Collection
+     * @var Collection|CollectionInterface
      */
     protected rels;
 

--- a/phalcon/Http/Message/AbstractMessage.zep
+++ b/phalcon/Http/Message/AbstractMessage.zep
@@ -15,6 +15,7 @@
 namespace Phalcon\Http\Message;
 
 use Phalcon\Collection;
+use Phalcon\Collection\CollectionInterface;
 use Phalcon\Http\Message\Exception\InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
@@ -32,7 +33,7 @@ abstract class AbstractMessage extends AbstractCommon
     protected body { get };
 
     /**
-     * @var Collection
+     * @var Collection|CollectionInterface
      */
     protected headers;
 
@@ -285,11 +286,11 @@ abstract class AbstractMessage extends AbstractCommon
      *
      * @see: http://tools.ietf.org/html/rfc7230#section-5.4
      *
-     * @param Collection $collection
+     * @param CollectionInterface $collection
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    final protected function checkHeaderHost(<Collection> collection) -> <Collection>
+    final protected function checkHeaderHost(<CollectionInterface> collection) -> <CollectionInterface>
     {
         var data, host, hostArray;
         array header;
@@ -446,9 +447,9 @@ abstract class AbstractMessage extends AbstractCommon
      *
      * @param array $headers
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    final protected function populateHeaderCollection(array headers) -> <Collection>
+    final protected function populateHeaderCollection(array headers) -> <CollectionInterface>
     {
         var collection, name, value;
 
@@ -491,7 +492,7 @@ abstract class AbstractMessage extends AbstractCommon
     /**
      * Sets the headers
      */
-    final protected function processHeaders(var headers) -> <Collection>
+    final protected function processHeaders(var headers) -> <CollectionInterface>
     {
         var collection;
 
@@ -499,7 +500,7 @@ abstract class AbstractMessage extends AbstractCommon
             let collection = this->populateHeaderCollection(headers);
             let collection = this->checkHeaderHost(collection);
         } else {
-            if unlikely !(typeof headers === "object" && headers instanceof Collection) {
+            if unlikely !(typeof headers === "object" && headers instanceof CollectionInterface) {
                 throw new InvalidArgumentException(
                     "Headers needs to be either an array or instance of Phalcon\\Collection"
                 );

--- a/phalcon/Http/Message/AbstractRequest.zep
+++ b/phalcon/Http/Message/AbstractRequest.zep
@@ -14,7 +14,6 @@
 
 namespace Phalcon\Http\Message;
 
-use Phalcon\Collection;
 use Phalcon\Http\Message\Exception\InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 

--- a/phalcon/Http/Message/ServerRequest.zep
+++ b/phalcon/Http/Message/ServerRequest.zep
@@ -15,6 +15,7 @@
 namespace Phalcon\Http\Message;
 
 use Phalcon\Collection;
+use Phalcon\Collection\CollectionInterface;
 use Phalcon\Http\Message\Exception\InvalidArgumentException;
 use Phalcon\Http\Message\Stream\Input;
 use Psr\Http\Message\ServerRequestInterface;
@@ -28,7 +29,7 @@ use Psr\Http\Message\UriInterface;
 final class ServerRequest extends AbstractRequest implements ServerRequestInterface
 {
     /**
-     * @var Collection
+     * @var Collection|CollectionInterface
      */
     protected attributes;
 

--- a/phalcon/Http/Message/ServerRequestFactory.zep
+++ b/phalcon/Http/Message/ServerRequestFactory.zep
@@ -15,6 +15,7 @@
 namespace Phalcon\Http\Message;
 
 use Phalcon\Collection;
+use Phalcon\Collection\CollectionInterface;
 use Phalcon\Helper\Arr;
 use Phalcon\Http\Message\Exception\InvalidArgumentException;
 use Psr\Http\Message\ServerRequestFactoryInterface;
@@ -154,12 +155,12 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Calculates the host and port from the headers or the server superglobal
      *
-     * @param Collection $server
-     * @param Collection $headers
+     * @param CollectionInterface $server
+     * @param CollectionInterface $headers
      *
      * @return array
      */
-    private function calculateUriHost(<Collection> server, <Collection> headers) -> array
+    private function calculateUriHost(<CollectionInterface> server, <CollectionInterface> headers) -> array
     {
         var host, port;
         array defaults;
@@ -207,11 +208,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      * Get the path from the request from IIS7/Rewrite, REQUEST_URL or
      * ORIG_PATH_INFO
      *
-     * @param Collection $server
+     * @param CollectionInterface $server
      *
      * @return string
      */
-    private function calculateUriPath(<Collection> server) -> string
+    private function calculateUriPath(<CollectionInterface> server) -> string
     {
         var iisRewrite, origPathInfo, requestUri, unencodedUrl;
         /**
@@ -247,11 +248,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Get the query string from the server array
      *
-     * @param Collection $server
+     * @param CollectionInterface $server
      *
      * @return string
      */
-    private function calculateUriQuery(<Collection> server) -> string
+    private function calculateUriQuery(<CollectionInterface> server) -> string
     {
         return ltrim(server->get("QUERY_STRING", ""), "?");
     }
@@ -259,12 +260,12 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Calculates the scheme from the server variables
      *
-     * @param Collection $server
-     * @param Collection $headers
+     * @param CollectionInterface $server
+     * @param CollectionInterface $headers
      *
      * @return string
      */
-    private function calculateUriScheme(<Collection> server, <Collection> headers) -> string
+    private function calculateUriScheme(<CollectionInterface> server, <CollectionInterface> headers) -> string
     {
         var header, isHttps;
         string scheme;
@@ -333,13 +334,13 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Returns a header
      *
-     * @param Collection $headers
+     * @param CollectionInterface $headers
      * @param string     $name
      * @param mixed|null $defaultValue
      *
      * @return mixed|string
      */
-    private function getHeader(<Collection> headers, string name, var defaultValue = null) -> var
+    private function getHeader(<CollectionInterface> headers, string name, var defaultValue = null) -> var
     {
         var value;
 
@@ -383,11 +384,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Processes headers from SAPI
      *
-     * @param Collection $server
+     * @param CollectionInterface $server
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    private function parseHeaders(<Collection> server) -> <Collection>
+    private function parseHeaders(<CollectionInterface> server) -> <CollectionInterface>
     {
         var headers, key, name, serverArray, value;
 
@@ -440,11 +441,11 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Parse the $_SERVER array amd check the server protocol. Raise an
      *
-     * @param Collection $server The server variables
+     * @param CollectionInterface $server The server variables
      *
      * @return string
      */
-    private function parseProtocol(<Collection> server) -> string
+    private function parseProtocol(<CollectionInterface> server) -> string
     {
         var localProtocol, protocol, protocols;
 
@@ -485,9 +486,9 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      * @param array $server Either verbatim, or with an added
      *                      HTTP_AUTHORIZATION header.
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    private function parseServer(array server) -> <Collection>
+    private function parseServer(array server) -> <CollectionInterface>
     {
         var collection, headers, headersCollection;
 
@@ -514,9 +515,9 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
      *
      * @param array $files
      *
-     * @return Collection
+     * @return CollectionInterface
      */
-    private function parseUploadedFiles(array files) -> <Collection>
+    private function parseUploadedFiles(array files) -> <CollectionInterface>
     {
         var collection, data, key, file;
 
@@ -561,12 +562,12 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
     /**
      * Calculates the Uri from the server superglobal or the headers
      *
-     * @param Collection $server
-     * @param Collection $headers
+     * @param CollectionInterface $server
+     * @param CollectionInterface $headers
      *
      * @return Uri
      */
-    private function parseUri(<Collection> server, <Collection> headers) -> <Uri>
+    private function parseUri(<CollectionInterface> server, <CollectionInterface> headers) -> <Uri>
     {
         var path, query, scheme, split, uri;
 

--- a/phalcon/Logger/LoggerFactory.zep
+++ b/phalcon/Logger/LoggerFactory.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Logger;
 
 use Phalcon\Config;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Helper\Arr;
 use Phalcon\Logger;
 
@@ -53,7 +54,7 @@ class LoggerFactory
             adapters, name, options;
         array data;
 
-        if typeof config == "object" && config instanceof Config {
+        if typeof config == "object" && config instanceof ConfigInterface {
             let config = config->toArray();
         }
 

--- a/phalcon/Security/JWT/Builder.zep
+++ b/phalcon/Security/JWT/Builder.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Security\JWT;
 
 use Phalcon\Collection;
+use Phalcon\Collection\CollectionInterface;
 use Phalcon\Helper\Base64;
 use Phalcon\Helper\Json;
 use Phalcon\Security\JWT\Exceptions\ValidatorException;
@@ -23,22 +24,22 @@ use Phalcon\Security\JWT\Token\Token;
 /**
  * Class Builder
  *
- * @property Collection      $claims
- * @property Collection      $jose
- * @property string          $passphrase
- * @property SignerInterface $signer
+ * @property CollectionInterface  $claims
+ * @property CollectionInterface  $jose
+ * @property string               $passphrase
+ * @property SignerInterface      $signer
  *
  * @link https://tools.ietf.org/html/rfc7519
  */
 class Builder
 {
     /**
-     * @var Collection
+     * @var CollectionInterface
      */
     private claims;
 
     /**
-     * @var Collection
+     * @var CollectionInterface
      */
     private jose;
 

--- a/phalcon/Storage/Adapter/Memory.zep
+++ b/phalcon/Storage/Adapter/Memory.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Storage\Adapter;
 
 use Phalcon\Collection;
+use Phalcon\Collection\CollectionInterface;
 use Phalcon\Helper\Arr;
 use Phalcon\Storage\Exception;
 use Phalcon\Storage\SerializerFactory;
@@ -22,7 +23,7 @@ use Phalcon\Storage\Serializer\SerializerInterface;
 class Memory extends AbstractAdapter
 {
     /**
-     * @var Collection
+     * @var Collection|CollectionInterface
      */
     protected data;
 

--- a/phalcon/Validation/AbstractValidator.zep
+++ b/phalcon/Validation/AbstractValidator.zep
@@ -10,7 +10,6 @@
 
 namespace Phalcon\Validation;
 
-use Phalcon\Collection;
 use Phalcon\Helper\Arr;
 use Phalcon\Messages\Message;
 use Phalcon\Validation;
@@ -54,7 +53,7 @@ abstract class AbstractValidator implements ValidatorInterface
         if template {
             // save custom message in options
             let options["message"] = template;
-                        
+
             unset options["template"];
             unset options[0];
         }

--- a/phalcon/Validation/ValidatorInterface.zep
+++ b/phalcon/Validation/ValidatorInterface.zep
@@ -10,7 +10,6 @@
 
 namespace Phalcon\Validation;
 
-use Phalcon\Collection;
 use Phalcon\Validation;
 
 /**


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/15106

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
- Added `Phalcon\Collection\CollectionInterface` and `Phalcon\Config\ConfiInterface`.
- Replaced all `Phalcon\Collection` typehints by `Phalcon\Collection\CollectionInterface`.
- Replaced all `Phalcon\Config` typehints by `Phalcon\Config\ConfiInterface`.
- Replaced instanceof checks to interfaces.

Why?
For example if you create your custom classes of config or collection, and pass to core services (ex: `Phalcon\Di::loadFromConfig()`), it will fail on typecheck. But implementing interface can give some flexible way of extending config or collection

Thanks

