### PR TITLE
Bump PSR_VERSION to `1.1.0` in win builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -396,7 +396,7 @@ jobs:
       - name: Setup Environment Variables
         run: |
           Write-Output "PHP_SDK_VERSION=2.2.0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-          Write-Output "PSR_VERSION=1.0.1" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          Write-Output "PSR_VERSION=1.1.0" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           Write-Output "PHP_DEVPACK=C:\tools\php-devpack" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Output "PHP_SDK_PATH=C:\tools\php-sdk" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append

--- a/package.xml
+++ b/package.xml
@@ -25,8 +25,8 @@
   <date>2021-09-16</date>
   <time>17:00:00</time>
   <version>
-    <release>5.0.0alpha5</release>
-    <api>5.0.0alpha5</api>
+    <release>5.0.0alpha6</release>
+    <api>5.0.0alpha6</api>
   </version>
   <stability>
     <release>alpha</release>


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

