### PR TITLE
T15129 - Cookies::set() options parameter fixed

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -51,6 +51,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Validation\Validator\Uniqueness` fixed except query [#15084](https://github.com/phalcon/cphalcon/issues/15084)
 - Fixed `Phalcon\Mvc\Model` to also check the params option in cascade relations when deleting. [#15098](https://github.com/phalcon/cphalcon/issues/15098) 
 - Fixed `Phalcon\Mvc\Model\CriteriaInterface::where()` parameters. [#15144](https://github.com/phalcon/cphalcon/issues/15144) 
+- Fixed `Phalcon\Http\Response\Cookies::set()` to utilize the options parameter correctly. [#15129](https://github.com/phalcon/cphalcon/issues/15129) 
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Http/Response/Cookies.zep
+++ b/phalcon/Http/Response/Cookies.zep
@@ -243,7 +243,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
             let cookie =
                 <CookieInterface> this->container->get(
                     "Phalcon\\Http\\Cookie",
-                    [name, value, expire, path, secure, domain, httpOnly]
+                    [name, value, expire, path, secure, domain, httpOnly, options]
                 );
 
             /**
@@ -271,6 +271,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
             cookie->setSecure(secure);
             cookie->setDomain(domain);
             cookie->setHttpOnly(httpOnly);
+            cookie->setOptions(options);
             cookie->setSignKey(this->signKey);
         }
 

--- a/tests/unit/Http/Response/Cookies/GetSetCest.php
+++ b/tests/unit/Http/Response/Cookies/GetSetCest.php
@@ -84,4 +84,90 @@ class SetCest extends HttpBase
         $I->assertNotRegexp('/HttpOnly$/', $cookieTwo);
         $I->assertNotRegexp('/HttpOnly$/', $cookieThree);
     }
+
+    /**
+     * Test Http\Response\Cookies - set() options parameter
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-09-10
+     * @issue https://github.com/phalcon/cphalcon/issues/15129
+     */
+    public function httpCookieSetOptions(UnitTester $I)
+    {
+        $I->wantToTest('Http\Response\Cookies - set() options parameter');
+
+        if (!version_compare(phpversion(), '7.3', '>=')) {
+            $I->skipTest('Cookie options are only available starting from PHP 7.3');
+        }
+
+        $I->checkExtensionIsLoaded('xdebug');
+
+        $this->setDiService('crypt');
+        $container = $this->getDi();
+
+        $cookie = new Cookies();
+        $cookie->setDI($container);
+        $cookie->useEncryption(false);
+
+        $cookie->set(
+            'samesite-cookie-1',
+            'potato',
+            time() + 86400,
+            '/',
+            false,
+            'localhost',
+            false,
+            [
+                'samesite' => 'None'
+            ]
+        );
+
+        $cookie->set(
+            'samesite-cookie-2',
+            'potato',
+            time() + 86400,
+            '/',
+            false,
+            'localhost',
+            false,
+            [
+                'samesite' => 'Lax'
+            ]
+        );
+
+        $cookie->set(
+            'samesite-cookie-3',
+            'potato',
+            time() + 86400,
+            '/',
+            false,
+            'localhost',
+            false,
+            [
+                'samesite' => 'Strict'
+            ]
+        );
+
+        $cookie->set(
+            'samesite-cookie-4',
+            'potato',
+            time() + 86400,
+            '/',
+            false,
+            'localhost',
+            false
+        );
+
+        $cookie->send();
+
+        $cookieOne   = $this->getCookie('samesite-cookie-1');
+        $cookieTwo   = $this->getCookie('samesite-cookie-2');
+        $cookieThree = $this->getCookie('samesite-cookie-3');
+        $cookieFour  = $this->getCookie('samesite-cookie-4');
+
+        $I->assertRegexp('/SameSite=None$/', $cookieOne);
+        $I->assertRegexp('/SameSite=Lax$/', $cookieTwo);
+        $I->assertRegexp('/SameSite=Strict$/', $cookieThree);
+        $I->assertNotRegexp('/SameSite/', $cookieFour);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: fixes #15129 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

Fixed `Phalcon\Http\Response\Cookies::set()` to utilize the options parameter correctly.
Thank you @michalzielanski, for your suggestions https://github.com/phalcon/cphalcon/issues/15129#issuecomment-686486393.

Thanks,
zsilbi