### PR TITLE
changed the getPreparedQuery return type to QueryInterface

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -5231,7 +5231,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * shared prepare query logic for find and findFirst method
      */
-    private static function getPreparedQuery(var params, var limit = null) -> <Query>
+    private static function getPreparedQuery(var params, var limit = null) -> <QueryInterface>
     {
         var builder, bindParams, bindTypes, transaction, cache, manager, query,
             container;


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15562 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Mvc\Model::getPreparedQuery()` to return `QueryInterface` instead of `Query` 

Thanks

