### PR TITLE
T15984 null arguments deprecation

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,9 @@
 ## Changed
 - Changed the `StringVal` filter to now use `htmlspecialchars()` [#15978](https://github.com/phalcon/cphalcon/issues/15978) 
 
+## Fixed
+- Fixed `Phalcon\Http\Response::getQualityHeader()` to check if the server variable is `null` before performing `preg_split` [#15984](https://github.com/phalcon/cphalcon/issues/15984) 
+
 ## Added
 - Added `StringValLegacy` filter using `filter_var()` for PHP < 8.1 [#15978](https://github.com/phalcon/cphalcon/issues/15978) 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Steps:
 ### Social Media
 * [Telegram](https://phalcon.io/telegram)
 * [Gab](https://phalcon.io/gab)
-* [Parler](https://phalcon.io/parler)
+* [LinkedIn](https://phalcon.io/linkedin)
 * [MeWe](https://phalcon.io/mewe)
 * [Facebook](https://phalcon.io/fb)
 * [Twitter](https://phalcon.io/t)

--- a/docker/7.4/.bashrc
+++ b/docker/7.4/.bashrc
@@ -74,6 +74,9 @@ alias untar='tar xvf'
 # Zephir related
 alias untar='tar xvf'
 
+NB_CORES=$(grep -c '^processor' /proc/cpuinfo)
+export MAKEFLAGS="-j$((NB_CORES)) -l${NB_CORES}"
+
 if [ ! -f ./zephir ]; then
     wget --no-clobber -O ./zephir https://github.com/phalcon/zephir/releases/download/$ZEPHIR_VERSION/zephir.phar
     chmod +x ./zephir

--- a/docker/7.4/Dockerfile
+++ b/docker/7.4/Dockerfile
@@ -1,10 +1,6 @@
 FROM composer:latest as composer
 FROM php:7.4-fpm
 
-# Compilation parameters
-RUN CPU_CORES="$(getconf _NPROCESSORS_ONLN)";
-ENV MAKEFLAGS="-j${CPU_CORES}"
-
 ADD ./extra.ini /usr/local/etc/php/conf.d/
 
 # User/Group globals

--- a/docker/7.4/extra.ini
+++ b/docker/7.4/extra.ini
@@ -1,3 +1,8 @@
+error_reporting=E_ALL
+display_errors="On"
+display_startup_errors="On"
+log_errors="On"
+error_log=/tmp/php_errors.log
 memory_limit=512M
 apc.enable_cli="On"
 session.save_path="/tmp"

--- a/docker/8.0/.bashrc
+++ b/docker/8.0/.bashrc
@@ -74,6 +74,9 @@ alias untar='tar xvf'
 # Zephir related
 alias untar='tar xvf'
 
+NB_CORES=$(grep -c '^processor' /proc/cpuinfo)
+export MAKEFLAGS="-j$((NB_CORES)) -l${NB_CORES}"
+
 if [ ! -f ./zephir ]; then
     wget --no-clobber -O ./zephir https://github.com/phalcon/zephir/releases/download/$ZEPHIR_VERSION/zephir.phar
     chmod +x ./zephir

--- a/docker/8.0/Dockerfile
+++ b/docker/8.0/Dockerfile
@@ -1,10 +1,6 @@
 FROM composer:latest as composer
 FROM php:8.0-fpm
 
-# Compilation parameters
-RUN CPU_CORES="$(getconf _NPROCESSORS_ONLN)";
-ENV MAKEFLAGS="-j${CPU_CORES}"
-
 ADD ./extra.ini /usr/local/etc/php/conf.d/
 
 # User/Group globals

--- a/docker/8.0/extra.ini
+++ b/docker/8.0/extra.ini
@@ -1,3 +1,8 @@
+error_reporting=E_ALL
+display_errors="On"
+display_startup_errors="On"
+log_errors="On"
+error_log=/tmp/php_errors.log
 memory_limit=512M
 apc.enable_cli="On"
 session.save_path="/tmp"

--- a/docker/8.1/.bashrc
+++ b/docker/8.1/.bashrc
@@ -74,6 +74,9 @@ alias untar='tar xvf'
 # Zephir related
 alias untar='tar xvf'
 
+NB_CORES=$(grep -c '^processor' /proc/cpuinfo)
+export MAKEFLAGS="-j$((NB_CORES)) -l${NB_CORES}"
+
 if [ ! -f ./zephir ]; then
     wget --no-clobber -O ./zephir https://github.com/phalcon/zephir/releases/download/$ZEPHIR_VERSION/zephir.phar
     chmod +x ./zephir

--- a/docker/8.1/Dockerfile
+++ b/docker/8.1/Dockerfile
@@ -1,10 +1,6 @@
 FROM composer:latest as composer
 FROM php:8.1-fpm
 
-# Compilation parameters
-RUN CPU_CORES="$(getconf _NPROCESSORS_ONLN)";
-ENV MAKEFLAGS="-j${CPU_CORES}"
-
 ADD ./extra.ini /usr/local/etc/php/conf.d/
 
 # User/Group globals

--- a/docker/8.1/extra.ini
+++ b/docker/8.1/extra.ini
@@ -1,3 +1,8 @@
+error_reporting=E_ALL
+display_errors="On"
+display_startup_errors="On"
+log_errors="On"
+error_log=/tmp/php_errors.log
 memory_limit=512M
 apc.enable_cli="On"
 session.save_path="/tmp"

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -1403,21 +1403,25 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      */
     final protected function getQualityHeader(string! serverIndex, string! name) -> array
     {
-        var returnedParts, parts, part, headerParts, headerPart, split;
+        var headerPart, headerParts, headerSplit, part, parts, returnedParts, serverValue, split;
 
-        let returnedParts = [];
+        let returnedParts = [],
+            serverValue   = this->getServer(serverIndex);
+
+        let serverValue = (null === serverValue) ? "" : serverValue;
 
         let parts = preg_split(
             "/,\\s*/",
-            this->getServer(serverIndex),
+            serverValue,
             -1,
             PREG_SPLIT_NO_EMPTY
         );
 
         for part in parts {
-            let headerParts = [];
+            let headerParts = [],
+                headerSplit = preg_split("/\s*;\s*/", trim(part), -1, PREG_SPLIT_NO_EMPTY);
 
-            for headerPart in preg_split("/\s*;\s*/", trim(part), -1, PREG_SPLIT_NO_EMPTY) {
+            for headerPart in headerSplit {
                 if strpos(headerPart, "=") !== false {
                     let split = explode("=", headerPart, 2);
 


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15984 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Http\Response::getQualityHeader()` to check if the server variable is `null` before performing `preg_split`

Thanks

