### PR TITLE
#15074 - Change return from `array` to `ResultsetInterface` in Model Paginator

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -12,6 +12,7 @@
 - Changed the interpolation for the formatters to use the `Phalcon\Support\Helper\Str\Interpolate` [#15411](https://github.com/phalcon/cphalcon/issues/15411)
 - Changed the exceptions thrown from factories to be more specific to their namespaces vs. the Factory generic one [#15411](https://github.com/phalcon/cphalcon/issues/15411)
 - Changed `Phalcon\Mvc\Model\ManagerInterface:getRelationByAlias()` return type from `Relation|bool` to `RelationInterface|bool` [#15343](https://github.com/phalcon/cphalcon/issues/15343)
+- Changed `Phalcon\Paginator\Repository:getItems()` return type from `array` to `ResultsetInterface` [#15074](https://github.com/phalcon/cphalcon/issues/15074)
 
 ## Added
 - Added `BINARY` and `VARBINARY` support for Phalcon\Db\Adapter\Mysql [#14927](https://github.com/phalcon/cphalcon/issues/14927)

--- a/phalcon/Paginator/Adapter/Model.zep
+++ b/phalcon/Paginator/Adapter/Model.zep
@@ -90,7 +90,7 @@ class Model extends AbstractAdapter
      */
     public function paginate() -> <RepositoryInterface>
     {
-        var config, items, pageItems, modelClass, parameters;
+        var config, modelClass, parameters, pageItems = [];
         int pageNumber, limit, rowcount, next, totalPages,
             previous;
 
@@ -100,13 +100,12 @@ class Model extends AbstractAdapter
             modelClass = <ModelInterface> config["model"],
             parameters = Arr::get(config, "parameters", [], "array");
 
-        //Prevents 0 or negative page numbers
+        // Prevents 0 or negative page numbers
         if pageNumber <= 0 {
             let pageNumber = 1;
         }
 
-        let rowcount  = (int) call_user_func([modelClass, "count"], parameters),
-            pageItems = [];
+        let rowcount = (int) call_user_func([modelClass, "count"], parameters);
 
         if rowcount % limit != 0 {
             let totalPages = (int) (rowcount / limit + 1);
@@ -118,14 +117,13 @@ class Model extends AbstractAdapter
             let parameters["limit"]  = limit,
                 parameters["offset"] = limit * (pageNumber - 1);
 
-            let items = <ResultsetInterface> call_user_func(
+            let pageItems = <ResultsetInterface> call_user_func(
                 [modelClass, "find"],
                 parameters
             );
-            let pageItems = items->toArray();
         }
 
-        //Fix next
+        // Fix next
         let next = pageNumber + 1;
 
         if next > totalPages {

--- a/tests/database/Paginator/Adapter/Model/PaginateCest.php
+++ b/tests/database/Paginator/Adapter/Model/PaginateCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Test\Database\Paginator\Adapter\Model;
 
 use DatabaseTester;
+use PDO;
 use Phalcon\Paginator\Adapter\Model;
 use Phalcon\Paginator\Repository;
 use Phalcon\Storage\Exception;
@@ -42,6 +43,7 @@ class PaginateCest
      *
      * @group mysql
      * @group sqlite
+     * @group pgsql
      */
     public function paginatorAdapterModelPaginate(DatabaseTester $I)
     {
@@ -158,6 +160,7 @@ class PaginateCest
      *
      * @group mysql
      * @group sqlite
+     * @group pgsql
      */
     public function paginatorAdapterModelPaginateParametersString(DatabaseTester $I): void
     {
@@ -200,6 +203,7 @@ class PaginateCest
      *
      * @group mysql
      * @group sqlite
+     * @group pgsql
      */
     public function paginatorAdapterModelPaginateParametersArrayString(DatabaseTester $I): void
     {
@@ -239,6 +243,41 @@ class PaginateCest
         $I->assertEquals(1, $page->getCurrent());
     }
 
+    /**
+     * @param DatabaseTester $I
+     *
+     * @group mysql
+     * @group sqlite
+     * @group pgsql
+     */
+    public function paginatorAdapterModelPaginateEmpty(DatabaseTester $I)
+    {
+        $I->wantToTest('Paginator\Adapter\Model - paginate() - empty');
+
+        $paginator = new Model(
+            [
+                'model'      => Invoices::class,
+                'parameters' => [
+                    'inv_cst_id < -1',
+                ],
+                'limit'      => 5,
+                'page'       => 1,
+            ]
+        );
+
+        // First Page
+        $page = $paginator->paginate();
+
+        $I->assertInstanceOf(Repository::class, $page);
+
+        $I->assertCount(0, $page->getItems());
+        $I->assertIsArray($page->getItems());
+        $I->assertEquals(1, $page->getPrevious());
+        $I->assertEquals(0, $page->getNext());
+        $I->assertEquals(0, $page->getLast());
+        $I->assertEquals(5, $page->getLimit());
+        $I->assertEquals(1, $page->getCurrent());
+    }
 
     /**
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: paginate()


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

