### PR TITLE
T15569 Indicate that ManagerInterface::createBuilder can accept array

### DIFF
--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -2066,6 +2066,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Creates a Phalcon\Mvc\Model\Query\Builder
+     *
+     * @param array|string|null params
      */
     public function createBuilder(var params = null) -> <BuilderInterface>
     {

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -81,7 +81,7 @@ interface ManagerInterface
     /**
      * Creates a Phalcon\Mvc\Model\Query\Builder
      *
-     * @param string $params
+     * @param array|string|null params
      */
     public function createBuilder(params = null) -> <BuilderInterface>;
 


### PR DESCRIPTION
Hello!

* Type: code quality
* Link to issue: https://github.com/phalcon/cphalcon/issues/15569

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
`Model\ManagerInterface::createBuilder` only specifies a string as a supported type, although an array is also supported. The Model\Manager::createBuilder itself does not have a type specified, therefore in the PHPDoc it is indicated as "mixed". 

Thanks
