### PR TITLE
T14764 gettext setlocale 2

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -23,6 +23,7 @@
 - Added `Phalcon\Support\HelperFactory` for an easier creation/access of helpers [#15411](https://github.com/phalcon/cphalcon/issues/15411)
 
 ## Changed
+- Changed `Phalcon\Translate\Adapter\Gettext::setLocale` signature to allow the category and an array of locales [#14764](https://github.com/phalcon/cphalcon/issues/14764)
 - `Phalcon\Version` is now moved to `Phalcon\Support\Version`
     - `_getSpecialVersion` and `_getVersion` have been removed (marked deprecated in v4)
     - The class is no longer static; it has to be instantiated first

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,6 +1,12 @@
 # [5.0.0-alpha.2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0-alpha.2) (xxxx-xx-xx)
 
 ## Changed
+- Changed `Phalcon\Translate\Adapter\Gettext::setLocale` signature to allow the category and an array of locales [#14764](https://github.com/phalcon/cphalcon/issues/14764)
+- `Phalcon\Version` is now moved to `Phalcon\Support\Version`
+    - `_getSpecialVersion` and `_getVersion` have been removed (marked deprecated in v4)
+    - The class is no longer static; it has to be instantiated first
+    - References to `Phalcon\Debug` and the Volt compiler have been adjusted [#15422](https://github.com/phalcon/cphalcon/issues/15422)
+- `Phalcon\Debug` is now moved to `Phalcon\Support\Debug`; CSS/JS references updated [#14817](https://github.com/phalcon/cphalcon/issues/14817)
 - Changed the logging names types to uppercase [#15375](https://github.com/phalcon/cphalcon/issues/15375)
 - Changes to the `Phalcon\Logger`:
     - Renamed `Phalcon\Logger\Item::getName` to `Phalcon\Logger\Item::getLevelName`
@@ -21,14 +27,6 @@
 - Added `Phalcon\Validation\Validator\File\AbstractFile::checkIsUploadedFile()` method to allow overriding when adding files to the `$_FILES` array directly (not uploading). [#15051](https://github.com/phalcon/cphalcon/issues/15051)
 - Added `Phalcon\Support\Helper\Str\Interpolate` to be used throughout the code for interpolation (Logger/Translator) `%type%` to `%level%` to align with the variables [#15411](https://github.com/phalcon/cphalcon/issues/15411)
 - Added `Phalcon\Support\HelperFactory` for an easier creation/access of helpers [#15411](https://github.com/phalcon/cphalcon/issues/15411)
-
-## Changed
-- Changed `Phalcon\Translate\Adapter\Gettext::setLocale` signature to allow the category and an array of locales [#14764](https://github.com/phalcon/cphalcon/issues/14764)
-- `Phalcon\Version` is now moved to `Phalcon\Support\Version`
-    - `_getSpecialVersion` and `_getVersion` have been removed (marked deprecated in v4)
-    - The class is no longer static; it has to be instantiated first
-    - References to `Phalcon\Debug` and the Volt compiler have been adjusted [#15422](https://github.com/phalcon/cphalcon/issues/15422)
-- `Phalcon\Debug` is now moved to `Phalcon\Support\Debug`; CSS/JS references updated [#14817](https://github.com/phalcon/cphalcon/issues/14817)
 
 ## Fixed
 - Corrected the `Phalcon\Db\Profiler\Item` calculation for seconds [#15249](https://github.com/phalcon/cphalcon/issues/15249) 

--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -1,10 +1,23 @@
 FROM composer:2.0.8 as composer
 FROM php:7.4-fpm
 
+# Compilation parameters
 RUN CPU_CORES="$(getconf _NPROCESSORS_ONLN)";
 ENV MAKEFLAGS="-j${CPU_CORES}"
 
 ADD ./extra.ini /usr/local/etc/php/conf.d/
+
+# User/Group globals
+ENV MY_USER="phalcon" \
+	MY_GROUP="phalcon" \
+	MY_UID="1000" \
+	MY_GID="1000" \
+	PHP_VERSION="7.4"
+
+# User and Group
+RUN set -eux && \
+	groupadd -g ${MY_GID} -r ${MY_GROUP} && \
+	useradd -u ${MY_UID} -m -s /bin/bash -g ${MY_GROUP} ${MY_USER}
 
 # Update
 RUN apt update -y && \

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -1,10 +1,23 @@
 FROM composer:2.0.8 as composer
 FROM php:8.0-fpm
 
+# Compilation parameters
 RUN CPU_CORES="$(getconf _NPROCESSORS_ONLN)";
 ENV MAKEFLAGS="-j${CPU_CORES}"
 
 ADD ./extra.ini /usr/local/etc/php/conf.d/
+
+# User/Group globals
+ENV MY_USER="phalcon" \
+	MY_GROUP="phalcon" \
+	MY_UID="1000" \
+	MY_GID="1000" \
+	PHP_VERSION="7.4"
+
+# User and Group
+RUN set -eux && \
+	groupadd -g ${MY_GID} -r ${MY_GROUP} && \
+	useradd -u ${MY_UID} -m -s /bin/bash -g ${MY_GROUP} ${MY_USER}
 
 # Update
 RUN apt update -y && \
@@ -33,15 +46,9 @@ RUN pecl install psr && \
     pecl install msgpack && \
     pecl install apcu && \
     pecl install yaml && \
+    pecl install imagick && \
     pecl install memcached && \
     pecl install xdebug
-
-# Remove this RUN when imagick will be available via pecl
-RUN cd /opt && \
-    git clone https://github.com/Imagick/imagick && \
-    cd imagick && \
-    phpize && ./configure && \
-    make && make install
 
 # Locale
 RUN sed -i -e 's/# de_DE.UTF-8 UTF-8/de_DE.UTF-8 UTF-8/' /etc/locale.gen && \
@@ -58,8 +65,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 # Zephir Parser
-RUN cd /opt && \
-    curl -s https://raw.githubusercontent.com/phalcon/zephir/development/.ci/install-zephir-parser.sh | bash
+RUN curl -s https://raw.githubusercontent.com/phalcon/zephir/development/.ci/install-zephir-parser.sh | bash
 
 # Install PHP extensions
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg=/usr/include/ --enable-gd

--- a/phalcon/Translate/Adapter/Gettext.zep
+++ b/phalcon/Translate/Adapter/Gettext.zep
@@ -207,7 +207,7 @@ class Gettext extends AbstractAdapter implements ArrayAccess
     public function setLocale(int! category, array localeArray = []) -> string | bool
     {
         let this->locale   = setlocale(category, localeArray),
-            this->category = category;git
+            this->category = category;
 
         putenv("LC_ALL=" . this->locale);
         putenv("LANG=" . this->locale);

--- a/phalcon/Translate/Adapter/Gettext.zep
+++ b/phalcon/Translate/Adapter/Gettext.zep
@@ -204,14 +204,10 @@ class Gettext extends AbstractAdapter implements ArrayAccess
      * $gettext->setLocale(LC_ALL, "de_DE@euro", "de_DE", "de", "ge");
      * ```
      */
-    public function setLocale(int! category, string! locale) -> string | bool
+    public function setLocale(int! category, array localeArray = []) -> string | bool
     {
-        let this->locale = call_user_func_array(
-            "setlocale",
-            func_get_args()
-        );
-
-        let this->category = category;
+        let this->locale   = setlocale(category, localeArray),
+            this->category = category;git
 
         putenv("LC_ALL=" . this->locale);
         putenv("LANG=" . this->locale);

--- a/tests/_data/assets/config/factory.ini
+++ b/tests/_data/assets/config/factory.ini
@@ -39,7 +39,7 @@ options.page = 1
 
 [translate]
 adapter = gettext
-options.locale = en_US.utf8
+options.locale[] = en_US.utf8
 options.defaultDomain = messages
 options.directory = PATH_DATA"assets/translation/gettext"
 options.category = 5

--- a/tests/_data/fixtures/Traits/TranslateGettextTrait.php
+++ b/tests/_data/fixtures/Traits/TranslateGettextTrait.php
@@ -33,7 +33,7 @@ trait TranslateGettextTrait
     protected function getGettextConfig(): array
     {
         return [
-            'locale'        => 'en_US.utf8',
+            'locale'        => ['en_US.utf8'],
             'defaultDomain' => 'messages',
             'directory'     => dataDir('assets/translation/gettext'),
             'category'      => LC_MESSAGES,

--- a/tests/unit/Translate/Adapter/Gettext/ConstructCest.php
+++ b/tests/unit/Translate/Adapter/Gettext/ConstructCest.php
@@ -36,20 +36,10 @@ class ConstructCest
         $I->wantToTest('Translate\Adapter\Gettext - constructor');
 
         $params     = $this->getGettextConfig();
-        $translator = new Gettext(
-            new InterpolatorFactory(),
-            $params
-        );
+        $translator = new Gettext(new InterpolatorFactory(), $params);
 
-        $I->assertInstanceOf(
-            ArrayAccess::class,
-            $translator
-        );
-
-        $I->assertInstanceOf(
-            AdapterInterface::class,
-            $translator
-        );
+        $I->assertInstanceOf(ArrayAccess::class, $translator);
+        $I->assertInstanceOf(AdapterInterface::class, $translator);
     }
 
     /**

--- a/tests/unit/Translate/Adapter/Gettext/GetSetLocaleCest.php
+++ b/tests/unit/Translate/Adapter/Gettext/GetSetLocaleCest.php
@@ -35,16 +35,20 @@ class GetSetLocaleCest
         $params     = $this->getGettextConfig();
         $translator = new Gettext(new InterpolatorFactory(), $params);
 
-        $I->assertEquals(
-            'en_US.utf8',
-            $translator->getLocale()
-        );
+        $expected = 'en_US.utf8';
+        $actual   = $translator->getLocale();
+        $I->assertEquals($expected, $actual);
 
-        $translator->setLocale(1, 'ru');
+        $translator->setLocale(1, ['ru']);
 
-        $I->assertEquals(
-            '',
-            $translator->getLocale()
-        );
+        $expected = '';
+        $actual   = $translator->getLocale();
+        $I->assertEquals($expected, $actual);
+
+        $translator->setLocale(1, ['ru_RU.utf8']);
+
+        $expected = 'ru_RU.utf8';
+        $actual   = $translator->getLocale();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Translate/TranslateFactory/LoadCest.php
+++ b/tests/unit/Translate/TranslateFactory/LoadCest.php
@@ -53,7 +53,7 @@ class LoadCest
             $interpolator = new InterpolatorFactory();
             $factory      = new TranslateFactory($interpolator);
             $adapter      = $factory->load($options);
-            $locale       = $options->options->locale;
+        $locale       = $options->options->locale[0];
 
             $I->assertInstanceOf(Gettext::class, $adapter);
             $I->assertEquals($options->options->category, $adapter->getCategory());
@@ -82,7 +82,7 @@ class LoadCest
             $interpolator = new InterpolatorFactory();
             $factory      = new TranslateFactory($interpolator);
             $adapter      = $factory->load($options);
-            $locale       = $options['options']['locale'];
+        $locale       = $options['options']['locale'][0];
 
             $I->assertInstanceOf(Gettext::class, $adapter);
             $I->assertEquals($options['options']['category'], $adapter->getCategory());

--- a/tests/unit/Translate/TranslateFactory/LoadCest.php
+++ b/tests/unit/Translate/TranslateFactory/LoadCest.php
@@ -53,7 +53,7 @@ class LoadCest
             $interpolator = new InterpolatorFactory();
             $factory      = new TranslateFactory($interpolator);
             $adapter      = $factory->load($options);
-        $locale       = $options->options->locale[0];
+            $locale       = $options->options->locale[0];
 
             $I->assertInstanceOf(Gettext::class, $adapter);
             $I->assertEquals($options->options->category, $adapter->getCategory());
@@ -82,7 +82,7 @@ class LoadCest
             $interpolator = new InterpolatorFactory();
             $factory      = new TranslateFactory($interpolator);
             $adapter      = $factory->load($options);
-        $locale       = $options['options']['locale'][0];
+            $locale       = $options['options']['locale'][0];
 
             $I->assertInstanceOf(Gettext::class, $adapter);
             $I->assertEquals($options['options']['category'], $adapter->getCategory());


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14764 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed the signature of setLocale in `Translate\Adapter\Gettext` to allow multiple locale declarations if necessary. Aligns with `setlocale`

Thanks

