### PR TITLE
T15879 crypt length

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,3 +1,8 @@
+# [5.0.0rc1](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0beta3) (xxxx-xx-xx)
+
+## Added
+- Added `Phalcon\Encryption\Crypt::isValidDecryptLength($input)` to allow checking for the length of the decryption string [#15879](https://github.com/phalcon/cphalcon/issues/15879)
+ 
 # [5.0.0beta3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0beta3) (2022-02-06)
 
 ## Changed

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -992,7 +992,8 @@ class Crypt implements CryptInterface
     {
         var cipher, length, version;
 
-        let cipher = this->cipher;
+        let cipher  = this->cipher,
+            version = phpversion();
 
         globals_set("warning.enable", false);
 

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -444,9 +444,9 @@ class Crypt implements CryptInterface
     {
         var length;
 
-        let length = this->phpOpensslCipherIvLength();
+        let length = $this->phpOpensslCipherIvLength(this->cipher);
 
-        if unlikely length < 0 {
+        if length === false {
             return false;
         }
 
@@ -988,40 +988,9 @@ class Crypt implements CryptInterface
         return function_exists(name);
     }
 
-    protected function phpOpensslCipherIvLength() -> int
+    protected function phpOpensslCipherIvLength(string cipher) -> int|bool
     {
-        var cipher, length, version;
-
-        let cipher  = this->cipher,
-            version = phpversion();
-
-        globals_set("warning.enable", false);
-
-        if version_compare(version, "8.0", ">=") {
-            set_error_handler(
-                function (number, message, file, line) {
-                    globals_set("warning.enable", true);
-                },
-                E_WARNING
-            );
-        } else {
-            set_error_handler(
-                function (number, message, file, line, context) {
-                    globals_set("warning.enable", true);
-                },
-                E_WARNING
-            );
-        }
-
-        let length = openssl_cipher_iv_length(cipher);
-
-        restore_error_handler();
-
-        if unlikely (globals_get("warning.enable") || length === false) {
-            let length = -1;
-        }
-
-        return length;
+        return openssl_cipher_iv_length(cipher);
     }
 
     protected function phpOpensslRandomPseudoBytes(int length)

--- a/tests/unit/Encryption/Crypt/IsValidDecryptLengthCest.php
+++ b/tests/unit/Encryption/Crypt/IsValidDecryptLengthCest.php
@@ -15,7 +15,7 @@ namespace Phalcon\Tests\Unit\Encryption\Crypt;
 
 use Phalcon\Encryption\Crypt;
 use UnitTester;
-use function substr;
+
 use function uniqid;
 
 class IsValidDecryptLengthCest

--- a/tests/unit/Encryption/Crypt/IsValidDecryptLengthCest.php
+++ b/tests/unit/Encryption/Crypt/IsValidDecryptLengthCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Encryption\Crypt;
 
+use Codeception\Stub;
 use Phalcon\Encryption\Crypt;
 use UnitTester;
 
@@ -40,6 +41,30 @@ class IsValidDecryptLengthCest
 
         $actual = $crypt->isValidDecryptLength($encrypted);
         $I->assertTrue($actual);
+
+        $actual = $crypt->isValidDecryptLength('text');
+        $I->assertFalse($actual);
+    }
+
+    /**
+     * Tests Phalcon\Encryption\Crypt :: isValidDecryptLength() - false length
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-02-09
+     */
+    public function cryptGetSetKeyFalseLength(UnitTester $I)
+    {
+        $I->wantToTest('Crypt - isValidDecryptLength()');
+
+        $crypt = Stub::make(
+            Crypt::class,
+            [
+                'phpOpensslCipherIvLength' => false,
+            ]
+        );
+        $crypt->setKey('1234');
 
         $actual = $crypt->isValidDecryptLength('text');
         $I->assertFalse($actual);

--- a/tests/unit/Encryption/Crypt/IsValidDecryptLengthCest.php
+++ b/tests/unit/Encryption/Crypt/IsValidDecryptLengthCest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Encryption\Crypt;
+
+use Phalcon\Encryption\Crypt;
+use UnitTester;
+use function substr;
+use function uniqid;
+
+class IsValidDecryptLengthCest
+{
+    /**
+     * Tests Phalcon\Encryption\Crypt :: isValidDecryptLength()
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-02-09
+     */
+    public function cryptGetSetKey(UnitTester $I)
+    {
+        $I->wantToTest('Crypt - isValidDecryptLength()');
+
+        $crypt = new Crypt();
+        $crypt->setKey('1234');
+
+        $input     = uniqid();
+        $encrypted = $crypt->encrypt($input);
+
+        $actual = $crypt->isValidDecryptLength($encrypted);
+        $I->assertTrue($actual);
+
+        $actual = $crypt->isValidDecryptLength('text');
+        $I->assertFalse($actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature 
* Link to issue: #15879 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Encryption\Crypt::isValidDecryptLength($input)` to allow checking for the length of the decryption string 

Thanks

