### PR TITLE
#15553 - Fix Query::getExpression return type

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,8 @@
 # [5.0.0alpha7](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (xxxx-xx-xx)
 
+## Fixed
+- Fixed `Query::getExpression()` return type [#15553](https://github.com/phalcon/cphalcon/issues/15553)
+
 # [5.0.0alpha6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (2021-09-16)
 
 ## Changed

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -1542,9 +1542,9 @@ class Query implements QueryInterface, InjectionAwareInterface
     }
 
     /**
-     * Resolves an expression from its intermediate code into a string
+     * Resolves an expression from its intermediate code into an array
      */
-    final protected function getExpression(array expr, bool quoting = true) -> string
+    final protected function getExpression(array expr, bool quoting = true) -> array
     {
         var exprType, exprLeft, exprRight, left = null, right = null,
             listItems, exprListItem, exprReturn, value, escapedValue,

--- a/tests/unit/Mvc/Model/Query/GetExpressionCest.php
+++ b/tests/unit/Mvc/Model/Query/GetExpressionCest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Mvc\Model\Query;
+
+use Phalcon\Mvc\Model\Query;
+use UnitTester;
+
+class GetExpressionCest
+{
+    private $PHQL_T_AND = 266;
+    private $PHQL_T_OR = 267;
+
+    /**
+     * Tests Phalcon\Mvc\Model\Query :: getExpression()
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2021-09-21
+     * @issue        15553
+     */
+    public function mvcModelQueryGetExpression(UnitTester $I)
+    {
+        $I->wantToTest('Phalcon\Mvc\Model\Query - getExpression()');
+
+        $valueOne = [
+            'type' => 'binary-op',
+            'op' => 'AND',
+            'left' => null,
+            'right' => null,
+        ];
+        $valueTwo = [
+            'type' => 'binary-op',
+            'op' => 'OR',
+            'left' => null,
+            'right' => null,
+        ];
+
+        $oneExpr = [
+            'type' => $this->PHQL_T_AND,
+        ];
+
+        $twoExpr = [
+            'type' => $this->PHQL_T_OR,
+        ];
+
+        $query = new Query();
+        $reflection = new \ReflectionClass(Query::class);
+        $getExpression = $reflection->getMethod('getExpression');
+        $getExpression->setAccessible(true);
+
+        $I->assertEquals($getExpression->invokeArgs($query, [$oneExpr, false]), $valueOne);
+        $I->assertEquals($getExpression->invokeArgs($query, [$twoExpr, false]), $valueTwo);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15553 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
`Phalcon\Mvc\Model\Query::getExpression()` return type missmatch fixed

Thanks

