### PR TITLE
Fixed comment in http response headers

### DIFF
--- a/phalcon/Http/Response/Headers.zep
+++ b/phalcon/Http/Response/Headers.zep
@@ -60,7 +60,7 @@ class Headers implements HeadersInterface
     }
 
     /**
-     * Removes a header to be sent at the end of the request
+     * Removes a header by its name
      */
     public function remove(string header) -> <HeadersInterface>
     {


### PR DESCRIPTION
Fixed comment in http response headers delete method

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

