### PR TITLE
Feature: callable relation params

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -44,6 +44,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Changed the visibility of properties in `Phalcon\Http\Message\Uri` to work with `clone`. [#15040](https://github.com/phalcon/cphalcon/issues/15040)
 - Change `Phalcon\Validation\AbstractValidator::__construct`. Save custom validator message in options. [#15053](https://github.com/phalcon/cphalcon/issues/15053) [@ivan-zolotavin](https://github.com/ivan-zolotavin)
 - Add proxy methods without `_` prefix in methods names: `getRelatedRecords()`, `groupResult()`, `exists()`, `preSaveRelatedRecords()`, `preSave()`, `doLowUpdate()`, `postSaveRelatedRecords()`, `postSave()`, `cancelOperation()`, `doLowInsert()`, `getConnection()`, `getConnectionService()`, `getVersion()`, `getSpecial()` [#14971](https://github.com/phalcon/cphalcon/pull/14971)
+- Modified `Phalcon\Mvc\Model\Relation` to accept callable params for model relations. [#15158](https://github.com/phalcon/cphalcon/issues/15158)
 
 ## Fixed
 - Fixed `Phalcon\Db\Dialect\Mysql::getColumnDefinition` to recognize `size` for `DATETIME`, `TIME` and `TIMESTAMP` columns [#13297](https://github.com/phalcon/cphalcon/issues/13297)

--- a/phalcon/Mvc/Model/Relation.zep
+++ b/phalcon/Mvc/Model/Relation.zep
@@ -144,6 +144,10 @@ class Relation implements RelationInterface
 
         if fetch params, options["params"] {
             if params {
+                if is_callable(params) {
+                    return call_user_func(params);
+                }
+
                 return params;
             }
         }

--- a/tests/_data/fixtures/models/Customers.php
+++ b/tests/_data/fixtures/models/Customers.php
@@ -65,5 +65,26 @@ class Customers extends Model
                 ]
             ]
         );
+
+        $this->hasMany(
+            'cst_id',
+            Invoices::class,
+            'inv_cst_id',
+            [
+                'alias'      => 'unpaidInvoices',
+                'reusable'   => true,
+                'foreignKey' => [
+                    'action' => Model\Relation::NO_ACTION
+                ],
+                'params'     => function () {
+                    return [
+                        'inv_status_flag = :unpaid:',
+                        'bind' => [
+                            'unpaid' => Invoices::STATUS_UNPAID
+                        ]
+                    ];
+                }
+            ]
+        );
     }
 }

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -138,6 +138,11 @@ class DeleteCest
             $customer->paidInvoices->count()
         );
 
+        $I->assertEquals(
+            1,
+            $customer->unpaidInvoices->count()
+        );
+
         $I->assertTrue(
             $customer->delete()
         );


### PR DESCRIPTION
Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change: https://github.com/phalcon/docs/pull/2787

Small description of change:

Modified `Phalcon\Mvc\Model\Relation` to accept callable params for model relations.

Example use case:

```php
/**
 * @var DiInterface $container
 */
$container = $this->getDI();

$this->hasMany(
    'id', Documents::class, 'customerId', [
        'params' => function() use ($container) {
            /**
             * @var Languages $language
             */
            $language = $container->getShared('language');

            return [
                'languageId = :languageId:',
                'bind' => [
                    'languageId' => $language->id
                ]
            ];
        }
    ]
);
```

When `language` is changed in the dependency container, the relations will automatically use the new parameter.

Thanks,
zsilbi

