### PR TITLE
T15276 fix unset model property

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -49,6 +49,7 @@
 - Fixed `Phalcon\Mvc\Model::getRelated()` to correctly return relationships (cached or not) when the foreign key has changed [#15649](https://github.com/phalcon/cphalcon/issues/15649)
 - Fixed `Phalcon\Db\Adapter\Pdo\*`, `Phalcon\Mvc\Model` and `Phalcon\Mvc\Model\MetaData\Strategy\Annotations` to treat `BIGINT` numbers as string [#15632](https://github.com/phalcon/cphalcon/issues/15632)
 - Fixed `Phalcon\Crypt\Crypt::decrypt()` to correctly calculate the hash when using signed mode [#15717](https://github.com/phalcon/cphalcon/issues/15717)
+- Fixed `Phalcon\Mvc\Model\Manager::isVisibleModelProperty()` to correctly check if setting property is visible [#15276](https://github.com/phalcon/cphalcon/issues/15276)
 
 # [5.0.0alpha6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (2021-09-16)
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -19,6 +19,8 @@ use Phalcon\Mvc\ModelInterface;
 use Phalcon\Mvc\Model\Query\Builder;
 use Phalcon\Mvc\Model\Query\BuilderInterface;
 use Phalcon\Mvc\Model\Query\StatusInterface;
+use ReflectionClass;
+use ReflectionProperty;
 
 /**
  * Phalcon\Mvc\Model\Manager
@@ -417,13 +419,19 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      */
     final public function isVisibleModelProperty(<ModelInterface> model, string property) -> bool
     {
-        var properties, className, cleanModel;
+        var properties, className, cleanModel, publicProperties, classReflection,
+            reflectionProperties, reflectionProperty;
 
         let className = get_class(model);
 
         if !isset this->modelVisibility[className] {
-            let cleanModel = new className();
-            let this->modelVisibility[className] = get_object_vars(cleanModel);
+            let publicProperties = [];
+            let classReflection = new ReflectionClass(className);
+            let reflectionProperties = classReflection->getProperties(ReflectionProperty::IS_PUBLIC);
+            for reflectionProperty in reflectionProperties {
+                let publicProperties[reflectionProperty->name] = true;
+            }
+            let this->modelVisibility[className] = publicProperties;
         }
 
         let properties = this->modelVisibility[className];

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -417,12 +417,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      */
     final public function isVisibleModelProperty(<ModelInterface> model, string property) -> bool
     {
-        var properties, className;
+        var properties, className, cleanModel;
 
         let className = get_class(model);
 
         if !isset this->modelVisibility[className] {
-            let this->modelVisibility[className] = get_object_vars(model);
+            let cleanModel = new className();
+            let this->modelVisibility[className] = get_object_vars(cleanModel);
         }
 
         let properties = this->modelVisibility[className];


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15276

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Due to behavior of get_object_vars call in object scope (linked via $this), we couldn't detect public props after them being unsetted. Solved by initiating clean model instance.

Thanks

