### PR TITLE
T15113 - Aggregated query to use transaction

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -59,6 +59,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Crypt` performance issues. [#15118](https://github.com/phalcon/cphalcon/issues/15118)
 - Fixed `Phalcon\Mvc\Router\Route` unicode support in patterns [#15102](https://github.com/phalcon/cphalcon/issues/15102)
 - Fixed fatal error in `Phalcon\Mvc\Model::cloneResultMap()` when column map is used with `orm.cast_on_hydrate` turned on. [#14617](https://github.com/phalcon/cphalcon/issues/14617)
+- Fixed `Phalcon\Mvc\Model::sum()`, `average()`, `minimum()`, `maxmium()`, `count()` to utilize the transaction parameter. [#15113](https://github.com/phalcon/cphalcon/issues/15113)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4290,7 +4290,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     {
         var params, distinctColumn, groupColumn, columns, bindParams, bindTypes,
             resultset, cache, firstRow, groupColumns, builder, query, container,
-            manager;
+            manager, transaction;
 
         let container = Di::getDefault();
         let manager = <ManagerInterface> container->getShared("modelsManager");
@@ -4334,6 +4334,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         );
 
         let query = <QueryInterface> builder->getQuery();
+
+        if fetch transaction, params[self::TRANSACTION_INDEX] {
+            if transaction instanceof TransactionInterface {
+                query->setTransaction(transaction);
+            }
+        }
 
         /**
          * Check for bind parameters

--- a/tests/database/Mvc/Model/SumCest.php
+++ b/tests/database/Mvc/Model/SumCest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Test\Database\Mvc\Model;
 
 use DatabaseTester;
 use Phalcon\Mvc\Model\Resultset\Simple;
+use Phalcon\Mvc\Model\Transaction\Manager;
 use Phalcon\Storage\Exception;
 use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
@@ -34,7 +35,8 @@ class SumCest
     /**
      * Executed before each test
      *
-     * @param  DatabaseTester $I
+     * @param DatabaseTester $I
+     *
      * @return void
      */
     public function _before(DatabaseTester $I): void
@@ -50,10 +52,23 @@ class SumCest
         $this->invoiceMigration = new InvoicesMigration($I->getConnection());
     }
 
+
+    public function _after(DatabaseTester $I): void
+    {
+        /**
+         * @var Manager $transactionManager
+         */
+        $transactionManager = $this->getDi()->getShared('transactionManager');
+
+        if ($transactionManager->has()) {
+            $transactionManager->rollback();
+        }
+    }
+
     /**
      * Tests Phalcon\Mvc\Model :: sum()
      *
-     * @param  DatabaseTester $I
+     * @param DatabaseTester $I
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-01-30
@@ -124,12 +139,12 @@ class SumCest
             ]
         );
         $I->assertInstanceOf(Simple::class, $results);
-        $I->assertEquals(1, (int) $results[0]->inv_cst_id);
-        $I->assertEquals(232, (int) $results[0]->sumatory);
-        $I->assertEquals(2, (int) $results[1]->inv_cst_id);
-        $I->assertEquals(33, (int) $results[1]->sumatory);
-        $I->assertEquals(3, (int) $results[2]->inv_cst_id);
-        $I->assertEquals(1, (int) $results[2]->sumatory);
+        $I->assertEquals(1, (int)$results[0]->inv_cst_id);
+        $I->assertEquals(232, (int)$results[0]->sumatory);
+        $I->assertEquals(2, (int)$results[1]->inv_cst_id);
+        $I->assertEquals(33, (int)$results[1]->sumatory);
+        $I->assertEquals(3, (int)$results[2]->inv_cst_id);
+        $I->assertEquals(1, (int)$results[2]->sumatory);
 
         $results = Invoices::sum(
             [
@@ -139,11 +154,64 @@ class SumCest
             ]
         );
         $I->assertInstanceOf(Simple::class, $results);
-        $I->assertEquals(3, (int) $results[0]->inv_cst_id);
-        $I->assertEquals(1, (int) $results[0]->sumatory);
-        $I->assertEquals(2, (int) $results[1]->inv_cst_id);
-        $I->assertEquals(33, (int) $results[1]->sumatory);
-        $I->assertEquals(1, (int) $results[2]->inv_cst_id);
-        $I->assertEquals(232, (int) $results[2]->sumatory);
+        $I->assertEquals(3, (int)$results[0]->inv_cst_id);
+        $I->assertEquals(1, (int)$results[0]->sumatory);
+        $I->assertEquals(2, (int)$results[1]->inv_cst_id);
+        $I->assertEquals(33, (int)$results[1]->sumatory);
+        $I->assertEquals(1, (int)$results[2]->inv_cst_id);
+        $I->assertEquals(232, (int)$results[2]->sumatory);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: sum()
+     *
+     * @param DatabaseTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-01-30
+     *
+     * @group  mysql
+     * @group  pgsql
+     */
+    public function mvcModelSumTransaction(DatabaseTester $I)
+    {
+        $I->wantToTest('Phalcon\Mvc\Model :: sum() - with transaction');
+
+        $this->insertDataInvoices($this->invoiceMigration, 7, null, 2, 'ccc');
+        $this->insertDataInvoices($this->invoiceMigration, 1, null, 3, 'aaa');
+        $this->insertDataInvoices($this->invoiceMigration, 11, null, 1, 'aaa');
+
+        $originalTotal = Invoices::sum(
+            [
+                'column' => 'inv_total'
+            ]
+        );
+
+        /**
+         * @var Manager $transactionManager
+         */
+        $transactionManager = $this->getDi()->getShared('transactionManager');
+        $transaction        = $transactionManager->get();
+
+        /**
+         * @var Invoices $deletedInvoice
+         */
+        $deletedInvoice = Invoices::findFirst();
+        $deletedInvoice->setTransaction($transaction);
+        $deletedInvoice->delete();
+
+        $total = Invoices::sum(
+            [
+                'column'      => 'inv_total',
+                'transaction' => $transaction
+            ]
+        );
+
+        $I->assertEquals(
+            $originalTotal - $deletedInvoice->inv_total,
+            $total
+        );
+
+        $transaction->rollback();
     }
 }

--- a/tests/database/Mvc/Model/SumCest.php
+++ b/tests/database/Mvc/Model/SumCest.php
@@ -177,9 +177,9 @@ class SumCest
     {
         $I->wantToTest('Phalcon\Mvc\Model :: sum() - with transaction');
 
-        $this->insertDataInvoices($this->invoiceMigration, 7, null, 2, 'ccc');
-        $this->insertDataInvoices($this->invoiceMigration, 1, null, 3, 'aaa');
-        $this->insertDataInvoices($this->invoiceMigration, 11, null, 1, 'aaa');
+        $this->insertDataInvoices($this->invoiceMigration, 7, 'default', 2, 'ccc');
+        $this->insertDataInvoices($this->invoiceMigration, 1, 'default', 3, 'aaa');
+        $this->insertDataInvoices($this->invoiceMigration, 11, 'default', 1, 'aaa');
 
         $originalTotal = Invoices::sum(
             [


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: closes #15113 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

Use transaction for aggregated queries (like `Model::sum()`)

Thanks,
zsilbi
