### PR TITLE
T15067 Fix controller name parsing route

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -71,6 +71,7 @@
     - `escapeUrl()` becomes `url()`
     - `setHtmlQuoteType()` becomes `setFlags()` [#15757](https://github.com/phalcon/cphalcon/issues/15757)
 - Changed `Phalcon\Encryption\Security::hash()` to also use `password_hash()` and accept `ARGON2*` algorithms [#15731](https://github.com/phalcon/cphalcon/issues/15731) 
+- Removed uncamelize of `realClassName` in `Phalcon\Mvc\Router\Route::getRoutePaths()` if definition is string to make processing same as if array definition [#15067](https://github.com/phalcon/cphalcon/issues/15067) 
 
 ## Added
 - Added more tests in the suite for additional code coverage [#15691](https://github.com/phalcon/cphalcon/issues/15691)

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -496,8 +496,7 @@ class Route implements RouteInterface
                     let realClassName = controllerName;
                 }
 
-                // Always pass the controller to lowercase
-                let routePaths["controller"] = uncamelize(realClassName);
+                let routePaths["controller"] = realClassName;
             }
 
             // Process action name

--- a/tests/integration/Mvc/Router/Route/GetRoutePathsCest.php
+++ b/tests/integration/Mvc/Router/Route/GetRoutePathsCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Integration\Mvc\Router\Route;
 
 use IntegrationTester;
+use Phalcon\Mvc\Router\Route;
 
 /**
  * Class GetRoutePathsCest
@@ -29,6 +30,11 @@ class GetRoutePathsCest
     public function mvcRouterRouteGetRoutePaths(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Router\Route - getRoutePaths()');
-        $I->skipTest('Need implementation');
+
+        $arrayDefinition = ["controller" => 'FooBar', "action" => 'baz'];
+        $stringDefinition = "FooBar::baz";
+
+        $I->assertEquals($arrayDefinition, Route::getRoutePaths($arrayDefinition));
+        $I->assertEquals($arrayDefinition, Route::getRoutePaths($stringDefinition));
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15067 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
String format router definition processing is different for controller name because of uncamelize of this option.
Removed uncamelize.

Thanks

