### PR TITLE
T15102 - Router unicode support

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -56,6 +56,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Http\Response\Cookies::set()` to utilize the options parameter correctly [#15129](https://github.com/phalcon/cphalcon/issues/15129)
 - Fixed `Phalcon\Http\Cookie::send()` to define `options` parameter [#15142](https://github.com/phalcon/cphalcon/issues/15142)
 - Fixed `Phalcon\Crypt` performance issues. [#15118](https://github.com/phalcon/cphalcon/issues/15118)
+- Fixed `Phalcon\Mvc\Router\Route` unicode support in patterns. [#15102](https://github.com/phalcon/cphalcon/issues/15102)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -56,7 +56,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Http\Response\Cookies::set()` to utilize the options parameter correctly [#15129](https://github.com/phalcon/cphalcon/issues/15129)
 - Fixed `Phalcon\Http\Cookie::send()` to define `options` parameter [#15142](https://github.com/phalcon/cphalcon/issues/15142)
 - Fixed `Phalcon\Crypt` performance issues. [#15118](https://github.com/phalcon/cphalcon/issues/15118)
-- Fixed `Phalcon\Mvc\Router\Route` unicode support in patterns. [#15102](https://github.com/phalcon/cphalcon/issues/15102)
+- Fixed `Phalcon\Mvc\Router\Route` unicode support in patterns [#15102](https://github.com/phalcon/cphalcon/issues/15102)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -129,6 +129,8 @@ class Route implements RouteInterface
         /**
          * Check if the pattern has parentheses or square brackets in order to
          * add the regex delimiters
+         *
+         * `u` flag is required to support unicode
          */
         if memstr(pattern, "(") || memstr(pattern, "[") {
             return "#^" . pattern . "$#u";

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -131,7 +131,7 @@ class Route implements RouteInterface
          * add the regex delimiters
          */
         if memstr(pattern, "(") || memstr(pattern, "[") {
-            return "#^" . pattern . "$#";
+            return "#^" . pattern . "$#u";
         }
 
         return pattern;

--- a/tests/integration/Mvc/Router/Route/CompilePatternCest.php
+++ b/tests/integration/Mvc/Router/Route/CompilePatternCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Mvc\Router\Route;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router\Route;
 
 /**
  * Class CompilePatternCest
@@ -24,11 +25,46 @@ class CompilePatternCest
      * Tests Phalcon\Mvc\Router\Route :: compilePattern()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @since  2020-10-05
      */
     public function mvcRouterRouteCompilePattern(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Router\Route - compilePattern()');
-        $I->skipTest('Need implementation');
+
+        /**
+         * Simple
+         */
+        $simpleRoute = new Route(
+            '/my-simple-route'
+        );
+
+        $I->assertEquals(
+            '/my-simple-route',
+            $simpleRoute->getCompiledPattern()
+        );
+
+        /**
+         * Placeholder
+         */
+        $placeholderRoute = new Route(
+            '/:module/:namespace/:controller/:action/:params/:int'
+        );
+
+        $I->assertEquals(
+            '#^/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)(/.*)*/([0-9]+)$#u',
+            $placeholderRoute->getCompiledPattern()
+        );
+
+        /**
+         * Custom regex
+         */
+        $regexRoute = new Route(
+            '/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)(/.*)*/([0-9]+)'
+        );
+
+        $I->assertEquals(
+            '#^/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)/([\\w0-9\\_\\-]+)(/.*)*/([0-9]+)$#u',
+            $regexRoute->getCompiledPattern()
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: closes #15102 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

The `u` flag was removed by accident in https://github.com/phalcon/cphalcon/commit/bded353362da5494644dd140c83a99f63c50802d

Thanks,
zsilbi

