### PR TITLE
fixing Flash\Session::has() returning always true

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -7,3 +7,4 @@
 - Fixed `Phalcon\Storage\Adapter` failing to retrieve empty like stored data (such as [], 0, false) [15125](https://github.com/phalcon/cphalcon/issues/15125) 
 - Fixed declarations for `function getEventsManager()` to allow null return [15010](https://github.com/phalcon/cphalcon/issues/15010)
 - Removed underscore from method names (starting) to abide with PSR-12 [15345](https://github.com/phalcon/cphalcon/issues/15345)
+- Fixed `Phalcon\Flash\Session::has()` to properly check if any messages are existing [15204](https://github.com/phalcon/cphalcon/issues/15204)

--- a/phalcon/Flash/Session.zep
+++ b/phalcon/Flash/Session.zep
@@ -31,26 +31,35 @@ class Session extends AbstractFlash
 
     /**
      * Returns the messages in the session flasher
+     *
+     * @param string|null $type
+     * @param bool $remove
+     *
+     * @return array
      */
-    public function getMessages(type = null, bool remove = true) -> array
+    public function getMessages(var type = null, bool remove = true) -> array
     {
         return this->getSessionMessages(remove, type);
     }
 
     /**
      * Checks whether there are messages
+     *
+     * @param string|null $type
+     *
+     * @return bool
      */
-    public function has(type = null) -> bool
+    public function has(var type = null) -> bool
     {
         var messages;
 
         let messages = this->getSessionMessages(false);
 
-        if typeof type != "string" {
-            return true;
+        if typeof type == "string" {
+            return isset messages[type];
         }
 
-        return isset messages[type];
+        return count(messages) > 0;
     }
 
     /**
@@ -58,7 +67,7 @@ class Session extends AbstractFlash
      *
      * @return null|string|void
      */
-    public function message(string type, string message) -> string | null
+    public function message(var type, string message) -> string | null
     {
         var messages;
 
@@ -93,8 +102,13 @@ class Session extends AbstractFlash
 
     /**
      * Returns the messages stored in session
+     *
+     * @param bool        $remove
+     * @param string|null $type
+     *
+     * @return array
      */
-    protected function getSessionMessages(bool remove, type = null) -> array
+    protected function getSessionMessages(bool remove, var type = null) -> array
     {
         var session, messages, returnMessages;
 

--- a/tests/unit/Flash/Session/HasCest.php
+++ b/tests/unit/Flash/Session/HasCest.php
@@ -13,20 +13,78 @@ declare(strict_types=1);
 
 namespace Phalcon\Test\Unit\Flash\Session;
 
+use Phalcon\Flash\Session;
+use Phalcon\Storage\Exception;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
 use UnitTester;
 
 class HasCest
 {
+
+    use DiTrait;
+
+    public function _before(UnitTester $I): void
+    {
+        $this->newDi();
+
+        try {
+            $this->setDiService('escaper');
+            $this->setDiService('sessionStream');
+        } catch (Exception $e) {
+            $I->fail($e->getMessage());
+        }
+
+        if (PHP_SESSION_ACTIVE !== session_status()) {
+            session_start();
+        }
+
+        if (!isset($_SESSION)) {
+            $_SESSION = [];
+        }
+    }
+
+    /**
+     * Executed after each test
+     *
+     * @param  UnitTester $I
+     * @return void
+     */
+    public function _after(UnitTester $I): void
+    {
+        session_destroy();
+    }
+
+    /**
+     * Return flash instance
+     */
+    protected function getFlash(): Session
+    {
+        $container = $this->getDi();
+
+        $flash = new Session();
+        $flash->setDI($container);
+
+        return $flash;
+    }
+
     /**
      * Tests Phalcon\Flash\Session :: has()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
+     * @since  2021-03-30
      */
     public function flashSessionHas(UnitTester $I)
     {
-        $I->wantToTest('Flash\Session - has()');
+        $flash = $this->getFlash();
 
-        $I->skipTest('Need implementation');
+        $I->assertFalse($flash->has());
+
+        $flash->success("test success");
+
+        $I->assertTrue($flash->has());
+
+        $I->assertFalse($flash->has("error"));
+
+        $I->assertTrue($flash->has("success"));
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/cphalcon/issues/15204

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

I am basically reverting the changes on Flash\Session::has() from this PR https://github.com/phalcon/cphalcon/pull/13994/files

I don't agree with the way funtion is changed, feels like just a bug

Thanks

