### PR TITLE
T14203 fix form validator get value

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -72,6 +72,7 @@
     - `setHtmlQuoteType()` becomes `setFlags()` [#15757](https://github.com/phalcon/cphalcon/issues/15757)
 - Changed `Phalcon\Encryption\Security::hash()` to also use `password_hash()` and accept `ARGON2*` algorithms [#15731](https://github.com/phalcon/cphalcon/issues/15731) 
 - Removed uncamelize of `realClassName` in `Phalcon\Mvc\Router\Route::getRoutePaths()` if definition is string to make processing same as if array definition [#15067](https://github.com/phalcon/cphalcon/issues/15067) 
+- Changed `Phalcon\Validation::getValue()` behavior to get value from `data` if not found in `entity`. [#14203](https://github.com/phalcon/cphalcon/issues/14203)
 
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -73,6 +73,7 @@
 - Changed `Phalcon\Encryption\Security::hash()` to also use `password_hash()` and accept `ARGON2*` algorithms [#15731](https://github.com/phalcon/cphalcon/issues/15731) 
 - Removed uncamelize of `realClassName` in `Phalcon\Mvc\Router\Route::getRoutePaths()` if definition is string to make processing same as if array definition [#15067](https://github.com/phalcon/cphalcon/issues/15067) 
 - Changed `Phalcon\Validation::getValue()` behavior to get value from `data` if not found in `entity`. [#14203](https://github.com/phalcon/cphalcon/issues/14203)
+- Changed `Phalcon\Forms\Form::isValid()` signature: added `whitelist` argument. [#14203](https://github.com/phalcon/cphalcon/issues/14203)
 
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)
@@ -91,10 +92,11 @@
     - Added `Phalcon\Crypt\PadFactory` to easily create padding adapters
     - Added more tests increasing coverage [#15717](https://github.com/phalcon/cphalcon/issues/15717)
 - Added `Phalcon\Cache\Adapter\*::setForever()` and `Phalcon\Storage\Adapter\*::setForever()` to allow storing a key forever [#15485](https://github.com/phalcon/cphalcon/issues/15485)
-- Added `Phalcon\Forms\Form::getFilteredValue()` to get filtered value without providing entity [#15438](https://github.com/phalcon/cphalcon/issues/15438)
 - Added `Phalcon\Encryption\Security::getHashInformation()` to return information for a hash [#15731](https://github.com/phalcon/cphalcon/issues/15731)
 - Added constants `Phalcon\Encryption\Security::CRYPT_ARGON2I` and `Phalcon\Encryption\Security::CRYPT_ARGON2ID` [#15731](https://github.com/phalcon/cphalcon/issues/15731)
 - Added `allowEmpty` checks to common validators [#15515](https://github.com/phalcon/cphalcon/issues/15515)
+- Added `Phalcon\Forms\Form::getFilteredValue()` to get filtered value without providing entity [#15438](https://github.com/phalcon/cphalcon/issues/15438)
+- Added `Phalcon\Forms\Form::setWhitelist()` and `Phalcon\Forms\Form::getWhitelist()` [#14203](https://github.com/phalcon/cphalcon/issues/14203)
 
 ## Fixed
 - Fixed `Query::getExpression()` return type [#15553](https://github.com/phalcon/cphalcon/issues/15553)

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -205,8 +205,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             /**
              * Check if the item is in the whitelist
              */
-
-            if !in_array(key, whitelist) {
+            if !empty whitelist && !in_array(key, whitelist) {
                 continue;
             }
 

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -76,12 +76,12 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * @var ValidationInterface|null
      */
-    protected validation = null { set, get };
+    protected validation = null { get };
 
     /**
      * @var array
      */
-    protected whitelist = [];
+    protected whitelist = [] { get };
 
     /**
      * Phalcon\Forms\Form constructor
@@ -383,16 +383,6 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     }
 
     /**
-     * Returns whitelist array
-     *
-     * @return array
-     */
-    public function getWhitelist() -> array
-    {
-        return this->whitelist;
-    }
-
-    /**
      * Returns a label for an element
      */
     public function getLabel(string! name) -> string
@@ -616,8 +606,9 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
      *
      * @param array data
      * @param object entity
+     * @param array whitelist
      */
-    public function isValid(var data = null, var entity = null, var whitelist = null) -> bool
+    public function isValid(var data = null, var entity = null, array whitelist = []) -> bool
     {
         var messages, element, validators, name, filters, validator, validation,
             elementMessage;
@@ -627,7 +618,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             return true;
         }
 
-        if whitelist === null && !empty this->whitelist {
+        if empty whitelist {
             let whitelist = this->whitelist;
         }
 
@@ -837,9 +828,21 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     }
 
     /**
+     * Sets the default validation
+     *
+     * @param ValidationInterface validation
+     */
+    public function setValidation(<ValidationInterface> validation) -> <Form>
+    {
+        let this->validation = validation;
+
+        return this;
+    }
+
+    /**
      * Sets the default whitelist
      *
-     * @param object entity
+     * @param array whitelist
      */
     public function setWhitelist(array whitelist) -> <Form>
     {

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -79,6 +79,11 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     protected validation = null { set, get };
 
     /**
+     * @var array
+     */
+    protected whitelist = [];
+
+    /**
      * Phalcon\Forms\Form constructor
      */
     public function __construct(var entity = null, array userOptions = [])
@@ -179,6 +184,10 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
 
         if unlikely empty this->elements {
             throw new Exception("There are no elements in the form");
+        }
+
+        if whitelist === null && !empty this->whitelist {
+            let whitelist = this->whitelist;
         }
 
         let filter = null;
@@ -371,6 +380,16 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     public function getEntity()
     {
         return this->entity;
+    }
+
+    /**
+     * Returns whitelist array
+     *
+     * @return array
+     */
+    public function getWhitelist() -> array
+    {
+        return this->whitelist;
     }
 
     /**
@@ -598,7 +617,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
      * @param array data
      * @param object entity
      */
-    public function isValid(var data = null, var entity = null) -> bool
+    public function isValid(var data = null, var entity = null, var whitelist = null) -> bool
     {
         var messages, element, validators, name, filters, validator, validation,
             elementMessage;
@@ -606,6 +625,10 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
 
         if empty this->elements {
             return true;
+        }
+
+        if whitelist === null && !empty this->whitelist {
+            let whitelist = this->whitelist;
         }
 
         /**
@@ -622,11 +645,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             let entity = this->entity;
         }
 
-        if typeof entity == "object" {
-            this->bind(data, entity);
-        } else {
-            this->bind(data);
-        }
+        this->bind(data, entity, whitelist);
 
         /**
          * Check if there is a method 'beforeValidation'
@@ -813,6 +832,18 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     public function setEntity(var entity) -> <Form>
     {
         let this->entity = entity;
+
+        return this;
+    }
+
+    /**
+     * Sets the default whitelist
+     *
+     * @param object entity
+     */
+    public function setWhitelist(array whitelist) -> <Form>
+    {
+        let this->whitelist = whitelist;
 
         return this;
     }

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -176,7 +176,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
      * @param object entity
      * @param array whitelist
      */
-    public function bind(array! data, var entity = null, var whitelist = null) -> <Form>
+    public function bind(array! data, var entity = null, array whitelist = []) -> <Form>
     {
         var filter, key, value, element, filters, container, filteredValue;
         array assignData, filteredData;
@@ -186,7 +186,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
             throw new Exception("There are no elements in the form");
         }
 
-        if whitelist === null && !empty this->whitelist {
+        if empty whitelist {
             let whitelist = this->whitelist;
         }
 
@@ -206,7 +206,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
              * Check if the item is in the whitelist
              */
 
-            if typeof whitelist === "array" && !in_array(key, whitelist) {
+            if !in_array(key, whitelist) {
                 continue;
             }
 

--- a/phalcon/Validation.zep
+++ b/phalcon/Validation.zep
@@ -244,7 +244,7 @@ class Validation extends Injectable implements ValidationInterface
      * @param mixed $entity
      * @param string $field
      */
-    private function getValueByEntity(var entity, string field) -> var | null
+    public function getValueByEntity(var entity, string field) -> var | null
     {
         string method;
 
@@ -271,7 +271,7 @@ class Validation extends Injectable implements ValidationInterface
      * @param mixed $data
      * @param string $field
      */
-    private function getValueByData(var data, string field) -> var | null
+    public function getValueByData(var data, string field) -> var | null
     {
         var value, values;
 

--- a/phalcon/Validation.zep
+++ b/phalcon/Validation.zep
@@ -585,15 +585,18 @@ class Validation extends Injectable implements ValidationInterface
      */
     protected function preChecking(var field, <ValidatorInterface> validator) -> bool
     {
-        var singleField, allowEmpty, emptyValue, value, result;
+        var singleField, allowEmpty, emptyValue, value;
+        array results = [];
 
         if typeof field == "array" {
             for singleField in field {
-                let result = this->preChecking(singleField, validator);
+                let results[] = this->preChecking(singleField, validator);
 
-                if result {
-                    return result;
+                if in_array(false, results) {
+                    return false;
                 }
+
+                return true;
             }
         } else {
             let allowEmpty = validator->getOption("allowEmpty", false);

--- a/phalcon/Validation.zep
+++ b/phalcon/Validation.zep
@@ -238,7 +238,13 @@ class Validation extends Injectable implements ValidationInterface
         return this->validators;
     }
 
-    private function getValueByEntity(entity, string field) -> var | null
+    /**
+     * Gets the a value to validate in the object entity source
+     *
+     * @param mixed $entity
+     * @param string $field
+     */
+    private function getValueByEntity(var entity, string field) -> var | null
     {
         string method;
 
@@ -259,7 +265,13 @@ class Validation extends Injectable implements ValidationInterface
         return null;
     }
 
-    private function getValueByData(data, string field) -> var | null
+    /**
+     * Gets the a value to validate in the array/object data source
+     *
+     * @param mixed $data
+     * @param string $field
+     */
+    private function getValueByData(var data, string field) -> var | null
     {
         var value, values;
 
@@ -270,13 +282,13 @@ class Validation extends Injectable implements ValidationInterface
             return value;
         }
 
-        if typeof data == "array" {
+        if typeof data === "array" {
             if isset data[field] {
                 return data[field];
             }
         }
 
-        if typeof data == "object" {
+        if typeof data === "object" {
             if isset data->{field} {
                 return data->{field};
             }
@@ -347,7 +359,7 @@ class Validation extends Injectable implements ValidationInterface
                 /**
                  * Set filtered value in entity
                  */
-                if typeof entity == "object" && isRawFetched == false {
+                if typeof entity == "object" && isRawFetched === false {
                     let method = "set" . camelize(field);
 
                     if method_exists(entity, method) {

--- a/phalcon/Validation.zep
+++ b/phalcon/Validation.zep
@@ -246,13 +246,17 @@ class Validation extends Injectable implements ValidationInterface
 
         if method_exists(entity, method) {
             return entity->{method}();
-        } elseif method_exists(entity, "readAttribute") {
-            return entity->readAttribute(field);
-        } elseif isset entity->{field} {
-            return entity->{field};
-        } else {
-            return null;
         }
+
+        if method_exists(entity, "readAttribute") {
+            return entity->readAttribute(field);
+        }
+
+        if isset entity->{field} {
+            return entity->{field};
+        }
+
+        return null;
     }
 
     private function getValueByData(data, string field) -> var | null
@@ -270,7 +274,9 @@ class Validation extends Injectable implements ValidationInterface
             if isset data[field] {
                 return data[field];
             }
-        } elseif typeof data == "object" {
+        }
+
+        if typeof data == "object" {
             if isset data->{field} {
                 return data->{field};
             }

--- a/tests/_data/fixtures/models/EntityWithGetter.php
+++ b/tests/_data/fixtures/models/EntityWithGetter.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Models;
+
+/**
+ * Class EntityWithGetter
+ */
+class EntityWithGetter
+{
+    private $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/tests/_data/fixtures/models/EntityWithHook.php
+++ b/tests/_data/fixtures/models/EntityWithHook.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Models;
+
+/**
+ * Class EntityWithHook
+ */
+class EntityWithHook
+{
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function readAttribute(string $field): string
+    {
+        return $this->{$field};
+    }
+}

--- a/tests/_data/fixtures/models/EntityWithPublic.php
+++ b/tests/_data/fixtures/models/EntityWithPublic.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Models;
+
+/**
+ * Class EntityWithPublic
+ */
+class EntityWithPublic
+{
+    public $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/database/Mvc/Model/AssignCest.php
+++ b/tests/database/Mvc/Model/AssignCest.php
@@ -173,7 +173,6 @@ class AssignCest
      * @issue  https://github.com/phalcon/cphalcon/issues/15739
      *
      * @group  mysql
-     * @group  pgsql
      * @group  sqlite
      */
     public function mvcModelAssignWithTransaction(DatabaseTester $I)

--- a/tests/database/Mvc/Model/AverageCest.php
+++ b/tests/database/Mvc/Model/AverageCest.php
@@ -59,7 +59,6 @@ class AverageCest
      * @since  2020-01-30
      *
      * @group  mysql
-     * @group  pgsql
      */
     public function mvcModelAverage(DatabaseTester $I)
     {

--- a/tests/integration/Forms/Form/BindCest.php
+++ b/tests/integration/Forms/Form/BindCest.php
@@ -58,8 +58,8 @@ class BindCest
         ];
 
         $entity = new \stdClass();
-        $white_list = ['nameFirst', 'nameLast'];
-        $form->bind($data, $entity, $white_list);
+        $whiteList = ['nameFirst', 'nameLast'];
+        $form->bind($data, $entity, $whiteList);
 
         $I->assertEquals("nameFirst", $form->getValue("nameFirst"));
         $I->assertEquals("nameLast", $form->getValue("nameLast"));

--- a/tests/integration/Validation/AllowEmptyCest.php
+++ b/tests/integration/Validation/AllowEmptyCest.php
@@ -36,7 +36,7 @@ class AllowEmptyCest
         $validation->add('name', $validator);
         $messages = $validation->validate($data);
 
-        $I->assertInstanceOf(0, $messages->count());
+        $I->assertCount(0, $messages);
     }
 
     public function validationAllowEmptyTrue(IntegrationTester $I)
@@ -49,6 +49,6 @@ class AllowEmptyCest
         $validation->add('name', $validator);
         $messages = $validation->validate($data);
 
-        $I->assertTrue(0, $messages->count());
+        $I->assertCount(0, $messages);
     }
 }

--- a/tests/integration/Validation/AllowEmptyCest.php
+++ b/tests/integration/Validation/AllowEmptyCest.php
@@ -34,8 +34,9 @@ class AllowEmptyCest
         $validation = new Validation();
         $validator = new Alpha(['allowEmpty' => false]);
         $validation->add('name', $validator);
+        $messages = $validation->validate($data);
 
-        $I->assertInstanceOf(Messages::class, $validation->validate($data));
+        $I->assertInstanceOf(0, $messages->count());
     }
 
     public function validationAllowEmptyTrue(IntegrationTester $I)
@@ -46,7 +47,8 @@ class AllowEmptyCest
         $validation = new Validation();
         $validator = new Alpha(['allowEmpty' => true]);
         $validation->add('name', $validator);
+        $messages = $validation->validate($data);
 
-        $I->assertTrue($validation->validate($data));
+        $I->assertTrue(0, $messages->count());
     }
 }

--- a/tests/integration/Validation/GetValueByDataCest.php
+++ b/tests/integration/Validation/GetValueByDataCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Integration\Validation;
 
 use IntegrationTester;
+use Phalcon\Tests\Models\EntityWithPublic;
 use Phalcon\Validation;
 
 /**
@@ -47,9 +48,7 @@ class GetValueByDataCest
     {
         $I->wantToTest('Validation - getValueByData()');
 
-        $data = new class() {
-            public $name = GetValueByDataCest::NAME;
-        };
+        $data = new EntityWithPublic(self::NAME);
 
         $validation = new Validation();
         $value = $validation->getValueByData($data, 'name');

--- a/tests/integration/Validation/GetValueByDataCest.php
+++ b/tests/integration/Validation/GetValueByDataCest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Integration\Validation;
+
+use IntegrationTester;
+use Phalcon\Validation;
+
+/**
+ * Class GetValueByDataCest
+ */
+class GetValueByDataCest
+{
+    public const NAME = 'John Doe';
+
+    /**
+     * Tests Phalcon\Validation :: getValueByData()
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-04-16
+     */
+    public function validationGetValueByDataArray(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - getValueByData()');
+
+        $data = [
+            'name' => self::NAME,
+        ];
+
+        $validation = new Validation();
+        $value = $validation->getValueByData($data, 'name');
+
+        $I->assertSame($data['name'], $value);
+    }
+
+    public function validationGetValueByDataObject(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - getValueByData()');
+
+        $data = new class() {
+            public $name = GetValueByDataCest::NAME;
+        };
+
+        $validation = new Validation();
+        $value = $validation->getValueByData($data, 'name');
+
+        $I->assertSame($data->name, $value);
+    }
+}

--- a/tests/integration/Validation/GetValueByDataCest.php
+++ b/tests/integration/Validation/GetValueByDataCest.php
@@ -28,7 +28,7 @@ class GetValueByDataCest
      * Tests Phalcon\Validation :: getValueByData()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2019-04-16
+     * @since  2021-11-07
      */
     public function validationGetValueByDataArray(IntegrationTester $I)
     {

--- a/tests/integration/Validation/GetValueByEntityCest.php
+++ b/tests/integration/Validation/GetValueByEntityCest.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Integration\Validation;
 
 use IntegrationTester;
+use Phalcon\Tests\Models\EntityWithGetter;
+use Phalcon\Tests\Models\EntityWithHook;
+use Phalcon\Tests\Models\EntityWithPublic;
 use Phalcon\Validation;
 
 /**
@@ -29,55 +32,39 @@ class GetValueByEntityCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-04-16
      */
-    public function validationGetValueByEntityPublic(IntegrationTester $I)
+    public function validationGetValueByEntityPublic(IntegrationTester $I): void
     {
-        $I->wantToTest('Validation - getValueByEntity()');
+        $I->wantToTest('Validation - getValueByEntity() - public property');
 
-        $user = new class() {
-            public $name = GetValueByEntityCest::NAME;
-        };
+        $entity = new EntityWithPublic(self::NAME);
 
         $validation = new Validation();
-        $value = $validation->getValueByEntity($user, 'name');
+        $value = $validation->getValueByEntity($entity, 'name');
 
-        $I->assertSame($user->name, $value);
+        $I->assertSame($entity->name, $value);
     }
 
-    public function validationGetValueByEntityGetter(IntegrationTester $I)
+    public function validationGetValueByEntityGetter(IntegrationTester $I): void
     {
-        $I->wantToTest('Validation - getValueByEntity()');
+        $I->wantToTest('Validation - getValueByEntity() - getter');
 
-        $user = new class() {
-            private $name = GetValueByEntityCest::NAME;
-
-            public function getName()
-            {
-                return $this->name;
-            }
-        };
+        $entity = new EntityWithGetter(self::NAME);
 
         $validation = new Validation();
-        $value = $validation->getValueByEntity($user, 'name');
+        $value = $validation->getValueByEntity($entity, 'name');
 
-        $I->assertSame($user->getName(), $value);
+        $I->assertSame($entity->getName(), $value);
     }
 
-    public function validationGetValueByEntityReadAttribute(IntegrationTester $I)
+    public function validationGetValueByEntityReadAttribute(IntegrationTester $I): void
     {
-        $I->wantToTest('Validation - getValueByEntity()');
+        $I->wantToTest('Validation - getValueByEntity() - readAttribute');
 
-        $user = new class() {
-            private $name = GetValueByEntityCest::NAME;
-
-            public function readAttribute(string $field)
-            {
-                return $this->{$field};
-            }
-        };
+        $entity = new EntityWithHook(self::NAME);
 
         $validation = new Validation();
-        $value = $validation->getValueByEntity($user, 'name');
+        $value = $validation->getValueByEntity($entity, 'name');
 
-        $I->assertSame($user->readAttribute('name'), $value);
+        $I->assertSame($entity->readAttribute('name'), $value);
     }
 }

--- a/tests/integration/Validation/GetValueByEntityCest.php
+++ b/tests/integration/Validation/GetValueByEntityCest.php
@@ -30,7 +30,7 @@ class GetValueByEntityCest
      * Tests Phalcon\Validation :: getValueByEntity()
      *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2019-04-16
+     * @since  2021-11-07
      */
     public function validationGetValueByEntityPublic(IntegrationTester $I): void
     {

--- a/tests/integration/Validation/GetValueByEntityCest.php
+++ b/tests/integration/Validation/GetValueByEntityCest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Integration\Validation;
+
+use IntegrationTester;
+use Phalcon\Validation;
+
+/**
+ * Class GetValueByEntityCest
+ */
+class GetValueByEntityCest
+{
+    public const NAME = 'John Doe';
+
+    /**
+     * Tests Phalcon\Validation :: getValueByEntity()
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-04-16
+     */
+    public function validationGetValueByEntityPublic(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - getValueByEntity()');
+
+        $user = new class() {
+            public $name = GetValueByEntityCest::NAME;
+        };
+
+        $validation = new Validation();
+        $value = $validation->getValueByEntity($user, 'name');
+
+        $I->assertSame($user->name, $value);
+    }
+
+    public function validationGetValueByEntityGetter(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - getValueByEntity()');
+
+        $user = new class() {
+            private $name = GetValueByEntityCest::NAME;
+
+            public function getName()
+            {
+                return $this->name;
+            }
+        };
+
+        $validation = new Validation();
+        $value = $validation->getValueByEntity($user, 'name');
+
+        $I->assertSame($user->getName(), $value);
+    }
+
+    public function validationGetValueByEntityReadAttribute(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - getValueByEntity()');
+
+        $user = new class() {
+            private $name = GetValueByEntityCest::NAME;
+
+            public function readAttribute(string $field)
+            {
+                return $this->{$field};
+            }
+        };
+
+        $validation = new Validation();
+        $value = $validation->getValueByEntity($user, 'name');
+
+        $I->assertSame($user->readAttribute('name'), $value);
+    }
+}

--- a/tests/integration/Validation/Validator/Callback/ValidateCest.php
+++ b/tests/integration/Validation/Validator/Callback/ValidateCest.php
@@ -61,7 +61,7 @@ class ValidateCest
             ]
         );
 
-        $I->assertCount(0, $messages->count());
+        $I->assertCount(0, $messages);
 
 
         $messages = $validation->validate(
@@ -71,7 +71,7 @@ class ValidateCest
             ]
         );
 
-        $I->assertCount(0, $messages->count());
+        $I->assertCount(0, $messages);
 
 
         $messages = $validation->validate(
@@ -81,7 +81,7 @@ class ValidateCest
             ]
         );
 
-        $I->assertCount(1, $messages->count());
+        $I->assertCount(1, $messages);
 
 
         $expected = new Messages(

--- a/tests/integration/Validation/Validator/Callback/ValidateCest.php
+++ b/tests/integration/Validation/Validator/Callback/ValidateCest.php
@@ -48,6 +48,7 @@ class ValidateCest
                         return empty($data['admin']);
                     },
                     'message'    => 'You cant provide both admin and user.',
+                    'allowEmpty' => true,
                 ]
             )
         );
@@ -60,7 +61,7 @@ class ValidateCest
             ]
         );
 
-        $I->assertCount(0, $messages);
+        $I->assertCount(0, $messages->count());
 
 
         $messages = $validation->validate(
@@ -70,7 +71,7 @@ class ValidateCest
             ]
         );
 
-        $I->assertCount(0, $messages);
+        $I->assertCount(0, $messages->count());
 
 
         $messages = $validation->validate(
@@ -80,7 +81,7 @@ class ValidateCest
             ]
         );
 
-        $I->assertCount(1, $messages);
+        $I->assertCount(1, $messages->count());
 
 
         $expected = new Messages(


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #14203
* **POSSIBLY BREAKS BACKWARD COMPATIBILITY**

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

- `Phalcon\Validation::getValue()` seeks through `this->data` if not found in `this->entity`;
- `Phalcon\Forms\Form::isValid()` signature was changed: added 3rd argument `whitelist`;
- Added setter and getter for `whitelist` in `Phalcon\Forms\Form`.

Thanks

