### PR TITLE
Model::_checkForeignKeysReverseRestrict() to check relation params

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -52,6 +52,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Events\Manager:notifyEvent()` change in the order of notification event: first default event manager, then custom events and finally behaviors, [#14904](https://github.com/phalcon/cphalcon/issues/14904)
 - Fixed `Phalcon\Validation\Validator\Uniqueness` fixed except query [#15084](https://github.com/phalcon/cphalcon/issues/15084) 
 - Fixed `Phalcon\Mvc\Model` to also check the params option in cascade relations when deleting [#15098](https://github.com/phalcon/cphalcon/issues/15098)
+- Fixed `Phalcon\Mvc\Model` to also check the params option in restricted relations when deleting [#15172](https://github.com/phalcon/cphalcon/issues/15172)
 - Fixed `Phalcon\Mvc\Model::findFirst()` to return correct value [#15077](https://github.com/phalcon/cphalcon/issues/15077)
 - Fixed `Phalcon\Mvc\Model\CriteriaInterface::where()` parameters [#15144](https://github.com/phalcon/cphalcon/issues/15144)
 - Fixed `Phalcon\Http\Response\Cookies::set()` to utilize the options parameter correctly [#15129](https://github.com/phalcon/cphalcon/issues/15129)

--- a/tests/_data/fixtures/models/Customers.php
+++ b/tests/_data/fixtures/models/Customers.php
@@ -90,6 +90,27 @@ class Customers extends Model
                 }
             ]
         );
+
+        $this->hasMany(
+            'cst_id',
+            Invoices::class,
+            'inv_cst_id',
+            [
+                'alias'      => 'inactiveInvoices',
+                'reusable'   => true,
+                'foreignKey' => [
+                    'action' => Model\Relation::ACTION_RESTRICT
+                ],
+                'params'     => function () {
+                    return [
+                        'inv_status_flag = :inactive:',
+                        'bind' => [
+                            'inactive' => Invoices::STATUS_INACTIVE
+                        ]
+                    ];
+                }
+            ]
+        );
     }
 
     /**

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -102,6 +102,7 @@ class DeleteCest
         $lastName  = uniqid('cust-', true);
 
         $customersMigration = new CustomersMigration($connection);
+        $customersMigration->clear();
         $customersMigration->insert($custId, 0, $firstName, $lastName);
 
         $paidInvoiceId   = 4;
@@ -110,6 +111,7 @@ class DeleteCest
         $title = uniqid('inv-');
 
         $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->clear();
         $invoicesMigration->insert(
             $paidInvoiceId,
             $custId,


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

Similar to this: https://github.com/phalcon/cphalcon/pull/15126
The model now checks the params in the relation when deleting related records.

Thanks,
zsilbi

