### PR TITLE
fix #15252 - compare 000012345 and 12345

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,3 +3,4 @@
 ## Fixed
 - Fixed `Phalcon\Mvc\Model::average()` to return `float` value when is `string` [#15287](https://github.com/phalcon/cphalcon/pull/15287)
 - Fixed `Phalcon\Storage\Serializer\Igbinary` to store `is_numeric` and `bool` values properly [#15240](https://github.com/phalcon/cphalcon/pull/15240)
+- Fixed `Phalcon\Validation\Validator\Confirmation` was failing to compare cases such as 000123 = 123 [#15347](https://github.com/phalcon/cphalcon/pull/15347)

--- a/phalcon/Validation/Validator/Confirmation.zep
+++ b/phalcon/Validation/Validator/Confirmation.zep
@@ -133,6 +133,6 @@ class Confirmation extends AbstractValidator
             let b = mb_strtolower(b, "utf-8");
         }
 
-        return a == b;
+        return strcmp($a, $b) === 0;
     }
 }

--- a/tests/integration/Validation/Validator/Confirmation/ValidateCest.php
+++ b/tests/integration/Validation/Validator/Confirmation/ValidateCest.php
@@ -24,12 +24,15 @@ use Phalcon\Validation\Validator\Confirmation;
  */
 class ValidateCest
 {
+
     /**
      * Tests Phalcon\Validation\Validator\Confirmation :: validate() - single
      * field
      *
-     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @param IntegrationTester $I
+     *
      * @since  2016-06-05
+     * @author Wojciech Ślawski <jurigag@gmail.com>
      */
     public function validationValidatorConfirmationValidateSingleField(IntegrationTester $I)
     {
@@ -73,14 +76,44 @@ class ValidateCest
             1,
             $messages->count()
         );
+
+
+        // https://github.com/phalcon/cphalcon/issues/15252
+        $messages = $validation->validate(
+            [
+                'name'     => '000012345',
+                'nameWith' => '12345',
+            ]
+        );
+
+        $I->assertEquals(
+            1,
+            $messages->count(),
+            "Phalcon\Validation\Validator\Confirmation failed to compare 000012345=12345"
+        );
+
+        $messages = $validation->validate(
+            [
+                'name'     => 'asd',
+                'nameWith' => 'asdß',
+            ]
+        );
+
+        $I->assertEquals(
+            1,
+            $messages->count(),
+            "Phalcon\Validation\Validator\Confirmation failed to compare asd=asdß"
+        );
     }
 
     /**
      * Tests Phalcon\Validation\Validator\Confirmation :: validate() - multiple
      * field
      *
-     * @author Wojciech Ślawski <jurigag@gmail.com>
+     * @param IntegrationTester $I
+     *
      * @since  2016-06-05
+     * @author Wojciech Ślawski <jurigag@gmail.com>
      */
     public function validationValidatorConfirmationValidateMultipleField(IntegrationTester $I)
     {
@@ -173,8 +206,10 @@ class ValidateCest
      * Tests Phalcon\Validation\Validator\Confirmation :: validate() - empty
      * value
      *
-     * @author Stanislav Kiryukhin <korsar.zn@gmail.com>
+     * @param IntegrationTester $I
+     *
      * @since  2015-09-06
+     * @author Stanislav Kiryukhin <korsar.zn@gmail.com>
      */
     public function validationValidatorConfirmationValidateEmptyValues(IntegrationTester $I)
     {


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15252

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

changed how we compare strings in Confirmation validator

Thanks

