### PR TITLE
T14928 Fixed allow empty file validation

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -105,6 +105,7 @@
 - Fixed `Phalcon\Db\Adapter\AbstractAdapter::getSQLVariables()` to return an empty array when initialized [#15637](https://github.com/phalcon/cphalcon/issues/15637)
 - Fixed `Phalcon\Cache\Adapter\*` and `Phalcon\Storage\Adapter\*` to delete a key when `set()` is called with a zero or negative TTL [#15485](https://github.com/phalcon/cphalcon/issues/15485)
 - Fixed `Phalcon\Db\Adapter\Pdo\Mysql` to not use `PDO::ATTR_EMULATE_PREPARES` and `PDO::ATTR_STRINGIFY_FETCHES` by default. This allows numbers to be returned with resultsets instead of strings for numeric fields [#15361](https://github.com/phalcon/cphalcon/issues/15361) 
+- Fixed `Phalcon\Validation\Validator\File` to use `messageFileEmpty` [#14928](https://github.com/phalcon/cphalcon/issues/14928) 
 
 # [5.0.0alpha6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0alpha6) (2021-09-16)
 

--- a/phalcon/Validation/Validator/File.zep
+++ b/phalcon/Validation/Validator/File.zep
@@ -118,7 +118,23 @@ class File extends AbstractValidatorComposite
      */
     public function __construct(array! options = [])
     {
-        var included = null, key, message = null, validator, value;
+        var included = null, key, message = null, validator, value,
+            messageFileEmpty = null, messageIniSize = null, messageValid = null;
+
+        if isset options["messageFileEmpty"] {
+            let messageFileEmpty  = Arr::get(options, "messageFileEmpty");
+            unset options["messageFileEmpty"];
+        }
+
+        if isset options["messageIniSize"] {
+            let messageIniSize  = Arr::get(options, "messageIniSize");
+            unset options["messageIniSize"];
+        }
+
+        if isset options["messageValid"] {
+            let messageValid  = Arr::get(options, "messageValid");
+            unset options["messageValid"];
+        }
 
         // create individual validators
         for key, value in options {
@@ -238,6 +254,18 @@ class File extends AbstractValidatorComposite
                 unset options["messageEqualResolution"];
             } else {
                 continue;
+            }
+
+            if messageFileEmpty !== null {
+                validator->setMessageFileEmpty(messageFileEmpty);
+            }
+
+            if messageIniSize !== null {
+                validator->setMessageIniSize(messageIniSize);
+            }
+
+            if messageValid !== null {
+                validator->setMessageValid(messageValid);
             }
 
             let this->validators[] = validator;

--- a/phalcon/Validation/Validator/File.zep
+++ b/phalcon/Validation/Validator/File.zep
@@ -44,6 +44,9 @@ use Phalcon\Validation\Validator\File\Size\Min as MinFileSize;
  *             "messageType"          => "Allowed file types are :types",
  *             "maxResolution"        => "800x600",
  *             "messageMaxResolution" => "Max resolution of :field is :resolution",
+ *             "messageFileEmpty"     => "File is empty",
+ *             "messageIniSize"       => "Ini size is not valid",
+ *             "messageValid"         => "File is not valid",
  *         ]
  *     )
  * );
@@ -113,7 +116,10 @@ class File extends AbstractValidatorComposite
      *     'messageMinResolution' => '',
      *     'equalResolution' => '1000x1000',
      *     'messageEqualResolution' => '',
-     *     'allowEmpty' => false
+     *     'allowEmpty' => false,
+     *     'messageFileEmpty' => '',
+     *     'messageIniSize' => '',
+     *     'messageValid' => ''
      * ]
      */
     public function __construct(array! options = [])

--- a/tests/integration/Validation/Validator/File/CustomMessagesCest.php
+++ b/tests/integration/Validation/Validator/File/CustomMessagesCest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Integration\Validation\Validator\File;
+
+use IntegrationTester;
+use Phalcon\Tests\Fixtures\Traits\ValidationTrait;
+use Phalcon\Validation\Validator\File;
+
+/**
+ * Class CustomMessagesCest
+ */
+class CustomMessagesCest
+{
+    use ValidationTrait;
+
+    /**
+     * Tests Phalcon\Validation\Validator\File :: customMessages[]
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2018-11-13
+     */
+    public function validationValidatorFileCustomMessages(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation\Validator\File - customMessages[]');
+
+        $options = [
+            'maxSize' => '0.5M',
+            'messageFileEmpty' => 'File is empty',
+            'messageIniSize' => 'Ini size is not valid',
+            'messageValid' => 'File is not valid',
+        ];
+        $file = new File($options);
+        $validators = $file->getValidators();
+
+        /** @var File\AbstractFile $validator */
+        foreach ($validators as $validator) {
+            $messageFileEmpty = $validator->getMessageFileEmpty();
+            $messageIniSize = $validator->getMessageIniSize();
+            $messageValid = $validator->getMessageValid();
+
+            $I->assertEquals($options['messageFileEmpty'], $messageFileEmpty);
+            $I->assertEquals($options['messageIniSize'], $messageIniSize);
+            $I->assertEquals($options['messageValid'], $messageValid);
+        }
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #14928 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Passed additional messages to `Phalcon\Validation\Validator\File` composition.

Thanks

