### PR TITLE
Adding InitializationAwareInterface

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,6 +5,7 @@
 
 ## Added
 - Added `Phalcon\Encryption\Crypt::isValidDecryptLength($input)` to allow checking for the length of the decryption string [#15879](https://github.com/phalcon/cphalcon/issues/15879)
+- Added `Phalcon\Di\InitializationAwareInterface` to allow auto calling the `initialize` method when accessing service through DIC
  
 # [5.0.0beta3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0beta3) (2022-02-06)
 

--- a/phalcon/Di/Di.zep
+++ b/phalcon/Di/Di.zep
@@ -19,6 +19,7 @@ use Phalcon\Config\Adapter\Yaml;
 use Phalcon\Config\ConfigInterface;
 use Phalcon\Di\ServiceInterface;
 use Phalcon\Events\ManagerInterface;
+use Phalcon\Di\InitializationAwareInterface;
 use Phalcon\Di\InjectionAwareInterface;
 use Phalcon\Di\ServiceProviderInterface;
 
@@ -239,6 +240,10 @@ class Di implements DiInterface
         if typeof instance == "object" {
             if instance instanceof InjectionAwareInterface {
                 instance->setDI(this);
+            }
+
+            if instance instanceof InitializationAwareInterface {
+                instance->initialize();
             }
         }
 

--- a/phalcon/Di/InitializationAwareInterface.zep
+++ b/phalcon/Di/InitializationAwareInterface.zep
@@ -1,0 +1,6 @@
+namespace Phalcon\Di;
+
+interface InitializationAwareInterface
+{
+    public function initialize() -> void;
+}

--- a/tests/_data/fixtures/Di/InitializationAwareComponent.php
+++ b/tests/_data/fixtures/Di/InitializationAwareComponent.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Fixtures\Di;
+
+use Phalcon\Di\InitializationAwareInterface;
+
+/**
+ * Class InitializationAwareComponent
+ *
+ * @package Phalcon\Tests\Fixtures\Di
+ */
+class InitializationAwareComponent implements InitializationAwareInterface
+{
+    private bool $initialized = false;
+
+    public function initialize(): void
+    {
+        $this->initialized = true;
+    }
+
+    public function isInitialized(): bool
+    {
+        return $this->initialized;
+    }
+}

--- a/tests/unit/Di/InitializationAwareCest.php
+++ b/tests/unit/Di/InitializationAwareCest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Di;
+
+use Phalcon\Di\Di;
+use Phalcon\Tests\Fixtures\Di\InitializationAwareComponent;
+use UnitTester;
+
+/**
+ * Class InitializationAwareCest
+ *
+ * @package Phalcon\Tests\Unit\Di
+ */
+class InitializationAwareCest
+{
+    /**
+     * Tests Phalcon\Di\Di :: initialization aware interface
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-09-09
+     */
+    public function diInitializationAware(UnitTester $I)
+    {
+        $I->wantToTest('Di - initialization aware interface');
+
+        $di = new Di();
+
+        $I->assertEquals(true, $di->get(InitializationAwareComponent::class)->isInitialized());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: N/A

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

I find myself constantly adding a method of 'initialize' to most everything, and calling it either in the service creation or through some other means. This PR adds an interface to allow the DIC to call it automatically given the class implements the interface in the same way the InjectionAwareInterface works. 

Thanks

