### PR TITLE
Fix grammar error (then -> than)

### DIFF
--- a/phalcon/Paginator/Adapter/AbstractAdapter.zep
+++ b/phalcon/Paginator/Adapter/AbstractAdapter.zep
@@ -99,7 +99,7 @@ abstract class AbstractAdapter implements AdapterInterface
     public function setLimit(int limit) -> <AdapterInterface>
     {
         if limit <= 0 {
-            throw new Exception("Limit must be greater then zero");
+            throw new Exception("Limit must be greater than zero");
         }
         let this->limitRows = limit;
 

--- a/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/GetSetLimitCest.php
@@ -74,7 +74,7 @@ class GetSetLimitCest
 
         $I->expectThrowable(
             new Exception(
-                'Limit must be greater then zero'
+                'Limit must be greater than zero'
             ),
             function () use ($builder) {
                 $paginator = new QueryBuilder(

--- a/tests/integration/Mvc/Dispatcher/Refactor/DispatcherInitializeMethodCest.php
+++ b/tests/integration/Mvc/Dispatcher/Refactor/DispatcherInitializeMethodCest.php
@@ -155,7 +155,7 @@ class DispatcherInitializeMethodCest extends BaseDispatcher
         $dispatcher->getEventsManager()->attach(
             'dispatch:beforeException',
             function () use ($dispatcherListener) {
-                // Returning anything other then <tt>false</tt> should bubble the exception.
+                // Returning anything other than <tt>false</tt> should bubble the exception.
                 $dispatcherListener->trace(
                     'beforeException: custom before exception bubble'
                 );


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change: Fixed the same grammar error in three places in the repository. The word "then" was misused instead of the word "than" for a comparison.

Thanks,
Robin van der Vliet