### PR TITLE
T15184 - Session\Adapter prefix option

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -65,6 +65,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Mvc\Model::__set()` to clear `dirtyRelated` when empty array is set. [#14822](https://github.com/phalcon/cphalcon/issues/14822)
 - Fixed `Phalcon\Mvc\Model` to skip columns with default values when the `DEFAULT` keyword is not supported by the database adapter (SQLite) [#15180](https://github.com/phalcon/cphalcon/issues/15180)
 - Fixed `Phalcon\Mvc\Router` to handle numeric routes properly [#14926](https://github.com/phalcon/cphalcon/issues/14926)
+- Fixed `Phalcon\Session\Adapter\Redis` and `Phalcon\Session\Adapter\Libmemcached` to utilize the prefix option [#15184](https://github.com/phalcon/cphalcon/issues/15184)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Session/Adapter/Libmemcached.zep
+++ b/phalcon/Session/Adapter/Libmemcached.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Session\Adapter;
 
 use Phalcon\Storage\AdapterFactory;
+use Phalcon\Helper\Arr;
 
 /**
  * Phalcon\Session\Adapter\Libmemcached
@@ -37,7 +38,7 @@ class Libmemcached extends AbstractAdapter
      */
     public function __construct(<AdapterFactory> factory, array! options = [])
     {
-        let options["prefix"] = "sess-memc-",
+        let options["prefix"] = Arr::get(options, "prefix", "sess-memc-"),
             this->adapter     = factory->newInstance("libmemcached", options);
     }
 }

--- a/phalcon/Session/Adapter/Redis.zep
+++ b/phalcon/Session/Adapter/Redis.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Session\Adapter;
 
 use Phalcon\Storage\AdapterFactory;
+use Phalcon\Helper\Arr;
 
 /**
  * Phalcon\Session\Adapter\Redis
@@ -32,7 +33,7 @@ use Phalcon\Storage\AdapterFactory;
      */
     public function __construct(<AdapterFactory> factory, array! options = [])
     {
-        let options["prefix"] = "sess-reds-",
+        let options["prefix"] = Arr::get(options, "prefix", "sess-reds-"),
             this->adapter     = factory->newInstance("redis", options);
     }
 }

--- a/tests/integration/Session/Adapter/Libmemcached/ConstructCest.php
+++ b/tests/integration/Session/Adapter/Libmemcached/ConstructCest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Session\Adapter\Libmemcached;
 
 use IntegrationTester;
+use Phalcon\Session\Adapter\Libmemcached;
+use Phalcon\Storage\AdapterFactory;
+use Phalcon\Storage\SerializerFactory;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
-use Phalcon\Test\Fixtures\Traits\SessionTrait;
 use SessionHandlerInterface;
 
 class ConstructCest
@@ -37,6 +39,44 @@ class ConstructCest
         $I->assertInstanceOf(
             SessionHandlerInterface::class,
             $adapter
+        );
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Libmemcached :: __construct() - with custom prefix
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-10-23
+     */
+    public function sessionAdapterLibmemcachedConstructWithPrefix(IntegrationTester $I)
+    {
+        $I->wantToTest('Session\Adapter\Libmemcached - __construct() - with custom prefix');
+
+        $options           = getOptionsLibmemcached();
+        $options['prefix'] = 'my-custom-prefix-';
+
+        $serializerFactory = new SerializerFactory();
+        $factory           = new AdapterFactory($serializerFactory);
+
+        $memcachedSession = new Libmemcached($factory, $options);
+
+        $I->assertTrue(
+            $memcachedSession->write(
+                'my-session-prefixed-key',
+                'test-data'
+            )
+        );
+
+        $memcachedStorage = $factory->newInstance('libmemcached', $options);
+
+        $I->assertEquals(
+            'my-custom-prefix-',
+            $memcachedStorage->getPrefix()
+        );
+
+        $I->assertEquals(
+            'test-data',
+            $memcachedStorage->get('my-session-prefixed-key')
         );
     }
 }

--- a/tests/integration/Session/Adapter/Redis/ConstructCest.php
+++ b/tests/integration/Session/Adapter/Redis/ConstructCest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Phalcon\Test\Integration\Session\Adapter\Redis;
 
 use IntegrationTester;
+use Phalcon\Session\Adapter\Redis;
+use Phalcon\Storage\AdapterFactory;
+use Phalcon\Storage\SerializerFactory;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
-use Phalcon\Test\Fixtures\Traits\SessionTrait;
 use SessionHandlerInterface;
 
 class ConstructCest
@@ -37,6 +39,44 @@ class ConstructCest
         $I->assertInstanceOf(
             SessionHandlerInterface::class,
             $adapter
+        );
+    }
+
+    /**
+     * Tests Phalcon\Session\Adapter\Redis :: __construct() - with custom prefix
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2020-10-23
+     */
+    public function sessionAdapterRedisConstructWithPrefix(IntegrationTester $I)
+    {
+        $I->wantToTest('Session\Adapter\Redis - __construct() - with custom prefix');
+
+        $options           = getOptionsRedis();
+        $options['prefix'] = 'my-custom-prefix-';
+
+        $serializerFactory = new SerializerFactory();
+        $factory           = new AdapterFactory($serializerFactory);
+
+        $redisSession = new Redis($factory, $options);
+
+        $I->assertTrue(
+            $redisSession->write(
+                'my-session-prefixed-key',
+                'test-data'
+            )
+        );
+
+        $redisStorage = $factory->newInstance('redis', $options);
+
+        $I->assertEquals(
+            'my-custom-prefix-',
+            $redisStorage->getPrefix()
+        );
+
+        $I->assertEquals(
+            'test-data',
+            $redisStorage->get('my-session-prefixed-key')
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15184 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG

Small description of change:

Fixed `Phalcon\Session\Adapter\Redis` and `Phalcon\Session\Adapter\Libmemcached` to utilize the prefix option

Thanks,
zsilbi

