### PR TITLE
Update Session/Manager to validate session IDs before starting session

### DIFF
--- a/phalcon/Session/Manager.zep
+++ b/phalcon/Session/Manager.zep
@@ -151,7 +151,7 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
      */
     public function getName() -> string
     {
-        if "" !== this->name {
+        if "" === this->name {
             let this->name = session_name();
         }
 
@@ -305,6 +305,10 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
      */
     public function start() -> bool
     {
+        var name, value;
+
+        let name = this->getName();
+
         /**
          * Check if the session exists
          */
@@ -321,6 +325,16 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
 
         if unlikely !(this->adapter instanceof SessionHandlerInterface) {
             throw new Exception("The session adapter is not valid");
+        }
+
+        /**
+         * Verify that the session value is alphanumeric, otherwise we
+         * unset the cookie to allow it to be created by session_start().
+         */
+        if fetch value, _COOKIE[name] {
+            if !ctype_alnum(value) {
+                unset _COOKIE[name];
+            }
         }
 
         /**
@@ -363,10 +377,10 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
 
         let uniqueId = this->uniqueId;
 
-		if !empty uniqueId {
-			return this->uniqueId . "#" . key;
-		} else {
-			return key;
-		}
+        if !empty uniqueId {
+            return this->uniqueId . "#" . key;
+        } else {
+            return key;
+        }
     }
 }

--- a/phalcon/Session/Manager.zep
+++ b/phalcon/Session/Manager.zep
@@ -332,7 +332,7 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
          * unset the cookie to allow it to be created by session_start().
          */
         if fetch value, _COOKIE[name] {
-            if !ctype_alnum(value) {
+            if !preg_match("/^[a-z0-9]+$/iD", value) {
                 unset _COOKIE[name];
             }
         }

--- a/tests/unit/Session/ManagerCest.php
+++ b/tests/unit/Session/ManagerCest.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Session;
 
+use Codeception\Example;
 use Phalcon\Session\Adapter\Noop;
 use Phalcon\Session\Manager;
 use UnitTester;
 
+use function session_abort;
 use function session_destroy;
 use function session_status;
+use function session_name;
 
 class ManagerCest
 {
@@ -47,6 +50,46 @@ class ManagerCest
 
         $I->assertTrue(
             $session->start()
+        );
+    }
+
+    /**
+     * Tests Phalcon\Session\Manager :: start()
+     * Tests to ensure that the session value is alpha numeric and won't
+     * cause undefined behaviour when saving or reading sessions.
+     *
+     * @example {"session": "valid", "expected": true}
+     * @example {"session": "./invalid", "expected": false}
+     *
+     * @since 2021-02-02
+     */
+    public function validateSessionValue(UnitTester $I, Example $example)
+    {
+        $name = session_name();
+        $I->wantToTest('Manager - start() on CLI mode w/o session_start');
+
+        if (PHP_SESSION_ACTIVE === session_status()) {
+            // Please note: further tests may need $_SESSION variable
+            @session_destroy();
+            @session_abort();
+            unset($_SESSION);
+        }
+
+        // Create fake session cookie
+        $_COOKIE[$name] = $example["session"];
+
+        // Start Session
+        $session = new Manager();
+        $session->setAdapter(
+            new Noop()
+        );
+
+        $session->start();
+
+        // Check if session value has been sanitized
+        $I->assertEquals(
+            $example["expected"],
+            isset($_COOKIE[$name])
         );
     }
 }


### PR DESCRIPTION
Here's a patch to validate session IDs before opening the PHP session. Before this patch, sessions with invalid characters could be created and used.

This patch ensures that sessions IDs are alphanumeric. When a session ID doesn't match that criteria, it's unset and then the function `session_start()` will generate a new ID for the session.

**Concerns:**
This patch could possibly break user implemented Session Adapters if they implemented the method `create_sid()` from `SessionIdInterface`. This would happen if their code were to generate an ID that is not alphanumeric.

**Other Changes:**
I changed the method `getName()` in `Session\Manager` as it wouldn't get the session name unless you had previously set a session name in the manager.

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

