### PR TITLE
T15180 - SQLite adapter to support `NOT NULL` columns with default values

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -32,6 +32,8 @@ This component will be used in the Data Mapper implementation but can be used as
 This component can be used to create SQL statements using a fluent interface. Optionally the statements can be executed from the builder itself using the `DataMapper\Pdo` connection. [#14734](https://github.com/phalcon/cphalcon/issues/14734)
 - Added `Phalcon\Mvc\Micro\LazyLoader::getHandler()` to return real handler when using lazy loaded controllers for `Phalcon\Mvc\Micro` [#14871](https://github.com/phalcon/cphalcon/issues/14871) [@Jurigag](https://github.com/Jurigag)
 - Added `Phalcon\Collection\CollectionInterface` and `Phalcon\Config\ConfigInterface` to use as typehints when extending or implementing custom classes [#15106](https://github.com/phalcon/cphalcon/issues/15106) [@BeMySlaveDarlin](https://github.com/BeMySlaveDarlin)
+- Added `Phalcon\Db\Adapter\AdapterInterface::getDefaultValue()` and `supportsDefaultValue()` methods to properly support the `DEFAULT` keyword [#15180](https://github.com/phalcon/cphalcon/issues/15180)
+- Added `Phalcon\Db\Adapter\AbstractAdapter::supportsDefaultValue()` method to properly support the `DEFAULT` keyword [#15180](https://github.com/phalcon/cphalcon/issues/15180)
 
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)
@@ -62,6 +64,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed fatal error in `Phalcon\Mvc\Model::cloneResultMap()` when column map is used with `orm.cast_on_hydrate` turned on. [#14617](https://github.com/phalcon/cphalcon/issues/14617)
 - Fixed `Phalcon\Mvc\Model::sum()`, `average()`, `minimum()`, `maxmium()`, `count()` to utilize the transaction parameter. [#15113](https://github.com/phalcon/cphalcon/issues/15113)
 - Fixed `Phalcon\Mvc\Model::__set()` to clear `dirtyRelated` when empty array is set. [#14822](https://github.com/phalcon/cphalcon/issues/14822)
+- Fixed `Phalcon\Mvc\Model` to skip columns with default values when the `DEFAULT` keyword is not supported by the database adapter (SQLite) [#15180](https://github.com/phalcon/cphalcon/issues/15180)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Db/Adapter/AbstractAdapter.zep
+++ b/phalcon/Db/Adapter/AbstractAdapter.zep
@@ -691,6 +691,8 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *     ]
      * );
      *```
+     *
+     * @todo Return NULL if this is not supported by the adapter
      */
     public function getDefaultValue() -> <RawValue>
     {
@@ -1304,6 +1306,16 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     public function useExplicitIdValue() -> bool
     {
         return false;
+    }
+
+    /**
+     * Check whether the database system support the DEFAULT
+     * keyword (SQLite does not support it)
+     *
+     * @deprecated Will re removed in the next version
+     */
+    public function supportsDefaultValue() -> bool {
+        return true;
     }
 
     /**

--- a/phalcon/Db/Adapter/AdapterInterface.zep
+++ b/phalcon/Db/Adapter/AdapterInterface.zep
@@ -221,6 +221,29 @@ interface AdapterInterface
     public function getDefaultIdValue() -> <RawValue>;
 
     /**
+     * Returns the default value to make the RBDM use the default value declared
+     * in the table definition
+     *
+     *```php
+     * // Inserting a new robot with a valid default value for the column 'year'
+     * $success = $connection->insert(
+     *     "robots",
+     *     [
+     *         "Astro Boy",
+     *         $connection->getDefaultValue()
+     *     ],
+     *     [
+     *         "name",
+     *         "year",
+     *     ]
+     * );
+     *```
+     *
+     * @todo Return NULL if this is not supported by the adapter
+     */
+    public function getDefaultValue() -> <RawValue>;
+
+    /**
      * Return internal PDO handler
      */
     public function getInternalHandler() -> <\PDO>;
@@ -393,6 +416,13 @@ interface AdapterInterface
      * columns
      */
     public function useExplicitIdValue() -> bool;
+
+    /**
+     * SQLite does not support the DEFAULT keyword
+     *
+     * @deprecated Will re removed in the next version
+     */
+    public function supportsDefaultValue() -> bool;
 
     /**
      * Generates SQL checking for the existence of a schema.view

--- a/phalcon/Db/Adapter/Pdo/Sqlite.zep
+++ b/phalcon/Db/Adapter/Pdo/Sqlite.zep
@@ -468,6 +468,15 @@ class Sqlite extends PdoAdapter
     }
 
     /**
+     * SQLite does not support the DEFAULT keyword
+     *
+     * @deprecated Will re removed in the next version
+     */
+    public function supportsDefaultValue() -> bool {
+        return false;
+    }
+
+    /**
      * Returns PDO adapter DSN defaults as a key-value map.
      */
     protected function getDsnDefaults() -> array

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -3519,10 +3519,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                      */
                     if fetch value, this->{attributeField} {
                         if value === null && isset defaultValues[field] {
-                            let value = connection->getDefaultValue();
-
                             let snapshot[attributeField]           = defaultValues[field],
                                 unsetDefaultValues[attributeField] = defaultValues[field];
+
+                            if unlikely false === connection->supportsDefaultValue() {
+                                continue;
+                            }
+
+                            let value = connection->getDefaultValue();
                         } else {
                             let snapshot[attributeField] = value;
                         }
@@ -3541,10 +3545,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                             bindTypes[] = bindType;
                     } else {
                         if isset defaultValues[field] {
-                            let values[] = connection->getDefaultValue();
-
                             let snapshot[attributeField]           = defaultValues[field],
                                 unsetDefaultValues[attributeField] = defaultValues[field];
+
+                            if unlikely false === connection->supportsDefaultValue() {
+                                continue;
+                            }
+
+                            let values[] = connection->getDefaultValue();
                         } else {
                             let values[]                 = value,
                                 snapshot[attributeField] = value;

--- a/tests/_data/assets/schemas/mysql.sql
+++ b/tests/_data/assets/schemas/mysql.sql
@@ -17,9 +17,9 @@ drop table if exists `co_customers_defaults`;
 create table co_customers_defaults
 (
     `cst_id`          int(10) auto_increment primary key,
-    `cst_status_flag` tinyint(1)   null DEFAULT 1,
-    `cst_name_last`   varchar(100) null DEFAULT 'cst_default_lastName',
-    `cst_name_first`  varchar(50)  null DEFAULT 'cst_default_firstName'
+    `cst_status_flag` tinyint(1)   not null DEFAULT 1,
+    `cst_name_last`   varchar(100) not null DEFAULT 'cst_default_lastName',
+    `cst_name_first`  varchar(50)  not null DEFAULT 'cst_default_firstName'
 );
             
 create index co_customers_defaults_cst_status_flag_index

--- a/tests/_data/assets/schemas/pgsql.sql
+++ b/tests/_data/assets/schemas/pgsql.sql
@@ -30,9 +30,9 @@ drop table if exists co_customers_defaults;
 create table co_customers_defaults
 (
     cst_id          serial not null constraint co_customers_defaults_pk primary key,
-    cst_status_flag smallint   null DEFAULT 1,
-    cst_name_last   varchar(100) null DEFAULT 'cst_default_lastName',
-    cst_name_first  varchar(50)  null DEFAULT 'cst_default_firstName'
+    cst_status_flag smallint   not null DEFAULT 1,
+    cst_name_last   varchar(100) not null DEFAULT 'cst_default_lastName',
+    cst_name_first  varchar(50)  not null DEFAULT 'cst_default_firstName'
 );
             
 create index co_customers_defaults_cst_status_flag_index

--- a/tests/_data/assets/schemas/sqlite.sql
+++ b/tests/_data/assets/schemas/sqlite.sql
@@ -7,9 +7,9 @@ drop table if exists co_customers_defaults;
 create table co_customers_defaults
 (
     cst_id          integer constraint co_customers_defaults_pk primary key autoincrement,
-    cst_status_flag integer      null DEFAULT 1,
-    cst_name_last   text         null DEFAULT 'cst_default_lastName',
-    cst_name_first  text         null DEFAULT 'cst_default_firstName'
+    cst_status_flag integer      not null DEFAULT 1,
+    cst_name_last   text         not null DEFAULT 'cst_default_lastName',
+    cst_name_first  text         not null DEFAULT 'cst_default_firstName'
 );
             
 create index co_customers_defaults_cst_status_flag_index

--- a/tests/_data/fixtures/Migrations/CustomersDefaultsMigration.php
+++ b/tests/_data/fixtures/Migrations/CustomersDefaultsMigration.php
@@ -66,9 +66,9 @@ drop table if exists `co_customers_defaults`;
 create table co_customers_defaults
 (
     `cst_id`          int(10) auto_increment primary key,
-    `cst_status_flag` tinyint(1)   null DEFAULT 1,
-    `cst_name_last`   varchar(100) null DEFAULT 'cst_default_lastName',
-    `cst_name_first`  varchar(50)  null DEFAULT 'cst_default_firstName'
+    `cst_status_flag` tinyint(1)   not null DEFAULT 1,
+    `cst_name_last`   varchar(100) not null DEFAULT 'cst_default_lastName',
+    `cst_name_first`  varchar(50)  not null DEFAULT 'cst_default_firstName'
 );
             ",
             "
@@ -96,9 +96,9 @@ drop table if exists co_customers_defaults;
 create table co_customers_defaults
 (
     cst_id          integer constraint co_customers_defaults_pk primary key autoincrement,
-    cst_status_flag integer      null DEFAULT 1,
-    cst_name_last   text         null DEFAULT 'cst_default_lastName',
-    cst_name_first  text         null DEFAULT 'cst_default_firstName'
+    cst_status_flag integer      not null DEFAULT 1,
+    cst_name_last   text         not null DEFAULT 'cst_default_lastName',
+    cst_name_first  text         not null DEFAULT 'cst_default_firstName'
 );
             ",
             "
@@ -126,9 +126,9 @@ drop table if exists co_customers_defaults;
 create table co_customers_defaults
 (
     cst_id          serial not null constraint co_customers_defaults_pk primary key,
-    cst_status_flag smallint   null DEFAULT 1,
-    cst_name_last   varchar(100) null DEFAULT 'cst_default_lastName',
-    cst_name_first  varchar(50)  null DEFAULT 'cst_default_firstName'
+    cst_status_flag smallint   not null DEFAULT 1,
+    cst_name_last   varchar(100) not null DEFAULT 'cst_default_lastName',
+    cst_name_first  varchar(50)  not null DEFAULT 'cst_default_firstName'
 );
             ",
             "

--- a/tests/database/Mvc/Model/SaveCest.php
+++ b/tests/database/Mvc/Model/SaveCest.php
@@ -16,6 +16,7 @@ namespace Phalcon\Test\Integration\Mvc\Model;
 use DatabaseTester;
 use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\MetaData;
+use Phalcon\Test\Fixtures\Migrations\CustomersDefaultsMigration;
 use Phalcon\Test\Fixtures\Migrations\CustomersMigration;
 use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Test\Fixtures\Migrations\SourcesMigration;
@@ -310,7 +311,7 @@ class SaveCest
         /** @var \PDO $connection */
         $connection = $I->getConnection();
 
-        $customersMigration = new CustomersMigration($connection);
+        $customersMigration = new CustomersDefaultsMigration($connection);
         $customersMigration->clear();
 
         $customer = new CustomersDefaults();

--- a/tests/database/Mvc/Model/UpdateCest.php
+++ b/tests/database/Mvc/Model/UpdateCest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Phalcon\Test\Database\Mvc\Model;
 
 use DatabaseTester;
+use Phalcon\Test\Fixtures\Migrations\CustomersDefaultsMigration;
 use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\CustomersDefaults;
 use Phalcon\Test\Models\Invoices;
 
 use function uniqid;
@@ -90,6 +92,77 @@ class UpdateCest
                 'inv_created_at'  => null,
             ],
             $record->toArray()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: update() - with default values
+     *
+     * @see    https://github.com/phalcon/cphalcon/issues/14924
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2020-10-18
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelSaveAfterWithoutDefaultValues(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - update() - with default values');
+
+        /** @var \PDO $connection */
+        $connection = $I->getConnection();
+
+        $customersMigration = new CustomersDefaultsMigration($connection);
+        $customersMigration->clear();
+
+        /**
+         * Customer is created manually with empty first and last name
+         */
+        $customersMigration->insert(1, 1, null, null);
+
+        $manualCustomer = CustomersDefaults::findFirst(1);
+
+        $I->assertEquals(
+            '',
+            $manualCustomer->cst_name_first
+        );
+
+        $I->assertEquals(
+            '',
+            $manualCustomer->cst_name_last
+        );
+
+        /**
+         * Validation should fail because we don't allow
+         * empty strings for `not null` columns
+         */
+        $I->assertFalse(
+            $manualCustomer->update()
+        );
+
+        /**
+         * Customer is created by ORM with proper default values
+         */
+        $ormCustomer = new CustomersDefaults();
+
+        $I->assertTrue(
+            $ormCustomer->create()
+        );
+
+        $I->assertEquals(
+            'cst_default_firstName',
+            $ormCustomer->cst_name_first
+        );
+
+        $I->assertEquals(
+            'cst_default_lastName',
+            $ormCustomer->cst_name_last
+        );
+
+        $I->assertTrue(
+            $ormCustomer->update()
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15180

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

Added `Phalcon\Db\Adapter\AdapterInterface::getDefaultValue()` and `supportsDefaultValue()` methods to properly support the `DEFAULT` keyword
Added `Phalcon\Db\Adapter\AbstractAdapter::supportsDefaultValue()` method to properly support the `DEFAULT` keyword
Fixed `Phalcon\Mvc\Model` to skip columns with default values when the `DEFAULT` keyword is not supported by the database adapter (SQLite)

Thanks,
zsilbi