### PR TITLE
T15361 find toarray

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -100,6 +100,7 @@
 - Fixed `Phalcon\Storage\Adapter\Redis::getAdapter()` and `Phalcon\Cache\Adapter\Redis::getAdapter()` to accept the connection timeout in the constructor `options` [#15744](https://github.com/phalcon/cphalcon/issues/15744) 
 - Fixed `Phalcon\Db\Adapter\AbstractAdapter::getSQLVariables()` to return an empty array when initialized [#15637](https://github.com/phalcon/cphalcon/issues/15637)
 - Fixed `Phalcon\Cache\Adapter\*` and `Phalcon\Storage\Adapter\*` to delete a key when `set()` is called with a zero or negative TTL [#15485](https://github.com/phalcon/cphalcon/issues/15485)
+- Fixed `Phalcon\Db\Adapter\Pdo\Mysql` to not use `PDO::ATTR_EMULATE_PREPARES` and `PDO::ATTR_STRINGIFY_FETCHES` by default. This allows numbers to be returned with resultsets instead of strings for numeric fields [#15361](https://github.com/phalcon/cphalcon/issues/15361) 
 
 # [5.0.0alpha6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (2021-09-16)
 

--- a/phalcon/Db/Adapter/Pdo/Mysql.zep
+++ b/phalcon/Db/Adapter/Pdo/Mysql.zep
@@ -68,7 +68,7 @@ class Mysql extends PdoAdapter
     {
         /**
          * Returning numbers as numbers and not strings. If the user already
-         * set this option in the descriptor["options"], we do not have to set`
+         * set this option in the descriptor["options"], we do not have to set
          * anything
          */
         if (!isset(descriptor["options"][\PDO::ATTR_EMULATE_PREPARES])) {

--- a/phalcon/Db/Adapter/Pdo/Mysql.zep
+++ b/phalcon/Db/Adapter/Pdo/Mysql.zep
@@ -50,6 +50,38 @@ class Mysql extends PdoAdapter
     protected type = "mysql";
 
     /**
+     * Constructor for Phalcon\Db\Adapter\Pdo
+     *
+     * @param array descriptor = [
+     *     'host' => 'localhost',
+     *     'port' => '3306',
+     *     'dbname' => 'blog',
+     *     'username' => 'sigma'
+     *     'password' => 'secret'
+     *     'dialectClass' => null,
+     *     'options' => [],
+     *     'dsn' => null,
+     *     'charset' => 'utf8mb4'
+     * ]
+     */
+    public function __construct(array! descriptor)
+    {
+        /**
+         * Returning numbers as numbers and not strings. If the user already
+         * set this option in the descriptor["options"], we do not have to set`
+         * anything
+         */
+        if (!isset(descriptor["options"][\PDO::ATTR_EMULATE_PREPARES])) {
+            let descriptor["options"][\PDO::ATTR_EMULATE_PREPARES]  = false;
+        }
+        if (!isset(descriptor["options"][\PDO::ATTR_STRINGIFY_FETCHES])) {
+            let descriptor["options"][\PDO::ATTR_STRINGIFY_FETCHES]  = false;
+        }
+
+        parent::__construct(descriptor);
+    }
+
+    /**
      * Adds a foreign key to a table
      */
     public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> bool

--- a/tests/database/Db/Adapter/Pdo/ConnectCest.php
+++ b/tests/database/Db/Adapter/Pdo/ConnectCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Database\Db\Adapter\Pdo;
 
 use DatabaseTester;
+use PDO;
 use Phalcon\Db\Adapter\PdoFactory;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 
@@ -51,6 +52,10 @@ class ConnectCest
 
         $options = getOptionsMysql();
         $options['persistent'] = true;
+        $options['options']    = [
+            PDO::ATTR_EMULATE_PREPARES  => false,
+            PDO::ATTR_STRINGIFY_FETCHES => false,
+        ];
 
         $connection = (new PdoFactory())->newInstance('mysql', $options);
 

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -39,9 +39,12 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray()
      *
-     * @group mysql
-     * @group pgsql
-     * @group sqlite
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-11-03
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
      */
     public function mvcModelToArray(DatabaseTester $I)
     {
@@ -87,9 +90,12 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray() - column map
      *
-     * @group mysql
-     * @group pgsql
-     * @group sqlite
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-11-03
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
      */
     public function mvcModelToArrayColumnMap(DatabaseTester $I)
     {
@@ -135,10 +141,13 @@ class ToArrayCest
     /**
      * Tests Phalcon\Mvc\Model :: toArray() - find first columns
      *
-     * @issue 1701
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-11-03
      *
-     * @group mysql
-     * @group sqlite
+     * @issue https://github.com/phalcon/cphalcon/issues/1701
+     *
+     * @group  mysql
+     * @group  sqlite
      */
     public function mvcModelToArrayFindFirstColumns(DatabaseTester $I)
     {
@@ -175,5 +184,81 @@ class ToArrayCest
         ];
         $actual   = $invoice->toArray();
         $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: toArray() - find - castOnHydrate/forceCasting
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-11-03
+     *
+     * @issue https://github.com/phalcon/cphalcon/issues/15361
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelToArrayFindCastOnHydrateForceCasting(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - toArray() - find - castOnHydrate/forceCasting');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $title      = uniqid('inv-');
+        $date       = date('Y-m-d H:i:s');
+
+        $migration = new InvoicesMigration($connection);
+        $migration->insert(4, 1, 0, $title, 111.26, $date);
+        $migration->insert(5, 2, 1, $title, 222.19, $date);
+
+        Invoices::setup(
+            [
+                'forceCasting'  => true,
+                'castOnHydrate' => true,
+            ]
+        );
+
+        $invoices = Invoices::findFirst();
+
+        $expected = [
+            'inv_id'          => 4,
+            'inv_cst_id'      => 1,
+            'inv_status_flag' => 0,
+            'inv_title'       => $title,
+            'inv_total'       => 111.26,
+            'inv_created_at'  => $date,
+        ];
+        $actual   = $invoices->toArray();
+        $I->assertEquals($expected, $actual);
+
+        $invoices = Invoices::find();
+
+        $expected = [
+            [
+                'inv_id'          => 4,
+                'inv_cst_id'      => 1,
+                'inv_status_flag' => 0,
+                'inv_title'       => $title,
+                'inv_total'       => 111.26,
+                'inv_created_at'  => $date,
+            ],
+            [
+                'inv_id'          => 5,
+                'inv_cst_id'      => 2,
+                'inv_status_flag' => 1,
+                'inv_title'       => $title,
+                'inv_total'       => 222.19,
+                'inv_created_at'  => $date,
+            ]
+        ];
+        $actual   = $invoices->toArray();
+        $I->assertSame($expected, $actual);
+
+        Invoices::setup(
+            [
+                'forceCasting'  => false,
+                'castOnHydrate' => false,
+            ]
+        );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15361 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Fixed `Phalcon\Db\Adapter\Pdo\Mysql` to not use `PDO::ATTR_EMULATE_PREPARES` and `PDO::ATTR_STRINGIFY_FETCHES` by default. This allows numbers to be returned with resultsets instead of strings for numeric fields

