### PR TITLE
removing $ characters

### DIFF
--- a/phalcon/Assets/Asset.zep
+++ b/phalcon/Assets/Asset.zep
@@ -264,7 +264,7 @@ class Asset implements AssetInterface
      */
     public function isAutoVersion() -> bool
     {
-        return $this->isAutoVersion;
+        return this->isAutoVersion;
     }
 
     /**

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -444,7 +444,7 @@ class Crypt implements CryptInterface
     {
         var length;
 
-        let length = $this->phpOpensslCipherIvLength(this->cipher);
+        let length = this->phpOpensslCipherIvLength(this->cipher);
 
         if length === false {
             return false;

--- a/phalcon/Html/Attributes.zep
+++ b/phalcon/Html/Attributes.zep
@@ -23,7 +23,7 @@ class Attributes extends Collection implements RenderInterface
      */
     public function render() -> string
     {
-        return $this->renderAttributes(this->toArray());
+        return this->renderAttributes(this->toArray());
     }
 
     /**

--- a/phalcon/Support/Debug.zep
+++ b/phalcon/Support/Debug.zep
@@ -141,7 +141,7 @@ class Debug
             link    = "https://docs.phalcon.io/"
             . version->getPart(Version::VERSION_MAJOR)
             . "."
-            . $version->getPart(Version::VERSION_MEDIUM)
+            . version->getPart(Version::VERSION_MEDIUM)
             . "/en/";
 
         return "<div class=\"version\">Phalcon Framework "

--- a/phalcon/Support/Helper/Str/PascalCase.zep
+++ b/phalcon/Support/Helper/Str/PascalCase.zep
@@ -60,7 +60,7 @@ class PascalCase
          */
         if strpos(delimiters, "\\-") !== false || strpos(delimiters, "-") !== false {
             let delimiters = str_replace(["\\-", "-"], ["", ""], delimiters),
-                delimiters = "-" . $delimiters;
+                delimiters = "-" . delimiters;
         }
 
         let result = preg_split(


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15900

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Removing leftover `$` characters in variables

Thanks

