### PR TITLE
T15567 Form entity not passed with validation

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -41,6 +41,7 @@
 - Fixed `Phalcon\Db\Adapter\AbstractAdapter:delete()` when `bindTypes` argument is passed. [#15363](https://github.com/phalcon/cphalcon/issues/15363)
 - Fixed `Phalcon\Storage\Adapter\Redis::getAdapter` to use passed `connectionTimeout`, `retryInterval` and `readTimeout` options for the connection [#15484](https://github.com/phalcon/cphalcon/issues/15484)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler` for a use case when a block will return null vs an array for `statementList` in PHP 8 [#15556](https://github.com/phalcon/cphalcon/issues/15556)
+- Fixed `Phalcon\Forms\Form` when no entity is passed with isValid(), it uses the entity set in the form [#15567](https://github.com/phalcon/cphalcon/issues/15567)
 
 # [5.0.0-alpha.2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0-alpha.2) (2021-05-05)
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,6 +5,7 @@
 
 ## Fixed
 - Fixed `Phalcon\Container` interface to abide with `Psr\Container\ContainerInterface` after the upgrade to PSR 1.1.x [#15504](https://github.com/phalcon/cphalcon/issues/15504)
+- Fixed `Phalcon\Forms\Form` when no entity is passed with isValid(), it uses the entity set in the form [#15567](https://github.com/phalcon/cphalcon/issues/15567)
 
 # [5.0.0alpha3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha3) (2021-06-30)
 
@@ -41,7 +42,6 @@
 - Fixed `Phalcon\Db\Adapter\AbstractAdapter:delete()` when `bindTypes` argument is passed. [#15363](https://github.com/phalcon/cphalcon/issues/15363)
 - Fixed `Phalcon\Storage\Adapter\Redis::getAdapter` to use passed `connectionTimeout`, `retryInterval` and `readTimeout` options for the connection [#15484](https://github.com/phalcon/cphalcon/issues/15484)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler` for a use case when a block will return null vs an array for `statementList` in PHP 8 [#15556](https://github.com/phalcon/cphalcon/issues/15556)
-- Fixed `Phalcon\Forms\Form` when no entity is passed with isValid(), it uses the entity set in the form [#15567](https://github.com/phalcon/cphalcon/issues/15567)
 
 # [5.0.0-alpha.2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0-alpha.2) (2021-05-05)
 

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -591,7 +591,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         } else {
             if typeof this->entity == "object" {
                 this->bind(data, this->entity);
-                let entity = this->entity
+                let entity = this->entity;
             }
         }
 

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -591,6 +591,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         } else {
             if typeof this->entity == "object" {
                 this->bind(data, this->entity);
+                let entity = this->entity
             }
         }
 

--- a/tests/unit/Forms/FormEntityCest.php
+++ b/tests/unit/Forms/FormEntityCest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Phalcon\Test\Unit\Forms;
 
 use Phalcon\Forms\Element\Text;
@@ -11,10 +12,7 @@ use UnitTester;
 
 class FormEntityCest
 {
-
     use DiTrait;
-
-
 
     /**
      * Tests Phalcon\Forms\Form :: isValid()
@@ -38,13 +36,18 @@ class FormEntityCest
         $name = new Text('prd_name');
         $form->add($name);
 
-        $isValid = $form->isValid(['prd_name' => "Nikodem Tomlinson"]); //normal this is from _POST
+        /**
+         * normal this is from _POST
+         */
+        $isValid = $form->isValid(['prd_name' => "Nikodem Tomlinson"]);
 
         $I->assertFalse($isValid);
 
-        //Validation.zep line 456 is called, so the isValid method calls validate and sets the same entity as the form
+        /**
+         * Validation.zep line 456 is called, so the isValid method calls
+         * validate and sets the same entity as the form
+         */
         $I->assertNotNull($validator->getEntity());
         $I->assertEquals($product->prd_name, $validator->getEntity()->prd_name);
     }
-
 }

--- a/tests/unit/Forms/FormEntityCest.php
+++ b/tests/unit/Forms/FormEntityCest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Phalcon\Test\Unit\Forms;
+
+use Phalcon\Forms\Element\Text;
+use Phalcon\Forms\Form;
+use Phalcon\Test\Fixtures\Traits\DiTrait;
+use Phalcon\Test\Models\Users;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\StringLength\Max;
+use UnitTester;
+
+class FormEntityCest
+{
+
+    use DiTrait;
+
+
+
+    /**
+     * Tests Phalcon\Forms\Form :: isValid()
+     *
+     * @author Stijn Leenknegt <stijn@diagro.be>
+     * @since  2021-07-10
+     */
+    public function helperArrIsUnique(UnitTester $I)
+    {
+        $I->wantToTest('Phalcon\Forms\Form  - isValid()');
+
+        $validator = new Validation();
+        $validator->add('name', new Max(['max' => 15]));
+
+        $user = new Users();
+
+        $form = new Form($user);
+        $form->setValidation($validator);
+        $name = new Text('name');
+        $form->add($name);
+
+        $isValid = $form->isValid(['name' => "Nikodem Tomlinson"]);
+
+        $I->assertFalse($isValid);
+
+        //Validation.zep line 456 is called, so the isValid method calls validate and sets the same entity as the form
+        $I->assertNotNull($validator->getEntity());
+        $I->assertEquals($user->name, $validator->getEntity()->name);
+    }
+
+}

--- a/tests/unit/Forms/FormEntityCest.php
+++ b/tests/unit/Forms/FormEntityCest.php
@@ -4,7 +4,7 @@ namespace Phalcon\Test\Unit\Forms;
 use Phalcon\Forms\Element\Text;
 use Phalcon\Forms\Form;
 use Phalcon\Test\Fixtures\Traits\DiTrait;
-use Phalcon\Test\Models\Users;
+use Phalcon\Test\Models\Products;
 use Phalcon\Validation;
 use Phalcon\Validation\Validator\StringLength\Max;
 use UnitTester;
@@ -22,27 +22,27 @@ class FormEntityCest
      * @author Stijn Leenknegt <stijn@diagro.be>
      * @since  2021-07-10
      */
-    public function helperArrIsUnique(UnitTester $I)
+    public function isValidEntity(UnitTester $I)
     {
         $I->wantToTest('Phalcon\Forms\Form  - isValid()');
 
         $validator = new Validation();
-        $validator->add('name', new Max(['max' => 15]));
+        $validator->add('prd_name', new Max(['max' => 15]));
 
-        $user = new Users();
+        $product = new Products();
 
-        $form = new Form($user);
+        $form = new Form($product);
         $form->setValidation($validator);
-        $name = new Text('name');
+        $name = new Text('prd_name');
         $form->add($name);
 
-        $isValid = $form->isValid(['name' => "Nikodem Tomlinson"]);
+        $isValid = $form->isValid(['prd_name' => "Nikodem Tomlinson"]); //normal this is from _POST
 
         $I->assertFalse($isValid);
 
         //Validation.zep line 456 is called, so the isValid method calls validate and sets the same entity as the form
         $I->assertNotNull($validator->getEntity());
-        $I->assertEquals($user->name, $validator->getEntity()->name);
+        $I->assertEquals($product->prd_name, $validator->getEntity()->prd_name);
     }
 
 }

--- a/tests/unit/Forms/FormEntityCest.php
+++ b/tests/unit/Forms/FormEntityCest.php
@@ -26,6 +26,8 @@ class FormEntityCest
     {
         $I->wantToTest('Phalcon\Forms\Form  - isValid()');
 
+        $this->setNewFactoryDefault(); //create default DI
+
         $validator = new Validation();
         $validator->add('prd_name', new Max(['max' => 15]));
 


### PR DESCRIPTION
* Type: bug fix 
* Link to issue: https://github.com/phalcon/cphalcon/issues/15567

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Assign the form entity to the entity variable in the isValid method if no entity is provided.

