### PR TITLE
Testing environment fixes + PHP 7.4 for nanobox

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -55,6 +55,7 @@ The PHP extensions enabled are:
 - imagick
 - iconv
 - igbinary
+- intl
 - json
 - memcached
 - mbstring
@@ -68,6 +69,7 @@ The PHP extensions enabled are:
 - redis
 - session
 - simplexml
+- sqlite3
 - tokenizer
 - yaml
 - zephir_parser
@@ -92,7 +94,7 @@ $ php tests/_ci/generate-db-schemas.php
 First you need to re-generate base classes for all suites:
 
 ```shell script
-$ ./vendor/bin/codecept build
+$ php vendor/bin/codecept build
 ```
 
 You will also need to provide Codeception configuration and run Docker containers:
@@ -110,25 +112,25 @@ $ cd ..
 Then, run the tests on a terminal:
 
 ```shell script
-./vendor/bin/codecept run
+php vendor/bin/codecept run
 # OR
-./vendor/bin/codecept run --debug # Detailed output
+php vendor/bin/codecept run --debug # Detailed output
 ```
 
 Execute `unit` test with `run unit` command:
 
 ```shell script
-$ ./vendor/bin/codecept run unit
+$ php vendor/bin/codecept run unit
 ```
 
 To run database related tests you need to run the `database` suite specifying
 the RDBMS and group:
 
 ```shell script
-$ ./vendor/bin/codecept run database -g common
-$ ./vendor/bin/codecept run database -g mysql --env mysql
-$ ./vendor/bin/codecept run database -g sqlite --env sqlite
-$ ./vendor/bin/codecept run database -g pgsql --env pgsql
+$ php vendor/bin/codecept run database -g common
+$ php vendor/bin/codecept run database -g mysql --env mysql
+$ php vendor/bin/codecept run database -g sqlite --env sqlite
+$ php vendor/bin/codecept run database -g pgsql --env pgsql
 ```
 
 Available options:
@@ -154,15 +156,15 @@ navigate to the folder where you have cloned the repository (or a fork of it).
 
 Nanobox reads its configuration, so as to start the environment, from a file
 called `boxfile.yml` located at the root of your folder. By default, the file
-is not there to allow for more flexibility. We have two setup files, one for
-PHP 7.2 and one for PHP 7.3. If you wish to set up an environment for Phalcon
+is not there to allow for more flexibility. We have three setup files for
+PHP 7.2, PHP 7.3 and PHP 7.4. If you wish to set up an environment for Phalcon
 using PHP 7.2, you can copy the relevant file at the root of your folder:
 
 ```shell script
 $ cp -v ./tests/_ci/nanobox/boxfile.7.2.yml ./boxfile.yml
 ```
 
-You can also create a 7.3 environment by copying the relevant file.
+You can also create a 7.3 or 7.4 environment by copying the relevant file.
 
 Run
 ```shell script
@@ -219,12 +221,20 @@ After the compilation is completed, you can check if the extension is loaded:
 /app $ php -m | grep phalcon
 ```
 
+Note that Phalcon v4+ requires the [PSR][psr] extension to be loaded before Phalcon. In this environment we have compiled it for you. Once you see `phalcon` in the list, you have the extension compiled and ready to use.
+
 ### Setup databases
+
+First, we need to have a `.env` file in the project root.
+
+```shell script
+/app $ cp tests/_ci/nanobox/.env.example .env
+```
 
 To generate the necessary database schemas, you need to run the relevant script:
 
 ```shell script
-/app $ php ./tests/_ci/generage-db-schemas.php
+/app $ php tests/_ci/generate-db-schemas.php
 ```
 
 The script looks for classes located under `tests/_data/fixtures/Migrations`.
@@ -242,48 +252,67 @@ SQL statements. Running the generate script (as seen above) will update the
 schema file so that Codeception can load it in your RDBMS prior to running the
 tests.
 
+To populate the databases you will need to run the following script:
+
+```shell script
+/app $ tests/_ci/nanobox/setup-dbs-nanobox.sh
+```  
+
 ### Run tests
 
 First you need to re-generate base classes for all suites:
 
 ```shell script
-/app $ codecept build
+/app $ php vendor/bin/codecept build
+```
+
+The output should show:
+```bash
+Building Actor classes for suites: cli, database, integration, unit
+ -> CliTesterActions.php generated successfully. 152 methods added
+\CliTester includes modules: Asserts, Cli, \Helper\Cli, \Helper\Unit
+ -> DatabaseTesterActions.php generated successfully. 252 methods added
+\DatabaseTester includes modules: Phalcon4, Redis, Asserts, Filesystem, Helper\Database, Helper\Unit
+ -> IntegrationTesterActions.php generated successfully. 251 methods added
+\IntegrationTester includes modules: Phalcon4, Redis, Asserts, Filesystem, Helper\Integration, Helper\PhalconLibmemcached, Helper\Unit
+ -> UnitTesterActions.php generated successfully. 166 methods added
+\UnitTester includes modules: Apc, Asserts, Filesystem, Helper\Unit
 ```
 
 Then, run the tests on a terminal:
 
 ```shell script
-/app $ codecept run
+/app $ php vendor/bin/codecept run
 # OR
-/app $ codecept run --debug # Detailed output
+/app $ php vendor/bin/codecept run --debug # Detailed output
 ```
 
 Execute `unit` test with `run unit` command:
 
 ```shell script
-/app $ codecept run unit
+/app $ php vendor/bin/codecept run unit
 ```
 
 Execute all tests from a folder:
 
 ```shell script
-/app $ codecept run tests/unit/some/folder/
+/app $ php vendor/bin/codecept run tests/unit/some/folder/
 ```
 
 Execute single test:
 
 ```shell script
-/app $ codecept run tests/unit/some/folder/some/test/file.php
+/app $ php vendor/bin/codecept run tests/unit/some/folder/some/test/file.php
 ```
 
 To run database related tests you need to run the `database` suite specifying
 the RDBMS and group:
 
 ```shell script
-/app $ codecept run tests/database -g common
-/app $ codecept run tests/database -g mysql --env mysql
-/app $ codecept run tests/database -g sqlite --env sqlite
-/app $ codecept run tests/database -g pgsql --env pgsql
+/app $ php vendor/bin/codecept run tests/database -g common
+/app $ php vendor/bin/codecept run tests/database -g mysql --env mysql
+/app $ php vendor/bin/codecept run tests/database -g sqlite --env sqlite
+/app $ php vendor/bin/codecept run tests/database -g pgsql --env pgsql
 ```
 
 Available options:
@@ -317,3 +346,4 @@ Thanks!
 [composer]: http://getcomposer.org
 [codeception-intro]: http://codeception.com/docs/01-Introduction
 [codeception-cmds]: http://codeception.com/docs/reference/Commands
+[psr]: https://github.com/jbboehr/php-psr

--- a/tests/_ci/nanobox/boxfile.7.2.yml
+++ b/tests/_ci/nanobox/boxfile.7.2.yml
@@ -14,6 +14,7 @@ run.config:
       - imagick
       - iconv
       - igbinary
+      - intl
       - json
       - mbstring
       - memcached
@@ -24,6 +25,7 @@ run.config:
       - pdo_sqlite
       - session
       - simplexml
+      - sqlite3
       - tokenizer
       - yaml
       - xml

--- a/tests/_ci/nanobox/boxfile.7.3.yml
+++ b/tests/_ci/nanobox/boxfile.7.3.yml
@@ -13,7 +13,6 @@ run.config:
       - gettext
       - imagick
       - iconv
-      - igbinary
       - intl
       - json
       - mbstring
@@ -78,7 +77,7 @@ run.config:
         CURRENT_FOLDER=$(pwd)
         rm -fR $CURRENT_FOLDER/build/msgpack-php
         cd $CURRENT_FOLDER/build
-        git clone --depth=1 https://github.com/msgpack/msgpack-php.git
+        git clone --depth=1 --branch msgpack-2.1.1 https://github.com/msgpack/msgpack-php.git
         cd msgpack-php
         set -e
         phpize
@@ -90,6 +89,25 @@ run.config:
         unset CURRENT_FOLDER
       )
     - echo -e 'extension=msgpack.so' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # Igbinary extension compilation
+    - |
+      (
+        CURRENT_FOLDER=$(pwd)
+        rm -fR $CURRENT_FOLDER/build/igbinary
+        cd $CURRENT_FOLDER/build
+        git clone --depth=1 https://github.com/igbinary/igbinary.git
+        cd igbinary
+        set -e
+        phpize
+        ./configure --with-php-config=$(which php-config)
+        make -j"$(getconf _NPROCESSORS_ONLN)"
+        make install
+        cd $CURRENT_FOLDER
+        rm -fR $CURRENT_FOLDER/build/igbinary
+        unset CURRENT_FOLDER
+      )
+    - echo -e 'extension=igbinary.so' >> "/data/etc/php/dev_php.ini"
     #===========================================================================
     # Zephir Parser
     - |

--- a/tests/_ci/nanobox/boxfile.7.3.yml
+++ b/tests/_ci/nanobox/boxfile.7.3.yml
@@ -77,7 +77,7 @@ run.config:
         CURRENT_FOLDER=$(pwd)
         rm -fR $CURRENT_FOLDER/build/msgpack-php
         cd $CURRENT_FOLDER/build
-        git clone --depth=1 --branch msgpack-2.1.1 https://github.com/msgpack/msgpack-php.git
+        git clone --depth=1 https://github.com/msgpack/msgpack-php.git
         cd msgpack-php
         set -e
         phpize

--- a/tests/_ci/nanobox/boxfile.7.3.yml
+++ b/tests/_ci/nanobox/boxfile.7.3.yml
@@ -14,6 +14,7 @@ run.config:
       - imagick
       - iconv
       - igbinary
+      - intl
       - json
       - mbstring
       - memcached
@@ -24,6 +25,7 @@ run.config:
       - pdo_sqlite
       - session
       - simplexml
+      - sqlite3
       - tokenizer
       - yaml
       - xml

--- a/tests/_ci/nanobox/boxfile.7.4.yml
+++ b/tests/_ci/nanobox/boxfile.7.4.yml
@@ -1,0 +1,159 @@
+run.config:
+  engine: php
+  engine.config:
+    runtime: php-7.4
+    extensions:
+      - apcu
+      - ctype
+      - curl
+      - dom
+      - fileinfo
+      - gd
+      - gmp
+      - gettext
+      - imagick
+      - iconv
+      - intl
+      - json
+      - mbstring
+      - memcached
+      - phar
+      - pdo
+      - pdo_mysql
+      - pdo_pgsql
+      - pdo_sqlite
+      - session
+      - simplexml
+      - sqlite3
+      - tokenizer
+      - yaml
+      - xml
+      - xmlwriter
+      - zip
+      - zlib
+      - mongodb
+      - redis
+    zend_extensions:
+      - opcache
+    dev_zend_extensions:
+      # Removed xdebug (will be back when Xdebug 2.7.0 is stable)
+      #      add:
+      #        - xdebug
+      rm:
+        - opcache
+  extra_packages:
+    - autoconf
+    - freefonts
+    - freetype2
+    - fontconfig
+    - mysql-client
+    #    - postgresql94-client
+    - re2c
+    - sqlite3
+  extra_steps:
+    #===========================================================================
+    # PSR extension compilation
+    - |
+      (
+        CURRENT_FOLDER=$(pwd)
+        rm -fR $CURRENT_FOLDER/build/php-psr
+        cd $CURRENT_FOLDER/build
+        git clone --depth=1 https://github.com/jbboehr/php-psr.git
+        cd php-psr
+        set -e
+        phpize
+        ./configure --with-php-config=$(which php-config)
+        make -j"$(getconf _NPROCESSORS_ONLN)"
+        make install
+        cd $CURRENT_FOLDER
+        rm -fR $CURRENT_FOLDER/build/php-psr
+        unset CURRENT_FOLDER
+      )
+    - echo -e 'extension=psr.so' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # Msgpack extension compilation
+    - |
+      (
+        CURRENT_FOLDER=$(pwd)
+        rm -fR $CURRENT_FOLDER/build/msgpack-php
+        cd $CURRENT_FOLDER/build
+        git clone --depth=1 https://github.com/msgpack/msgpack-php.git
+        cd msgpack-php
+        set -e
+        phpize
+        ./configure --with-php-config=$(which php-config)
+        make -j"$(getconf _NPROCESSORS_ONLN)"
+        make install
+        cd $CURRENT_FOLDER
+        rm -fR $CURRENT_FOLDER/build/msgpack-php
+        unset CURRENT_FOLDER
+      )
+    - echo -e 'extension=msgpack.so' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # Igbinary extension compilation
+    - |
+      (
+        CURRENT_FOLDER=$(pwd)
+        rm -fR $CURRENT_FOLDER/build/igbinary
+        cd $CURRENT_FOLDER/build
+        git clone --depth=1 https://github.com/igbinary/igbinary.git
+        cd igbinary
+        set -e
+        phpize
+        ./configure --with-php-config=$(which php-config)
+        make -j"$(getconf _NPROCESSORS_ONLN)"
+        make install
+        cd $CURRENT_FOLDER
+        rm -fR $CURRENT_FOLDER/build/igbinary
+        unset CURRENT_FOLDER
+      )
+    - echo -e 'extension=igbinary.so' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # Zephir Parser
+    - |
+      (
+        CURRENT_FOLDER=$(pwd)
+        rm -fR $CURRENT_FOLDER/build/php-zephir-parser
+        cd $CURRENT_FOLDER/build
+        git clone --depth=1 https://github.com/phalcon/php-zephir-parser.git
+        cd php-zephir-parser
+        set -e
+        phpize
+        ./configure --with-php-config=$(which php-config)
+        make -j"$(getconf _NPROCESSORS_ONLN)"
+        make install
+        cd $CURRENT_FOLDER
+        rm -fR $CURRENT_FOLDER/build/php-zephir-parser
+        unset CURRENT_FOLDER
+      )
+    - echo -e 'extension=zephir_parser.so' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # This is here so that Phalcon can be used right after compilation
+    - echo -e 'extension=phalcon.so' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # Options for session, opcache and apcu
+    - echo -e 'session.save_path="/tmp"' >> "/data/etc/php/dev_php.ini"
+    - echo -e 'opcache.enable_cli=1' >> "/data/etc/php/dev_php.ini"
+    - echo -e 'apcu.enabled=1' >> "/data/etc/php/dev_php.ini"
+    - echo -e 'apcu.enable_cli=1' >> "/data/etc/php/dev_php.ini"
+    - echo -e 'apc.enabled=1' >> "/data/etc/php/dev_php.ini"
+    - echo -e 'apc.enable_cli=1' >> "/data/etc/php/dev_php.ini"
+    #===========================================================================
+    # Get the Zephir phar
+    - wget --no-clobber -O /data/bin/zephir https://github.com/phalcon/zephir/releases/download/0.12.19/zephir.phar
+    - chmod +x /data/bin/zephir
+
+data.memcached:
+  image: nanobox/memcached:1.4
+
+data.mongodb:
+  image: mongo:4.0
+
+data.mysql:
+  image: nanobox/mysql:5.7
+
+data.postgres:
+  image: nanobox/postgresql:9.5
+
+data.redis:
+  image: nanobox/redis:3.2

--- a/tests/_data/fixtures/Traits/GdTrait.php
+++ b/tests/_data/fixtures/Traits/GdTrait.php
@@ -29,14 +29,41 @@ trait GdTrait
     }
 
     /**
+     * @param UnitTester $I
+     */
+    private function checkJpegSupport(UnitTester $I): void
+    {
+        if (!$this->hasJpegSupport()) {
+            $I->skipTest(
+                sprintf("Extension 'gd' is compiled without JPEG support.")
+            );
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function hasJpegSupport(): bool
+    {
+        $gdInfo = gd_info();
+
+        return isset($gdInfo['JPEG Support']) && $gdInfo['JPEG Support'];
+    }
+
+    /**
      * Images to process
      */
     private function getImages(): array
     {
-        return [
-            'jpg' => dataDir('assets/images/phalconphp.jpg'),
-            'png' => dataDir('assets/images/logo.png'),
+        $images = [
+            'png' => dataDir('assets/images/logo.png')
         ];
+
+        if ($this->hasJpegSupport()) {
+            $images['jpg'] = dataDir('assets/images/phalconphp.jpg');
+        }
+
+        return $images;
     }
 
     /**

--- a/tests/_data/fixtures/Traits/GdTrait.php
+++ b/tests/_data/fixtures/Traits/GdTrait.php
@@ -35,7 +35,7 @@ trait GdTrait
     {
         if (!$this->hasJpegSupport()) {
             $I->skipTest(
-                sprintf("Extension 'gd' is compiled without JPEG support.")
+                "Extension 'gd' is compiled without JPEG support."
             );
         }
     }
@@ -47,7 +47,7 @@ trait GdTrait
     {
         $gdInfo = gd_info();
 
-        return isset($gdInfo['JPEG Support']) && $gdInfo['JPEG Support'];
+        return !empty($gdInfo['JPEG Support']);
     }
 
     /**
@@ -56,7 +56,7 @@ trait GdTrait
     private function getImages(): array
     {
         $images = [
-            'png' => dataDir('assets/images/logo.png')
+            'png' => dataDir('assets/images/logo.png'),
         ];
 
         if ($this->hasJpegSupport()) {

--- a/tests/_support/Helper/Database.php
+++ b/tests/_support/Helper/Database.php
@@ -114,7 +114,7 @@ class Database extends \Codeception\Module
                 return sprintf(
                     "pgsql:host=%s;dbname=%s;user=%s;password=%s",
                     env('DATA_POSTGRES_HOST', '127.0.0.1'),
-                    getenv('DATA_POSTGRES_NAME', 'phalcon'),
+                    env('DATA_POSTGRES_NAME', 'phalcon'),
                     $this->username,
                     $this->password
                 );

--- a/tests/integration/Storage/Serializer/Msgpack/SerializeCest.php
+++ b/tests/integration/Storage/Serializer/Msgpack/SerializeCest.php
@@ -25,23 +25,25 @@ class SerializeCest
     /**
      * Tests Phalcon\Storage\Serializer\Msgpack :: serialize()
      *
-     * @dataProvider getExamples
+     * @note         dataProvider is not used here, it messes up console output
      *
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2019-03-30
      */
-    public function storageSerializerMsgpackSerialize(IntegrationTester $I, Example $example)
+    public function storageSerializerMsgpackSerialize(IntegrationTester $I)
     {
-        $I->wantToTest('Storage\Serializer\Msgpack - serialize() - ' . $example[0]);
+        $I->wantToTest('Storage\Serializer\Msgpack - serialize()');
 
-        $serializer = new Msgpack($example[1]);
+        foreach ($this->getExamples() as $example) {
+            $serializer = new Msgpack($example[1]);
 
-        $expected = $example[2];
+            $expected = $example[2];
 
-        $I->assertEquals(
-            $expected,
-            $serializer->serialize()
-        );
+            $I->assertEquals(
+                $expected,
+                $serializer->serialize()
+            );
+        }
     }
 
     private function getExamples(): array

--- a/tests/integration/Storage/Serializer/Msgpack/UnserializeCest.php
+++ b/tests/integration/Storage/Serializer/Msgpack/UnserializeCest.php
@@ -23,21 +23,25 @@ class UnserializeCest
     /**
      * Tests Phalcon\Storage\Serializer\Msgpack :: unserialize()
      *
-     * @dataProvider getExamples
+     * @note         dataProvider is not used here, it messes up console output
      *
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2019-03-30
      */
-    public function storageSerializerMsgpackUnserialize(IntegrationTester $I, Example $example)
+    public function storageSerializerMsgpackUnserialize(IntegrationTester $I)
     {
-        $I->wantToTest('Storage\Serializer\Msgpack - unserialize() - ' . $example[0]);
-        $serializer = new Msgpack();
-        $serialized = msgpack_pack($example[1]);
-        $serializer->unserialize($serialized);
+        $I->wantToTest('Storage\Serializer\Msgpack - unserialize()');
 
-        $expected = $example[1];
-        $actual   = $serializer->getData();
-        $I->assertEquals($expected, $actual);
+        foreach ($this->getExamples() as $example) {
+            $serializer = new Msgpack();
+            $serialized = msgpack_pack($example[1]);
+            $serializer->unserialize($serialized);
+
+            $expected = $example[1];
+            $actual   = $serializer->getData();
+
+            $I->assertEquals($expected, $actual);
+        }
     }
 
     /**

--- a/tests/unit/Image/Adapter/Gd/BlurCest.php
+++ b/tests/unit/Image/Adapter/Gd/BlurCest.php
@@ -31,6 +31,8 @@ class BlurCest
     {
         $I->wantToTest('Image\Adapter\Gd - blur()');
 
+        $this->checkJpegSupport($I);
+
         $params = [
             'jpg' => [
                 [1, 'fbf9f3e3c3c18183'],

--- a/tests/unit/Image/Adapter/Gd/CropCest.php
+++ b/tests/unit/Image/Adapter/Gd/CropCest.php
@@ -31,6 +31,8 @@ class CropCest
     {
         $I->wantToTest('Image\Adapter\Gd - crop()');
 
+        $this->checkJpegSupport($I);
+
         $image = new Gd(
             dataDir('assets/images/phalconphp.jpg')
         );
@@ -77,6 +79,8 @@ class CropCest
     public function imageAdapterGdCropJpgWithOffset(UnitTester $I)
     {
         $I->wantToTest('Image\Adapter\Gd - crop()');
+
+        $this->checkJpegSupport($I);
 
         $image = new Gd(
             dataDir('assets/images/phalconphp.jpg')

--- a/tests/unit/Image/Adapter/Gd/GetHeightCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetHeightCest.php
@@ -31,6 +31,8 @@ class GetHeightCest
     {
         $I->wantToTest('Image\Adapter\Gd - getHeight() - from jpg image');
 
+        $this->checkJpegSupport($I);
+
         $gd = new Gd(dataDir('assets/images/phalconphp.jpg'));
 
         $I->assertSame(

--- a/tests/unit/Image/Adapter/Gd/GetImageCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetImageCest.php
@@ -27,9 +27,11 @@ class GetImageCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function imageAdapterGdGetImage(UnitTester $I)
+    public function imageAdapterGdGetImageFromJpg(UnitTester $I)
     {
         $I->wantToTest('Image\Adapter\Gd - getImage() - from jpg image');
+
+        $this->checkJpegSupport($I);
 
         foreach ($this->getImages() as $image) {
             $gd = new Gd($image);

--- a/tests/unit/Image/Adapter/Gd/GetImageCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetImageCest.php
@@ -27,11 +27,9 @@ class GetImageCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function imageAdapterGdGetImageFromJpg(UnitTester $I)
+    public function imageAdapterGdGetImage(UnitTester $I)
     {
-        $I->wantToTest('Image\Adapter\Gd - getImage() - from jpg image');
-
-        $this->checkJpegSupport($I);
+        $I->wantToTest('Image\Adapter\Gd - getImage()');
 
         foreach ($this->getImages() as $image) {
             $gd = new Gd($image);

--- a/tests/unit/Image/Adapter/Gd/GetMimeCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetMimeCest.php
@@ -31,6 +31,8 @@ class GetMimeCest
     {
         $I->wantToTest('Image\Adapter\Gd - getMime() - image/jpg');
 
+        $this->checkJpegSupport($I);
+
         $gd = new Gd(dataDir('assets/images/phalconphp.jpg'));
 
         $I->assertSame(

--- a/tests/unit/Image/Adapter/Gd/GetRealpathCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetRealpathCest.php
@@ -31,6 +31,8 @@ class GetRealpathCest
     {
         $I->wantToTest('Image\Adapter\Gd - getRealpath()');
 
+        $this->checkJpegSupport($I);
+
         foreach ($this->getImages() as $image) {
             $image = str_replace("/", DIRECTORY_SEPARATOR, $image);
             $gd    = new Gd($image);

--- a/tests/unit/Image/Adapter/Gd/GetTypeCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetTypeCest.php
@@ -31,6 +31,8 @@ class GetTypeCest
     {
         $I->wantToTest('Image\Adapter\Gd - getType() - from jpg image');
 
+        $this->checkJpegSupport($I);
+
         $gd = new Gd(dataDir('assets/images/phalconphp.jpg'));
 
         $I->assertSame(

--- a/tests/unit/Image/Adapter/Gd/GetVersionCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetVersionCest.php
@@ -31,6 +31,8 @@ class GetVersionCest
     {
         $I->wantToTest('Image\Adapter\Gd - getVersion()');
 
+        $this->checkJpegSupport($I);
+
         $gd = new Gd(dataDir('assets/images/phalconphp.jpg'));
 
         $I->assertRegExp(

--- a/tests/unit/Image/Adapter/Gd/GetWidthCest.php
+++ b/tests/unit/Image/Adapter/Gd/GetWidthCest.php
@@ -31,6 +31,8 @@ class GetWidthCest
     {
         $I->wantToTest('Image\Adapter\Gd - getWidth() - from jpg image');
 
+        $this->checkJpegSupport($I);
+
         $gd = new Gd(dataDir('assets/images/phalconphp.jpg'));
 
         $I->assertSame(

--- a/tests/unit/Image/Adapter/Gd/MaskCest.php
+++ b/tests/unit/Image/Adapter/Gd/MaskCest.php
@@ -31,6 +31,8 @@ class MaskCest
     {
         $I->wantToTest('Image\Adapter\Gd - mask()');
 
+        $this->checkJpegSupport($I);
+
         $image = new Gd(
             dataDir('assets/images/logo.png')
         );

--- a/tests/unit/Image/Adapter/Gd/PixelateCest.php
+++ b/tests/unit/Image/Adapter/Gd/PixelateCest.php
@@ -31,6 +31,8 @@ class PixelateCest
     {
         $I->wantToTest('Image\Adapter\Gd - pixelate()');
 
+        $this->checkJpegSupport($I);
+
         $params = [
             [7, 'fbf9f7e3c3c18183'],
             [21, 'fbf9f7e3c1c3c183'],

--- a/tests/unit/Image/Adapter/Gd/ResizeCest.php
+++ b/tests/unit/Image/Adapter/Gd/ResizeCest.php
@@ -31,6 +31,8 @@ class ResizeCest
     {
         $I->wantToTest('Image\Adapter\Gd - resize() - jpg image');
 
+        $this->checkJpegSupport($I);
+
         $image = new Gd(
             dataDir('assets/images/phalconphp.jpg')
         );

--- a/tests/unit/Image/Adapter/Gd/RotateCest.php
+++ b/tests/unit/Image/Adapter/Gd/RotateCest.php
@@ -31,6 +31,8 @@ class RotateCest
     {
         $I->wantToTest('Image\Adapter\Gd - rotate()');
 
+        $this->checkJpegSupport($I);
+
         $params = [
             'jpg' => [
                 [0, 'fbf9f3e3c3c18183'],

--- a/tests/unit/Image/Adapter/Gd/SaveCest.php
+++ b/tests/unit/Image/Adapter/Gd/SaveCest.php
@@ -31,6 +31,8 @@ class SaveCest
     {
         $I->wantToTest('Image\Adapter\Gd - save()');
 
+        $this->checkJpegSupport($I);
+
         $outputDir   = 'tests/image/gd';
         $resultImage = 'save.';
 

--- a/tests/unit/Image/Adapter/Gd/SharpenCest.php
+++ b/tests/unit/Image/Adapter/Gd/SharpenCest.php
@@ -31,6 +31,8 @@ class SharpenCest
     {
         $I->wantToTest('Image\Adapter\Gd - sharpen()');
 
+        $this->checkJpegSupport($I);
+
         $outputDir = 'tests/image/gd';
         $params    = [
             [10, 'fbf9f3e3c3c18183'],

--- a/tests/unit/Image/Adapter/Gd/TextCest.php
+++ b/tests/unit/Image/Adapter/Gd/TextCest.php
@@ -31,6 +31,8 @@ class TextCest
     {
         $I->wantToTest('Image\Adapter\Gd - text()');
 
+        $this->checkJpegSupport($I);
+
         $outputDir = 'tests/image/gd';
 
         $params = [

--- a/tests/unit/Image/Adapter/Gd/WatermarkCest.php
+++ b/tests/unit/Image/Adapter/Gd/WatermarkCest.php
@@ -32,6 +32,8 @@ class WatermarkCest
     {
         $I->wantToTest('Image\Adapter\Gd - watermark() - jpg inside jpg');
 
+        $this->checkJpegSupport($I);
+
         $image = new Gd(
             dataDir('assets/images/phalconphp.jpg')
         );
@@ -76,6 +78,8 @@ class WatermarkCest
     {
         $I->wantToTest('Image\Adapter\Gd - watermark() - png inside jpg');
 
+        $this->checkJpegSupport($I);
+
         $image = new Gd(
             dataDir('assets/images/phalconphp.jpg')
         );
@@ -116,6 +120,8 @@ class WatermarkCest
     public function imageAdapterGdWatermarkJpgInsidePng(UnitTester $I)
     {
         $I->wantToTest('Image\Adapter\Gd - watermark() - jpg inside png');
+
+        $this->checkJpegSupport($I);
 
         $image = new Gd(
             dataDir('assets/images/logo.png')


### PR DESCRIPTION
Hello!

* Type: bug fix and documentation

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Nanobox boxfiles were outdated: 
 - `intl` and `sqlite3` extension were missing
 - Packages for the `igbinary` extension were not available for PHP 7.3+, had to have them compiled manually.
 
Running msgpack integration tests (for example `php vendor/bin/codecept run tests/integration/Storage/Serializer/Msgpack/SerializeCest.php`) were outputting special characters to the console and froze it inside nanobox, so I had to remove the `@dataProvider` to fix this.

Updated README.md with some fixes and clarifications.

Also created a PR in https://github.com/phalcon/docs/pull/2783 for the 4.0 branch as it still applies to the current stuff.

Thanks,
zsilbi
