### PR TITLE
T15269 settings string

### DIFF
--- a/.ci/phalcon.ini
+++ b/.ci/phalcon.ini
@@ -26,6 +26,6 @@ extension = phalcon.so
 ; phalcon.orm.ignore_unknown_columns = Off
 ; phalcon.orm.late_state_binding = Off
 ; phalcon.orm.not_null_validations = On
-; phalcon.orm.resultset_prefetch_records = 0
+; phalcon.orm.resultset_prefetch_records = "0"
 ; phalcon.orm.update_snapshot_on_save = On
 ; phalcon.orm.virtual_foreign_keys = On

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -45,6 +45,7 @@
     - Refactored the code for more efficiency and speed [#15720](https://github.com/phalcon/cphalcon/issues/15720)
 - Changed `Phalcon\Db\Adapter\AdapterInterface::getInternalHandler()` and `Phalcon\Db\Adapter\Pdo\AbstractPdo::getInternalHandler()` to return `var` instead of `\PDO` for custom adapters with different engines [#15119](https://github.com/phalcon/cphalcon/issues/15119) 
 - Moved `Phalcon\Filter` to `Phalcon\Filter\Filter`; added more tests [#15726](https://github.com/phalcon/cphalcon/issues/15726)
+- Changed `Phalcon\Mvc\ModelgetPreparedQuery()` to return `QueryInterface` instead of `Query` [#15562](https://github.com/phalcon/cphalcon/issues/15562)
 
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -59,6 +59,7 @@
 - Fixed `Phalcon\Crypt\Crypt::decrypt()` to correctly calculate the hash when using signed mode [#15717](https://github.com/phalcon/cphalcon/issues/15717)
 - Fixed `Phalcon\Mvc\Model\Manager::isVisibleModelProperty()` to correctly check if setting property is visible [#15276](https://github.com/phalcon/cphalcon/issues/15276)
 - Fixed `Phalcon\Config\Config::merge` to retain numeric indexes in deep merges [#14705](https://github.com/phalcon/cphalcon/issues/14705)
+- Fixed globals (Zephir change) to correctly display string values for global settings in `phpinfo()` [#15269](https://github.com/phalcon/cphalcon/issues/15269)
 
 # [5.0.0alpha6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (2021-09-16)
 

--- a/config.json
+++ b/config.json
@@ -135,8 +135,8 @@
       "default": "NULL"
     },
     "orm.resultset_prefetch_records": {
-      "type": "int",
-      "default": 0
+      "type": "string",
+      "default": "0"
     },
     "orm.unique_cache_id": {
       "type": "int",

--- a/docker/7.4/.bashrc
+++ b/docker/7.4/.bashrc
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ZEPHIR_VERSION="0.15.0"
+ZEPHIR_VERSION="0.15.2"
 
 # Easier navigation: .., ..., ...., ....., ~ and -
 alias ..="cd .."
@@ -82,6 +82,7 @@ fi
 alias zephir='./zephir '
 alias zf='./zephir fullclean'
 alias zg='./zephir generate'
+alias zs='./zephir generate'
 alias cpl='zf && zg && cd ext/ && ./install && ..'
 alias codecept='php -d extension=ext/modules/phalcon.so ./vendor/bin/codecept '
 alias phpcs='php -d extension=ext/modules/phalcon.so ./vendor/bin/phpcs '

--- a/docker/8.0/.bashrc
+++ b/docker/8.0/.bashrc
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ZEPHIR_VERSION="0.15.0"
+ZEPHIR_VERSION="0.15.2"
 
 # Easier navigation: .., ..., ...., ....., ~ and -
 alias ..="cd .."
@@ -82,6 +82,7 @@ fi
 alias zephir='./zephir '
 alias zf='./zephir fullclean'
 alias zg='./zephir generate'
+alias zs='./zephir generate'
 alias cpl='zf && zg && cd ext/ && ./install && ..'
 alias codecept='php -d extension=ext/modules/phalcon.so ./vendor/bin/codecept '
 alias phpcs='php -d extension=ext/modules/phalcon.so ./vendor/bin/phpcs '

--- a/tests/unit/Mvc/GlobalsCest.php
+++ b/tests/unit/Mvc/GlobalsCest.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Test\Unit\Mvc;
+
+use Codeception\Example;
+use UnitTester;
+
+use function ini_get;
+
+class GlobalsCest
+{
+    /**
+     * Tests Phalcon\Mvc :: globals
+     *
+     * @dataProvider getExamples
+     *
+     * @param UnitTester $I
+     * @param Example    $example
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-10-24
+     * @issue  https://github.com/phalcon/cphalcon/issues/15269
+     */
+    public function mvcModelGlobals(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Phalcon\Mvc\Model\Query - globals ' . $example['setting']);
+
+        $actual = ini_get($example['setting']);
+        $I->assertNotFalse($actual);
+
+        $expected = $example['value'];
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @return array<array-key, array<string, mixed>>
+     */
+    private function getExamples(): array
+    {
+        return [
+            [
+                'setting' => 'phalcon.db.escape_identifiers',
+                'value'   => '1',
+            ],
+                [
+                'setting' => 'phalcon.db.force_casting',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.cast_last_insert_id_to_int',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.cast_on_hydrate',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.column_renaming',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.disable_assign_setters',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.enable_implicit_joins',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.enable_literals',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.events',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.exception_on_failed_metadata_save',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.exception_on_failed_save',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.ignore_unknown_columns',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.late_state_binding',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.not_null_validations',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.resultset_prefetch_records',
+                'value'   => '0',
+            ],
+            [
+                'setting' => 'phalcon.orm.update_snapshot_on_save',
+                'value'   => '1',
+            ],
+            [
+                'setting' => 'phalcon.orm.virtual_foreign_keys',
+                'value'   => '1',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15269 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

`resultset_prefetch_records` is now visible in `phpinfo` - string global settings supported; added test

Thanks

