### PR TITLE
T15632 bigint not int

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -19,6 +19,7 @@
 ## Fixed
 - Fixed `Query::getExpression()` return type [#15553](https://github.com/phalcon/cphalcon/issues/15553)
 - Fixed `Phalcon\Mvc\Model::getRelated()` to correctly return relationships (cached or not) when the foreign key has changed [#15649](https://github.com/phalcon/cphalcon/issues/15649)
+- Fixed `Phalcon\Db\Adapter\Pdo\*`, `Phalcon\Mvc\Model` and `Phalcon\Mvc\Model\MetaData\Strategy\Annotations` to treat `BIGINT` numbers as string [#15632](https://github.com/phalcon/cphalcon/issues/15632)
 
 # [5.0.0alpha6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (2021-09-16)
 

--- a/phalcon/Db/Adapter/Pdo/Mysql.zep
+++ b/phalcon/Db/Adapter/Pdo/Mysql.zep
@@ -139,7 +139,7 @@ class Mysql extends PdoAdapter
                 case starts_with(columnType, "bigint", true):
                     let definition["type"] = Column::TYPE_BIGINTEGER,
                         definition["isNumeric"] = true,
-                        definition["bindType"] = Column::BIND_PARAM_INT;
+                        definition["bindType"] = Column::BIND_PARAM_STR;
 
                     break;
 

--- a/phalcon/Db/Adapter/Pdo/Postgresql.zep
+++ b/phalcon/Db/Adapter/Pdo/Postgresql.zep
@@ -215,7 +215,7 @@ class Postgresql extends PdoAdapter
                 case memstr(columnType, "bigint"):
                     let definition["type"] = Column::TYPE_BIGINTEGER,
                         definition["isNumeric"] = true,
-                        definition["bindType"] = Column::BIND_PARAM_INT;
+                        definition["bindType"] = Column::BIND_PARAM_STR;
 
                     break;
 

--- a/phalcon/Db/Adapter/Pdo/Sqlite.zep
+++ b/phalcon/Db/Adapter/Pdo/Sqlite.zep
@@ -146,7 +146,7 @@ class Sqlite extends PdoAdapter
                  */
                 let definition["type"] = Column::TYPE_BIGINTEGER,
                     definition["isNumeric"] = true,
-                    definition["bindType"] = Column::BIND_PARAM_INT;
+                    definition["bindType"] = Column::BIND_PARAM_STR;
             } elseif memstr(columnType, "int") || memstr(columnType, "INT") {
                 /**
                  * Smallint/Integers/Int are int

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -876,7 +876,6 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
             if value != "" && value !== null {
                 switch attribute[1] {
-                    case Column::TYPE_BIGINTEGER:
                     case Column::TYPE_INTEGER:
                     case Column::TYPE_MEDIUMINTEGER:
                     case Column::TYPE_SMALLINTEGER:

--- a/phalcon/Mvc/Model/MetaData/Strategy/Annotations.zep
+++ b/phalcon/Mvc/Model/MetaData/Strategy/Annotations.zep
@@ -182,7 +182,7 @@ class Annotations implements StrategyInterface
             switch feature {
                 case "biginteger":
                     let fieldTypes[columnName] = Column::TYPE_BIGINTEGER,
-                        fieldBindTypes[columnName] = Column::BIND_PARAM_INT,
+                        fieldBindTypes[columnName] = Column::BIND_PARAM_STR,
                         numericTyped[columnName] = true;
                     break;
 

--- a/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
+++ b/tests/database/Db/Adapter/Pdo/DescribeColumnsCest.php
@@ -207,7 +207,7 @@ class DescribeColumnsCest
             // field_bigint             bigint        unsigned                      null,
             5  => [
                 0 => 'field_bit_default',
-                1 => Column::BIND_PARAM_INT,
+                1 => Column::BIND_PARAM_STR,
                 2 => false,
                 3 => false,
                 4 => false,
@@ -219,7 +219,7 @@ class DescribeColumnsCest
             // field_bigint_default     bigint        default 1                     null,
             6  => [
                 0 => 'field_bigint',
-                1 => Column::BIND_PARAM_INT,
+                1 => Column::BIND_PARAM_STR,
                 2 => true,
                 3 => false,
                 4 => false,


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15632 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Db\Adapter\Pdo\*`, `Phalcon\Mvc\Model` and `Phalcon\Mvc\Model\MetaData\Strategy\Annotations` to treat `BIGINT` numbers as string 

Thanks

