### PR TITLE
T15515 Fix allow empty validation

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -92,6 +92,7 @@
 - Added `Phalcon\Forms\Form::getFilteredValue()` to get filtered value without providing entity [#15438](https://github.com/phalcon/cphalcon/issues/15438)
 - Added `Phalcon\Encryption\Security::getHashInformation()` to return information for a hash [#15731](https://github.com/phalcon/cphalcon/issues/15731)
 - Added constants `Phalcon\Encryption\Security::CRYPT_ARGON2I` and `Phalcon\Encryption\Security::CRYPT_ARGON2ID` [#15731](https://github.com/phalcon/cphalcon/issues/15731)
+- Added `allowEmpty` checks to common validators [#15515](https://github.com/phalcon/cphalcon/issues/15515)
 
 ## Fixed
 - Fixed `Query::getExpression()` return type [#15553](https://github.com/phalcon/cphalcon/issues/15553)

--- a/phalcon/Validation/AbstractValidator.zep
+++ b/phalcon/Validation/AbstractValidator.zep
@@ -211,6 +211,24 @@ abstract class AbstractValidator implements ValidatorInterface
     }
 
     /**
+     * Checks if field can be empty.
+     *
+     * @return bool
+     */
+    protected function allowEmpty(var field, var value) -> bool
+    {
+        var allowEmpty;
+
+        let allowEmpty = this->getOption("allowEmpty", false);
+
+        if typeof allowEmpty == "array" {
+            let allowEmpty = isset allowEmpty[field] ? allowEmpty[field] : false;
+        }
+
+        return allowEmpty && empty value;
+    }
+
+    /**
      * Create a default message by factory
      *
      * @return Message

--- a/phalcon/Validation/AbstractValidator.zep
+++ b/phalcon/Validation/AbstractValidator.zep
@@ -213,6 +213,9 @@ abstract class AbstractValidator implements ValidatorInterface
     /**
      * Checks if field can be empty.
      *
+     * @param mixed field
+     * @param mixed value
+     *
      * @return bool
      */
     protected function allowEmpty(var field, var value) -> bool
@@ -221,7 +224,7 @@ abstract class AbstractValidator implements ValidatorInterface
 
         let allowEmpty = this->getOption("allowEmpty", false);
 
-        if typeof allowEmpty == "array" {
+        if typeof allowEmpty === "array" {
             let allowEmpty = isset allowEmpty[field] ? allowEmpty[field] : false;
         }
 

--- a/phalcon/Validation/Validator/Alnum.zep
+++ b/phalcon/Validation/Validator/Alnum.zep
@@ -73,6 +73,9 @@ class Alnum extends AbstractValidator
         var value;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if !ctype_alnum(value) {
             validation->appendMessage(

--- a/phalcon/Validation/Validator/Alpha.zep
+++ b/phalcon/Validation/Validator/Alpha.zep
@@ -74,6 +74,9 @@ class Alpha extends AbstractValidator
         var value;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if preg_match("/[^[:alpha:]]/imu", value) {
             validation->appendMessage(

--- a/phalcon/Validation/Validator/Between.zep
+++ b/phalcon/Validation/Validator/Between.zep
@@ -90,6 +90,10 @@ class Between extends AbstractValidator
             minimum = this->getOption("minimum"),
             maximum = this->getOption("maximum");
 
+        if this->allowEmpty(field, value) {
+            return true;
+        }
+
         if typeof minimum == "array" {
             let minimum = minimum[field];
         }

--- a/phalcon/Validation/Validator/Callback.zep
+++ b/phalcon/Validation/Validator/Callback.zep
@@ -69,8 +69,7 @@ class Callback extends AbstractValidator
      * @param array options = [
      *     'message' => '',
      *     'template' => '',
-     *     'callback' => null,
-     *     'allowEmpty' => false
+     *     'callback' => null
      * ]
      */
     public function __construct(array! options = [])
@@ -95,9 +94,6 @@ class Callback extends AbstractValidator
             }
 
             let returnedValue = call_user_func(callback, data);
-            if this->allowEmpty(field, returnedValue) {
-                return true;
-            }
 
             if typeof returnedValue == "boolean" {
                 if !returnedValue {

--- a/phalcon/Validation/Validator/Callback.zep
+++ b/phalcon/Validation/Validator/Callback.zep
@@ -95,6 +95,9 @@ class Callback extends AbstractValidator
             }
 
             let returnedValue = call_user_func(callback, data);
+            if this->allowEmpty(field, returnedValue) {
+                return true;
+            }
 
             if typeof returnedValue == "boolean" {
                 if !returnedValue {

--- a/phalcon/Validation/Validator/Confirmation.zep
+++ b/phalcon/Validation/Validator/Confirmation.zep
@@ -66,8 +66,7 @@ class Confirmation extends AbstractValidator
      *     'template' => '',
      *     'with' => '',
      *     'labelWith' => '',
-     *     'ignoreCase' => false,
-     *     'allowEmpty' => false
+     *     'ignoreCase' => false
      * ]
      */
     public function __construct(array! options = [])

--- a/phalcon/Validation/Validator/CreditCard.zep
+++ b/phalcon/Validation/Validator/CreditCard.zep
@@ -74,6 +74,9 @@ class CreditCard extends AbstractValidator
         var value, valid;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         let valid = this->verifyByLuhnAlgorithm(value);
 

--- a/phalcon/Validation/Validator/Date.zep
+++ b/phalcon/Validation/Validator/Date.zep
@@ -81,8 +81,11 @@ class Date extends AbstractValidator
         var value, format;
 
         let value = validation->getValue(field);
-        let format = this->getOption("format");
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
+        let format = this->getOption("format");
         if typeof format == "array" {
             let format = format[field];
         }

--- a/phalcon/Validation/Validator/Digit.zep
+++ b/phalcon/Validation/Validator/Digit.zep
@@ -72,6 +72,9 @@ class Digit extends AbstractValidator
     public function validate(<Validation> validation, var field) -> bool
     {
         var value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if is_int(value) || ctype_digit(value) {
             return true;

--- a/phalcon/Validation/Validator/Email.zep
+++ b/phalcon/Validation/Validator/Email.zep
@@ -72,6 +72,9 @@ class Email extends AbstractValidator
     public function validate(<Validation> validation, var field) -> bool
     {
         var value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if !filter_var(value, FILTER_VALIDATE_EMAIL) {
             validation->appendMessage(

--- a/phalcon/Validation/Validator/ExclusionIn.zep
+++ b/phalcon/Validation/Validator/ExclusionIn.zep
@@ -88,6 +88,9 @@ class ExclusionIn extends AbstractValidator
         var value, domain, replacePairs, strict, fieldDomain;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         /**
          * A domain is an array with a list of valid values

--- a/phalcon/Validation/Validator/Identical.zep
+++ b/phalcon/Validation/Validator/Identical.zep
@@ -82,6 +82,9 @@ class Identical extends AbstractValidator
         bool valid;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if this->hasOption("accepted") {
             let accepted = this->getOption("accepted");

--- a/phalcon/Validation/Validator/InclusionIn.zep
+++ b/phalcon/Validation/Validator/InclusionIn.zep
@@ -82,6 +82,9 @@ class InclusionIn extends AbstractValidator
         var value, domain, replacePairs, strict, fieldDomain;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         /**
          * A domain is an array with a list of valid values

--- a/phalcon/Validation/Validator/Ip.zep
+++ b/phalcon/Validation/Validator/Ip.zep
@@ -93,35 +93,26 @@ class Ip extends AbstractValidator
      */
     public function validate(<Validation> validation, var field) -> bool
     {
-        var value, version, allowPrivate, allowReserved, allowEmpty, options;
+        var value, version, allowPrivate, allowReserved, options;
 
-        let value = validation->getValue(field),
-            version = this->getOption("version", FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6);
+        let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
+        let version = this->getOption("version", FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6);
         if typeof version == "array" {
             let version = version[field];
         }
 
         let allowPrivate = this->getOption("allowPrivate") ? 0 : FILTER_FLAG_NO_PRIV_RANGE;
-
         if typeof allowPrivate == "array" {
             let allowPrivate = allowPrivate[field];
         }
 
         let allowReserved = this->getOption("allowReserved") ? 0 : FILTER_FLAG_NO_RES_RANGE;
-
         if typeof allowReserved == "array" {
             let allowReserved = allowReserved[field];
-        }
-
-        let allowEmpty = this->getOption("allowEmpty", false);
-
-        if typeof allowEmpty == "array" {
-            let allowEmpty = isset allowEmpty[field] ? allowEmpty[field] : false;
-        }
-
-        if allowEmpty && empty value {
-            return true;
         }
 
         let options = [

--- a/phalcon/Validation/Validator/Numericality.zep
+++ b/phalcon/Validation/Validator/Numericality.zep
@@ -80,6 +80,10 @@ class Numericality extends AbstractValidator
             value   = str_replace(" ", "", value),
             pattern = "/((^[-]?[0-9,]+(.[0-9]+)?$)|(^[-]?[0-9.]+(,[0-9]+)?$))/";
 
+        if this->allowEmpty(field, value) {
+            return true;
+        }
+
         if !preg_match(pattern, value) {
             validation->appendMessage(
                 this->messageFactory(validation, field)

--- a/phalcon/Validation/Validator/PresenceOf.zep
+++ b/phalcon/Validation/Validator/PresenceOf.zep
@@ -72,6 +72,9 @@ class PresenceOf extends AbstractValidator
     public function validate(<Validation> validation, var field) -> bool
     {
         var value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if value === null || value === "" {
             validation->appendMessage(

--- a/phalcon/Validation/Validator/Regex.zep
+++ b/phalcon/Validation/Validator/Regex.zep
@@ -84,6 +84,9 @@ class Regex extends AbstractValidator
         // Check if the value match using preg_match in the PHP userland
         let matches = null;
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         let pattern = this->getOption("pattern");
 

--- a/phalcon/Validation/Validator/StringLength/Max.zep
+++ b/phalcon/Validation/Validator/StringLength/Max.zep
@@ -89,6 +89,9 @@ class Max extends AbstractValidator
         var value, length, maximum, replacePairs, included, result;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         // Check if mbstring is available to calculate the correct length
         if function_exists("mb_strlen") {

--- a/phalcon/Validation/Validator/StringLength/Min.zep
+++ b/phalcon/Validation/Validator/StringLength/Min.zep
@@ -89,6 +89,9 @@ class Min extends AbstractValidator
         var value, length, minimum, replacePairs, included, result;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         // Check if mbstring is available to calculate the correct length
         if function_exists("mb_strlen") {

--- a/phalcon/Validation/Validator/Url.zep
+++ b/phalcon/Validation/Validator/Url.zep
@@ -75,6 +75,9 @@ class Url extends AbstractValidator
         var options, result, value;
 
         let value = validation->getValue(field);
+        if this->allowEmpty(field, value) {
+            return true;
+        }
 
         if fetch options, this->options["options"] {
             let result = filter_var(value, FILTER_VALIDATE_URL, options);

--- a/tests/integration/Mvc/Router/HandleCest.php
+++ b/tests/integration/Mvc/Router/HandleCest.php
@@ -236,7 +236,7 @@ class HandleCest
         );
 
         $I->assertEquals(
-            'about',
+            'About',
             $router->getControllerName()
         );
 
@@ -299,7 +299,7 @@ class HandleCest
         );
 
         $I->assertEquals(
-            'about',
+            'About',
             $router->getControllerName()
         );
 

--- a/tests/integration/Validation/AllowEmptyCest.php
+++ b/tests/integration/Validation/AllowEmptyCest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Integration\Validation;
+
+use IntegrationTester;
+use Phalcon\Validation;
+use Phalcon\Validation\Validator\Alpha;
+
+class AllowEmptyCest
+{
+    /**
+     * Tests Phalcon\Validation :: allowEmpty()
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2021-11-07
+     */
+    public function validationAllowEmptyFalse(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - allowEmpty() - false');
+
+        $data = ['name' => ''];
+        $validation = new Validation();
+        $validator = new Alpha(['allowEmpty' => false]);
+        $validation->add('name', $validator);
+
+        $I->assertFalse($validation->validate($data));
+    }
+
+    public function validationAllowEmptyTrue(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation - allowEmpty() - true');
+
+        $data = ['name' => ''];
+        $validation = new Validation();
+        $validator = new Alpha(['allowEmpty' => true]);
+        $validation->add('name', $validator);
+
+        $I->assertTrue($validation->validate($data));
+    }
+}

--- a/tests/integration/Validation/AllowEmptyCest.php
+++ b/tests/integration/Validation/AllowEmptyCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Integration\Validation;
 
 use IntegrationTester;
+use Phalcon\Messages\Messages;
 use Phalcon\Validation;
 use Phalcon\Validation\Validator\Alpha;
 
@@ -34,7 +35,7 @@ class AllowEmptyCest
         $validator = new Alpha(['allowEmpty' => false]);
         $validation->add('name', $validator);
 
-        $I->assertFalse($validation->validate($data));
+        $I->assertInstanceOf(Messages::class, $validation->validate($data));
     }
 
     public function validationAllowEmptyTrue(IntegrationTester $I)

--- a/tests/integration/Validation/Validator/Callback/ValidateCest.php
+++ b/tests/integration/Validation/Validator/Callback/ValidateCest.php
@@ -48,7 +48,6 @@ class ValidateCest
                         return empty($data['admin']);
                     },
                     'message'    => 'You cant provide both admin and user.',
-                    'allowEmpty' => true,
                 ]
             )
         );


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15515

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Fixed usage of `allowEmpty` option in common validation.

Thanks

