### PR TITLE
Fix max allowed version

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -118,7 +118,7 @@
     <required>
       <php>
         <min>7.2.0</min>
-        <max>8.0.0</max>
+        <max>7.4.99</max>
       </php>
       <pearinstaller>
         <min>1.4.0</min>


### PR DESCRIPTION
To not allow 8.0.0 (and all beta/RC), as "max" is allowed

