### PR TITLE
T15334 headers sent twice

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,7 @@
 ## Added
 - Added BINARY and VARBINARY support for Phalcon\Db\Adapter\Mysql [#14927](https://github.com/phalcon/cphalcon/issues/14927)
 - Added `Phalcon\Db\Profiler\Item::getTotalElapsedNanoseconds()` and `Phalcon\Db\Profiler\Item::getTotalElapsedMilliseconds()` for more precision [#15249](https://github.com/phalcon/cphalcon/issues/15249)
+- Added `Phalcon\Http\Response\Cookies::isSent()` and `Phalcon\Http\Response\Headers::isSent()`; Added logic to not send the headers or cookies twice. [#15334](https://github.com/phalcon/cphalcon/issues/15334)
 
 ## Changed
 - `Phalcon\Version` is now moved to `Phalcon\Support\Version`

--- a/phalcon/Http/Response.zep
+++ b/phalcon/Http/Response.zep
@@ -57,16 +57,6 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
     /**
      * @var bool
      */
-    protected isCookiesSent = false;
-
-    /**
-     * @var bool
-     */
-    protected isHeadersSent = false;
-
-    /**
-     * @var bool
-     */
     protected sent = false;
 
     protected statusCodes;
@@ -211,22 +201,6 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
         let headers = this->getHeaders();
 
         return headers->has(name);
-    }
-
-    /**
-     * Check if the response has sent the cookies already
-     */
-    public function isCookiesSent() -> bool
-    {
-        return this->isCookiesSent;
-    }
-
-    /**
-     * Check if the response has sent the headers already
-     */
-    public function isHeadersSent() -> bool
-    {
-        return this->isHeadersSent;
     }
 
     /**
@@ -388,14 +362,10 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
     {
         var cookies;
 
-        if true !== this->isCookiesSent {
-            let cookies = this->cookies;
+        let cookies = this->cookies;
 
-            if typeof cookies == "object" {
-                cookies->send();
-            }
-
-            let this->isCookiesSent = true;
+        if typeof cookies == "object" {
+            cookies->send();
         }
 
         return this;
@@ -408,24 +378,20 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
     {
         var headers, eventsManager;
 
-        if true !== this->isHeadersSent {
-            let headers = <HeadersInterface> this->getHeaders();
-            let eventsManager = <ManagerInterface> this->getEventsManager();
+        let headers = <HeadersInterface> this->getHeaders();
+        let eventsManager = <ManagerInterface> this->getEventsManager();
 
-            if typeof eventsManager == "object" {
-                if eventsManager->fire("response:beforeSendHeaders", this) === false {
-                    return false;
-                }
+        if typeof eventsManager == "object" {
+            if eventsManager->fire("response:beforeSendHeaders", this) === false {
+                return false;
             }
+        }
 
-            /**
-             * Send headers
-             */
-            if headers->send() && typeof eventsManager == "object" {
-                eventsManager->fire("response:afterSendHeaders", this);
-            }
-
-            let this->isHeadersSent = true;
+        /**
+         * Send headers
+         */
+        if headers->send() && typeof eventsManager == "object" {
+            eventsManager->fire("response:afterSendHeaders", this);
         }
 
         return this;

--- a/phalcon/Http/Response/Cookies.zep
+++ b/phalcon/Http/Response/Cookies.zep
@@ -65,8 +65,19 @@ use Phalcon\Http\Cookie\CookieInterface;
  */
 class Cookies extends AbstractInjectionAware implements CookiesInterface
 {
+    /**
+     * @var array
+     */
     protected cookies = [];
 
+    /**
+     * @var bool
+     */
+    protected isSent = false;
+
+    /**
+     * @var bool
+     */
     protected registered = false;
 
     /**
@@ -75,6 +86,9 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
      */
     protected signKey = null;
 
+    /**
+     * @var bool
+     */
     protected useEncryption = true;
 
     /**
@@ -167,6 +181,14 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
     }
 
     /**
+     * Returns if the headers have already been sent
+     */
+    public function isSent() -> bool
+    {
+        return this->isSent;
+    }
+
+    /**
      * Returns if the bag is automatically encrypting/decrypting cookies
      */
     public function isUsingEncryption() -> bool
@@ -192,13 +214,15 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
     {
         var cookie;
 
-        if headers_sent() {
+        if true === headers_sent() || true === this->isSent() {
             return false;
         }
 
         for cookie in this->cookies {
             cookie->send();
         }
+
+        let this->isSent = true;
 
         return true;
     }

--- a/phalcon/Http/Response/Headers.zep
+++ b/phalcon/Http/Response/Headers.zep
@@ -17,7 +17,15 @@ namespace Phalcon\Http\Response;
  */
 class Headers implements HeadersInterface
 {
+    /**
+     * @var array
+     */
     protected headers = [];
+
+    /**
+     * @var bool
+     */
+    protected isSent = false;
 
     /**
      * Gets a header value from the internal bag
@@ -41,6 +49,14 @@ class Headers implements HeadersInterface
     public function has(string name) -> bool
     {
         return isset this->headers[name];
+    }
+
+    /**
+     * Returns if the headers have already been sent
+     */
+    public function isSent() -> bool
+    {
+        return this->isSent;
     }
 
     /**
@@ -72,7 +88,7 @@ class Headers implements HeadersInterface
     {
         var header, value;
 
-        if headers_sent() {
+        if true === headers_sent() || true === this->isSent() {
             return false;
         }
 
@@ -96,6 +112,8 @@ class Headers implements HeadersInterface
                 }
             }
         }
+
+        let this->isSent = true;
 
         return true;
     }

--- a/phalcon/Mvc/Application.zep
+++ b/phalcon/Mvc/Application.zep
@@ -67,6 +67,9 @@ use Phalcon\Mvc\ModuleDefinitionInterface;
  */
 class Application extends AbstractApplication
 {
+    /**
+     * @var bool
+     */
     protected implicitView = true;
 
     /**
@@ -78,16 +81,6 @@ class Application extends AbstractApplication
      * @var bool
      */
     protected sendHeaders = true;
-
-    /**
-     * @var bool
-     */
-    protected isHeadersSent = false;
-
-    /**
-     * @var bool
-     */
-    protected isCookiesSent = false;
 
     /**
      * Handles a MVC request
@@ -409,19 +402,15 @@ class Application extends AbstractApplication
         /**
          * Check whether send headers or not (by default yes)
          */
-        if true === this->sendHeaders  && false === this->isHeadersSent {
+        if this->sendHeaders  {
             response->sendHeaders();
-
-            let this->isHeadersSent = true;
         }
 
         /**
          * Check whether send cookies or not (by default yes)
          */
-        if true === this->sendCookies && false === this->isCookiesSent {
+        if this->sendCookies {
             response->sendCookies();
-
-            let this->isCookiesSent = true;
         }
 
         /**

--- a/phalcon/Mvc/Application.zep
+++ b/phalcon/Mvc/Application.zep
@@ -69,9 +69,25 @@ class Application extends AbstractApplication
 {
     protected implicitView = true;
 
+    /**
+     * @var bool
+     */
     protected sendCookies = true;
 
+    /**
+     * @var bool
+     */
     protected sendHeaders = true;
+
+    /**
+     * @var bool
+     */
+    protected isHeadersSent = false;
+
+    /**
+     * @var bool
+     */
+    protected isCookiesSent = false;
 
     /**
      * Handles a MVC request
@@ -393,15 +409,19 @@ class Application extends AbstractApplication
         /**
          * Check whether send headers or not (by default yes)
          */
-        if this->sendHeaders  {
+        if true === this->sendHeaders  && false === this->isHeadersSent {
             response->sendHeaders();
+
+            let this->isHeadersSent = true;
         }
 
         /**
          * Check whether send cookies or not (by default yes)
          */
-        if this->sendCookies {
+        if true === this->sendCookies && false === this->isCookiesSent {
             response->sendCookies();
+
+            let this->isCookiesSent = true;
         }
 
         /**

--- a/tests/unit/Http/Response/Cookies/SendCest.php
+++ b/tests/unit/Http/Response/Cookies/SendCest.php
@@ -53,4 +53,38 @@ class SendCest extends HttpBase
 
         $I->assertTrue($oCookie->send());
     }
+
+    /**
+     * Tests Phalcon\Http\Response\Cookies :: send() - twice
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-04-22
+     * @issue  15334
+     */
+    public function httpResponseCookiesSendTwice(UnitTester $I)
+    {
+        $I->wantToTest('Http\Response\Cookies - send() - twice');
+
+        $name  = 'framework';
+        $value = 'phalcon';
+
+        $this->setDiService('crypt');
+        $container = $this->getDi();
+
+        $cookie = new Cookies();
+        $cookie->setDI($container);
+        $cookie->set($name, $value);
+
+        $actual = $cookie->isSent();
+        $I->assertFalse($actual);
+
+        $actual = $cookie->send();
+        $I->assertTrue($actual);
+
+        $actual = $cookie->isSent();
+        $I->assertTrue($actual);
+
+        $actual = $cookie->send();
+        $I->assertFalse($actual);
+    }
 }

--- a/tests/unit/Http/Response/Headers/SendCest.php
+++ b/tests/unit/Http/Response/Headers/SendCest.php
@@ -33,8 +33,36 @@ class SendCest
         $headers->set('Content-Type', 'text/html; charset=UTF-8');
         $headers->set('Content-Encoding', 'gzip');
 
-        $I->assertTrue(
-            $headers->send()
-        );
+        $actual = $headers->send();
+        $I->assertTrue($actual);
+    }
+
+    /**
+     * Tests Phalcon\Http\Response\Headers :: send() - twice
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-04-22
+     * @issue  15334
+     */
+    public function httpResponseHeadersSendTwice(UnitTester $I)
+    {
+        $I->wantToTest('Http\Response\Headers - send() - twice');
+
+        $headers = new Headers();
+
+        $headers->set('Content-Type', 'text/html; charset=UTF-8');
+        $headers->set('Content-Encoding', 'gzip');
+
+        $actual = $headers->isSent();
+        $I->assertFalse($actual);
+
+        $actual = $headers->send();
+        $I->assertTrue($actual);
+
+        $actual = $headers->isSent();
+        $I->assertTrue($actual);
+
+        $actual = $headers->send();
+        $I->assertFalse($actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: Fixes #15334 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Http\Response\Cookies::isSent()` and `Phalcon\Http\Response\Headers::isSent()`; Added logic to not send the headers or cookies twice.

Thanks

