### PR TITLE
T15098 Mvc\Model delete cascade relations with params

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -389,7 +389,7 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           ini-values: apc.enable_cli=on, session.save_path=C:\temp
           tools: pecl, prestissimo
-          extensions: mbstring, intl, json, yaml, apcu, psr, imagick, gd, redis, igbinary, msgpack-beta, sqlite3
+          extensions: mbstring, intl, json, yaml, apcu, psr, imagick, gd, redis, igbinary, sqlite3, msgpack
         env:
           PHPTS: ${{ matrix.ts }}
 

--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -49,6 +49,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Db\Dialect\Mysql::getColumnDefinition` to recognize `size` for `DATETIME`, `TIME` and `TIMESTAMP` columns [#13297](https://github.com/phalcon/cphalcon/issues/13297)
 - Fixed `Phalcon\Events\Manager` to provide callable support [#13322](https://github.com/phalcon/cphalcon/issues/13322), [#15045](https://github.com/phalcon/cphalcon/pull/15045)
 - Fixed `Phalcon\Validation\Validator\Uniqueness` fixed except query [#15084](https://github.com/phalcon/cphalcon/issues/15084)
+- Fixed `Phalcon\Mvc\Model` to also check the params option in cascade relations when deleting. [#15098](https://github.com/phalcon/cphalcon/issues/15098)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -49,7 +49,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Db\Dialect\Mysql::getColumnDefinition` to recognize `size` for `DATETIME`, `TIME` and `TIMESTAMP` columns [#13297](https://github.com/phalcon/cphalcon/issues/13297)
 - Fixed `Phalcon\Events\Manager` to provide callable support [#13322](https://github.com/phalcon/cphalcon/issues/13322), [#15045](https://github.com/phalcon/cphalcon/pull/15045)
 - Fixed `Phalcon\Validation\Validator\Uniqueness` fixed except query [#15084](https://github.com/phalcon/cphalcon/issues/15084)
-- Fixed `Phalcon\Mvc\Model` to also check the params option in cascade relations when deleting. [#15098](https://github.com/phalcon/cphalcon/issues/15098)
+- Fixed `Phalcon\Mvc\Model` to also check the params option in cascade relations when deleting. [#15098](https://github.com/phalcon/cphalcon/issues/15098) 
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,6 +105,15 @@ install:
         -Platform   $Env:PLATFORM
 
   - ps: >-
+      InstallPeclExtension `
+        -Name       msgpack `
+        -Version    2.1.0 `
+        -PhpVersion $Env:PHP_VERSION `
+        -BuildType  $Env:BUILD_TYPE `
+        -VC         $Env:VC_VERSION `
+        -Platform   $Env:PLATFORM
+
+  - ps: >-
       InstallZephirParser `
         -Version    $Env:ZEPHIR_PARSER_VERSION `
         -BuildId    $Env:ZEPHIR_PARSER_RELEASE `
@@ -116,6 +125,7 @@ install:
 before_build:
   - ps: EnablePhpExtension -Name psr
   - ps: EnablePhpExtension -Name redis
+  - ps: EnablePhpExtension -Name msgpack
   - ps: EnablePhpExtension -Name zephir_parser -PrintableName "Zephir Parser"
 
 build_script:

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -3332,12 +3332,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 this
             );
 
-            /**
-             * Delete the related
-             * Stop the operation if needed
-             */
-            if related->delete() === false {
-                return false;
+            if related {
+                /**
+                 * Delete related if there is any
+                 * Stop the operation if needed
+                 */
+                if related->delete() === false {
+                    return false;
+                }
             }
         }
 

--- a/tests/_data/fixtures/models/Customers.php
+++ b/tests/_data/fixtures/models/Customers.php
@@ -58,7 +58,7 @@ class Customers extends Model
                     'action' => Model\Relation::ACTION_CASCADE
                 ],
                 'params'     => [
-                    'cst_status_flag = :paid:',
+                    'inv_status_flag = :paid:',
                     'bind' => [
                         'paid' => Invoices::STATUS_PAID
                     ]

--- a/tests/_data/fixtures/models/Customers.php
+++ b/tests/_data/fixtures/models/Customers.php
@@ -18,10 +18,10 @@ use Phalcon\Mvc\Model;
 /**
  * Class Customers
  *
- * @property int    $cst_id;
- * @property int    $cst_status_flag;
- * @property string $cst_name_last;
- * @property string $cst_name_first;
+ * @property int    $cst_id
+ * @property int    $cst_status_flag
+ * @property string $cst_name_last
+ * @property string $cst_name_first
  */
 class Customers extends Model
 {
@@ -39,8 +39,30 @@ class Customers extends Model
             Invoices::class,
             'inv_cst_id',
             [
-                'alias'    => 'invoices',
-                'reusable' => true,
+                'alias'      => 'invoices',
+                'reusable'   => true,
+                'foreignKey' => [
+                    'action' => Model\Relation::NO_ACTION
+                ]
+            ]
+        );
+
+        $this->hasMany(
+            'cst_id',
+            Invoices::class,
+            'inv_cst_id',
+            [
+                'alias'      => 'paidInvoices',
+                'reusable'   => true,
+                'foreignKey' => [
+                    'action' => Model\Relation::ACTION_CASCADE
+                ],
+                'params'     => [
+                    'cst_status_flag = :paid:',
+                    'bind' => [
+                        'paid' => Invoices::STATUS_PAID
+                    ]
+                ]
             ]
         );
     }

--- a/tests/_data/fixtures/models/Invoices.php
+++ b/tests/_data/fixtures/models/Invoices.php
@@ -30,6 +30,9 @@ use Phalcon\Mvc\Model;
  */
 class Invoices extends Model
 {
+    const STATUS_UNPAID = 0;
+    const STATUS_PAID   = 1;
+
     public $inv_id;
     public $inv_cst_id;
     public $inv_status_flag;

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -14,7 +14,10 @@ declare(strict_types=1);
 namespace Phalcon\Test\Database\Mvc\Model;
 
 use DatabaseTester;
+use Phalcon\Test\Fixtures\Migrations\CustomersMigration;
+use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Customers;
 use Phalcon\Test\Models\Invoices;
 
 use function date;
@@ -31,6 +34,15 @@ class DeleteCest
     {
         $this->setNewFactoryDefault();
         $this->setDatabase($I);
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->clear();
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->clear();
     }
 
     /**
@@ -65,5 +77,81 @@ class DeleteCest
 
         $result = $invoice->delete();
         $I->assertTrue($result);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: delete() with related items
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2020-08-02
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelDeleteCascadeRelated(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - delete() with related items');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+
+        $custId = 2;
+
+        $firstName = uniqid('cust-', true);
+        $lastName  = uniqid('cust-', true);
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->insert($custId, 0, $firstName, $lastName);
+
+        $paidInvoiceId   = 4;
+        $unpaidInvoiceId = 5;
+
+        $title = uniqid('inv-');
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert(
+            $paidInvoiceId,
+            $custId,
+            Invoices::STATUS_PAID,
+            $title . '-paid'
+        );
+        $invoicesMigration->insert(
+            $unpaidInvoiceId,
+            $custId,
+            Invoices::STATUS_UNPAID,
+            $title . '-unpaid'
+        );
+
+        /**
+         * @var Customers $customer
+         */
+        $customer = Customers::findFirst($custId);
+
+        $I->assertEquals(
+            2,
+            $customer->invoices->count()
+        );
+
+        $I->assertEquals(
+            1,
+            $customer->paidInvoices->count()
+        );
+
+        $I->assertTrue(
+            $customer->delete()
+        );
+
+        $invoices = Invoices::find();
+
+        $I->assertEquals(
+            1,
+            $invoices->count()
+        );
+
+        $I->assertEquals(
+            $unpaidInvoiceId,
+            $invoices[0]->inv_id
+        );
     }
 }

--- a/tests/database/Mvc/Model/GetRelatedCest.php
+++ b/tests/database/Mvc/Model/GetRelatedCest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Database\Mvc\Model;
+
+use Codeception\Example;
+use DatabaseTester;
+use Phalcon\Mvc\Model;
+use Phalcon\Mvc\Model\Exception;
+use Phalcon\Test\Fixtures\Migrations\CustomersMigration;
+use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Customers;
+use Phalcon\Test\Models\Invoices;
+
+use function uniqid;
+
+/**
+ * Class GetRelatedCest
+ */
+class GetRelatedCest
+{
+    use DiTrait;
+
+    public function _before(DatabaseTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDatabase($I);
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->clear();
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->clear();
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: getRelated()
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2020-08-02
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelGetRelated(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - getRelated()');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+
+        $custId = 2;
+
+        $firstName = uniqid('cust-', true);
+        $lastName  = uniqid('cust-', true);
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->insert($custId, 0, $firstName, $lastName);
+
+        $paidInvoiceId   = 4;
+        $unpaidInvoiceId = 5;
+
+        $title = uniqid('inv-');
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert(
+            $paidInvoiceId,
+            $custId,
+            Invoices::STATUS_PAID,
+            $title . '-paid'
+        );
+        $invoicesMigration->insert(
+            $unpaidInvoiceId,
+            $custId,
+            Invoices::STATUS_UNPAID,
+            $title . '-unpaid'
+        );
+
+        /**
+         * @var Customers $customer
+         */
+        $customer = Customers::findFirst($custId);
+
+        $invoices = $customer->getRelated(
+            'invoices',
+            [
+                'order' => 'inv_id DESC'
+            ]
+        );
+
+        $I->assertEquals(
+            2,
+            $invoices->count()
+        );
+
+        $I->assertInstanceOf(
+            Invoices::class,
+            $invoices[0]
+        );
+
+        $I->assertEquals(
+            $unpaidInvoiceId,
+            $invoices[0]->id
+        );
+
+        $I->assertEquals(
+            $paidInvoiceId,
+            $invoices[1]->id
+        );
+
+        $paidInvoices = $customer->getRelated(
+            'paidInvoices'
+        );
+
+        $I->assertEquals(
+            1,
+            $paidInvoices->count()
+        );
+
+        $I->assertInstanceOf(
+            Invoices::class,
+            $paidInvoices[0]
+        );
+
+        $I->assertEquals(
+            $paidInvoiceId,
+            $paidInvoices[0]->id
+        );
+    }
+}

--- a/tests/database/Mvc/Model/GetRelatedCest.php
+++ b/tests/database/Mvc/Model/GetRelatedCest.php
@@ -115,12 +115,12 @@ class GetRelatedCest
 
         $I->assertEquals(
             $unpaidInvoiceId,
-            $invoices[0]->id
+            $invoices[0]->inv_id
         );
 
         $I->assertEquals(
             $paidInvoiceId,
-            $invoices[1]->id
+            $invoices[1]->inv_id
         );
 
         $paidInvoices = $customer->getRelated(
@@ -139,7 +139,7 @@ class GetRelatedCest
 
         $I->assertEquals(
             $paidInvoiceId,
-            $paidInvoices[0]->id
+            $paidInvoices[0]->inv_id
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15098

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

Modified `Mvc\Model::_checkForeignKeysReverseCascade()` to use `Models\Manager::getRelationRecords()` when deleting related records.
Added tests for: `Mvc\Model::getRelated()` and `Mvc\Model::delete()` to ensure the `params` option is used properly when accessing and deleting related models.

Thanks,
zsilbi

