### PR TITLE
T15292 flash css classes

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,9 @@
 ## Changed
 - Changed `composer.json` to use PSR 1.1.x [#15504](https://github.com/phalcon/cphalcon/issues/15504)
 
+## Added
+- Added `Phalcon\Flash\Direct::setCssIconClasses` and `Phalcon\Flash\Session::setCssIconClasses` to allow setting icons in the flash messages (bootstrap related) [#15292](https://github.com/phalcon/cphalcon/issues/15292)
+
 ## Fixed
 - Fixed `Phalcon\Container` interface to abide with `Psr\Container\ContainerInterface` after the upgrade to PSR 1.1.x [#15504](https://github.com/phalcon/cphalcon/issues/15504)
 

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -43,6 +43,11 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     protected cssClasses = [] { get };
 
     /**
+     * @var array
+     */
+    protected iconCssClasses = [] { get };
+
+    /**
      * @var string
      */
     protected customTemplate = "" { get };
@@ -177,7 +182,27 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     }
 
     /**
-     * Set an custom template for showing the messages
+     * Set an array with CSS classes to format the icon messages
+     */
+    public function setIconCssClasses(array! iconCssClasses) -> <FlashInterface>
+    {
+        let this->iconCssClasses  = iconCssClasses;
+
+        return this;
+    }
+
+    /**
+     * Set an array with CSS classes to format the icon messages
+     */
+    public function setIconCssClasses(array! iconCssClasses) -> <FlashInterface>
+    {
+        let this->iconCssClasses  = iconCssClasses;
+
+        return this;
+    }
+    
+    /**
+     * Set a custom template for showing the messages
      */
     public function setCustomTemplate(string! customTemplate) -> <FlashInterface>
     {
@@ -315,13 +340,17 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     }
 
 
-    private function getTemplate(string cssClassses) -> string
+    private function getTemplate(string cssClassses, string iconCssClassses) -> string
     {
         if "" === this->customTemplate {
-            if "" === cssClassses {
+            if "" === cssClassses && "" === iconCssClassses {
                 return "<div>%message%</div>" . PHP_EOL;
             } else {
-                return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+                if !empty iconCssClassses {
+                    return "<div class=\"%cssClass%\"><i class=\"%iconCssClass%\"></i> %message%</div>" . PHP_EOL;
+                } else {
+                    return "<div class=\"%cssClass%\">%message%</div>" . PHP_EOL;
+                }
             }
         }
 
@@ -353,7 +382,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      */
     private function prepareHtmlMessage(string type, string message) -> string
     {
-        var classes, cssClasses, typeClasses, automaticHtml;
+        var classes, cssClasses, iconCssClasses, typeClasses, typeIconClasses, automaticHtml;
 
         let automaticHtml = (bool) this->automaticHtml;
 
@@ -362,6 +391,8 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
         }
 
         let classes = this->cssClasses;
+        let iconClasses = this->iconCssClasses;
+
 
         if fetch typeClasses, classes[type] {
             if typeof typeClasses == "array" {
@@ -373,16 +404,29 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
             let cssClasses = "";
         }
 
+        if fetch typeIconClasses, iconClasses[type] {
+            if typeof typeIconClasses == "array" {
+                let iconCssClasses = join(" ", typeIconClasses);
+            } else {
+                let iconCssClasses = typeIconClasses;
+            }
+        } else {
+            let iconCssClasses = "";
+        }
+
+
         return str_replace(
             [
                 "%cssClass%",
+                "%iconCssClass%",
                 "%message%"
             ],
             [
                 cssClasses,
+                iconCssClasses,
                 message
             ],
-            this->getTemplate(cssClasses)
+            this->getTemplate(cssClasses, iconCssClasses)
         );
     }
 }

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -182,7 +182,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
     }
 
     /**
-     * Set an array with CSS classes to format the icon messages
+     * Set an array with CSS classes to format the messages
      */
     public function setIconCssClasses(array! iconCssClasses) -> <FlashInterface>
     {
@@ -389,6 +389,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
         if !automaticHtml {
             return message;
         }
+
 
         let classes = this->cssClasses;
         let iconClasses = this->iconCssClasses;

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -258,7 +258,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
         bool implicitFlush;
         var content, msg, htmlMessage, preparedMsg;
 
-        let implicitFlush = (bool) this->implicitFlush;
+        let implicitFlush = this->implicitFlush;
 
         if typeof message == "array" {
             /**

--- a/tests/unit/Flash/Direct/SetCssIconClassesCest.php
+++ b/tests/unit/Flash/Direct/SetCssIconClassesCest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Flash\Direct;
+
+use Codeception\Example;
+use Phalcon\Escaper;
+use Phalcon\Flash\Direct;
+use UnitTester;
+use const PHP_EOL;
+
+class SetCssIconClassesCest
+{
+    /**
+     * Tests Phalcon\Flash\Direct :: setCssIconClasses()
+     *
+     * @param UnitTester $I
+     * @param Example    $example
+     *
+     * @dataProvider getExamples
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2021-08-13
+     */
+    public function flashDirectSetCssIconClasses(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Flash\Direct - setCssIconClasses() - ' . $example[0]);
+
+        $flash = $this->setupFlash();
+
+        $actual   = $flash->{$example[0]}('test');
+        $expected = "<div class=\"{$example[1]}\"><i class=\"%cssIconClasses%\"></i> test</div>" . PHP_EOL;
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Flash\Direct :: setCssIconClasses() - custom template
+     *
+     * @param UnitTester $I
+     * @param Example    $example
+     *
+     * @dataProvider getExamples
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2021-08-13
+     */
+    public function flashDirectSetCssIconClassesCustomTemplate(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Flash\Direct - setCssIconClasses() - custom template - ' . $example[0]);
+
+        $template = '<div class="%cssClass%"><i class="%iconCssClass%"></i> %message% '
+            . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>'
+            . '</div>';
+        $flash    = $this->setupFlash();
+
+        $flash->setCustomTemplate($template);
+        $actual   = $flash->{$example[0]}('test');
+        $expected = "<div class=\"{$example[1]}\"><i class=\"{$example[2]}\"></i> test "
+            . '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>'
+            . '</div>';
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return \string[][]
+     */
+    private function getExamples(): array
+    {
+        return [
+            [
+                'error',
+                'errorPhalcon',
+                'errorIconPhalcon',
+            ],
+            [
+                'success',
+                'successPhalcon',
+                'successIconPhalcon',
+            ],
+            [
+                'notice',
+                'noticePhalcon',
+                'noticeIconPhalcon',
+            ],
+            [
+                'warning',
+                'warningPhalcon',
+                'warningIconPhalcon',
+            ],
+        ];
+    }
+
+    private function setupFlash(): Direct
+    {
+        $flash = new Direct(new Escaper());
+
+        $flash
+            ->setImplicitFlush(false)
+            ->setCssClasses(
+                [
+                    'error'   => 'errorPhalcon',
+                    'success' => 'successPhalcon',
+                    'notice'  => 'noticePhalcon',
+                    'warning' => 'warningPhalcon',
+                ]
+            )
+            ->setCssIconClasses(
+                [
+                    'error'   => 'errorIconPhalcon',
+                    'success' => 'successIconPhalcon',
+                    'notice'  => 'noticeIconPhalcon',
+                    'warning' => 'warningIconPhalcon',
+                ]
+            )
+        ;
+
+        return $flash;
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #15292 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `setCssIconClasses` in `Phalcon\Flash\*` to allow setting icons in the flash messages (bootstrap related).

Credit: @escribiendocodigo
Original PR: https://github.com/phalcon/cphalcon/issues/15292

Thanks

