### PR TITLE
set injectable container to default DI when no DI is set.

### DIFF
--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -122,6 +122,8 @@ abstract class Injectable implements InjectionAwareInterface
                 throw new Exception(
                     Exception::containerServiceNotFound("internal services")
                 );
+            } else {
+                this->setDI(container);
             }
         }
 

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -15,7 +15,7 @@ namespace Phalcon\Test\Unit\Di\Injectable;
 
 use Phalcon\Di;
 use InjectableComponent;
-use \stdClass;
+use stdClass;
 use UnitTester;
 
 class GetDIDefaultCest

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -84,7 +84,7 @@ class GetDIDefaultCest
         try {
             $className = get_class($ic);
             $reflection = new \ReflectionClass($className);
-        } catch (\ReflectionException $e) 
+        } catch (\ReflectionException $e)
         {
         }
         

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -36,8 +36,8 @@ class GetDIDefaultCest
         require_once dataDir('fixtures/Di/InjectableComponent.php');
         Di::reset();
         $di = new Di();
-        $di->set('std', function() {
-            return new \stdClass();
+        $di->set('std', function () {
+            return new stdClass();
         });
         
         $ic = new InjectableComponent(); //no DI is set in this Injectable object
@@ -46,7 +46,9 @@ class GetDIDefaultCest
         try {
             $className = get_class($ic);
             $reflection = new \ReflectionClass($className);
-        } catch(\ReflectionException $e) {}
+        } catch (\ReflectionException $e) 
+        {
+        }
         
         $prop = $reflection->getProperty('container');
         $prop->setAccessible(true);
@@ -71,8 +73,8 @@ class GetDIDefaultCest
         Di::reset();
         $di = new Di();
         $other = new Di();
-        $other->set('std', function() {
-            return new \stdClass();
+        $other->set('std', function () {
+            return new stdClass();
         });
         
         $ic = new InjectableComponent(); //no DI is set in this Injectable object
@@ -82,7 +84,9 @@ class GetDIDefaultCest
         try {
             $className = get_class($ic);
             $reflection = new \ReflectionClass($className);
-        } catch(\ReflectionException $e) {}
+        } catch (\ReflectionException $e) 
+        {
+        }
         
         $prop = $reflection->getProperty('container');
         $prop->setAccessible(true);

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -51,7 +51,7 @@ class GetDIDefaultCest
         $prop = $reflection->getProperty('container');
         $prop->setAccessible(true);
         
-        $I->assertEquals($di, $prop->getValue());
+        $I->assertEquals($di, $prop->getValue($ic));
     }
     
     /**
@@ -87,7 +87,7 @@ class GetDIDefaultCest
         $prop = $reflection->getProperty('container');
         $prop->setAccessible(true);
         
-        $I->assertEquals($other, $prop->getValue());
-        $I->assertNotEquals($di, $prop->getValue());
+        $I->assertEquals($other, $prop->getValue($ic));
+        $I->assertNotEquals($di, $prop->getValue($ic));
     }
 }

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Di\Injectable;
+
+use Phalcon\Di;
+use InjectableComponent;
+use \stdClass;
+use UnitTester;
+
+class GetDIDefaultCest
+{
+    /**
+     * Unit Tests Phalcon\Di\Injectable :: getDI()
+     *
+     * Test when an Injectable object has no DI set and a call has been made to getDI(), should set the container property.
+     * It's tested with the Controller class
+     *
+     * @author Stijn Leenknegt <stijn@diagro.be>
+     * @since  2020-08-13
+     */
+    public function diInjectableGetDIContainer(UnitTester $I)
+    {
+        $I->wantToTest('Di\Injectable - getDI()');
+
+        require_once dataDir('fixtures/Di/InjectableComponent.php');
+        Di::reset();
+        $di = new Di();
+        $di->set('std', function() {
+            return new \stdClass();
+        });
+        
+        $ic = new InjectableComponent(); //no DI is set in this Injectable object
+        $std = $ic->std; //calls __get which calls getDI() method, which should set the container to the default DI
+        
+        try {
+            $className = get_class($ic);
+            $reflection = new \ReflectionClass($className);
+        } catch(\ReflectionException $e) {}
+        
+        $prop = $reflection->getProperty('container');
+        $prop->setAccessible(true);
+        
+        $I->assertEquals($di, $prop->getValue());
+    }
+    
+    /**
+     * Unit Tests Phalcon\Di\Injectable :: getDI()
+     *
+     * Test when an Injectable object has set an other DI.
+     * Setting the container to the default DI, should not happen!
+     *
+     * @author Stijn Leenknegt <stijn@diagro.be>
+     * @since  2020-08-13
+     */
+    public function diInjectableGetDIOtherContainer(UnitTester $I)
+    {
+        $I->wantToTest('Di\Injectable - getDI()');
+
+        require_once dataDir('fixtures/Di/InjectableComponent.php');
+        Di::reset();
+        $di = new Di();
+        $other = new Di();
+        $other->set('std', function() {
+            return new \stdClass();
+        });
+        
+        $ic = new InjectableComponent(); //no DI is set in this Injectable object
+        $ic->setDI($other);
+        $std = $ic->std; //calls __get which calls getDI() method, which should not set the container to the default DI!
+        
+        try {
+            $className = get_class($ic);
+            $reflection = new \ReflectionClass($className);
+        } catch(\ReflectionException $e) {}
+        
+        $prop = $reflection->getProperty('container');
+        $prop->setAccessible(true);
+        
+        $I->assertEquals($other, $prop->getValue());
+        $I->assertNotEquals($di, $prop->getValue());
+    }
+}

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -46,8 +46,7 @@ class GetDIDefaultCest
         try {
             $className = get_class($ic);
             $reflection = new \ReflectionClass($className);
-        } catch (\ReflectionException $e) 
-        {
+        } catch (\ReflectionException $e) {
         }
         
         $prop = $reflection->getProperty('container');
@@ -84,8 +83,7 @@ class GetDIDefaultCest
         try {
             $className = get_class($ic);
             $reflection = new \ReflectionClass($className);
-        } catch (\ReflectionException $e)
-        {
+        } catch (\ReflectionException $e) {
         }
         
         $prop = $reflection->getProperty('container');

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -23,7 +23,7 @@ class GetDIDefaultCest
     /**
      * Unit Tests Phalcon\Di\Injectable :: getDI()
      *
-     * Test when an Injectable object has no DI set and a call has been made to getDI(), 
+     * Test when an Injectable object has no DI set and a call has been made to getDI(),
      * should set the container property.
      * It's tested with the Controller class
      *

--- a/tests/unit/Di/Injectable/GetDIContainerCest.php
+++ b/tests/unit/Di/Injectable/GetDIContainerCest.php
@@ -23,7 +23,8 @@ class GetDIDefaultCest
     /**
      * Unit Tests Phalcon\Di\Injectable :: getDI()
      *
-     * Test when an Injectable object has no DI set and a call has been made to getDI(), should set the container property.
+     * Test when an Injectable object has no DI set and a call has been made to getDI(), 
+     * should set the container property.
      * It's tested with the Controller class
      *
      * @author Stijn Leenknegt <stijn@diagro.be>


### PR DESCRIPTION
Hello!

* Type: code quality

**In raising this pull request, I confirm the following:**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [ ] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

When no container is set in the Injectable class, it always call the function Di::getDefault(). When you call the __get() a lot, this is just a repeated call. So my proposal is to set the container property to the default DI when not DI is set. 

It's a little bit extra performance.

Thanks

