### PR TITLE
T15240 igbinary serialize numbers

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,3 +2,4 @@
 
 ## Fixed
 - Fixed `Phalcon\Mvc\Model::average()` to return `float` value when is `string` [#15287](https://github.com/phalcon/cphalcon/pull/15287)
+- Fixed `Phalcon\Storage\Serializer\Igbinary` to store `is_numeric` and `bool` values properly [#15240](https://github.com/phalcon/cphalcon/pull/15240)

--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
   </stability>
   <license uri="https://license.phalcon.io">BSD 3-Clause License</license>
   <notes>
-    Full changelog can be found at: https://github.com/phalcon/cphalcon/blob/master/CHANGELOG-4.1.md
+    Full changelog can be found at: https://github.com/phalcon/cphalcon/blob/master/CHANGELOG-5.0.md
 
     # [4.1.0](https://github.com/phalcon/cphalcon/releases/tag/v4.1.0) (2020-10-31)
     ## Added
@@ -109,7 +109,7 @@
       <file name="php_phalcon.h" role="src" />
       <file name="phalcon.zep.h" role="src" />
       <file name="LICENSE.txt" role="doc" />
-      <file name="CHANGELOG-4.1.md" role="doc" />
+      <file name="CHANGELOG-5.0.md" role="doc" />
       <file name="CODE_OF_CONDUCT.md" role="doc" />
       <file name="CODE_OWNERS.TXT" role="doc" />
     </dir>

--- a/phalcon/Storage/Serializer/Igbinary.zep
+++ b/phalcon/Storage/Serializer/Igbinary.zep
@@ -17,11 +17,6 @@ class Igbinary extends AbstractSerializer
 	 */
 	public function serialize() -> string
 	{
-        //if !this->isSerializable(this->data) {
-        if empty this->data || typeof this->data === "bool" {
-            return this->data;
-        }
-
 		return igbinary_serialize(this->data);
 	}
 

--- a/phalcon/Storage/Serializer/Igbinary.zep
+++ b/phalcon/Storage/Serializer/Igbinary.zep
@@ -17,7 +17,8 @@ class Igbinary extends AbstractSerializer
 	 */
 	public function serialize() -> string
 	{
-        if !this->isSerializable(this->data) {
+        //if !this->isSerializable(this->data) {
+        if empty this->data || typeof this->data === "bool" {
             return this->data;
         }
 

--- a/tests/database/Mvc/Model/Behavior/SoftDeleteCest.php
+++ b/tests/database/Mvc/Model/Behavior/SoftDeleteCest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Test\Database\Mvc\Model;
+namespace Phalcon\Test\Database\Mvc\Model\Behavior;
 
 use DatabaseTester;
 use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;

--- a/tests/database/Mvc/Model/Behavior/TimestampableCest.php
+++ b/tests/database/Mvc/Model/Behavior/TimestampableCest.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Test\Database\Mvc\Model;
+namespace Phalcon\Test\Database\Mvc\Model\Behavior;
 
 use DatabaseTester;
 use Phalcon\Test\Fixtures\Migrations\InvoicesMigration;

--- a/tests/integration/Storage/Serializer/Igbinary/SerializeCest.php
+++ b/tests/integration/Storage/Serializer/Igbinary/SerializeCest.php
@@ -52,17 +52,17 @@ class SerializeCest
             [
                 'label'    => 'null',
                 'value'    => null,
-                'expected' => null,
+                'expected' => igbinary_serialize(null),
             ],
             [
                 'label'    => 'true',
                 'value'    => true,
-                'expected' => true,
+                'expected' => igbinary_serialize(true),
             ],
             [
                 'label'    => 'false',
                 'value'    => false,
-                'expected' => false,
+                'expected' => igbinary_serialize(false),
             ],
             [
                 'label'    => 'integer',

--- a/tests/integration/Storage/Serializer/Igbinary/SerializeCest.php
+++ b/tests/integration/Storage/Serializer/Igbinary/SerializeCest.php
@@ -32,11 +32,13 @@ class SerializeCest
      */
     public function storageSerializerIgbinarySerialize(IntegrationTester $I, Example $example)
     {
-        $I->wantToTest('Storage\Serializer\Igbinary - serialize() - ' . $example[0]);
+        $I->wantToTest(
+            'Storage\Serializer\Igbinary - serialize() - ' . $example['label']
+        );
 
-        $serializer = new Igbinary($example[1]);
+        $serializer = new Igbinary($example['value']);
 
-        $expected = $example[2];
+        $expected = $example['expected'];
 
         $I->assertEquals(
             $expected,
@@ -48,44 +50,44 @@ class SerializeCest
     {
         return [
             [
-                'null',
-                null,
-                null,
+                'label'    => 'null',
+                'value'    => null,
+                'expected' => null,
             ],
             [
-                'true',
-                true,
-                true,
+                'label'    => 'true',
+                'value'    => true,
+                'expected' => true,
             ],
             [
-                'false',
-                false,
-                false,
+                'label'    => 'false',
+                'value'    => false,
+                'expected' => false,
             ],
             [
-                'integer',
-                1234,
-                1234,
+                'label'    => 'integer',
+                'value'    => 1234,
+                'expected' => igbinary_serialize(1234),
             ],
             [
-                'float',
-                1.234,
-                1.234,
+                'label'    => 'float',
+                'value'    => 1.234,
+                'expected' => igbinary_serialize(1.234),
             ],
             [
-                'string',
-                'Phalcon Framework',
-                igbinary_serialize('Phalcon Framework'),
+                'label'    => 'string',
+                'value'    => 'Phalcon Framework',
+                'expected' => igbinary_serialize('Phalcon Framework'),
             ],
             [
-                'array',
-                ['Phalcon Framework'],
-                igbinary_serialize(['Phalcon Framework']),
+                'label'    => 'array',
+                'value'    => ['Phalcon Framework'],
+                'expected' => igbinary_serialize(['Phalcon Framework']),
             ],
             [
-                'object',
-                new stdClass(),
-                igbinary_serialize(new stdClass()),
+                'label'    => 'object',
+                'value'    => new stdClass(),
+                'expected' => igbinary_serialize(new stdClass()),
             ],
         ];
     }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: Fixes #15240 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Corrected igbinary serailzer to handle `is_numeric` and `bool` values properly

