### PR TITLE
Fix related records auto-save with belongsTo() relation

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1,4 +1,3 @@
-
 /**
  * This file is part of the Phalcon Framework.
  *
@@ -1006,6 +1005,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 continue;
             }
 
+            record->setDirtyState(self::DIRTY_STATE_TRANSIENT);
             let dirtyRelated[name] = record;
         }
 
@@ -4727,7 +4727,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     protected function preSaveRelatedRecords(<AdapterInterface> connection, related) -> bool
     {
         var className, manager, type, relation, columns, referencedFields,
-            referencedModel, message, nesting, name, record;
+            message, nesting, name, record;
 
         let nesting = false;
 
@@ -4767,7 +4767,6 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     }
 
                     let columns = relation->getFields(),
-                        referencedModel = relation->getReferencedModel(),
                         referencedFields = relation->getReferencedFields();
 
                     if unlikely typeof columns == "array" {

--- a/tests/database/Mvc/Model/SaveCest.php
+++ b/tests/database/Mvc/Model/SaveCest.php
@@ -300,6 +300,66 @@ class SaveCest
     }
 
     /**
+     * Tests Phalcon\Mvc\Model :: save() with related records property (relation many - belongs)
+     *
+     * @author Balázs Németh <https://github.com/zsilbi>
+     * @since  2020-11-04
+     *
+     * @see https://github.com/phalcon/cphalcon/issues/15148
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelSaveWithRelatedManyAndBelongsRecordsProperty(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - save() with related records property (relation many - belongs)');
+
+        /** @var \PDO $connection */
+        $connection = $I->getConnection();
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->clear();
+        $invoicesMigration->insert(77, 1, 0, uniqid('inv-', true));
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->clear();
+        $customersMigration->insert(1, 1, 'test_firstName_1', 'test_lastName_1');
+
+        /**
+         * @var Invoices $invoice
+         */
+        $invoice = InvoicesKeepSnapshots::findFirst(77);
+
+        $I->assertEquals(
+            1,
+            $invoice->customer->id
+        );
+
+        $invoice->customer->cst_name_first  = 'new_firstName';
+        $invoice->customer->cst_status_flag = 0;
+
+        $I->assertTrue(
+            $invoice->save()
+        );
+
+        /**
+         * @var Customers $customer
+         */
+        $customer = Customers::findFirst(1);
+
+        $I->assertEquals(
+            'new_firstName',
+            $customer->cst_name_first
+        );
+
+        $I->assertEquals(
+            0,
+            $customer->cst_status_flag
+        );
+    }
+
+    /**
      * Tests Phalcon\Mvc\Model :: save() after using related records getters
      *
      * @see    https://github.com/phalcon/cphalcon/issues/13964


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15148

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change: 

Models: with a relation `belongsTo()` - `hasMany()`, the related records need to be saved in `preSaveRelatedRecords()`. This fix update the dirtyState of related records to trigger related records save.