### PR TITLE
T15241 - db persistent flag

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -8,6 +8,7 @@
 - Corrected the `Phalcon\Db\Profiler\Item` calculation for seconds [#15249](https://github.com/phalcon/cphalcon/issues/15249) 
 - Corrected `Phalcon\Http\Message\ServerRequestFactory` to populate with superglobals [#15286](https://github.com/phalcon/cphalcon/issues/15286)
 - Corrected `Phalcon\Mvc\Model\Query\BuilderInterface::orderBy` to use `var` instead of `string` [#15415](https://github.com/phalcon/cphalcon/issues/15415)
+- Corrected `Phalcon\Db\Adapter\Pdo\AbstractPdo::connect` to take into account the `persistent` option for relevant connections [#15241](https://github.com/phalcon/cphalcon/issues/15241)
 
 # [5.0.0-alpha.1](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0-alpha.1) (2020-03-31)
 

--- a/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
+++ b/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
@@ -249,7 +249,7 @@ abstract class AbstractPdo extends AbstractAdapter
     public function connect(array descriptor = null) -> bool
     {
         var username, password, dsnParts, dsnAttributes, dsnAttributesCustomRaw,
-            dsnAttributesMap, options, key, value;
+            dsnAttributesMap, key, options, persistent, value;
 
         if empty descriptor {
             let descriptor = (array) this->descriptor;
@@ -278,6 +278,10 @@ abstract class AbstractPdo extends AbstractAdapter
             unset descriptor["options"];
         } else {
             let options = [];
+        }
+
+        if fetch persistent, descriptor["persistent"] {
+            let options[\PDO::ATTR_PERSISTENT] = (bool) persistent;
         }
 
         // Set PDO to throw exceptions when an error is encountered.

--- a/tests/database/Db/Adapter/Pdo/ConnectCest.php
+++ b/tests/database/Db/Adapter/Pdo/ConnectCest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Database\Db\Adapter\Pdo;
+
+use DatabaseTester;
+use PDO;
+use Phalcon\Db\Adapter\PdoFactory;
+use Phalcon\Db\Column;
+use Phalcon\Test\Fixtures\Migrations\ComplexDefaultMigration;
+use Phalcon\Test\Fixtures\Migrations\DialectMigration;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use function getOptionsMysql;
+use function getOptionsPostgresql;
+use function getOptionsSqlite;
+
+class ConnectCest
+{
+    use DiTrait;
+
+    /**
+     * Executed before each test
+     *
+     * @param DatabaseTester $I
+     *
+     * @return void
+     */
+    public function _before(DatabaseTester $I): void
+    {
+        $this->setNewFactoryDefault();
+    }
+
+    /**
+     * Tests Phalcon\Db\Adapter\Pdo :: connect() - persistent
+     *
+     * @param DatabaseTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-04-20
+     *
+     * @group  mysql
+     */
+    public function dbAdapterPdoConnectPersistent(DatabaseTester $I)
+    {
+        $I->wantToTest('Db\Adapter\Pdo - connect() - supported');
+
+        $options = getOptionsMysql();
+        $options['persistent'] = true;
+
+        $connection = (new PdoFactory())->newInstance('mysql', $options);
+
+        $expected = $options;
+        $actual   = $connection->getDescriptor();
+
+        $I->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: Fixes #15241 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Corrected `Phalcon\Db\Adapter\Pdo\AbstractPdo::connect` to take into account the `persistent` option for relevant connections

Thanks

