### PR TITLE
T15117 - Controller::initialize() is skipped

### DIFF
--- a/tests/_data/fixtures/controllers/InitController.php
+++ b/tests/_data/fixtures/controllers/InitController.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Controllers;
+
+use Phalcon\Http\Response;
+use Phalcon\Mvc\Controller;
+
+class InitController extends Controller
+{
+    public function initialize()
+    {
+        throw new \Exception(
+            'Initialize called'
+        );
+    }
+
+    public function indexAction()
+    {
+    }
+}


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: #15117

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR

Small description of change:

Added test to confirm that this issue has already been fixed.

Thanks,
zsilbi

