### PR TITLE
T15154 acl getinheritedroles

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -19,6 +19,7 @@
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)
 - Added `Phalcon\Events\AbstractEventsAware` class to handle the Events Manager when necessary [#15691](https://github.com/phalcon/cphalcon/issues/15691)
+- Added `Phalcon\Acl\Adapter\AdapterInterface::getInheritedRoles()` and `Phalcon\Acl\Adapter\Memory::getInheritedRoles()` that returns the inherited roles based on a passed role name (or all if no parameter supplied) [#15154](https://github.com/phalcon/cphalcon/issues/15154)
 
 ## Fixed
 - Fixed `Query::getExpression()` return type [#15553](https://github.com/phalcon/cphalcon/issues/15553)

--- a/phalcon/Acl/Adapter/AdapterInterface.zep
+++ b/phalcon/Acl/Adapter/AdapterInterface.zep
@@ -96,6 +96,13 @@ interface AdapterInterface
     public function getComponents() -> <ComponentInterface[]>;
 
     /**
+     * Returns the inherited roles for a passed role name. If no role name
+     * has been specified it will return the whole array. If the role has not
+     * been found it returns an empty array
+     */
+    public function getInheritedRoles(string roleName = "") -> array;
+
+    /**
      * Check whether a role is allowed to access an action from a component
      */
     public function isAllowed(roleName, componentName, string access, array parameters = null) -> bool;

--- a/phalcon/Acl/Adapter/AdapterInterface.zep
+++ b/phalcon/Acl/Adapter/AdapterInterface.zep
@@ -75,9 +75,21 @@ interface AdapterInterface
     public function getActiveComponent() -> null | string;
 
     /**
+     * Return an array with every component registered in the list
+     */
+    public function getComponents() -> <ComponentInterface[]>;
+
+    /**
      * Returns the default ACL access level
      */
     public function getDefaultAction() -> int;
+
+    /**
+     * Returns the inherited roles for a passed role name. If no role name
+     * has been specified it will return the whole array. If the role has not
+     * been found it returns an empty array
+     */
+    public function getInheritedRoles(string roleName = "") -> array;
 
     /**
      * Returns the default ACL access level for no arguments provided in
@@ -90,17 +102,6 @@ interface AdapterInterface
      */
     public function getRoles() -> <RoleInterface[]>;
 
-    /**
-     * Return an array with every component registered in the list
-     */
-    public function getComponents() -> <ComponentInterface[]>;
-
-    /**
-     * Returns the inherited roles for a passed role name. If no role name
-     * has been specified it will return the whole array. If the role has not
-     * been found it returns an empty array
-     */
-    public function getInheritedRoles(string roleName = "") -> array;
 
     /**
      * Check whether a role is allowed to access an action from a component

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -533,6 +533,26 @@ class Memory extends AbstractAdapter
     }
 
     /**
+     * Returns the inherited roles for a passed role name. If no role name
+     * has been specified it will return the whole array. If the role has not
+     * been found it returns an empty array
+     */
+    public function getInheritedRoles(string roleName = "") -> array
+    {
+        var result;
+
+        if empty roleName {
+            return this->roleInherits;
+        }
+
+        if !fetch result, this->roleInherits[roleName] {
+            return [];
+        }
+
+        return result;
+    }
+
+    /**
      * Check whether a role is allowed to access an action from a component
      *
      * ```php

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -524,7 +524,7 @@ class Memory extends AbstractAdapter
     {
         var result;
 
-        if empty roleName {
+        if "" === roleName {
             return this->roleInherits;
         }
 

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -508,23 +508,6 @@ class Memory extends AbstractAdapter
      }
 
     /**
-     * Returns the default ACL access level for no arguments provided in
-     * `isAllowed` action if a `func` (callable) exists for `accessKey`
-     */
-    public function getNoArgumentsDefaultAction() -> int
-    {
-        return this->noArgumentsDefaultAction;
-    }
-
-    /**
-     * Return an array with every role registered in the list
-     */
-    public function getRoles() -> <RoleInterface[]>
-    {
-        return this->roles;
-    }
-
-    /**
      * Return an array with every component registered in the list
      */
     public function getComponents() -> <ComponentInterface[]>
@@ -550,6 +533,23 @@ class Memory extends AbstractAdapter
         }
 
         return result;
+    }
+
+    /**
+     * Returns the default ACL access level for no arguments provided in
+     * `isAllowed` action if a `func` (callable) exists for `accessKey`
+     */
+    public function getNoArgumentsDefaultAction() -> int
+    {
+        return this->noArgumentsDefaultAction;
+    }
+
+    /**
+     * Return an array with every role registered in the list
+     */
+    public function getRoles() -> <RoleInterface[]>
+    {
+        return this->roles;
     }
 
     /**

--- a/tests/unit/Acl/Adapter/Memory/GetInheritedRolesCest.php
+++ b/tests/unit/Acl/Adapter/Memory/GetInheritedRolesCest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Acl\Adapter\Memory;
+
+use Phalcon\Acl\Adapter\Memory;
+use Phalcon\Acl\Component;
+use Phalcon\Acl\Exception;
+use Phalcon\Acl\Role;
+use UnitTester;
+
+/**
+ * Class GetInheritedRolesCest
+ *
+ * @package Phalcon\Tests\Unit\Acl\Adapter\Memory
+ */
+class GetInheritedRolesCest
+{
+    /**
+     * Tests Phalcon\Acl\Adapter\Memory :: getInheritedRoles()
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-10-02
+     * @issue  https://github.com/phalcon/cphalcon/issues/15154
+     */
+    public function aclAdapterMemoryGetInheritedRoles(UnitTester $I)
+    {
+        $I->wantToTest('Acl\Adapter\Memory - getInheritedRoles()');
+
+        $acl = new Memory();
+
+        $acl->addRole(new Role('administrator'));
+        $acl->addRole(new Role('memberOne'));
+        $acl->addRole(new Role('memberTwo'));
+        $acl->addRole(new Role('guestOne'));
+        $acl->addRole(new Role('guestTwo'));
+
+        /**
+         * Inheritance
+         */
+        $actual = $acl->addInherit('administrator', 'memberOne');
+        $I->assertTrue($actual);
+        $actual = $acl->addInherit('administrator', 'memberTwo');
+        $I->assertTrue($actual);
+        $actual = $acl->addInherit('memberTwo', 'guestOne');
+        $I->assertTrue($actual);
+        $actual = $acl->addInherit('memberTwo', 'guestTwo');
+        $I->assertTrue($actual);
+
+        $expected = [];
+        $actual   = $acl->getInheritedRoles('unknown');
+        $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'memberOne',
+            'memberTwo',
+        ];
+        $actual   = $acl->getInheritedRoles('administrator');
+        $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'administrator' => [
+                'memberOne',
+                'memberTwo',
+            ],
+            'memberTwo'      => [
+                'guestOne',
+                'guestTwo',
+            ],
+        ];
+        $actual   = $acl->getInheritedRoles();
+        $I->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #15154 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Acl\Adapter\AdapterInterface::getInheritedRoles()` and `Phalcon\Acl\Adapter\Memory::getInheritedRoles()` that returns the inherited roles based on a passed role name (or all if no parameter supplied)

Thanks

