### PR TITLE
T14810 - Model::cloneResult() to use setters

### DIFF
--- a/tests/_data/fixtures/models/CustomersKeepSnapshots.php
+++ b/tests/_data/fixtures/models/CustomersKeepSnapshots.php
@@ -18,17 +18,17 @@ use Phalcon\Mvc\Model;
 /**
  * Class CustomersKeepSnapshots
  *
- * @property int    $cst_id;
+ * @property int    $cst_id         ;
  * @property int    $cst_status_flag;
- * @property string $cst_name_last;
- * @property string $cst_name_first;
+ * @property string $cst_name_last  ;
+ * @property string $cst_name_first ;
  */
 class CustomersKeepSnapshots extends Model
 {
     public $cst_id;
-    public $cst_status_flag;
     public $cst_name_last;
     public $cst_name_first;
+    protected $cst_status_flag;
 
     public function initialize()
     {
@@ -44,5 +44,21 @@ class CustomersKeepSnapshots extends Model
                 'reusable' => true,
             ]
         );
+    }
+
+    /**
+     * @param int $status
+     */
+    public function setCstStatusFlag(int $status): void
+    {
+        $this->cst_status_flag = $status + 1;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCstStatusFlag(): int
+    {
+        return (int)$this->cst_status_flag;
     }
 }

--- a/tests/database/Mvc/Model/CloneResultCest.php
+++ b/tests/database/Mvc/Model/CloneResultCest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Database\Mvc\Model;
+
+use Codeception\Example;
+use DatabaseTester;
+use Phalcon\Mvc\Model;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\CustomersKeepSnapshots;
+use Phalcon\Test\Models\Invoices;
+use Phalcon\Test\Models\InvoicesMap;
+
+/**
+ * Class CloneResultCest
+ */
+class CloneResultCest
+{
+    use DiTrait;
+
+    public function _before(DatabaseTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDatabase($I);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: cloneResult()
+     *
+     * @dataProvider modelDataProvider
+     *
+     * @param DatabaseTester $I
+     * @param Example        $example
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2020-10-16
+     *
+     * @group        mysql
+     * @group        pgsql
+     * @group        sqlite
+     */
+    public function cloneResult(DatabaseTester $I, Example $example)
+    {
+        $I->wantToTest('Mvc\Model - cloneResult()');
+
+        $base = new Invoices();
+
+        $data = [
+            'inv_id'          => $example['inv_id'],
+            'inv_cst_id'      => $example['inv_cst_id'],
+            'inv_status_flag' => $example['inv_status_flag'],
+            'inv_title'       => $example['inv_title'],
+            'inv_total'       => $example['inv_total'],
+            'inv_created_at'  => $example['inv_created_at']
+        ];
+
+        /**
+         * @var InvoicesMap $invoice
+         */
+        $invoice = Model::cloneResult(
+            $base,
+            $data
+        );
+
+        $I->assertEquals(
+            $data,
+            $invoice->toArray()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: cloneResult() is using setters
+     *
+     * @param DatabaseTester $I
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2020-10-16
+     *
+     * @group        mysql
+     * @group        pgsql
+     * @group        sqlite
+     */
+    public function cloneResultUsingSetters(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - cloneResult() is using setters');
+
+        $base = new CustomersKeepSnapshots();
+
+        $customer = Model::cloneResult(
+            $base,
+            [
+                'cst_status_flag' => 2
+            ]
+        );
+
+        $I->assertEquals(
+            3,
+            $customer->cst_status_flag
+        );
+    }
+
+    /**
+     * @return array
+     */
+    protected function modelDataProvider(): array
+    {
+        return [
+            [
+                'inv_id'          => '1',
+                'inv_cst_id'      => '42',
+                'inv_status_flag' => '1',
+                'inv_title'       => 'Test title',
+                'inv_total'       => '3.14',
+                'inv_created_at'  => '2020-10-05 20:43',
+            ],
+            [
+                'inv_id'          => 1,
+                'inv_cst_id'      => 42,
+                'inv_status_flag' => 1,
+                'inv_title'       => 'Test title',
+                'inv_total'       => 3.14,
+                'inv_created_at'  => '2020-10-05 20:43',
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14810

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG

Small description of change:

Seems like this issue still occurs using Zephir 0.12.19
Added test to verify it.

Thanks,
zsilbi

