### PR TITLE
5.0.x

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -445,3 +445,8 @@
 - Fixed signature of `Phalcon\Assets\Manager::addCss()`
 - Fixed signature of `Phalcon\Assets\Manager::addJs()`
 - Fixed signature of `Phalcon\Db\Adapter\AdapterInterface::execute()`, `Phalcon\Db\Adapter\AdapterInterface::fetchOne()` and `Phalcon\Db\Adapter\AdapterInterface::query()`
+- Fixed `Phalcon\Annotations\Reader::parse()` to return constants annotations [#15919](https://github.com/phalcon/cphalcon/issues/15919)
+- Added `Phalcon\Annotations\Reflection::getConstantsAnnotations()` method that returns constants annotations [#15919](https://github.com/phalcon/cphalcon/issues/15919)
+- Changes to the `Phalcon\Annotations\Adapter\AdapterInterface`:
+    - Added `getConstant()` method that returns class constant annotations collection
+    - Added `getConstants()` method that returns class constants annotations array list

--- a/phalcon/Annotations/Adapter/AbstractAdapter.zep
+++ b/phalcon/Annotations/Adapter/AbstractAdapter.zep
@@ -72,6 +72,79 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
+     * Returns the annotations found in a specific constant
+     */
+    public function getConstant(string className, string constantName) -> <Collection>
+    {
+        var constants, constant;
+
+        let constants = this->getConstants(className);
+
+        if !fetch constant, constants[constantName] {
+            /**
+             * Returns a collection anyways
+             */
+            return new Collection();
+        }
+
+        return constant;
+    }
+
+    /**
+     * Returns the annotations found in all the class' constants
+     */
+    public function getConstants(string className) -> array
+    {
+        var classAnnotations;
+
+        /**
+         * Get the full annotations from the class
+         */
+        let classAnnotations = this->get(className);
+
+        return classAnnotations->getConstantsAnnotations();
+    }
+
+    /**
+     * Returns the annotations found in a specific property
+     */
+    public function getProperty(string className, string propertyName) -> <Collection>
+    {
+        var classAnnotations, properties, property;
+
+        /**
+         * Get the full annotations from the class
+         */
+        let classAnnotations = this->get(className);
+
+        let properties = classAnnotations->getPropertiesAnnotations();
+
+        if !fetch property, properties[propertyName] {
+            /**
+             * Returns a collection anyways
+             */
+            return new Collection();
+        }
+
+        return property;
+    }
+
+    /**
+     * Returns the annotations found in all the class' properties
+     */
+    public function getProperties(string className) -> array
+    {
+        var classAnnotations;
+
+        /**
+         * Get the full annotations from the class
+         */
+        let classAnnotations = this->get(className);
+
+        return classAnnotations->getPropertiesAnnotations();
+    }
+
+    /**
      * Returns the annotations found in a specific method
      */
     public function getMethod(string className, string methodName) -> <Collection>
@@ -112,45 +185,6 @@ abstract class AbstractAdapter implements AdapterInterface
         let classAnnotations = this->get(className);
 
         return classAnnotations->getMethodsAnnotations();
-    }
-
-    /**
-     * Returns the annotations found in a specific property
-     */
-    public function getProperty(string className, string propertyName) -> <Collection>
-    {
-        var classAnnotations, properties, property;
-
-        /**
-         * Get the full annotations from the class
-         */
-        let classAnnotations = this->get(className);
-
-        let properties = classAnnotations->getPropertiesAnnotations();
-
-        if !fetch property, properties[propertyName] {
-            /**
-             * Returns a collection anyways
-             */
-            return new Collection();
-        }
-
-        return property;
-    }
-
-    /**
-     * Returns the annotations found in all the class' methods
-     */
-    public function getProperties(string className) -> array
-    {
-        var classAnnotations;
-
-        /**
-         * Get the full annotations from the class
-         */
-        let classAnnotations = this->get(className);
-
-        return classAnnotations->getPropertiesAnnotations();
     }
 
     /**

--- a/phalcon/Annotations/Adapter/AdapterInterface.zep
+++ b/phalcon/Annotations/Adapter/AdapterInterface.zep
@@ -25,14 +25,14 @@ interface AdapterInterface
     public function get(string className) -> <Reflection>;
 
     /**
-     * Returns the annotations found in a specific method
+     * Returns the annotations found in a specific constant
      */
-    public function getMethod(string className, string methodName) -> <Collection>;
+    public function getConstant(string className, string constantName) -> <Collection>;
 
     /**
-     * Returns the annotations found in all the class' methods
+     * Returns the annotations found in all the class' constants
      */
-    public function getMethods(string className) -> array;
+    public function getConstants(string className) -> array;
 
     /**
      * Returns the annotations found in a specific property
@@ -43,6 +43,16 @@ interface AdapterInterface
      * Returns the annotations found in all the class' methods
      */
     public function getProperties(string className) -> array;
+
+    /**
+     * Returns the annotations found in a specific method
+     */
+    public function getMethod(string className, string methodName) -> <Collection>;
+
+    /**
+     * Returns the annotations found in all the class' methods
+     */
+    public function getMethods(string className) -> array;
 
     /**
      * Returns the annotation reader

--- a/phalcon/Annotations/Reader.zep
+++ b/phalcon/Annotations/Reader.zep
@@ -24,7 +24,8 @@ class Reader implements ReaderInterface
     {
         var reflection, comment, properties, methods, property, method,
             classAnnotations, line, annotationsProperties, propertyAnnotations,
-            annotationsMethods, methodAnnotations;
+            annotationsMethods, methodAnnotations, constants, constant,
+            constantAnnotations, anotationsConstants, constantReflection;
         array annotations;
 
         let annotations = [];
@@ -36,7 +37,6 @@ class Reader implements ReaderInterface
 
         let comment = reflection->getDocComment();
         if typeof comment == "string" {
-
             /**
              * Read annotations from class
              */
@@ -55,6 +55,46 @@ class Reader implements ReaderInterface
         }
 
         /**
+         * Get class constants
+         */
+        let constants = reflection->getConstants();
+
+        if count(constants) {
+            /**
+             * Line declaration for constants isn't available
+             */
+            let line = 1;
+            let anotationsConstants = [];
+
+            for constant in array_keys(constants) {
+                /**
+                 * Read comment from constant docblock
+                 */
+                let constantReflection = reflection->getReflectionConstant(constant);
+                let comment = constantReflection->getDocComment();
+
+                if typeof comment == "string" {
+                    /**
+                     * Parse constant docblock comment
+                     */
+                    let constantAnnotations = phannot_parse_annotations(
+                        comment,
+                        reflection->getFileName(),
+                        line
+                    );
+
+                    if typeof constantAnnotations == "array" {
+                        let anotationsConstants[constant] = constantAnnotations;
+                    }
+                }
+            }
+
+            if count(anotationsConstants) {
+                let annotations["constants"] = anotationsConstants;
+            }
+        }
+
+        /**
          * Get the class properties
          */
         let properties = reflection->getProperties();
@@ -64,18 +104,17 @@ class Reader implements ReaderInterface
              * Line declaration for properties isn't available
              */
             let line = 1;
-
             let annotationsProperties = [];
 
             for property in properties {
                 /**
-                 * Read comment from method
+                 * Read comment from property
                  */
                 let comment = property->getDocComment();
 
                 if typeof comment == "string" {
                     /**
-                     * Read annotations from the docblock
+                     * Parse property docblock comment
                      */
                     let propertyAnnotations = phannot_parse_annotations(
                         comment,
@@ -110,7 +149,7 @@ class Reader implements ReaderInterface
 
                 if typeof comment == "string" {
                     /**
-                     * Read annotations from class
+                     * Parse method docblock comment
                      */
                     let methodAnnotations = phannot_parse_annotations(
                         comment,

--- a/phalcon/Annotations/Reader.zep
+++ b/phalcon/Annotations/Reader.zep
@@ -22,10 +22,10 @@ class Reader implements ReaderInterface
      */
     public function parse(string className) -> array
     {
-        var reflection, comment, properties, methods, property, method,
-            classAnnotations, line, annotationsProperties, propertyAnnotations,
-            annotationsMethods, methodAnnotations, constants, constant,
-            constantAnnotations, anotationsConstants, constantReflection;
+        var reflection, comment, line, arrayKeys, classAnnotations,
+            properties,  property, annotationsProperties, propertyAnnotations,
+            methods, method, annotationsMethods, methodAnnotations,
+            constants, constant, anotationsConstants, constantAnnotations, constantReflection;
         array annotations;
 
         let annotations = [];
@@ -64,9 +64,10 @@ class Reader implements ReaderInterface
              * Line declaration for constants isn't available
              */
             let line = 1;
+            let arrayKeys = array_keys(constants);
             let anotationsConstants = [];
 
-            for constant in array_keys(constants) {
+            for constant in arrayKeys {
                 /**
                  * Read comment from constant docblock
                  */

--- a/phalcon/Annotations/ReaderInterface.zep
+++ b/phalcon/Annotations/ReaderInterface.zep
@@ -16,7 +16,7 @@ namespace Phalcon\Annotations;
 interface ReaderInterface
 {
     /**
-     * Reads annotations from the class docblocks, its methods and/or properties
+     * Reads annotations from the class docblocks, its constants, properties and methods
      */
     public function parse(string className) -> array;
 

--- a/phalcon/Annotations/Reflection.zep
+++ b/phalcon/Annotations/Reflection.zep
@@ -40,13 +40,19 @@ class Reflection
      * @var array
      * TODO: Make always array
      */
-    protected methodAnnotations;
+    protected constantAnnotations;
 
     /**
      * @var array
      * TODO: Make always array
      */
     protected propertyAnnotations;
+
+    /**
+     * @var array
+     * TODO: Make always array
+     */
+    protected methodAnnotations;
 
     /**
      * @var array
@@ -80,31 +86,31 @@ class Reflection
     }
 
     /**
-     * Returns the annotations found in the methods' docblocks
+     * Returns the annotations found in the constants' docblocks
      */
-    public function getMethodsAnnotations() -> <Collection[]> | bool
+    public function getConstantsAnnotations() -> <Collection[]> | bool
     {
-        var reflectionMethods, methodName, reflectionMethod;
+        var reflectionConstants, constant, reflectionConstant;
 
-        if this->methodAnnotations === null {
-            if fetch reflectionMethods, this->reflectionData["methods"] {
-                if count(reflectionMethods) {
-                    let this->methodAnnotations = [];
+        if this->constantAnnotations === null {
+            if fetch reflectionConstants, this->reflectionData["constants"] {
+                if count(reflectionConstants) {
+                    let this->constantAnnotations = [];
 
-                    for methodName, reflectionMethod in reflectionMethods {
-                        let this->methodAnnotations[methodName] = new Collection(
-                            reflectionMethod
+                    for constant, reflectionConstant in reflectionConstants {
+                        let this->constantAnnotations[constant] = new Collection(
+                            reflectionConstant
                         );
                     }
 
-                    return this->methodAnnotations;
+                    return this->constantAnnotations;
                 }
             }
 
-            let this->methodAnnotations = false;
+            let this->constantAnnotations = false;
         }
 
-        return this->methodAnnotations;
+        return this->constantAnnotations;
     }
 
     /**
@@ -133,6 +139,34 @@ class Reflection
         }
 
         return this->propertyAnnotations;
+    }
+
+    /**
+     * Returns the annotations found in the methods' docblocks
+     */
+    public function getMethodsAnnotations() -> <Collection[]> | bool
+    {
+        var reflectionMethods, methodName, reflectionMethod;
+
+        if this->methodAnnotations === null {
+            if fetch reflectionMethods, this->reflectionData["methods"] {
+                if count(reflectionMethods) {
+                    let this->methodAnnotations = [];
+
+                    for methodName, reflectionMethod in reflectionMethods {
+                        let this->methodAnnotations[methodName] = new Collection(
+                            reflectionMethod
+                        );
+                    }
+
+                    return this->methodAnnotations;
+                }
+            }
+
+            let this->methodAnnotations = false;
+        }
+
+        return this->methodAnnotations;
     }
 
     /**

--- a/tests/_data/fixtures/Annotations/TestClass.php
+++ b/tests/_data/fixtures/Annotations/TestClass.php
@@ -29,6 +29,13 @@ declare(strict_types=1);
 class TestClass
 {
     /**
+     * @Simple
+     */
+    const TEST_CONST1 = 'test-const-with-annotation';
+
+    const TEST_CONST2 = 'test-const-without-annotation';
+
+    /**
      * This is a property string
      *
      * @var string

--- a/tests/unit/Annotations/Reader/ParseCest.php
+++ b/tests/unit/Annotations/Reader/ParseCest.php
@@ -197,7 +197,7 @@ class ParseCest
 
         // Constants
         $I->assertTrue(isset($parsing['constants']));
-        $I->assertCount(1, isset($parsing['constants']));
+        $I->assertCount(1, $parsing['constants']);
         $I->assertFalse(isset($parsing['constants']['TEST_CONST2']));
         $I->assertEquals('Simple', $parsing['properties']['TEST_CONST1'][0]['name']);
 

--- a/tests/unit/Annotations/Reader/ParseCest.php
+++ b/tests/unit/Annotations/Reader/ParseCest.php
@@ -199,7 +199,7 @@ class ParseCest
         $I->assertTrue(isset($parsing['constants']));
         $I->assertCount(1, $parsing['constants']);
         $I->assertFalse(isset($parsing['constants']['TEST_CONST2']));
-        $I->assertEquals('Simple', $parsing['properties']['TEST_CONST1'][0]['name']);
+        $I->assertEquals('Simple', $parsing['constants']['TEST_CONST1'][0]['name']);
 
         // Properties
         $I->assertTrue(isset($parsing['properties']));

--- a/tests/unit/Annotations/Reader/ParseCest.php
+++ b/tests/unit/Annotations/Reader/ParseCest.php
@@ -195,6 +195,12 @@ class ParseCest
         $I->assertEquals('key3', $parsing['class'][8]['arguments'][0]['expr']['items'][2]['name']);
         $I->assertEquals(308, $parsing['class'][8]['arguments'][0]['expr']['items'][2]['expr']['type']);
 
+        // Constants
+        $I->assertTrue(isset($parsing['constants']));
+        $I->assertCount(1, isset($parsing['constants']));
+        $I->assertFalse(isset($parsing['constants']['TEST_CONST2']));
+        $I->assertEquals('Simple', $parsing['properties']['TEST_CONST1'][0]['name']);
+
         // Properties
         $I->assertTrue(isset($parsing['properties']));
         $I->assertCount(3, $parsing['properties']);

--- a/tests/unit/Annotations/ReflectionCest.php
+++ b/tests/unit/Annotations/ReflectionCest.php
@@ -45,6 +45,16 @@ class ReflectionCest
             $reader->parse('TestClass')
         );
 
+        $constantsAnnotations = $reflection->getConstantsAnnotations();
+        $I->assertIsArray($constantsAnnotations);
+
+        $annotations = $constantsAnnotations['TEST_CONST1'];
+        $I->assertInstanceOf(
+            Collection::class,
+            $annotations
+        );
+        $I->assertTrue($annotations->has('Simple'));
+
         $methodsAnnotations = $reflection->getMethodsAnnotations();
 
         $I->assertIsArray($methodsAnnotations);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/15919

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Added support to class constants annotations

```php
    class MyClass
    {
          /**
           * @Simple
           */
          const MY_CONST = "test";
    }
    
    
    use \Phalcon\Annotations\Adapter\Memory;
    use \Phalcon\Annotations\Reader;
    use \Phalcon\Annotations\Reflection;  
    
    // Reader now returns constants array list that have annotations in docblock comments
    $reader = new Reader();
    $data = $reader->parse(MyClass::class);
    var_dump($data);

    // Reflection has a new method for getting constants annotations
    $reflection = new Reflection($data);
    var_dump($reflection->getConstantsAnnotations());


    // Annotation adapters has 2 new methods for getting constants annotations
    $memory = new Memory();
    var_dump($memory->getConstants(MyClass::class));                  // returns array
    var_dump($memory->getConstant(MyClass::class, 'TEST2'));     // returns Collection
```

Thanks

