### PR TITLE
T15489 loader require once

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,8 @@
 - Changes to the `Phalcon\Acl`:
   - Renamed `Phalcon\Acl\ComponentAware` to `Phalcon\Acl\ComponentAwareInterface`
   - Renamed `Phalcon\Acl\RoleAware` to `Phalcon\Acl\RoleAwareInterface` [#15691](https://github.com/phalcon/cphalcon/issues/15691)
+- Changed `require` to `require_once` in `Phalcon\Loader` to avoid conflicts with other loaders [#15489](https://github.com/phalcon/cphalcon/issues/15489)
+- Changed `require` to `require_once` in `Phalcon\Cli\Console` and `Phalcon\Mvc\Application` for a bit of extra performance [#15489](https://github.com/phalcon/cphalcon/issues/15489)
 
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)

--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -93,6 +93,6 @@ RUN docker-php-ext-enable \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 # Bash script with helper aliases
 COPY ./.bashrc /root/.bashrc
-COPY ./.bashrc /phalcon/.bashrc
+COPY ./.bashrc /home/phalcon/.bashrc
 
 CMD ["php-fpm"]

--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -93,5 +93,6 @@ RUN docker-php-ext-enable \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 # Bash script with helper aliases
 COPY ./.bashrc /root/.bashrc
+COPY ./.bashrc /phalcon/.bashrc
 
 CMD ["php-fpm"]

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -100,5 +100,6 @@ RUN docker-php-ext-enable \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 # Bash script with helper aliases
 COPY ./.bashrc /root/.bashrc
+COPY ./.bashrc /phalcon/.bashrc
 
 CMD ["php-fpm"]

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -100,6 +100,6 @@ RUN docker-php-ext-enable \
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 # Bash script with helper aliases
 COPY ./.bashrc /root/.bashrc
-COPY ./.bashrc /phalcon/.bashrc
+COPY ./.bashrc /home/phalcon/.bashrc
 
 CMD ["php-fpm"]

--- a/phalcon/Cli/Console.zep
+++ b/phalcon/Cli/Console.zep
@@ -109,7 +109,7 @@ class Console extends AbstractApplication
                 }
 
                 if !class_exists(className, false) {
-                    require path;
+                    require_once path;
                 }
             }
 

--- a/phalcon/Loader.zep
+++ b/phalcon/Loader.zep
@@ -118,7 +118,7 @@ class Loader implements EventsAwareInterface
                 eventsManager->fire("loader:pathFound", this, filePath);
             }
 
-            require filePath;
+            require_once filePath;
 
             return true;
         }
@@ -191,7 +191,7 @@ class Loader implements EventsAwareInterface
                         /**
                          * Simulate a require
                          */
-                        require filePath;
+                        require_once filePath;
 
                         /**
                          * Return true mean success
@@ -250,7 +250,7 @@ class Loader implements EventsAwareInterface
                     /**
                      * Simulate a require
                      */
-                    require filePath;
+                    require_once filePath;
 
                     /**
                      * Return true meaning success
@@ -375,7 +375,7 @@ class Loader implements EventsAwareInterface
                 /**
                  * Simulate a require
                  */
-                require filePath;
+                require_once filePath;
             }
         }
     }

--- a/phalcon/Mvc/Application.zep
+++ b/phalcon/Mvc/Application.zep
@@ -221,7 +221,7 @@ class Application extends AbstractApplication
                     }
 
                     if !class_exists(className, false) {
-                        require path;
+                        require_once path;
                     }
                 }
 


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15489 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Updated `Phalcon\Loader` to use `require_once` instead of `require` so as to avoid collisions with other loaders when loading files. 
Updated `Phalcon\Mvc\Application` and `Phalcon\Cli\Console` to use `require_once` for a bit of extra performance.

Thanks

