### PR TITLE
T15615 http method status constants

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,9 @@
 ## Changed
 - Changed `composer.json` to use PSR 1.1.x [#15504](https://github.com/phalcon/cphalcon/issues/15504)
 
+## Added
+- Added `Phalcon\Http\Message\RequestMethodInterface` and `Phalcon\Http\Message\ResponseStatusCodeInterface` that contain constants to be used for any HTTP implementations (see PHP-FIG) [#15615](https://github.com/phalcon/cphalcon/issues/15615)
+
 ## Fixed
 - Fixed `Phalcon\Container` interface to abide with `Psr\Container\ContainerInterface` after the upgrade to PSR 1.1.x [#15504](https://github.com/phalcon/cphalcon/issues/15504)
 

--- a/phalcon/Http/Message/AbstractRequest.zep
+++ b/phalcon/Http/Message/AbstractRequest.zep
@@ -20,14 +20,14 @@ use Psr\Http\Message\UriInterface;
 /**
  * Request methods
  */
-abstract class AbstractRequest extends AbstractMessage
+abstract class AbstractRequest extends AbstractMessage implements RequestMethodInterface
 {
     /**
      * Retrieves the HTTP method of the request.
      *
      * @var string
      */
-    protected method = "GET" { get };
+    protected method = self::METHOD_GET { get };
 
     /**
      * The request-target, if it has been provided or calculated.
@@ -196,15 +196,16 @@ abstract class AbstractRequest extends AbstractMessage
         var methods;
 
         let methods = [
-            "GET"     : 1,
-            "CONNECT" : 1,
-            "DELETE"  : 1,
-            "HEAD"    : 1,
-            "OPTIONS" : 1,
-            "PATCH"   : 1,
-            "POST"    : 1,
-            "PUT"     : 1,
-            "TRACE"   : 1
+            self::METHOD_CONNECT : 1,
+            self::METHOD_DELETE  : 1,
+            self::METHOD_GET     : 1,
+            self::METHOD_HEAD    : 1,
+            self::METHOD_OPTIONS : 1,
+            self::METHOD_PATCH   : 1,
+            self::METHOD_POST    : 1,
+            self::METHOD_PURGE   : 1,
+            self::METHOD_PUT     : 1,
+            self::METHOD_TRACE   : 1
         ];
 
         if unlikely !(!empty(method) &&

--- a/phalcon/Http/Message/Request.zep
+++ b/phalcon/Http/Message/Request.zep
@@ -34,7 +34,7 @@ final class Request extends AbstractRequest implements RequestInterface
      * @param array                           $headers
      */
     public function __construct(
-        string method = "GET",
+        string method = self::METHOD_GET,
         var uri = null,
         var body = "php://memory",
         var headers = []

--- a/phalcon/Http/Message/RequestMethodInterface.zep
+++ b/phalcon/Http/Message/RequestMethodInterface.zep
@@ -8,7 +8,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Phalcon\Http;
+namespace Phalcon\Http\Message;
 
 /**
  * Interface for Request methods

--- a/phalcon/Http/Message/Response.zep
+++ b/phalcon/Http/Message/Response.zep
@@ -22,7 +22,7 @@ use Psr\Http\Message\ResponseInterface;
 /**
  * PSR-7 Response
  */
-final class Response extends AbstractMessage implements ResponseInterface
+final class Response extends AbstractMessage implements ResponseInterface, ResponseStatusCodeInterface
 {
     /**
      * Gets the response reason phrase associated with the status code.
@@ -103,94 +103,105 @@ final class Response extends AbstractMessage implements ResponseInterface
     protected function getPhrases() -> array
     {
         return [
-            100 : "Continue",                                         // Information - RFC 7231, 6.2.1
-            101 : "Switching Protocols",                              // Information - RFC 7231, 6.2.2
-            102 : "Processing",                                       // Information - RFC 2518, 10.1
-            103 : "Early Hints",
-            200 : "OK",                                               // Success - RFC 7231, 6.3.1
-            201 : "Created",                                          // Success - RFC 7231, 6.3.2
-            202 : "Accepted",                                         // Success - RFC 7231, 6.3.3
-            203 : "Non-Authoritative Information",                    // Success - RFC 7231, 6.3.4
-            204 : "No Content",                                       // Success - RFC 7231, 6.3.5
-            205 : "Reset Content",                                    // Success - RFC 7231, 6.3.6
-            206 : "Partial Content",                                  // Success - RFC 7233, 4.1
-            207 : "Multi-status",                                     // Success - RFC 4918, 11.1
-            208 : "Already Reported",                                 // Success - RFC 5842, 7.1
-            218 : "This is fine",                                     // Unofficial - Apache Web Server
-            419 : "Page Expired",                                     // Unofficial - Laravel Framework
-            226 : "IM Used",                                          // Success - RFC 3229, 10.4.1
-            300 : "Multiple Choices",                                 // Redirection - RFC 7231, 6.4.1
-            301 : "Moved Permanently",                                // Redirection - RFC 7231, 6.4.2
-            302 : "Found",                                            // Redirection - RFC 7231, 6.4.3
-            303 : "See Other",                                        // Redirection - RFC 7231, 6.4.4
-            304 : "Not Modified",                                     // Redirection - RFC 7232, 4.1
-            305 : "Use Proxy",                                        // Redirection - RFC 7231, 6.4.5
-            306 : "Switch Proxy",                                     // Redirection - RFC 7231, 6.4.6 (Deprecated)
-            307 : "Temporary Redirect",                               // Redirection - RFC 7231, 6.4.7
-            308 : "Permanent Redirect",                               // Redirection - RFC 7538, 3
-            400 : "Bad Request",                                      // Client Error - RFC 7231, 6.5.1
-            401 : "Unauthorized",                                     // Client Error - RFC 7235, 3.1
-            402 : "Payment Required",                                 // Client Error - RFC 7231, 6.5.2
-            403 : "Forbidden",                                        // Client Error - RFC 7231, 6.5.3
-            404 : "Not Found",                                        // Client Error - RFC 7231, 6.5.4
-            405 : "Method Not Allowed",                               // Client Error - RFC 7231, 6.5.5
-            406 : "Not Acceptable",                                   // Client Error - RFC 7231, 6.5.6
-            407 : "Proxy Authentication Required",                    // Client Error - RFC 7235, 3.2
-            408 : "Request Time-out",                                 // Client Error - RFC 7231, 6.5.7
-            409 : "Conflict",                                         // Client Error - RFC 7231, 6.5.8
-            410 : "Gone",                                             // Client Error - RFC 7231, 6.5.9
-            411 : "Length Required",                                  // Client Error - RFC 7231, 6.5.10
-            412 : "Precondition Failed",                              // Client Error - RFC 7232, 4.2
-            413 : "Request Entity Too Large",                         // Client Error - RFC 7231, 6.5.11
-            414 : "Request-URI Too Large",                            // Client Error - RFC 7231, 6.5.12
-            415 : "Unsupported Media Type",                           // Client Error - RFC 7231, 6.5.13
-            416 : "Requested range not satisfiable",                  // Client Error - RFC 7233, 4.4
-            417 : "Expectation Failed",                               // Client Error - RFC 7231, 6.5.14
-            418 : "I'm a teapot",                                     // Client Error - RFC 7168, 2.3.3
-            420 : "Method Failure",                                   // Unofficial - Spring Framework
-            421 : "Misdirected Request",
-            422 : "Unprocessable Entity",                             // Client Error - RFC 4918, 11.2
-            423 : "Locked",                                           // Client Error - RFC 4918, 11.3
-            424 : "Failed Dependency",                                // Client Error - RFC 4918, 11.4
-            425 : "Unordered Collection",
-            426 : "Upgrade Required",                                 // Client Error - RFC 7231, 6.5.15
-            428 : "Precondition Required",                            // Client Error - RFC 6585, 3
-            429 : "Too Many Requests",                                // Client Error - RFC 6585, 4
-            431 : "Request Header Fields Too Large",                  // Client Error - RFC 6585, 5
-            440 : "Login Time-out",                                   // Unofficial - IIS
-            444 : "No Response",                                      // Unofficial - nginx
-            449 : "Retry With",                                       // Unofficial - IIS
-            494 : "Request header too large",                         // Unofficial - nginx
-            495 : "SSL Certificate Error",                            // Unofficial - nginx
-            496 : "SSL Certificate Required",                         // Unofficial - nginx
-            497 : "HTTP Request Sent to HTTPS Port",                  // Unofficial - nginx
-            499 : "Client Closed Request",                            // Unofficial - nginx
-            450 : "Blocked by Windows Parental Controls (Microsoft)", // Unofficial - nginx
-            451 : "Unavailable For Legal Reasons",                    // Client Error - RFC 7725, 3
-            498 : "Invalid Token (Esri)",                             // Unofficial - ESRI
-            500 : "Internal Server Error",                            // Server Error - RFC 7231, 6.6.1
-            501 : "Not Implemented",                                  // Server Error - RFC 7231, 6.6.2
-            502 : "Bad Gateway",                                      // Server Error - RFC 7231, 6.6.3
-            503 : "Service Unavailable",                              // Server Error - RFC 7231, 6.6.4
-            504 : "Gateway Time-out",                                 // Server Error - RFC 7231, 6.6.5
-            505 : "HTTP Version not supported",                       // Server Error - RFC 7231, 6.6.6
-            506 : "Variant Also Negotiates",                          // Server Error - RFC 2295, 8.1
-            507 : "Insufficient Storage",                             // Server Error - RFC 4918, 11.5
-            508 : "Loop Detected",                                    // Server Error - RFC 5842, 7.2
-            509 : "Bandwidth Limit Exceeded",                         // Unofficial - Apache/cPanel
-            510 : "Not Extended",                                     // Server Error - RFC 2774, 7
-            511 : "Network Authentication Required",                  // Server Error - RFC 6585, 6
-            520 : "Unknown Error",                                    // Unofficial - Cloudflare
-            521 : "Web Server Is Down",                               // Unofficial - Cloudflare
-            522 : "Connection Timed Out",                             // Unofficial - Cloudflare
-            523 : "Origin Is Unreachable",                            // Unofficial - Cloudflare
-            524 : "A Timeout Occurred",                               // Unofficial - Cloudflare
-            525 : "SSL Handshake Failed",                             // Unofficial - Cloudflare
-            526 : "Invalid SSL Certificate",                          // Unofficial - Cloudflare
-            527 : "Railgun Error",                                    // Unofficial - Cloudflare
-            530 : "Origin DNS Error",                                 // Unofficial - Cloudflare
-            598 : "Network read timeout error",                       // Unofficial
-            599 : "Network Connect Timeout Error"                     // Server Error - RFC 6585, 6
+            // Informational 1xx
+            self::STATUS_CONTINUE                             : "Continue",                                           // Information - RFC 7231, 6.2.1
+            self::STATUS_SWITCHING_PROTOCOLS                  : "Switching Protocols",                                // Information - RFC 7231, 6.2.2
+            self::STATUS_PROCESSING                           : "Processing",                                         // Information - RFC 2518, 10.1
+            self::STATUS_EARLY_HINTS                          : "Early Hints",
+
+            // Successful 2xx
+            self::STATUS_OK                                   : "OK",                                               // Success - RFC 7231, 6.3.1
+            self::STATUS_CREATED                              : "Created",                                          // Success - RFC 7231, 6.3.2
+            self::STATUS_ACCEPTED                             : "Accepted",                                         // Success - RFC 7231, 6.3.3
+            self::STATUS_NON_AUTHORITATIVE_INFORMATION        : "Non-Authoritative Information",                    // Success - RFC 7231, 6.3.4
+            self::STATUS_NO_CONTENT                           : "No Content",                                       // Success - RFC 7231, 6.3.5
+            self::STATUS_RESET_CONTENT                        : "Reset Content",                                    // Success - RFC 7231, 6.3.6
+            self::STATUS_PARTIAL_CONTENT                      : "Partial Content",                                  // Success - RFC 7233, 4.1
+            self::STATUS_MULTI_STATUS                         : "Multi-status",                                     // Success - RFC 4918, 11.1
+            self::STATUS_ALREADY_REPORTED                     : "Already Reported",                                 // Success - RFC 5842, 7.1
+            self::STATUS_IM_USED                              : "IM Used",                                          // Success - RFC 3229, 10.4.1
+
+            // Redirection 3xx
+            self::STATUS_MULTIPLE_CHOICES                     : "Multiple Choices",                                 // Redirection - RFC 7231, 6.4.1
+            self::STATUS_MOVED_PERMANENTLY                    : "Moved Permanently",                                // Redirection - RFC 7231, 6.4.2
+            self::STATUS_FOUND                                : "Found",                                            // Redirection - RFC 7231, 6.4.3
+            self::STATUS_SEE_OTHER                            : "See Other",                                        // Redirection - RFC 7231, 6.4.4
+            self::STATUS_NOT_MODIFIED                         : "Not Modified",                                     // Redirection - RFC 7232, 4.1
+            self::STATUS_USE_PROXY                            : "Use Proxy",                                        // Redirection - RFC 7231, 6.4.5
+            self::STATUS_RESERVED                             : "Switch Proxy",                                     // Redirection - RFC 7231, 6.4.6 (Deprecated)
+            self::STATUS_TEMPORARY_REDIRECT                   : "Temporary Redirect",                               // Redirection - RFC 7231, 6.4.7
+            self::STATUS_PERMANENT_REDIRECT                   : "Permanent Redirect",                               // Redirection - RFC 7538, 3
+
+            // Client Errors 4xx
+            self::STATUS_BAD_REQUEST                          : "Bad Request",                                      // Client Error - RFC 7231, 6.5.1
+            self::STATUS_UNAUTHORIZED                         : "Unauthorized",                                     // Client Error - RFC 7235, 3.1
+            self::STATUS_PAYMENT_REQUIRED                     : "Payment Required",                                 // Client Error - RFC 7231, 6.5.2
+            self::STATUS_FORBIDDEN                            : "Forbidden",                                        // Client Error - RFC 7231, 6.5.3
+            self::STATUS_NOT_FOUND                            : "Not Found",                                        // Client Error - RFC 7231, 6.5.4
+            self::STATUS_METHOD_NOT_ALLOWED                   : "Method Not Allowed",                               // Client Error - RFC 7231, 6.5.5
+            self::STATUS_NOT_ACCEPTABLE                       : "Not Acceptable",                                   // Client Error - RFC 7231, 6.5.6
+            self::STATUS_PROXY_AUTHENTICATION_REQUIRED        : "Proxy Authentication Required",                    // Client Error - RFC 7235, 3.2
+            self::STATUS_REQUEST_TIMEOUT                      : "Request Time-out",                                 // Client Error - RFC 7231, 6.5.7
+            self::STATUS_CONFLICT                             : "Conflict",                                         // Client Error - RFC 7231, 6.5.8
+            self::STATUS_GONE                                 : "Gone",                                             // Client Error - RFC 7231, 6.5.9
+            self::STATUS_LENGTH_REQUIRED                      : "Length Required",                                  // Client Error - RFC 7231, 6.5.10
+            self::STATUS_PRECONDITION_FAILED                  : "Precondition Failed",                              // Client Error - RFC 7232, 4.2
+            self::STATUS_PAYLOAD_TOO_LARGE                    : "Request Entity Too Large",                         // Client Error - RFC 7231, 6.5.11
+            self::STATUS_URI_TOO_LONG                         : "Request-URI Too Large",                            // Client Error - RFC 7231, 6.5.12
+            self::STATUS_UNSUPPORTED_MEDIA_TYPE               : "Unsupported Media Type",                           // Client Error - RFC 7231, 6.5.13
+            self::STATUS_RANGE_NOT_SATISFIABLE                : "Requested range not satisfiable",                  // Client Error - RFC 7233, 4.4
+            self::STATUS_EXPECTATION_FAILED                   : "Expectation Failed",                               // Client Error - RFC 7231, 6.5.14
+            self::STATUS_IM_A_TEAPOT                          : "I'm a teapot",                                     // Client Error - RFC 7168, 2.3.3
+            self::STATUS_MISDIRECTED_REQUEST                  : "Misdirected Request",
+            self::STATUS_UNPROCESSABLE_ENTITY                 : "Unprocessable Entity",                             // Client Error - RFC 4918, 11.2
+            self::STATUS_LOCKED                               : "Locked",                                           // Client Error - RFC 4918, 11.3
+            self::STATUS_FAILED_DEPENDENCY                    : "Failed Dependency",                                // Client Error - RFC 4918, 11.4
+            self::STATUS_TOO_EARLY                            : "Unordered Collection",
+            self::STATUS_UPGRADE_REQUIRED                     : "Upgrade Required",                                 // Client Error - RFC 7231, 6.5.15
+            self::STATUS_PRECONDITION_REQUIRED                : "Precondition Required",                            // Client Error - RFC 6585, 3
+            self::STATUS_TOO_MANY_REQUESTS                    : "Too Many Requests",                                // Client Error - RFC 6585, 4
+            self::STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE      : "Request Header Fields Too Large",                  // Client Error - RFC 6585, 5
+            self::STATUS_UNAVAILABLE_FOR_LEGAL_REASONS        : "Unavailable For Legal Reasons",                    // Client Error - RFC 7725, 3
+
+            // Server Errors 5xx
+            self::STATUS_INTERNAL_SERVER_ERROR                : "Internal Server Error",                            // Server Error - RFC 7231, 6.6.1
+            self::STATUS_NOT_IMPLEMENTED                      : "Not Implemented",                                  // Server Error - RFC 7231, 6.6.2
+            self::STATUS_BAD_GATEWAY                          : "Bad Gateway",                                      // Server Error - RFC 7231, 6.6.3
+            self::STATUS_SERVICE_UNAVAILABLE                  : "Service Unavailable",                              // Server Error - RFC 7231, 6.6.4
+            self::STATUS_GATEWAY_TIMEOUT                      : "Gateway Time-out",                                 // Server Error - RFC 7231, 6.6.5
+            self::STATUS_VERSION_NOT_SUPPORTED                : "HTTP Version not supported",                       // Server Error - RFC 7231, 6.6.6
+            self::STATUS_VARIANT_ALSO_NEGOTIATES              : "Variant Also Negotiates",                          // Server Error - RFC 2295, 8.1
+            self::STATUS_INSUFFICIENT_STORAGE                 : "Insufficient Storage",                             // Server Error - RFC 4918, 11.5
+            self::STATUS_LOOP_DETECTED                        : "Loop Detected",                                    // Server Error - RFC 5842, 7.2
+            self::STATUS_NOT_EXTENDED                         : "Not Extended",                                     // Server Error - RFC 2774, 7
+            self::STATUS_NETWORK_AUTHENTICATION_REQUIRED      : "Network Authentication Required",                  // Server Error - RFC 6585, 6
+
+            // Unofficial
+            self::STATUS_THIS_IS_FINE                         : "This is fine",                                     // Unofficial - Apache Web Server
+            self::STATUS_PAGE_EXPIRED                         : "Page Expired",                                     // Unofficial - Laravel Framework
+            self::STATUS_METHOD_FAILURE                       : "Method Failure",                                   // Unofficial - Spring Framework
+            self::STATUS_LOGIN_TIMEOUT                        : "Login Time-out",                                   // Unofficial - IIS
+            self::STATUS_NO_RESPONSE                          : "No Response",                                      // Unofficial - nginx
+            self::STATUS_RETRY_WITH                           : "Retry With",                                       // Unofficial - IIS
+            self::STATUS_BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS : "Blocked by Windows Parental Controls (Microsoft)", // Unofficial - nginx
+            self::STATUS_REQUEST_HEADER_TOO_LARGE             : "Request header too large",                         // Unofficial - nginx
+            self::STATUS_SSL_CERTIFICATE_ERROR                : "SSL Certificate Error",                            // Unofficial - nginx
+            self::STATUS_SSL_CERTIFICATE_REQUIRED             : "SSL Certificate Required",                         // Unofficial - nginx
+            self::STATUS_HTTP_REQUEST_SENT_TO_HTTPS_PORT      : "HTTP Request Sent to HTTPS Port",                  // Unofficial - nginx
+            self::STATUS_INVALID_TOKEN_ESRI                   : "Invalid Token (Esri)",                             // Unofficial - ESRI
+            self::STATUS_CLIENT_CLOSED_REQUEST                : "Client Closed Request",                            // Unofficial - nginx
+            self::STATUS_BANDWIDTH_LIMIT_EXCEEDED             : "Bandwidth Limit Exceeded",                         // Unofficial - Apache/cPanel
+            self::STATUS_UNKNOWN_ERROR                        : "Unknown Error",                                    // Unofficial - Cloudflare
+            self::STATUS_WEB_SERVER_IS_DOWN                   : "Web Server Is Down",                               // Unofficial - Cloudflare
+            self::STATUS_CONNECTION_TIMEOUT                   : "Connection Timed Out",                             // Unofficial - Cloudflare
+            self::STATUS_ORIGIN_IS_UNREACHABLE                : "Origin Is Unreachable",                            // Unofficial - Cloudflare
+            self::STATUS_TIMEOUT_OCCURRED                     : "A Timeout Occurred",                               // Unofficial - Cloudflare
+            self::STATUS_SSL_HANDSHAKE_FAILED                 : "SSL Handshake Failed",                             // Unofficial - Cloudflare
+            self::STATUS_INVALID_SSL_CERTIFICATE              : "Invalid SSL Certificate",                          // Unofficial - Cloudflare
+            self::STATUS_RAILGUN_ERROR                        : "Railgun Error",                                    // Unofficial - Cloudflare
+            self::STATUS_ORIGIN_DNS_ERROR                     : "Origin DNS Error",                                 // Unofficial - Cloudflare
+            self::STATUS_NETWORK_READ_TIMEOUT_ERROR           : "Network read timeout error",                       // Unofficial
+            self::STATUS_NETWORK_CONNECT_TIMEOUT_ERROR        : "Network Connect Timeout Error"                     // Unofficial
         ];
     }
 

--- a/phalcon/Http/Message/ResponseStatusCodeInterface.zep
+++ b/phalcon/Http/Message/ResponseStatusCodeInterface.zep
@@ -1,0 +1,142 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Http\Message;
+
+/**
+ * Interface for Request methods
+ *
+ * Implementation of this file has been influenced by PHP FIG
+ * @link    https://github.com/php-fig/http-message-util/
+ * @license https://github.com/php-fig/http-message-util/blob/master/LICENSE
+ *
+ * Defines constants for common HTTP status code.
+ *
+ * @see https://tools.ietf.org/html/rfc2295#section-8.1
+ * @see https://tools.ietf.org/html/rfc2324#section-2.3
+ * @see https://tools.ietf.org/html/rfc2518#section-9.7
+ * @see https://tools.ietf.org/html/rfc2774#section-7
+ * @see https://tools.ietf.org/html/rfc3229#section-10.4
+ * @see https://tools.ietf.org/html/rfc4918#section-11
+ * @see https://tools.ietf.org/html/rfc5842#section-7.1
+ * @see https://tools.ietf.org/html/rfc5842#section-7.2
+ * @see https://tools.ietf.org/html/rfc6585#section-3
+ * @see https://tools.ietf.org/html/rfc6585#section-4
+ * @see https://tools.ietf.org/html/rfc6585#section-5
+ * @see https://tools.ietf.org/html/rfc6585#section-6
+ * @see https://tools.ietf.org/html/rfc7231#section-6
+ * @see https://tools.ietf.org/html/rfc7238#section-3
+ * @see https://tools.ietf.org/html/rfc7725#section-3
+ * @see https://tools.ietf.org/html/rfc7540#section-9.1.2
+ * @see https://tools.ietf.org/html/rfc8297#section-2
+ * @see https://tools.ietf.org/html/rfc8470#section-7
+ */
+interface ResponseStatusCodeInterface
+{
+    // Informational 1xx
+    const STATUS_CONTINUE                        = 100;
+    const STATUS_SWITCHING_PROTOCOLS             = 101;
+    const STATUS_PROCESSING                      = 102;
+    const STATUS_EARLY_HINTS                     = 103;
+
+    // Successful 2xx
+    const STATUS_OK                              = 200;
+    const STATUS_CREATED                         = 201;
+    const STATUS_ACCEPTED                        = 202;
+    const STATUS_NON_AUTHORITATIVE_INFORMATION   = 203;
+    const STATUS_NO_CONTENT                      = 204;
+    const STATUS_RESET_CONTENT                   = 205;
+    const STATUS_PARTIAL_CONTENT                 = 206;
+    const STATUS_MULTI_STATUS                    = 207;
+    const STATUS_ALREADY_REPORTED                = 208;
+    const STATUS_IM_USED                         = 226;
+
+    // Redirection 3xx
+    const STATUS_MULTIPLE_CHOICES                = 300;
+    const STATUS_MOVED_PERMANENTLY               = 301;
+    const STATUS_FOUND                           = 302;
+    const STATUS_SEE_OTHER                       = 303;
+    const STATUS_NOT_MODIFIED                    = 304;
+    const STATUS_USE_PROXY                       = 305;
+    const STATUS_RESERVED                        = 306;
+    const STATUS_TEMPORARY_REDIRECT              = 307;
+    const STATUS_PERMANENT_REDIRECT              = 308;
+
+    // Client Errors 4xx
+    const STATUS_BAD_REQUEST                     = 400;
+    const STATUS_UNAUTHORIZED                    = 401;
+    const STATUS_PAYMENT_REQUIRED                = 402;
+    const STATUS_FORBIDDEN                       = 403;
+    const STATUS_NOT_FOUND                       = 404;
+    const STATUS_METHOD_NOT_ALLOWED              = 405;
+    const STATUS_NOT_ACCEPTABLE                  = 406;
+    const STATUS_PROXY_AUTHENTICATION_REQUIRED   = 407;
+    const STATUS_REQUEST_TIMEOUT                 = 408;
+    const STATUS_CONFLICT                        = 409;
+    const STATUS_GONE                            = 410;
+    const STATUS_LENGTH_REQUIRED                 = 411;
+    const STATUS_PRECONDITION_FAILED             = 412;
+    const STATUS_PAYLOAD_TOO_LARGE               = 413;
+    const STATUS_URI_TOO_LONG                    = 414;
+    const STATUS_UNSUPPORTED_MEDIA_TYPE          = 415;
+    const STATUS_RANGE_NOT_SATISFIABLE           = 416;
+    const STATUS_EXPECTATION_FAILED              = 417;
+    const STATUS_IM_A_TEAPOT                     = 418;
+    const STATUS_MISDIRECTED_REQUEST             = 421;
+    const STATUS_UNPROCESSABLE_ENTITY            = 422;
+    const STATUS_LOCKED                          = 423;
+    const STATUS_FAILED_DEPENDENCY               = 424;
+    const STATUS_TOO_EARLY                       = 425;
+    const STATUS_UPGRADE_REQUIRED                = 426;
+    const STATUS_PRECONDITION_REQUIRED           = 428;
+    const STATUS_TOO_MANY_REQUESTS               = 429;
+    const STATUS_REQUEST_HEADER_FIELDS_TOO_LARGE = 431;
+    const STATUS_UNAVAILABLE_FOR_LEGAL_REASONS   = 451;
+
+    // Server Errors 5xx
+    const STATUS_INTERNAL_SERVER_ERROR           = 500;
+    const STATUS_NOT_IMPLEMENTED                 = 501;
+    const STATUS_BAD_GATEWAY                     = 502;
+    const STATUS_SERVICE_UNAVAILABLE             = 503;
+    const STATUS_GATEWAY_TIMEOUT                 = 504;
+    const STATUS_VERSION_NOT_SUPPORTED           = 505;
+    const STATUS_VARIANT_ALSO_NEGOTIATES         = 506;
+    const STATUS_INSUFFICIENT_STORAGE            = 507;
+    const STATUS_LOOP_DETECTED                   = 508;
+    const STATUS_NOT_EXTENDED                    = 510;
+    const STATUS_NETWORK_AUTHENTICATION_REQUIRED = 511;
+
+    // Unofficial
+    const STATUS_THIS_IS_FINE                         = 218; // Unofficial - Apache Web Server
+    const STATUS_PAGE_EXPIRED                         = 419; // Unofficial - Laravel Framework
+    const STATUS_METHOD_FAILURE                       = 420; // Unofficial - Spring Framework
+    const STATUS_LOGIN_TIMEOUT                        = 440; // Unofficial - IIS
+    const STATUS_NO_RESPONSE                          = 444; // Unofficial - nginx
+    const STATUS_RETRY_WITH                           = 449; // Unofficial - IIS
+    const STATUS_BLOCKED_BY_WINDOWS_PARENTAL_CONTROLS = 450; // Unofficial - nginx
+    const STATUS_REQUEST_HEADER_TOO_LARGE             = 494; // Unofficial - nginx
+    const STATUS_SSL_CERTIFICATE_ERROR                = 495; // Unofficial - nginx
+    const STATUS_SSL_CERTIFICATE_REQUIRED             = 496; // Unofficial - nginx
+    const STATUS_HTTP_REQUEST_SENT_TO_HTTPS_PORT      = 497; // Unofficial - nginx
+    const STATUS_INVALID_TOKEN_ESRI                   = 498; // Unofficial - ESRI
+    const STATUS_CLIENT_CLOSED_REQUEST                = 499; // Unofficial - nginx
+    const STATUS_BANDWIDTH_LIMIT_EXCEEDED             = 509; // Unofficial - Apache/cPanel
+    const STATUS_UNKNOWN_ERROR                        = 520; // Unofficial - Cloudflare
+    const STATUS_WEB_SERVER_IS_DOWN                   = 521; // Unofficial - Cloudflare
+    const STATUS_CONNECTION_TIMEOUT                   = 522; // Unofficial - Cloudflare
+    const STATUS_ORIGIN_IS_UNREACHABLE                = 523; // Unofficial - Cloudflare
+    const STATUS_TIMEOUT_OCCURRED                     = 524; // Unofficial - Cloudflare
+    const STATUS_SSL_HANDSHAKE_FAILED                 = 525; // Unofficial - Cloudflare
+    const STATUS_INVALID_SSL_CERTIFICATE              = 526; // Unofficial - Cloudflare
+    const STATUS_RAILGUN_ERROR                        = 527; // Unofficial - Cloudflare
+    const STATUS_ORIGIN_DNS_ERROR                     = 530; // Unofficial - Cloudflare
+    const STATUS_NETWORK_READ_TIMEOUT_ERROR           = 598; // Unofficial
+    const STATUS_NETWORK_CONNECT_TIMEOUT_ERROR        = 599; // Unofficial
+}

--- a/phalcon/Http/Message/ServerRequest.zep
+++ b/phalcon/Http/Message/ServerRequest.zep
@@ -114,7 +114,7 @@ final class ServerRequest extends AbstractRequest implements ServerRequestInterf
      * @param string                   $protocol
      */
     public function __construct(
-        string method = "GET",
+        string method = self::METHOD_GET,
         var uri = null,
         array serverParams = [],
         var body = "php://input",

--- a/phalcon/Http/Message/ServerRequestFactory.zep
+++ b/phalcon/Http/Message/ServerRequestFactory.zep
@@ -26,7 +26,7 @@ use Psr\Http\Message\UploadedFileInterface;
 /**
  * PSR-17 ServerRequestFactory
  */
-class ServerRequestFactory implements ServerRequestFactoryInterface
+class ServerRequestFactory implements ServerRequestFactoryInterface, RequestMethodInterface
 {
     /**
      * Create a new server request.
@@ -114,7 +114,7 @@ class ServerRequestFactory implements ServerRequestFactoryInterface
             get               = this->checkNullArray(get, globalGet),
             post              = this->checkNullArray(post, globalPost),
             serverCollection  = this->parseServer(server),
-            method            = serverCollection->get("REQUEST_METHOD", "GET"),
+            method            = serverCollection->get("REQUEST_METHOD", self::METHOD_GET),
             protocol          = this->parseProtocol(serverCollection),
             headers           = this->parseHeaders(serverCollection),
             filesCollection   = this->parseUploadedFiles(files),

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -15,6 +15,7 @@ use Phalcon\Di\AbstractInjectionAware;
 use Phalcon\Events\ManagerInterface;
 use Phalcon\Filter\FilterInterface;
 use Phalcon\Helper\Json;
+use Phalcon\Http\Message\RequestMethodInterface;
 use Phalcon\Http\Request\File;
 use Phalcon\Http\Request\FileInterface;
 use Phalcon\Http\Request\Exception;

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -47,7 +47,7 @@ use stdClass;
  * $request->getLanguages();
  *```
  */
-class Request extends AbstractInjectionAware implements RequestInterface
+class Request extends AbstractInjectionAware implements RequestInterface, RequestMethodInterface
 {
     /**
      * @var FilterInterface|null
@@ -91,8 +91,13 @@ class Request extends AbstractInjectionAware implements RequestInterface
      * $userEmail = $request->get("user_email", "email");
      *```
      */
-    public function get(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function get(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         return this->getHelper(
             _REQUEST,
             name,
@@ -276,11 +281,15 @@ class Request extends AbstractInjectionAware implements RequestInterface
     /**
      * Retrieves a query/get value always sanitized with the preset filters
      */
-    public function getFilteredQuery(string! name = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function getFilteredQuery(
+        string! name = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         var filters;
 
-        if !fetch filters, this->queryFilters["get"][name] {
+        if !fetch filters, this->queryFilters[self::METHOD_GET][name] {
             let filters = [];
         }
 
@@ -296,11 +305,15 @@ class Request extends AbstractInjectionAware implements RequestInterface
     /**
      * Retrieves a post value always sanitized with the preset filters
      */
-    public function getFilteredPost(string! name = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function getFilteredPost(
+        string! name = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         var filters;
 
-        if !fetch filters, this->queryFilters["post"][name] {
+        if !fetch filters, this->queryFilters[self::METHOD_POST][name] {
             let filters = [];
         }
 
@@ -316,11 +329,15 @@ class Request extends AbstractInjectionAware implements RequestInterface
     /**
      * Retrieves a put value always sanitized with the preset filters
      */
-    public function getFilteredPut(string! name = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function getFilteredPut(
+        string! name = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         var filters;
 
-        if !fetch filters, this->queryFilters["put"][name] {
+        if !fetch filters, this->queryFilters[self::METHOD_PUT][name] {
             let filters = [];
         }
 
@@ -576,10 +593,10 @@ class Request extends AbstractInjectionAware implements RequestInterface
         if likely fetch requestMethod, server["REQUEST_METHOD"] {
             let returnMethod = strtoupper(requestMethod);
         } else {
-            return "GET";
+            return self::METHOD_GET;
         }
 
-        if "POST" === returnMethod {
+        if self::METHOD_POST === returnMethod {
             let overridedMethod = this->getHeader("X-HTTP-METHOD-OVERRIDE");
 
             if !empty overridedMethod {
@@ -592,7 +609,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
         }
 
         if !this->isValidHttpMethod(returnMethod) {
-            return "GET";
+            return self::METHOD_GET;
         }
 
         return returnMethod;
@@ -637,8 +654,13 @@ class Request extends AbstractInjectionAware implements RequestInterface
      * $userEmail = $request->getPost("user_email", "email");
      *```
      */
-    public function getPost(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function getPost(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         return this->getHelper(
             _POST,
             name,
@@ -660,8 +682,13 @@ class Request extends AbstractInjectionAware implements RequestInterface
      * $userEmail = $request->getPut("user_email", "email");
      *```
      */
-    public function getPut(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function getPut(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         var put, contentType;
 
         let put = this->putCache;
@@ -709,8 +736,13 @@ class Request extends AbstractInjectionAware implements RequestInterface
      * $id = $request->getQuery("id", null, 150);
      *```
      */
-    public function getQuery(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var
-    {
+    public function getQuery(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var {
         return this->getHelper(
             _GET,
             name,
@@ -811,8 +843,10 @@ class Request extends AbstractInjectionAware implements RequestInterface
     /**
      * Gets attached files as Phalcon\Http\Request\File instances
      */
-    public function getUploadedFiles(bool onlySuccessful = false, bool namedKeys = false) -> <FileInterface[]>
-    {
+    public function getUploadedFiles(
+        bool onlySuccessful = false,
+        bool namedKeys = false
+    ) -> <FileInterface[]> {
         var superFiles, prefix, input, smoothInput, file, dataFile;
         array files = [];
 
@@ -986,7 +1020,8 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isAjax() -> bool
     {
-        return this->hasServer("HTTP_X_REQUESTED_WITH") && this->getServer("HTTP_X_REQUESTED_WITH") === "XMLHttpRequest";
+        return this->hasServer("HTTP_X_REQUESTED_WITH") &&
+            this->getServer("HTTP_X_REQUESTED_WITH") === "XMLHttpRequest";
     }
 
     /**
@@ -995,7 +1030,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isConnect() -> bool
     {
-        return this->getMethod() === "CONNECT";
+        return this->getMethod() === self::METHOD_CONNECT;
     }
 
     /**
@@ -1004,7 +1039,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isDelete() -> bool
     {
-        return this->getMethod() === "DELETE";
+        return this->getMethod() === self::METHOD_DELETE;
     }
 
     /**
@@ -1013,7 +1048,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isGet() -> bool
     {
-        return this->getMethod() === "GET";
+        return this->getMethod() === self::METHOD_GET;
     }
 
     /**
@@ -1022,7 +1057,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isHead() -> bool
     {
-        return this->getMethod() === "HEAD";
+        return this->getMethod() === self::METHOD_HEAD;
     }
 
     /**
@@ -1066,7 +1101,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isOptions() -> bool
     {
-        return this->getMethod() === "OPTIONS";
+        return this->getMethod() === self::METHOD_OPTIONS;
     }
 
     /**
@@ -1075,7 +1110,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isPatch() -> bool
     {
-        return this->getMethod() === "PATCH";
+        return this->getMethod() === self::METHOD_PATCH;
     }
 
     /**
@@ -1084,7 +1119,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isPost() -> bool
     {
-        return this->getMethod() === "POST";
+        return this->getMethod() === self::METHOD_POST;
     }
 
     /**
@@ -1093,7 +1128,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isPut() -> bool
     {
-        return this->getMethod() === "PUT";
+        return this->getMethod() === self::METHOD_PUT;
     }
 
     /**
@@ -1102,7 +1137,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isPurge() -> bool
     {
-        return this->getMethod() === "PURGE";
+        return this->getMethod() === self::METHOD_PURGE;
     }
 
     /**
@@ -1148,7 +1183,7 @@ class Request extends AbstractInjectionAware implements RequestInterface
      */
     public function isTrace() -> bool
     {
-        return this->getMethod() === "TRACE";
+        return this->getMethod() === self::METHOD_TRACE;
     }
 
     /**
@@ -1157,16 +1192,16 @@ class Request extends AbstractInjectionAware implements RequestInterface
     public function isValidHttpMethod(string method) -> bool
     {
         switch strtoupper(method) {
-            case "GET":
-            case "POST":
-            case "PUT":
-            case "DELETE":
-            case "HEAD":
-            case "OPTIONS":
-            case "PATCH":
-            case "PURGE": // Squid and Varnish support
-            case "TRACE":
-            case "CONNECT":
+            case self::METHOD_CONNECT:
+            case self::METHOD_DELETE:
+            case self::METHOD_GET:
+            case self::METHOD_HEAD:
+            case self::METHOD_OPTIONS:
+            case self::METHOD_PATCH:
+            case self::METHOD_POST:
+            case self::METHOD_PURGE:  // Squid and Varnish support
+            case self::METHOD_PUT:
+            case self::METHOD_TRACE:
                 return true;
         }
 
@@ -1211,8 +1246,11 @@ class Request extends AbstractInjectionAware implements RequestInterface
      * Sets automatic sanitizers/filters for a particular field and for
      * particular methods
      */
-    public function setParameterFilters(string! name, array filters = [], array scope = []) -> <RequestInterface>
-    {
+    public function setParameterFilters(
+        string! name,
+        array filters = [],
+        array scope = []
+    ) -> <RequestInterface> {
         var filterService, sanitizer, localScope, scopeMethod;
 
         if unlikely count(filters) < 1 {
@@ -1232,13 +1270,17 @@ class Request extends AbstractInjectionAware implements RequestInterface
         }
 
         if count(scope) < 1 {
-            let localScope = ["get", "post", "put"];
+            let localScope = [
+                self::METHOD_GET,
+                self::METHOD_POST,
+                self::METHOD_PUT
+            ];
         } else {
             let localScope = scope;
         }
 
         for scopeMethod in localScope {
-            let this->queryFilters[scopeMethod][name] = filters;
+            let this->queryFilters[strtoupper(scopeMethod)][name] = filters;
         }
 
         return this;

--- a/phalcon/Http/RequestInterface.zep
+++ b/phalcon/Http/RequestInterface.zep
@@ -30,7 +30,13 @@ interface RequestInterface
      * $userEmail = $request->get("user_email", "email");
      *```
      */
-    public function get(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var;
+    public function get(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var;
 
     /**
      * Gets an array with mime/types and their quality accepted by the
@@ -205,7 +211,13 @@ interface RequestInterface
      * $userEmail = $request->getPost("user_email", "email");
      *```
      */
-    public function getPost(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var;
+    public function getPost(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var;
 
     /**
      * Gets a variable from put request
@@ -218,7 +230,13 @@ interface RequestInterface
      * $userEmail = $request->getPut("user_email", "email");
      *```
      */
-    public function getPut(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var;
+    public function getPut(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var;
 
     /**
      * Gets variable from $_GET superglobal applying filters if needed
@@ -235,7 +253,13 @@ interface RequestInterface
      * $id = $request->getQuery("id", null, 150);
      *```
      */
-    public function getQuery(string! name = null, var filters = null, var defaultValue = null, bool notAllowEmpty = false, bool noRecursive = false) -> var;
+    public function getQuery(
+        string! name = null,
+        var filters = null,
+        var defaultValue = null,
+        bool notAllowEmpty = false,
+        bool noRecursive = false
+    ) -> var;
 
     /**
      * Gets HTTP raw request body
@@ -267,7 +291,10 @@ interface RequestInterface
      * Gets attached files as Phalcon\Http\Request\FileInterface compatible
      * instances
      */
-    public function getUploadedFiles(bool onlySuccessful = false, bool namedKeys = false) -> <FileInterface[]>;
+    public function getUploadedFiles(
+        bool onlySuccessful = false,
+        bool namedKeys = false
+    ) -> <FileInterface[]>;
 
     /**
      * Gets HTTP user agent used to made the request

--- a/phalcon/Http/RequestMethodInterface.zep
+++ b/phalcon/Http/RequestMethodInterface.zep
@@ -1,0 +1,32 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Http;
+
+/**
+ * Interface for Request methods
+ *
+ * Implementation of this file has been influenced by PHP FIG
+ * @link    https://github.com/php-fig/http-message-util/
+ * @license https://github.com/php-fig/http-message-util/blob/master/LICENSE
+ */
+interface RequestMethodInterface
+{
+    const METHOD_CONNECT = "CONNECT";
+    const METHOD_DELETE  = "DELETE";
+    const METHOD_GET     = "GET";
+    const METHOD_HEAD    = "HEAD";
+    const METHOD_OPTIONS = "OPTIONS";
+    const METHOD_PATCH   = "PATCH";
+    const METHOD_POST    = "POST";
+    const METHOD_PURGE   = "PURGE";
+    const METHOD_PUT     = "PUT";
+    const METHOD_TRACE   = "TRACE";
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #15615 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added interfaces with constants for methods and status codes for the HTTP namespace. (see PHP-FIG)

Thanks

