### PR TITLE
T15494 sessionbag init

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -11,6 +11,10 @@
   - Renamed  `Phalcon\Collection\Exception` to `Phalcon\Support\Collection\Exception`
   - Renamed  `Phalcon\Collection\ReadOnly` to `Phalcon\Support\Collection\ReadOnly`
   - Renamed  `Phalcon\Collection` to `Phalcon\Support\Collection` [#15700](https://github.com/phalcon/cphalcon/issues/15700)
+- Changes to `Phalcon\Session\Bag`:
+  - Changed `Phalcon\Session\Bag::construct` to accept a container instead of internally calling the default
+  - Changed `Phalcon\Session\Bag::construct` to throw an exception if the container is not specified
+  - Changed `Phalcon\Session\Bag::init` to store the data in the session [#15494](https://github.com/phalcon/cphalcon/issues/15494)
 
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -73,7 +73,8 @@ abstract class Injectable implements InjectionAwareInterface
             let this->{"persistent"} = <BagInterface> container->get(
                 "sessionBag",
                 [
-                    get_class(this)
+                    get_class(this),
+                    container
                 ]
             );
 

--- a/phalcon/Session/Bag.zep
+++ b/phalcon/Session/Bag.zep
@@ -50,15 +50,21 @@ class Bag extends Collection implements InjectionAwareInterface
     /**
      * Phalcon\Session\Bag constructor
      */
-    public function __construct(string! name)
+    public function __construct(string! name, <DiInterface> container = null)
     {
-        var container, data, session;
+        var data, session;
 
         let this->name = name;
 
-        let container = Di::getDefault();
+        if unlikely null === container {
+            throw new Exception(
+                Exception::containerServiceNotFound(
+                    "the 'session' service"
+                )
+            );
+        }
 
-        if unlikely typeof container != "object" {
+        if unlikely true !== container->has("session") {
             throw new Exception(
                 Exception::containerServiceNotFound(
                     "the 'session' service"
@@ -76,7 +82,7 @@ class Bag extends Collection implements InjectionAwareInterface
             let data = [];
         }
 
-        parent::__construct(data);
+        this->init(data);
     }
 
     /**
@@ -103,6 +109,8 @@ class Bag extends Collection implements InjectionAwareInterface
     public function init(array! data = []) -> void
     {
         parent::init(data);
+
+        this->session->set(this->name, this->data);
     }
 
     /**

--- a/tests/_data/fixtures/Session/InjectableBag.php
+++ b/tests/_data/fixtures/Session/InjectableBag.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Fixtures\Session;
+
+use Phalcon\Di\Injectable;
+
+class InjectableBag extends Injectable
+{
+}

--- a/tests/integration/Session/Bag/ClearCest.php
+++ b/tests/integration/Session/Bag/ClearCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class ClearCest
 {
@@ -44,20 +43,18 @@ class ClearCest
             'five'  => 'six',
         ];
 
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
-        $I->assertEquals(
-            $data,
-            $collection->toArray()
-        );
+        $expected = $data;
+        $actual   = $collection->toArray();
+        $I->assertEquals($expected, $actual);
 
         $collection->clear();
 
-        $I->assertEquals(
-            0,
-            $collection->count()
-        );
+        $expected = 0;
+        $actual   = $collection->count();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/ConstructCest.php
+++ b/tests/integration/Session/Bag/ConstructCest.php
@@ -15,8 +15,8 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 
 use IntegrationTester;
 use Phalcon\Session\Bag;
+use Phalcon\Session\Exception;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class ConstructCest
 {
@@ -25,7 +25,6 @@ class ConstructCest
     public function _before(IntegrationTester $I)
     {
         $this->setNewFactoryDefault();
-        $this->setDiService('sessionStream');
     }
 
     /**
@@ -38,11 +37,41 @@ class ConstructCest
     {
         $I->wantToTest('Session\Bag - __construct()');
 
-        $collection = new Bag('BagTest');
+        $this->setDiService('sessionStream');
+        $collection = new Bag('BagTest', $this->container);
 
-        $I->assertInstanceOf(
-            Bag::class,
-            $collection
+        $class = Bag::class;
+        $I->assertInstanceOf($class, $collection);
+    }
+
+    /**
+     * Tests Phalcon\Session\Bag :: __construct() - exception
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-10-02
+     */
+    public function sessionBagConstructException(IntegrationTester $I)
+    {
+        $I->wantToTest('Session\Bag - __construct() - exception');
+
+        $I->expectThrowable(
+            new Exception(
+                "A dependency injection container is required to access the 'session' service"
+            ),
+            function () {
+                $collection = new Bag('BagTest');
+            }
+        );
+
+        $container = $this->container;
+
+        $I->expectThrowable(
+            new Exception(
+                "A dependency injection container is required to access the 'session' service"
+            ),
+            function () use ($container) {
+                $collection = new Bag('BagTest', $container);
+            }
         );
     }
 }

--- a/tests/integration/Session/Bag/CountCest.php
+++ b/tests/integration/Session/Bag/CountCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class CountCest
 {
@@ -44,18 +43,16 @@ class CountCest
             'five'  => 'six',
         ];
 
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
-        $I->assertCount(
-            3,
-            $collection->toArray()
-        );
+        $expected = 3;
+        $actual   = $collection->toArray();
+        $I->assertCount($expected, $actual);
 
-        $I->assertEquals(
-            3,
-            $collection->count()
-        );
+        $expected = 3;
+        $actual   = $collection->count();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/GetCest.php
+++ b/tests/integration/Session/Bag/GetCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class GetCest
 {
@@ -37,12 +36,13 @@ class GetCest
     public function sessionBagGet(IntegrationTester $I)
     {
         $I->wantToTest('Session\Bag - get()');
+
         $data       = [
             'one'   => 'two',
             'three' => 'four',
             'five'  => 'six',
         ];
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
         $collection->init($data);
 
         $expected = 'four';

--- a/tests/integration/Session/Bag/GetIteratorCest.php
+++ b/tests/integration/Session/Bag/GetIteratorCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class GetIteratorCest
 {
@@ -44,15 +43,14 @@ class GetIteratorCest
             'five'  => 'six',
         ];
 
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
         foreach ($collection as $key => $value) {
-            $I->assertEquals(
-                $data[$key],
-                $collection[$key]
-            );
+            $expected = $data[$key];
+            $actual   = $collection[$key];
+            $I->assertEquals($expected, $actual);
         }
     }
 }

--- a/tests/integration/Session/Bag/GetSetDICest.php
+++ b/tests/integration/Session/Bag/GetSetDICest.php
@@ -17,7 +17,6 @@ use IntegrationTester;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class GetSetDICest
 {
@@ -39,15 +38,13 @@ class GetSetDICest
     {
         $I->wantToTest("Session\Bag - getDI()/setDI()");
 
-        $session = new Bag('DiTest');
+        $container = new FactoryDefault();
+        $sessionBag = new Bag('DiTest', $this->container);
 
-        $di = new FactoryDefault();
+        $sessionBag->setDI($container);
 
-        $session->setDI($di);
-
-        $I->assertEquals(
-            $di,
-            $session->getDI()
-        );
+        $expected = $container;
+        $actual   = $sessionBag->getDI();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/HasCest.php
+++ b/tests/integration/Session/Bag/HasCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class HasCest
 {
@@ -43,7 +42,7 @@ class HasCest
             'five'  => 'six',
         ];
 
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
         $collection->init($data);
 
         $actual = $collection->has('three');

--- a/tests/integration/Session/Bag/InitCest.php
+++ b/tests/integration/Session/Bag/InitCest.php
@@ -16,7 +16,8 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
+
+use function var_dump;
 
 class InitCest
 {
@@ -43,19 +44,16 @@ class InitCest
             'three' => 'four',
             'five'  => 'six',
         ];
+        $collection = new Bag('BagTest', $this->container);
 
-        $collection = new Bag('BagTest');
-
-        $I->assertEquals(
-            0,
-            $collection->count()
-        );
+        $expected = 0;
+        $actual   = $collection->count();
+        $I->assertEquals($expected, $actual);
 
         $collection->init($data);
 
-        $I->assertEquals(
-            $data,
-            $collection->toArray()
-        );
+        $expected = $data;
+        $actual   = $collection->toArray();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/InjectableCest.php
+++ b/tests/integration/Session/Bag/InjectableCest.php
@@ -15,9 +15,13 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 
 use IntegrationTester;
 use Phalcon\Session\Bag;
+use Phalcon\Tests\Fixtures\Session\InjectableBag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 
-class ToArrayCest
+/**
+ * This is part of the DI Injectable
+ */
+class InjectableCest
 {
     use DiTrait;
 
@@ -28,26 +32,47 @@ class ToArrayCest
     }
 
     /**
-     * Tests Phalcon\Session\Bag :: toArray()
+     * Tests Phalcon\Session\Bag :: clear()
      *
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
      */
-    public function sessionBagToArray(IntegrationTester $I)
+    public function sessionBagClear(IntegrationTester $I)
     {
-        $I->wantToTest('Session\Bag - toArray()');
+        $I->wantToTest('Session\Bag - injectable');
 
+        /**
+         * Set a session bag
+         */
         $data = [
             'one'   => 'two',
             'three' => 'four',
             'five'  => 'six',
         ];
         $collection = new Bag('BagTest', $this->container);
-
         $collection->init($data);
 
+        /**
+         * Store it in the container
+         */
+        $this->container->set('sessionBag', $collection);
+
+        /**
+         * Create the injectable component - this can be a controller for
+         * instance, and set the container
+         */
+        $injectable = new InjectableBag();
+        $injectable->setDI($this->container);
+
+        /**
+         * Get the `persistent` property
+         */
+        $class      = Bag::class;
+        $sessionBag = $injectable->persistent;
+        $I->assertInstanceOf($class, $sessionBag);
+
         $expected = $data;
-        $actual = $collection->toArray();
+        $actual   = $sessionBag->toArray();
         $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/JsonSerializeCest.php
+++ b/tests/integration/Session/Bag/JsonSerializeCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class JsonSerializeCest
 {
@@ -43,14 +42,12 @@ class JsonSerializeCest
             'three' => 'four',
             'five'  => 'six',
         ];
-
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
-        $I->assertEquals(
-            $data,
-            $collection->jsonSerialize()
-        );
+        $expected = $data;
+        $actual   = $collection->jsonSerialize();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/RemoveCest.php
+++ b/tests/integration/Session/Bag/RemoveCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class RemoveCest
 {
@@ -43,16 +42,13 @@ class RemoveCest
             'three' => 'four',
             'five'  => 'six',
         ];
-
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
-        $I->assertEquals(
-            $data,
-            $collection->toArray()
-        );
-
+        $expected = $data;
+        $actual   = $collection->toArray();
+        $I->assertEquals($expected, $actual);
 
         $collection->remove('five');
 
@@ -60,12 +56,8 @@ class RemoveCest
             'one'   => 'two',
             'three' => 'four',
         ];
-
-        $I->assertEquals(
-            $expected,
-            $collection->toArray()
-        );
-
+        $actual = $collection->toArray();
+        $I->assertEquals($expected, $actual);
 
         $collection->remove('FIVE');
 
@@ -73,40 +65,27 @@ class RemoveCest
             'one'   => 'two',
             'three' => 'four',
         ];
-
-        $I->assertEquals(
-            $expected,
-            $collection->toArray()
-        );
-
+        $actual = $collection->toArray();
+        $I->assertEquals($expected, $actual);
 
         $collection->init($data);
-
         unset($collection['five']);
 
         $expected = [
             'one'   => 'two',
             'three' => 'four',
         ];
-
-        $I->assertEquals(
-            $expected,
-            $collection->toArray()
-        );
-
+        $actual = $collection->toArray();
+        $I->assertEquals($expected, $actual);
 
         $collection->init($data);
-
         $collection->offsetUnset('five');
 
         $expected = [
             'one'   => 'two',
             'three' => 'four',
         ];
-
-        $I->assertEquals(
-            $expected,
-            $collection->toArray()
-        );
+        $actual = $collection->toArray();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/SerializeCest.php
+++ b/tests/integration/Session/Bag/SerializeCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class SerializeCest
 {
@@ -43,14 +42,12 @@ class SerializeCest
             'three' => 'four',
             'five'  => 'six',
         ];
-
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
-        $I->assertEquals(
-            serialize($data),
-            $collection->serialize()
-        );
+        $expected = serialize($data);
+        $actual   = $collection->serialize();
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/SetCest.php
+++ b/tests/integration/Session/Bag/SetCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class SetCest
 {
@@ -38,36 +37,29 @@ class SetCest
     {
         $I->wantToTest('Session\Bag - set()');
 
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->set('three', 'two');
 
-        $I->assertEquals(
-            'two',
-            $collection->get('three')
-        );
-
+        $expected = 'two';
+        $actual   = $collection->get('three');
+        $I->assertEquals($expected, $actual);
 
         $collection->three = 'Phalcon';
 
-        $I->assertEquals(
-            'Phalcon',
-            $collection->get('three')
-        );
-
+        $expected = 'Phalcon';
+        $actual   = $collection->get('three');
+        $I->assertEquals($expected, $actual);
 
         $collection->offsetSet('three', 123);
 
-        $I->assertEquals(
-            123,
-            $collection->get('three')
-        );
-
+        $expected = 123;
+        $actual   = $collection->get('three');
+        $I->assertEquals($expected, $actual);
 
         $collection['three'] = true;
 
-        $I->assertTrue(
-            $collection->get('three')
-        );
+        $actual = $collection->get('three');
+        $I->assertTrue($actual);
     }
 }

--- a/tests/integration/Session/Bag/ToJsonCest.php
+++ b/tests/integration/Session/Bag/ToJsonCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class ToJsonCest
 {
@@ -43,19 +42,16 @@ class ToJsonCest
             'three' => 'four',
             'five'  => 'six',
         ];
-
-        $collection = new Bag('BagTest');
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->init($data);
 
-        $I->assertEquals(
-            json_encode($data),
-            $collection->toJson()
-        );
+        $expected = json_encode($data);
+        $actual   = $collection->toJson();
+        $I->assertEquals($expected, $actual);
 
-        $I->assertEquals(
-            json_encode($data, JSON_PRETTY_PRINT),
-            $collection->toJson(JSON_PRETTY_PRINT)
-        );
+        $expected = json_encode($data, JSON_PRETTY_PRINT);
+        $actual   = $collection->toJson(JSON_PRETTY_PRINT);
+        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/integration/Session/Bag/UnserializeCest.php
+++ b/tests/integration/Session/Bag/UnserializeCest.php
@@ -16,7 +16,6 @@ namespace Phalcon\Tests\Integration\Session\Bag;
 use IntegrationTester;
 use Phalcon\Session\Bag;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
-use Phalcon\Tests\Fixtures\Traits\SessionBagTrait;
 
 class UnserializeCest
 {
@@ -43,17 +42,13 @@ class UnserializeCest
             'three' => 'four',
             'five'  => 'six',
         ];
-
         $serialized = serialize($data);
-
-        $collection = new Bag('BagTest');
-
+        $collection = new Bag('BagTest', $this->container);
 
         $collection->unserialize($serialized);
 
-        $I->assertEquals(
-            $data,
-            $collection->toArray()
-        );
+        $expected = $data;
+        $actual   = $collection->toArray();
+        $I->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #15494 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Session\Bag::construct` to accept a container instead of internally calling the default
Changed `Phalcon\Session\Bag::construct` to throw an exception if the container is not specified
Changed `Phalcon\Session\Bag::init` to store the data in the session [#15494]


Thanks

