### PR TITLE
Ported the fix for "T15649 getrelated fk" from release 5.x.x into 4.1.x

### DIFF
--- a/CHANGELOG-4.1.md
+++ b/CHANGELOG-4.1.md
@@ -1,3 +1,11 @@
+
+# [4.1.3](https://github.com/phalcon/cphalcon/releases/tag/v4.1.3) (xxxx-xx-xx)
+
+## Fixed
+
+- Fixed `Phalcon\Mvc\Model::getRelated()` to correctly return relationships (cached or not) when the foreign key has changed [#15649](https://github.com/phalcon/cphalcon/issues/15649)
+
+
 # [4.1.2](https://github.com/phalcon/cphalcon/releases/tag/v4.1.2) (2021-04-22)
 
 ## Changed

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1906,23 +1906,36 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          * If there are any arguments, Manager with handle the caching of the records
          */
         if arguments === null {
+//            /**
+//             * If the related records are already in cache and the relation is reusable,
+//             * we return the cached records.
+//             */
+//            if relation->isReusable() && this->isRelationshipLoaded(lowerAlias) {
+//                let result = this->related[lowerAlias];
+//            } else {
+//                /**
+//                 * Call the 'getRelationRecords' in the models manager.
+//                 */
+//                let result = manager->getRelationRecords(relation, this, arguments);
+//
+//                /**
+//                 * We store relationship objects in the related cache if there were no arguments.
+//                 */
+//                let this->related[lowerAlias] = result;
+//            }
             /**
-             * If the related records are already in cache and the relation is reusable,
-             * we return the cached records.
+             * We do not need conditionals here. The models manager stores
+             * reusable related records so we utilize that and remove complexity
+             * from here. There is a very small decrease in performance since
+             * the models manager needs to calculate the unique key from
+             * the passed arguments and then check its internal cache
              */
-            if relation->isReusable() && this->isRelationshipLoaded(lowerAlias) {
-                let result = this->related[lowerAlias];
-            } else {
-                /**
-                 * Call the 'getRelationRecords' in the models manager.
-                 */
-                let result = manager->getRelationRecords(relation, this, arguments);
+            let result = manager->getRelationRecords(relation, this, arguments);
 
-                /**
-                 * We store relationship objects in the related cache if there were no arguments.
-                 */
-                let this->related[lowerAlias] = result;
-            }
+            /**
+             * We store relationship objects in the related cache if there were no arguments.
+             */
+            let this->related[lowerAlias] = result;
         } else {
             /**
              * Individually queried related records are handled by Manager.


### PR DESCRIPTION

Hi all, 

I am using Phalcon v4.1.2 and we encounter the issue fixed by
https://github.com/phalcon/cphalcon/pull/15702

I wanted to wait until Phalcon 5 was out of alpha/beta before upgrading, so I cherry-picked the change back into here.  Note 





* Type: bug fix
* Link to issue: [BUG]: Model virtual FK query not saving new value after execution #15649 https://github.com/phalcon/cphalcon/issues/15649

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Ported fixed to  `Phalcon\Mvc\Model::getRelated()` to correctly return relationships (cached or not) when the foreign key has changed.

Thank you to @niden for the actual fix.  I am just hoping to have this ported into the 4.1 

Thanks

