### PR TITLE
T15148 - Update properties of previously queried related records

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -216,7 +216,7 @@ jobs:
           DATA_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
           DATA_MEMCACHED_PORT: ${{ job.services.memcached.ports['11211'] }}
           DATA_MYSQL_USER: root
-        run: vendor/bin/codecept run --ext DotReporter database --env mysql -g mysql
+        run: vendor/bin/codecept run database --env mysql -g mysql
 
       - name: Run Database Tests (Sqlite)
         env:

--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -66,6 +66,7 @@ This component can be used to create SQL statements using a fluent interface. Op
 - Fixed `Phalcon\Mvc\Model` to skip columns with default values when the `DEFAULT` keyword is not supported by the database adapter (SQLite) [#15180](https://github.com/phalcon/cphalcon/issues/15180)
 - Fixed `Phalcon\Mvc\Router` to handle numeric routes properly [#14926](https://github.com/phalcon/cphalcon/issues/14926)
 - Fixed `Phalcon\Session\Adapter\Redis` and `Phalcon\Session\Adapter\Libmemcached` to utilize the prefix option [#15184](https://github.com/phalcon/cphalcon/issues/15184)
+- Fixed `Phalcon\Mvc\Model` to save the modified properties of previously queried single related records. [#15148](https://github.com/phalcon/cphalcon/issues/15148)
 
 ## Removed
 - Removed `Phalcon\Http\Cookie` binding to session [#11770](https://github.com/phalcon/cphalcon/issues/11770)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -976,8 +976,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      */
     protected function collectRelatedToSave() -> array
     {
-        var name, record, relatedToSave;
-        array related;
+        var name, record;
+        array related, dirtyRelated;
 
         /**
          * Load previously queried related records
@@ -987,10 +987,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         /**
          * Load unsaved related records
          */
-        let relatedToSave = this->dirtyRelated;
+        let dirtyRelated = this->dirtyRelated;
 
         for name, record in related {
-            if isset relatedToSave[name] {
+            if isset dirtyRelated[name] {
                 continue;
             }
 
@@ -998,10 +998,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 continue;
             }
 
-            let relatedToSave[name] = record;
+            let dirtyRelated[name] = record;
         }
 
-        return relatedToSave;
+        return dirtyRelated;
     }
 
     /**

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -974,9 +974,9 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @return array Related records that should be saved
      */
-    protected function collectRelatedForSave() -> array
+    protected function collectRelatedToSave() -> array
     {
-        var name, record, relatedForSave;
+        var name, record, relatedToSave;
         array related;
 
         /**
@@ -987,10 +987,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         /**
          * Load unsaved related records
          */
-        let relatedForSave = this->dirtyRelated;
+        let relatedToSave = this->dirtyRelated;
 
         for name, record in related {
-            if isset relatedForSave[name] {
+            if isset relatedToSave[name] {
                 continue;
             }
 
@@ -998,10 +998,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 continue;
             }
 
-            let relatedForSave[name] = record;
+            let relatedToSave[name] = record;
         }
 
-        return relatedForSave;
+        return relatedToSave;
     }
 
     /**
@@ -2407,8 +2407,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     public function save() -> bool
     {
         var metaData, schema, writeConnection, readConnection, source, table,
-            identityField, exists, success, relatedForSave;
-        bool hasRelatedForSave;
+            identityField, exists, success, relatedToSave;
+        bool hasRelatedToSave;
 
         let metaData = this->getModelsMetaData();
 
@@ -2427,15 +2427,15 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          * previously queried related records that
          * may have been modified
          */
-        let relatedForSave = this->collectRelatedForSave();
+        let relatedToSave = this->collectRelatedToSave();
 
         /**
          * Does it have unsaved related records
          */
-        let hasRelatedForSave = count(relatedForSave) > 0;
+        let hasRelatedToSave = count(relatedToSave) > 0;
 
-        if hasRelatedForSave {
-            if this->preSaveRelatedRecords(writeConnection, relatedForSave) === false {
+        if hasRelatedToSave {
+            if this->preSaveRelatedRecords(writeConnection, relatedToSave) === false {
                 return false;
             }
         }
@@ -2482,7 +2482,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             /**
              * Rollback the current transaction if there was validation errors
              */
-            if hasRelatedForSave {
+            if hasRelatedToSave {
                 writeConnection->rollback(false);
             }
 
@@ -2524,7 +2524,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let this->dirtyState = self::DIRTY_STATE_PERSISTENT;
         }
 
-        if hasRelatedForSave {
+        if hasRelatedToSave {
             /**
              * Rollbacks the implicit transaction if the master save has failed
              */
@@ -2536,7 +2536,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                  */
                 let success = this->postSaveRelatedRecords(
                     writeConnection,
-                    relatedForSave
+                    relatedToSave
                 );
             }
         }
@@ -2551,7 +2551,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         if success === false {
             this->cancelOperation();
         } else {
-            if hasRelatedForSave {
+            if hasRelatedToSave {
                 /**
                  * Clear unsaved related records storage
                  */

--- a/tests/database/Mvc/Model/SaveCest.php
+++ b/tests/database/Mvc/Model/SaveCest.php
@@ -218,11 +218,16 @@ class SaveCest
          */
         $invoice = Invoices::findFirst(77);
 
+        $I->assertEquals(
+            1,
+            $invoice->customer->id
+        );
+
         $invoice->customer->cst_name_first  = 'new_firstName';
         $invoice->customer->cst_status_flag = 0;
 
         $I->assertTrue(
-          $invoice->save()
+            $invoice->save()
         );
 
         /**

--- a/tests/database/Mvc/Model/SaveCest.php
+++ b/tests/database/Mvc/Model/SaveCest.php
@@ -187,6 +187,61 @@ class SaveCest
     }
 
     /**
+     * Tests Phalcon\Mvc\Model :: save() with related records property
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2020-10-31
+     *
+     * @see https://github.com/phalcon/cphalcon/issues/15148
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelSaveWithRelatedRecordsProperty(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - save() with related records property');
+
+        /** @var \PDO $connection */
+        $connection = $I->getConnection();
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->clear();
+        $invoicesMigration->insert(77, 1, 0, uniqid('inv-', true));
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->clear();
+        $customersMigration->insert(1, 1, 'test_firstName_1', 'test_lastName_1');
+
+        /**
+         * @var Invoices $invoice
+         */
+        $invoice = Invoices::findFirst(77);
+
+        $invoice->customer->cst_name_first  = 'new_firstName';
+        $invoice->customer->cst_status_flag = 0;
+
+        $I->assertTrue(
+          $invoice->save()
+        );
+
+        /**
+         * @var Customers $customer
+         */
+        $customer = Customers::findFirst(1);
+
+        $I->assertEquals(
+            'new_firstName',
+            $customer->cst_name_first
+        );
+
+        $I->assertEquals(
+            0,
+            $customer->cst_status_flag
+        );
+    }
+
+    /**
      * Tests Phalcon\Mvc\Model :: save() after fetching related records
      *
      * @see    https://github.com/phalcon/cphalcon/issues/13964
@@ -383,7 +438,7 @@ class SaveCest
         );
 
         // Assign relationship in both directions on unsaved models
-        $invoice->customer  = $customer;
+        $invoice->customer = $customer;
 
         $customer->invoices = [
             $invoice


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: closes #15148 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Fixed `Phalcon\Mvc\Model` to save the modified properties of previously queried single related records.
Added new method `Model::collectRelatedToSave()`

Thanks,
zsilbi

