### PR TITLE
T15123 Remove Mvc\Router::uriSource

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -54,5 +54,6 @@ This component can be used to create SQL statements using a fluent interface. Op
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)
   - `Phalcon\Http\Cookie` no longer depends on the session service and data will not be duplicated in the session. This made it difficult to use cookies in stateless applications (SPA).
+- Removed unused property `Phalcon\Mvc\Router::uriSource`. [#15123](https://github.com/phalcon/cphalcon/issues/15123)
 
 `

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -71,7 +71,6 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected params = [];
     protected removeExtraSlashes;
     protected routes;
-    protected uriSource;
     protected wasMatched = false;
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15123

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I have updated the relevant CHANGELOG

Small description of change:

Removed unused property `Phalcon\Mvc\Router::uriSource`.

Thanks,
zsilbi

