### PR TITLE
T15992 validation length

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,13 @@
 
 ## Fixed
 - Fixed `Phalcon\Tag::textArea()` to check if the value is `null` before calling `htmlspecialchars` [#15992](https://github.com/phalcon/cphalcon/issues/15992)
+- Fixed
+  - `Phalcon/Filter/Validation/Validator/Alnum`
+    `Phalcon/Filter/Validation/Validator/Alpha`
+    `Phalcon/Filter/Validation/Validator/Confirmation`
+    `Phalcon/Filter/Validation/Validator/CreditCard`
+    `Phalcon/Filter/Validation/Validator/StringLength/Max`
+    `Phalcon/Filter/Validation/Validator/StringLength/Min` to check if the value is `null` before calling internal PHP methods [#15992](https://github.com/phalcon/cphalcon/issues/15992)
 
 ## Added
 - Added support for `webp` images for `Phalcon\Image\Adapter\Gd` [#15977](https://github.com/phalcon/cphalcon/issues/15977)

--- a/phalcon/Filter/Validation/Validator/Alnum.zep
+++ b/phalcon/Filter/Validation/Validator/Alnum.zep
@@ -77,7 +77,7 @@ class Alnum extends AbstractValidator
             return true;
         }
 
-        if !ctype_alnum(value) {
+        if !ctype_alnum((string) value) {
             validation->appendMessage(
                 this->messageFactory(validation, field)
             );

--- a/phalcon/Filter/Validation/Validator/Alpha.zep
+++ b/phalcon/Filter/Validation/Validator/Alpha.zep
@@ -78,7 +78,7 @@ class Alpha extends AbstractValidator
             return true;
         }
 
-        if preg_match("/[^[:alpha:]]/imu", value) {
+        if preg_match("/[^[:alpha:]]/imu", (string) value) {
             validation->appendMessage(
                 this->messageFactory(validation, field)
             );

--- a/phalcon/Filter/Validation/Validator/Confirmation.zep
+++ b/phalcon/Filter/Validation/Validator/Confirmation.zep
@@ -90,7 +90,7 @@ class Confirmation extends AbstractValidator
         let value = validation->getValue(field),
             valueWith = validation->getValue(fieldWith);
 
-        if !this->compare(value, valueWith) {
+        if !this->compare((string) value, (string) valueWith) {
             let labelWith = this->getOption("labelWith");
 
             if typeof labelWith == "array" {

--- a/phalcon/Filter/Validation/Validator/CreditCard.zep
+++ b/phalcon/Filter/Validation/Validator/CreditCard.zep
@@ -78,7 +78,7 @@ class CreditCard extends AbstractValidator
             return true;
         }
 
-        let valid = this->verifyByLuhnAlgorithm(value);
+        let valid = this->verifyByLuhnAlgorithm((string) value);
 
         if !valid {
             validation->appendMessage(

--- a/phalcon/Filter/Validation/Validator/StringLength/Max.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength/Max.zep
@@ -95,9 +95,9 @@ class Max extends AbstractValidator
 
         // Check if mbstring is available to calculate the correct length
         if function_exists("mb_strlen") {
-            let length = mb_strlen(value);
+            let length = mb_strlen((string) value);
         } else {
-            let length = strlen(value);
+            let length = strlen((string) value);
         }
 
         let maximum = this->getOption("max");

--- a/phalcon/Filter/Validation/Validator/StringLength/Min.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength/Min.zep
@@ -95,9 +95,9 @@ class Min extends AbstractValidator
 
         // Check if mbstring is available to calculate the correct length
         if function_exists("mb_strlen") {
-            let length = mb_strlen(value);
+            let length = mb_strlen((string) value);
         } else {
-            let length = strlen(value);
+            let length = strlen((string) value);
         }
 
         let minimum = this->getOption("min");


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15992 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed 
 - `Phalcon/Filter/Validation/Validator/Alnum`
 - `Phalcon/Filter/Validation/Validator/Alpha`
 - `Phalcon/Filter/Validation/Validator/Confirmation`
 - `Phalcon/Filter/Validation/Validator/CreditCard`
 - `Phalcon/Filter/Validation/Validator/StringLength/Max`
 - `Phalcon/Filter/Validation/Validator/StringLength/Min`
 
to check if the value is `null` before calling internal PHP methods 


Thanks

