### PR TITLE
T15292 nfr add set icon css classes method for flash messages

### DIFF
--- a/.github/issue_template/bug_report.md
+++ b/.github/issue_template/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Questions? Forum: https://phalcon.link/forum or Discord: https://phalcon.link/discord
+Questions? Forum: https://phalcon.io/forum or Discord: https://phalcon.io/discord
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/BACKERS.md
+++ b/BACKERS.md
@@ -1,6 +1,6 @@
 ## Our Backers and supporters
 
-You can join them in supporting Phalcon and Zephir development by visiting our page on [Open Collective](https://opencollective.com/phalcon) or [Github sponsor](https://phalcon.link/fund) and becoming a sponsor or a backer!
+You can join them in supporting Phalcon and Zephir development by visiting our page on [Open Collective](https://opencollective.com/phalcon) or [Github sponsor](https://phalcon.io/fund) and becoming a sponsor or a backer!
 
 ### Supporters
 
@@ -52,7 +52,7 @@ You can join them in supporting Phalcon and Zephir development by visiting our p
     </tr>
     <tr>
     <td align="center" valign="bottom">   
-      <a href="https://phalcon.link/fund">
+      <a href="https://phalcon.io/fund">
        Support Us
       </a>
     </td>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -19,7 +19,7 @@ disagree.
 ## Conflict
 
 If ever conflict arises, please bring it to the attention of the maintainers 
-privately. You can always find us on our [Discord](https://phalcon.link/discord) 
+privately. You can always find us on our [Discord](https://phalcon.io/discord) 
 server or you can send us an email at team@phalcon.io 
 
 The core team maintains the final decision on any conflict that may arise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,19 +13,19 @@ follow this format, even those from core contributors.
 
 We use the GitHub issues for tracking bugs and feature requests and have limited bandwidth to address all of them. Thus we only accept bug reports, new feature requests and pull requests in GitHub. Our great community and contributors are happy to help you though! Please use these community resources for obtaining help.
 
-_Please use the [Documentation](https://phalcon.link/docs) before anything else. You can also use the search feature in our documents to find what you are looking for. If your question is still not answered, there are more options below._
+_Please use the [Documentation](https://phalcon.io/docs) before anything else. You can also use the search feature in our documents to find what you are looking for. If your question is still not answered, there are more options below._
 
-* Questions should go to [Official Forums](https://phalcon.link/forum)
+* Questions should go to [Official Forums](https://phalcon.io/forum)
 * Another way is to ask a question on [Stack Overflow](https://stackoverflow.com/) and tag it with
   [`phalcon`](https://stackoverflow.com/questions/tagged/phalcon)
-* Come join the Phalcon [Discord](https://phalcon.link/discord)
+* Come join the Phalcon [Discord](https://phalcon.io/discord)
 * Our social network accounts are:
-  * [Telegram](https://phalcon.link/telegram)
-  * [Parler](https://phalcon.link/parler)
-  * [Gab](https://phalcon.link/gab)
-  * [MeWe](https://phalcon.link/mewe)
-  * [Twitter](https://phalcon.link/t)
-  * [Facebook](https://phalcon.link/fb)
+  * [Telegram](https://phalcon.io/telegram)
+  * [Parler](https://phalcon.io/parler)
+  * [Gab](https://phalcon.io/gab)
+  * [MeWe](https://phalcon.io/mewe)
+  * [Twitter](https://phalcon.io/t)
+  * [Facebook](https://phalcon.io/fb)
 * If you still believe that what you found is a bug, please
   [open an issue](https://github.com/phalcon/cphalcon/issues/new)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Phalcon Framework
 
-[![Discord](https://img.shields.io/discord/310910488152375297?label=Discord&logo=discord&style=flat-square)](http://phalcon.link/discord)
+[![Discord](https://img.shields.io/discord/310910488152375297?label=Discord&logo=discord&style=flat-square)](http://phalcon.io/discord)
 [![Build Status](https://img.shields.io/travis/phalcon/cphalcon?logo=travis&style=flat-square)](https://travis-ci.org/phalcon/cphalcon)
 [![Windows Build](https://github.com/phalcon/cphalcon/workflows/Phalcon%20CI/badge.svg?branch=4.1.x)](https://github.com/phalcon/cphalcon/actions)
 [![Code Coverage](https://github.com/phalcon/cphalcon/workflows/Codecoverage/badge.svg?branch=4.1.x)](https://github.com/phalcon/cphalcon/actions)
@@ -46,20 +46,20 @@ Steps:
 * [Contributing to Phalcon](CONTRIBUTING.md) 
 * [Official Documentation](https://docs.phalcon.io/)
 * [Zephir](https://zephir-lang.com/) - The language Phalcon is written on
-* [Incubator](https://phalcon.link/incubator) - Community driven plugins and classes extending the framework (written in PHP)
+* [Incubator](https://phalcon.io/incubator) - Community driven plugins and classes extending the framework (written in PHP)
 
 ### Support
-* [Forum](https://phalcon.link/forum)
-* [Discord](https://phalcon.link/discord)
-* [Stack Overflow](https://phalcon.link/so)
+* [Forum](https://phalcon.io/forum)
+* [Discord](https://phalcon.io/discord)
+* [Stack Overflow](https://phalcon.io/so)
 
 ### Social Media
-* [Telegram](https://phalcon.link/telegram)
-* [Gab](https://phalcon.link/gab)
-* [Parler](https://phalcon.link/parler)
-* [MeWe](https://phalcon.link/mewe)
-* [Facebook](https://phalcon.link/fb)
-* [Twitter](https://phalcon.link/t)
+* [Telegram](https://phalcon.io/telegram)
+* [Gab](https://phalcon.io/gab)
+* [Parler](https://phalcon.io/parler)
+* [MeWe](https://phalcon.io/mewe)
+* [Facebook](https://phalcon.io/fb)
+* [Twitter](https://phalcon.io/t)
 
 
 ## Sponsors

--- a/build/README.md
+++ b/build/README.md
@@ -47,7 +47,7 @@ After running `gen-build.php` you are ready to build Phalcon extension.
 
 ## Building extension for Linux
 
-Please, refer to [Phalcon documentation](https://phalcon.link/docs)
+Please, refer to [Phalcon documentation](https://phalcon.io/docs)
 
 
 ## Building extension for Windows

--- a/composer.json
+++ b/composer.json
@@ -102,9 +102,9 @@
   "support": {
     "email": "support@phalcon.io",
     "issues": "https://github.com/phalcon/cphalcon/issues",
-    "forum": "https://phalcon.link/forum/",
+    "forum": "https://phalcon.io/forum/",
     "source": "https://github.com/phalcon/cphalcon",
-    "docs": "https://phalcon.link/docs/",
+    "docs": "https://phalcon.io/docs/",
     "rss": "https://blog.phalcon.io/rss"
   }
 }

--- a/package.xml
+++ b/package.xml
@@ -118,7 +118,7 @@
     <required>
       <php>
         <min>7.2.0</min>
-        <max>8.0.0</max>
+        <max>7.4.99</max>
       </php>
       <pearinstaller>
         <min>1.4.0</min>

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -43,6 +43,11 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     protected cssClasses = [] { get };
 
     /**
+     * @var array
+     */
+    protected iconCssClasses = [] { get };
+
+    /**
      * @var string
      */
     protected customTemplate = "" { get };
@@ -172,6 +177,16 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     public function setCssClasses(array! cssClasses) -> <FlashInterface>
     {
         let this->cssClasses = cssClasses;
+
+        return this;
+    }
+
+    /**
+     * Set an array with CSS classes to format the messages
+     */
+    public function setIconCssClasses(array! iconCssClasses) -> <FlashInterface>
+    {
+        let this->iconCssClasses  = iconCssClasses;
 
         return this;
     }
@@ -315,13 +330,17 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     }
 
 
-    private function getTemplate(string cssClassses) -> string
+    private function getTemplate(string cssClassses, string iconCssClassses) -> string
     {
         if "" === this->customTemplate {
-            if "" === cssClassses {
+            if "" === cssClassses && "" === iconCssClassses {
                 return "<div>%message%</div>" . PHP_EOL;
             } else {
-                return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+                if !empty iconCssClassses {
+                    return "<div class=\"%cssClass%\"><i class=\"%iconCssClass%\"></i> %message%</div>" . PHP_EOL;
+                } else {
+                    return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+                }
             }
         }
 
@@ -353,7 +372,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      */
     private function prepareHtmlMessage(string type, string message) -> string
     {
-        var classes, cssClasses, typeClasses, automaticHtml;
+        var classes, cssClasses, iconCssClasses, typeClasses, typeIconClasses, automaticHtml;
 
         let automaticHtml = (bool) this->automaticHtml;
 
@@ -361,7 +380,10 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
             return message;
         }
 
+
         let classes = this->cssClasses;
+        let iconClasses = this->iconCssClasses;
+
 
         if fetch typeClasses, classes[type] {
             if typeof typeClasses == "array" {
@@ -373,16 +395,29 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
             let cssClasses = "";
         }
 
+        if fetch typeIconClasses, iconClasses[type] {
+            if typeof typeIconClasses == "array" {
+                let iconCssClasses = join(" ", typeIconClasses);
+            } else {
+                let iconCssClasses = typeIconClasses;
+            }
+        } else {
+            let iconCssClasses = "";
+        }
+
+
         return str_replace(
             [
                 "%cssClass%",
+                "%iconCssClass%",
                 "%message%"
             ],
             [
                 cssClasses,
+                iconCssClasses,
                 message
             ],
-            this->getTemplate(cssClasses)
+            this->getTemplate(cssClasses, iconCssClasses)
         );
     }
 }

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -182,7 +182,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     }
 
     /**
-     * Set an array with CSS classes to format the messages
+     * Set an array with CSS classes to format the icon messages
      */
     public function setIconCssClasses(array! iconCssClasses) -> <FlashInterface>
     {

--- a/resources/CHANGELOG-4.1.md
+++ b/resources/CHANGELOG-4.1.md
@@ -37,7 +37,7 @@
 
 ## Changed
 - Added service checks for the session. Now cookies will be saved in the session only when the `session` service is defined [#11770](https://github.com/phalcon/cphalcon/issues/11770), [#14649](https://github.com/phalcon/cphalcon/pull/14649)
-- Changed `Phalcon\Db\Adapter\*::getRawSQLStatement()` to return the full SQL query with parameters [#12196](https://github.com/phalcon/cphalcon/issues/12196)
+- Changed `Phalcon\Db\Adapter\*::getRealSQLStatement()` to return the full SQL query with parameters [#12196](https://github.com/phalcon/cphalcon/issues/12196)
 - Changed `Phalcon\Filter::sanitize` to throw a `E_USER_NOTICE` when a filter does not exist. [#14679](https://github.com/phalcon/cphalcon/issues/14679)
 - PHQL now supports the use of any printable characters from the extended ASCII
   table for escaped identifiers. The exception characters are `[` and `]`. To


### PR DESCRIPTION
Hello!

[NFR] add setIconCssClasses() method for flash messages

```php
$flash->setIconCssClasses([
        'error'   => 'fas fa-exclamation-triangle',
        'success' => 'fas fa-check-circle',
        'notice'  => 'fas fa-info-circle',
        'warning' => 'fas fa-exclamation-triangle'
]);

```

Full example

```php

<?php

use Phalcon\Escaper;
use Phalcon\Flash\Direct;


$escaper = new Escaper();
$flash   = new Direct($escaper);

$customTemplate = '<div class="%cssClass%">
                       <i class="%iconCssClass%"></i>
                       %message%
                       <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                   </div>';



$flash->setCustomTemplate($customTemplate);
$flash->setCssClasses([
        'error'   => 'alert alert-danger alert-dismissible',
        'success' => 'alert alert-success alert-dismissible',
        'notice'  => 'alert alert-info alert-dismissible',
        'warning' => 'alert alert-warning alert-dismissible'
]);
$flash->setIconCssClasses([
        'error'   => 'fas fa-exclamation-triangle',
        'success' => 'fas fa-check-circle',
        'notice'  => 'fas fa-info-circle',
        'warning' => 'fas fa-exclamation-triangle'
]);


$flash->error('Something went wrong');

```

Thanks

