### PR TITLE
Update Form.zep

### DIFF
--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -566,6 +566,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             this->bind(data, entity);
         } else {
             if typeof this->entity == "object" {
+                let entity = this->entity;
                 this->bind(data, this->entity);
             }
         }


### PR DESCRIPTION
The uniqueness validator fails when using an entity in a form. In this form I assign a validator object. One of the rules in the validator is that the "name" field must be unique.

Works great but when I use this form to edit, it has a persisted entity. So the uniqueness validator checks that their is no record of that name and doesn't belong to the primary key field. 

Only problem is that the validator doesn't receive the entity object that is assigned to the form. It receives the entity that is passed to the method "isValid($data, $entity)". 

This one line added to the isValid function, passes the form entity as the entity to validation.

Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

