### PR TITLE
T14547 syslog phpeol

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ on:
 
 env:
   # All versions should be declared here
-  PHALCON_VERSION: 5.0.0beta2
-  ZEPHIR_PARSER_VERSION: 1.4.1
-  ZEPHIR_VERSION: 0.15.0
+  PHALCON_VERSION: 5.0.0beta3
+  ZEPHIR_PARSER_VERSION: 1.4.2
+  ZEPHIR_VERSION: 0.15.2
   PSR_VERSION: 1.1.0
 
   # For tests

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,4 +1,10 @@
-# [5.0.0beta2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0beta1) (2022-01-06)
+# [5.0.0beta3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0beta2) (xxxx-xx-xx)
+
+## Fixed
+- Fixed `Phalcon\Logger\AbstractAdapter::getFormattedItem()` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream` [#14547](https://github.com/phalcon/cphalcon/issues/14547)
+
+
+# [5.0.0beta2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0beta2) (2022-01-06)
 
 ## Fixed
 - `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall()` to check for container presence before checking the `tag` service [#15842](https://github.com/phalcon/cphalcon/issues/15842)

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "name": "phalcon",
   "description": "Phalcon is a full stack PHP framework, delivered as a PHP extension, offering lower resource consumption and high performance.",
   "author": "Phalcon Team and contributors",
-  "version": "5.0.0beta2",
+  "version": "5.0.0beta3",
   "verbose": false,
   "stubs": {
     "path": "ide\/%version%\/%namespace%\/",

--- a/package.xml
+++ b/package.xml
@@ -25,8 +25,8 @@
   <date>2021-11-16</date>
   <time>17:00:00</time>
   <version>
-    <release>5.0.0beta2</release>
-    <api>5.0.0beta2</api>
+    <release>5.0.0beta3</release>
+    <api>5.0.0beta3</api>
   </version>
   <stability>
     <release>beta</release>
@@ -35,17 +35,6 @@
   <license uri="https://license.phalcon.io">BSD 3-Clause License</license>
   <notes>
     Full changelog can be found at: https://github.com/phalcon/cphalcon/blob/master/CHANGELOG-5.0.md
-
-    ## Fixed
-    - `Phalcon\Mvc\View\Engine\Volt\Compiler::functionCall()` to check for container presence before checking the `tag` service [#15842](https://github.com/phalcon/cphalcon/issues/15842)
-    - `Phalcon\Di\FactoryDefault()` to set `assets` and `tag` as shared services [#15847](https://github.com/phalcon/cphalcon/issues/15847)
-    - `Phalcon\Forms\Element\AbstractElement::getLocalTagFactory()` to return the tagFactory from itself, the form, the DI or a new instance [#15847](https://github.com/phalcon/cphalcon/issues/15847)
-    - Changed references to `sha1` with `hash("sha256", $data)` to ensure that there are no collisions from the hashing algorithm  [#15844](https://github.com/phalcon/cphalcon/issues/15844)
-    - Changed `Phalcon\Support\Helper\Str\Camelize` to accept a third boolean parameter indicating whether the result will have the first letter capitalized or not [#15850](https://github.com/phalcon/cphalcon/issues/15850)
-
-    ## Added
-    - Added `Phalcon\Support\Helper\Str\KebabCase`, `Phalcon\Support\Helper\Str\PascalCase` and `Phalcon\Support\Helper\Str\SnakeCase` helpers [#15850](https://github.com/phalcon/cphalcon/issues/15850)
-
 
   </notes>
   <contents>

--- a/phalcon/Logger/Adapter/AbstractAdapter.zep
+++ b/phalcon/Logger/Adapter/AbstractAdapter.zep
@@ -199,7 +199,7 @@ abstract class AbstractAdapter implements AdapterInterface
 
         let formatter = this->getFormatter();
 
-        return formatter->format(item) . PHP_EOL;
+        return formatter->format(item);
     }
 
     /**

--- a/phalcon/Logger/Adapter/Stream.zep
+++ b/phalcon/Logger/Adapter/Stream.zep
@@ -134,7 +134,7 @@ class Stream extends AbstractAdapter
             }
         }
 
-        let message = this->getFormattedItem(item);
+        let message = this->getFormattedItem(item) . PHP_EOL;
 
         fwrite(this->handler, message);
     }

--- a/phalcon/Support/Version.zep
+++ b/phalcon/Support/Version.zep
@@ -77,7 +77,7 @@ class Version
      */
     protected function getVersion() -> array
     {
-        return [5, 0, 0, 2, 2];
+        return [5, 0, 0, 2, 3];
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #14547 (reintroduced)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Logger\AbstractAdapter::getFormattedItem()` to not add `PHP_EOL` at the end of the message and added it to the `Phalcon\Logger\Adapter\Stream` (reintroduced bug)

Thanks

