### PR TITLE
package both php 7 and 8 sources for pecl

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,11 +76,6 @@ jobs:
       - name: Create Pecl Package (PHP 8)
         id: pecl_create
         run: |
-          cp build/php8/safe/config.w32 config.w32
-          cp build/php8/safe/phalcon.zep.c phalcon.zep.c
-          cp build/php8/safe/config.m4 config.m4
-          cp build/php8/safe/php_phalcon.h php_phalcon.h
-          cp build/php8/safe/phalcon.zep.h phalcon.zep.h
           pecl package
           phalcon_package="`ls | grep phalcon-*tgz`"
           mv $phalcon_package phalcon-pecl.tgz

--- a/config.m4
+++ b/config.m4
@@ -1,0 +1,65 @@
+
+PHP_ARG_ENABLE(phalcon, whether to enable phalcon, [ --enable-phalcon   Enable Phalcon])
+
+if test "$PHP_PHALCON" = "yes"; then
+
+    PHP_VERSION=$($PHP_CONFIG --vernum)
+    PHP_STRING=$($PHP_CONFIG --version)
+    AC_MSG_CHECKING(PHP version)
+    if test $PHP_VERSION -lt 70401; then
+      AC_MSG_ERROR(PHP version $PHP_STRING is not supported)
+      subdir=build/php7/safe
+    elif test $PHP_VERSION -lt 80000; then
+      AC_MSG_RESULT($PHP_STRING)
+      subdir=build/php7/safe
+    else
+      AC_MSG_RESULT($PHP_STRING)
+      subdir=build/php8/safe
+    fi
+	AC_DEFINE(HAVE_PHALCON, 1, [Whether you have Phalcon])
+	PHP_NEW_EXTENSION(phalcon, $subdir/phalcon.zep.c, $ext_shared)
+    PHP_ADD_BUILD_DIR($abs_builddir/$subdir, 1)
+    PHP_ADD_INCLUDE([$ext_srcdir/$subdir])
+	PHP_SUBST(PHALCON_SHARED_LIBADD)
+
+	old_CPPFLAGS=$CPPFLAGS
+	CPPFLAGS="$CPPFLAGS $INCLUDES"
+
+	AC_CHECK_DECL(
+		[HAVE_BUNDLED_PCRE],
+		[
+			AC_CHECK_HEADERS(
+				[ext/pcre/php_pcre.h],
+				[
+					PHP_ADD_EXTENSION_DEP([phalcon], [pcre])
+					AC_DEFINE([ZEPHIR_USE_PHP_PCRE], [1], [Whether PHP pcre extension is present at compile time])
+				],
+				,
+				[[#include "main/php.h"]]
+			)
+		],
+		,
+		[[#include "php_config.h"]]
+	)
+
+	AC_CHECK_DECL(
+		[HAVE_JSON],
+		[
+			AC_CHECK_HEADERS(
+				[ext/json/php_json.h],
+				[
+					PHP_ADD_EXTENSION_DEP([phalcon], [json])
+					AC_DEFINE([ZEPHIR_USE_PHP_JSON], [1], [Whether PHP json extension is present at compile time])
+				],
+				,
+				[[#include "main/php.h"]]
+			)
+		],
+		,
+		[[#include "php_config.h"]]
+	)
+
+	CPPFLAGS=$old_CPPFLAGS
+
+	PHP_INSTALL_HEADERS([ext/phalcon], [$subdir/php_phalcon.h])
+fi

--- a/config.m4
+++ b/config.m4
@@ -8,7 +8,6 @@ if test "$PHP_PHALCON" = "yes"; then
     AC_MSG_CHECKING(PHP version)
     if test $PHP_VERSION -lt 70401; then
       AC_MSG_ERROR(PHP version $PHP_STRING is not supported)
-      subdir=build/php7/safe
     elif test $PHP_VERSION -lt 80000; then
       AC_MSG_RESULT($PHP_STRING)
       subdir=build/php7/safe

--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,21 @@
+
+ARG_ENABLE("phalcon", "enable phalcon", "no");
+
+if (PHP_PHALCON != "no") {
+  var old_conf_dir = configure_module_dirname;
+
+  /* XXX tricky job here, override configure_module_dirname, define the basic extension, then set it back */
+  if (PHP_VERSION == 7) {
+    configure_module_dirname = configure_module_dirname + "\\build\\php7\\safe";
+  } else if (PHP_VERSION == 8) {
+    configure_module_dirname = configure_module_dirname + "\\build\\php8\\safe";
+  } else {
+    ERROR("PHP version " + PHP_VERSION + "." + PHP_MINOR_VERSION + " is not supported");
+  }
+
+  EXTENSION("phalcon", "phalcon.zep.c", null, "-I"+configure_module_dirname);
+  configure_module_dirname = old_conf_dir;
+
+  ADD_FLAG("CFLAGS", "/D ZEPHIR_RELEASE /Oi /Ot /Oy /Ob2 /Gs /GF /Gy /GL");
+  ADD_FLAG("LDFLAGS", "/LTCG");
+}

--- a/package.xml
+++ b/package.xml
@@ -41,14 +41,27 @@
   <contents>
     <dir name="/">
       <file name="config.w32" role="src" />
-      <file name="phalcon.zep.c" role="src"  />
       <file name="config.m4" role="src"  />
-      <file name="php_phalcon.h" role="src" />
-      <file name="phalcon.zep.h" role="src" />
       <file name="LICENSE.txt" role="doc" />
       <file name="CHANGELOG-5.0.md" role="doc" />
       <file name="CODE_OF_CONDUCT.md" role="doc" />
       <file name="CODE_OWNERS.TXT" role="doc" />
+      <dir name="build">
+        <dir name="php7">
+          <dir name="safe">
+            <file name="phalcon.zep.c" role="src"  />
+            <file name="php_phalcon.h" role="src" />
+            <file name="phalcon.zep.h" role="src" />
+          </dir>
+        </dir>
+        <dir name="php8">
+          <dir name="safe">
+            <file name="phalcon.zep.c" role="src"  />
+            <file name="php_phalcon.h" role="src" />
+            <file name="phalcon.zep.h" role="src" />
+          </dir>
+        </dir>
+      </dir>
     </dir>
   </contents>
   <dependencies>


### PR DESCRIPTION
Trying to make things simpler for pecl, and allowing to use same package for both PHP 7 and 8

notice: config.w32 blindly written (inspired from zip ext by @cmb69)

Side effect: "phpize; ./configure; make" work in top directory 