### PR TITLE
Correct type hinting in ValidationInterface

### DIFF
--- a/phalcon/Validation/ValidationInterface.zep
+++ b/phalcon/Validation/ValidationInterface.zep
@@ -21,8 +21,10 @@ interface ValidationInterface
 {
     /**
      * Adds a validator to a field
+     *
+     * @param string|array field
      */
-    public function add(string field, <ValidatorInterface> validator) -> <ValidationInterface>;
+    public function add(var field, <ValidatorInterface> validator) -> <ValidationInterface>;
 
     /**
      * Appends a message to the messages list


### PR DESCRIPTION
Hello!

* Type: bug | code quality | documentation
* Link to issue: #14946

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] ~~I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change~~ _The documentation [already](https://github.com/phalcon/docs/blob/4.0/en/validation.md#methods) presents it as a mixed type_

Small description of change:

The first argument of `add` in the `ValidationInterface` can also be an array, not just a string.

https://github.com/phalcon/cphalcon/blob/3241d96e4bb01dc7746b74c9ce586250b8887c46/phalcon/Validation.zep#L67-L89

Thanks,
Robin van der Vliet