### PR TITLE
T15270 crypt exception with gcm

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -2,7 +2,7 @@
 
 ## Fixed
 - Fixed `Logger\Log::log()` `log` to recognize all log levels [#15214](https://github.com/phalcon/cphalcon/issues/15214)
-
+- Fixed `Crypt::encrypt()` to throw an exception when `ccm` or `gcm` modes are selected and no `authData` is present [#15270](https://github.com/phalcon/cphalcon/issues/15270)
 
 # [4.1.0](https://github.com/phalcon/cphalcon/releases/tag/v4.1.0) (2020-10-31)
 ## Added

--- a/phalcon/Crypt.zep
+++ b/phalcon/Crypt.zep
@@ -304,7 +304,11 @@ class Crypt implements CryptInterface
          * If the mode is "gcm" or "ccm" and auth data has been passed call it
          * with that data
          */
-        if ("-gcm" === mode || "-ccm" === mode) && !empty this->authData {
+        if ("-gcm" === mode || "-ccm" === mode) {
+            if empty this->authData {
+                throw new Exception("A tag must be provided when using AEAD mode");
+            }
+
             let authData      = this->authData,
                 authTag       = this->authTag,
                 authTagLength = this->authTagLength;

--- a/tests/unit/Crypt/EncryptCest.php
+++ b/tests/unit/Crypt/EncryptCest.php
@@ -113,11 +113,50 @@ class EncryptCest
      */
     public function cryptEncryptGcm(UnitTester $I)
     {
-        $I->wantToTest('Crypt - encrypt()');
+        $I->wantToTest('Crypt - encrypt() gcm/ccm');
 
         $ciphers = [
             'aes-128-gcm',
             'aes-128-ccm',
+            'aes-256-gcm',
+            'aes-256-ccm',
+        ];
+
+        foreach ($ciphers as $cipher) {
+            $I->expectThrowable(
+                new Exception(
+                    'A tag must be provided when using AEAD mode'
+                ),
+                function () use ($cipher) {
+                    $crypt = new Crypt();
+
+                    $crypt
+                        ->setCipher($cipher)
+                        ->setKey('123456')
+                        ->useSigning(false)
+                    ;
+
+                    $encryption = $crypt->encrypt('phalcon');
+                }
+            );
+        }
+    }
+
+    /**
+     * Tests Phalcon\Crypt :: encrypt() - gcm
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-05-15
+     */
+    public function cryptEncryptGcmWithData(UnitTester $I)
+    {
+        $I->wantToTest('Crypt - encrypt() gcm with data');
+
+        $ciphers = [
+            'aes-128-gcm',
+            'aes-128-ccm',
+            'aes-256-gcm',
+            'aes-256-ccm',
         ];
 
         $crypt = new Crypt();


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15270 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added exception when no authData is present and gcm/ccm modes are selected

Thanks

