### PR TITLE
Added getBuilder() in Mvc\Model\Manager

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -16,6 +16,8 @@
 
 ## Added
 - Added support for `webp` images for `Phalcon\Image\Adapter\Gd` [#15977](https://github.com/phalcon/cphalcon/issues/15977)
+- Added `Phalcon\Mvc\Model\ManagerInterface::getBuilder()` to return the existing builder (created by `createBuilder()`) [#15966](https://github.com/phalcon/cphalcon/issues/15966)
+- Added `Phalcon\Mvc\Model\Manager::getBuilder()` to return the existing builder (created by `createBuilder()`) [#15966](https://github.com/phalcon/cphalcon/issues/15966)
 
 # [5.0.0rc2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0RC2) (2022-06-09)
 

--- a/phalcon/Html/TagFactory.zep
+++ b/phalcon/Html/TagFactory.zep
@@ -59,7 +59,7 @@ use Phalcon\Factory\AbstractFactory;
  * @method inputTime(string $name, string $value = null, array $attributes = []): string
  * @method inputUrl(string $name, string $value = null, array $attributes = []): string
  * @method inputWeek(string $name, string $value = null, array $attributes = []): string
- * @method label(array $attributes = []): string
+ * @method label(string $label, array $attributes = [], bool $raw = false): string
  * @method link(string $indent = '    ', string $delimiter = PHP_EOL): string
  * @method meta(string $indent = '    ', string $delimiter = PHP_EOL): string
  * @method ol(string $text, array $attributes = [], bool $raw = false): string

--- a/phalcon/Html/TagFactory.zep
+++ b/phalcon/Html/TagFactory.zep
@@ -65,7 +65,7 @@ use Phalcon\Factory\AbstractFactory;
  * @method ol(string $text, array $attributes = [], bool $raw = false): string
  * @method script(string $indent = '    ', string $delimiter = PHP_EOL): string
  * @method style(string $indent = '    ', string $delimiter = PHP_EOL): string
- * @method title(string $indent = '', string $delimiter = PHP_EOL): string
+ * @method title(string $indent = '    ', string $delimiter = PHP_EOL): string
  * @method ul(string $text, array $attributes = [], bool $raw = false): string
  */
 class TagFactory extends AbstractFactory

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -233,9 +233,14 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Binds a behavior to a model
+     *
+     * @param ModelInterface    $model
+     * @param BehaviorInterface $behavior
      */
-    public function addBehavior(<ModelInterface> model, <BehaviorInterface> behavior) -> void
-    {
+    public function addBehavior(
+        <ModelInterface> model,
+        <BehaviorInterface> behavior
+    ) -> void {
         var entityName;
 
         let entityName = get_class_lower(model);
@@ -253,11 +258,21 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Setup a relation reverse many to one between two models
      *
-     * @param    array options
+     * @param ModelInterface $model
+     * @param mixed          $fields
+     * @param string         $referencedModel
+     * @param mixed          $referencedFields
+     * @param array          $options
+     *
+     * @return RelationInterface
      */
-    public function addBelongsTo(<ModelInterface> model, var fields, string! referencedModel,
-        var referencedFields, array options = []) -> <RelationInterface>
-    {
+    public function addBelongsTo(
+        <ModelInterface> model,
+        var fields,
+        string! referencedModel,
+        var referencedFields,
+        array options = []
+    ) -> <RelationInterface> {
         var entityName, referencedEntity, relation, relations, alias,
             lowerAlias, singleRelations;
         string keyRelation;
@@ -338,12 +353,21 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Setup a relation 1-n between two models
      *
-     * @param    mixed referencedFields
-     * @param    array options
+     * @param ModelInterface $model
+     * @param mixed          $fields
+     * @param string         $referencedModel
+     * @param mixed          $referencedFields
+     * @param array          $options
+     *
+     * @return RelationInterface
      */
-    public function addHasMany(<ModelInterface> model, var fields, string! referencedModel,
-        var referencedFields, array options = []) -> <RelationInterface>
-    {
+    public function addHasMany(
+        <ModelInterface> model,
+        var fields,
+        string! referencedModel,
+        var referencedFields,
+        array options = []
+    ) -> <RelationInterface> {
         var entityName, referencedEntity, hasMany, relation, relations, alias,
             lowerAlias, singleRelations;
         string keyRelation;
@@ -425,15 +449,27 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Setups a relation n-m between two models
      *
-     * @param    string fields
-     * @param    string intermediateFields
-     * @param    string intermediateReferencedFields
-     * @param    string referencedFields
-     * @param   array options
+     * @param ModelInterface $model
+     * @param mixed          $fields
+     * @param string         $intermediateModel
+     * @param mixed          $intermediateFields
+     * @param mixed          $intermediateReferencedFields
+     * @param string         $referencedModel
+     * @param mixed          $referencedFields
+     * @param array          $options
+     *
+     * @return RelationInterface
      */
-    public function addHasManyToMany(<ModelInterface> model, var fields, string! intermediateModel,
-        var intermediateFields, var intermediateReferencedFields, string! referencedModel, var referencedFields, array options = []) -> <RelationInterface>
-    {
+    public function addHasManyToMany(
+        <ModelInterface> model,
+        var fields,
+        string! intermediateModel,
+        var intermediateFields,
+        var intermediateReferencedFields,
+        string! referencedModel,
+        var referencedFields,
+        array options = []
+    ) -> <RelationInterface> {
         var entityName, referencedEntity, hasManyToMany, relation, relations,
             alias, lowerAlias, singleRelations, intermediateEntity;
         string keyRelation;
@@ -544,11 +580,21 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Setup a 1-1 relation between two models
      *
-     * @param array options
+     * @param ModelInterface $model
+     * @param mixed          $fields
+     * @param string         $referencedModel
+     * @param mixed          $referencedFields
+     * @param array          $options
+     *
+     * @return RelationInterface
      */
-    public function addHasOne(<ModelInterface> model, var fields, string! referencedModel,
-        var referencedFields, array options = []) -> <RelationInterface>
-    {
+    public function addHasOne(
+        <ModelInterface> model,
+        var fields,
+        string! referencedModel,
+        var referencedFields,
+        array options = []
+    ) -> <RelationInterface> {
         var entityName, referencedEntity, relation, relations, alias,
             lowerAlias, singleRelations;
         string keyRelation;
@@ -629,15 +675,27 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Setups a relation 1-1 between two models using an intermediate model
      *
-     * @param    string fields
-     * @param    string intermediateFields
-     * @param    string intermediateReferencedFields
-     * @param    string referencedFields
-     * @param   array options
+     * @param ModelInterface $model
+     * @param mixed          $fields
+     * @param string         $intermediateModel
+     * @param mixed          $intermediateFields
+     * @param mixed          $intermediateReferencedFields
+     * @param string         $referencedModel
+     * @param mixed          $referencedFields
+     * @param array          $options
+     *
+     * @return RelationInterface
      */
-    public function addHasOneThrough(<ModelInterface> model, var fields, string! intermediateModel,
-        var intermediateFields, var intermediateReferencedFields, string! referencedModel, var referencedFields, array options = []) -> <RelationInterface>
-    {
+    public function addHasOneThrough(
+        <ModelInterface> model,
+        var fields,
+        string! intermediateModel,
+        var intermediateFields,
+        var intermediateReferencedFields,
+        string! referencedModel,
+        var referencedFields,
+        array options = []
+    ) -> <RelationInterface> {
         var entityName, referencedEntity, hasOneThrough, relation, relations,
             alias, lowerAlias, singleRelations, intermediateEntity;
         string keyRelation;
@@ -786,6 +844,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Creates a Phalcon\Mvc\Model\Query without execute it
+     *
+     * @param string $phql
+     *
+     * @return QueryInterface
      */
     public function createQuery(string! phql) -> <QueryInterface>
     {
@@ -835,8 +897,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * $manager->executeQuery('DELETE FROM Robots WHERE id = :id:', ['id' => 1]);
      * ```
      *
+     * @param string     $phql
      * @param array|null $placeholders
      * @param array|null $types
+     *
      * @return ResultsetInterface|StatusInterface
      */
     public function executeQuery(string! phql, var placeholders = null, var types = null) -> var
@@ -912,6 +976,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *     new Robots()
      * );
      *```
+     *
+     * @param ModelInterface $model
+     *
+     * @return RelationInterface[] | array
      */
     public function getBelongsTo(<ModelInterface> model) -> <RelationInterface[]> | array
     {
@@ -926,6 +994,14 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Gets belongsTo related records from a model
+     *
+     * @param string         $modelName
+     * @param string         $modelRelation
+     * @param ModelInterface $record
+     * @param mixed|null     $parameters
+     * @param string|null    $method
+     *
+     * @return ResultsetInterface | bool
      */
     public function getBelongsToRecords(
         string! modelName,
@@ -960,6 +1036,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Returns the newly created Phalcon\Mvc\Model\Query\Builder or null
+     *
+     * @return BuilderInterface | null
      */
     public function getBuilder() -> <BuilderInterface> | null
     {
@@ -970,10 +1048,15 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Returns the connection service name used to read or write data related to
      * a model depending on the connection services
      *
+     * @param ModelInterface $model
+     * @param array          $connectionServices
+     *
      * @return string
      */
-    public function getConnectionService(<ModelInterface> model, connectionServices) -> string
-    {
+    public function getConnectionService(
+        <ModelInterface> model,
+        array connectionServices
+    ) -> string {
         var connection;
 
         if !fetch connection, connectionServices[get_class_lower(model)] {
@@ -984,7 +1067,12 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Returns a custom events manager related to a model or null if there is no related events manager
+     * Returns a custom events manager related to a model or null if there is
+     * no related events manager
+     *
+     * @param ModelInterface $model
+     *
+     * @return EventsManagerInterface | null
      */
     public function getCustomEventsManager(<ModelInterface> model) -> <EventsManagerInterface> | null
     {
@@ -1240,10 +1328,19 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Helper method to query records based on a relation definition
      *
+     * @param RelationInterface $relation
+     * @param ModelInterface    $record
+     * @param mixed|null        $parameters
+     * @param string|null       $method
+     *
      * @return \Phalcon\Mvc\Model\Resultset\Simple|int|false
      */
-    public function getRelationRecords(<RelationInterface> relation, <ModelInterface> record, var parameters = null, string method = null)
-    {
+    public function getRelationRecords(
+        <RelationInterface> relation,
+        <ModelInterface> record,
+        var parameters = null,
+        string method = null
+    ) {
         var referencedModel, intermediateModel, intermediateFields, fields,
             builder, extraParameters, refPosition, field, referencedFields,
             findParams, findArguments, uniqueKey, records, arguments, rows,
@@ -1308,7 +1405,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
              * Create a query builder
              */
             let builder = this->createBuilder(
-                this->_mergeFindParameters(extraParameters, parameters)
+                this->mergeFindParameters(extraParameters, parameters)
             );
 
             builder->from(referencedModel);
@@ -1382,10 +1479,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
             "di"        : record->{"getDi"}()
         ];
 
-        let findArguments = this->_mergeFindParameters(findParams, parameters);
+        let findArguments = this->mergeFindParameters(findParams, parameters);
 
         if typeof extraParameters == "array" {
-            let findParams = this->_mergeFindParameters(
+            let findParams = this->mergeFindParameters(
                 extraParameters,
                 findArguments
             );
@@ -1454,6 +1551,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Query all the relationships defined on a model
+     *
+     * @param string $modelName
+     *
+     * @return RelationInterface[]
      */
     public function getRelations(string! modelName) -> <RelationInterface[]>
     {
@@ -1513,6 +1614,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Query the first relationship defined between two models
+     *
+     * @param string $first
+     * @param string $second
+     *
+     * @return RelationInterface[] | bool
      */
     public function getRelationsBetween(string! first, string! second) -> <RelationInterface[]> | bool
     {
@@ -1561,6 +1667,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Returns a reusable object from the internal list
+     *
+     * @param string $modelName
+     * @param string $key
      */
     public function getReusableRecords(string! modelName, string! key)
     {
@@ -1575,6 +1684,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Returns the connection to write data related to a model
+     *
+     * @param ModelInterface $model
+     *
+     * @return AdapterInterface
      */
     public function getWriteConnection(<ModelInterface> model) -> <AdapterInterface>
     {
@@ -1583,6 +1696,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Returns the connection service name used to write data related to a model
+     *
+     * @param ModelInterface $model
+     *
+     * @return string
      */
     public function getWriteConnectionService(<ModelInterface> model) -> string
     {
@@ -1594,6 +1711,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Checks whether a model has a belongsTo relation with another model
+     *
+     * @param string $modelName
+     * @param string $modelRelation
+     *
+     * @return bool
      */
     public function hasBelongsTo(string! modelName, string! modelRelation) -> bool
     {
@@ -1602,6 +1724,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Checks whether a model has a hasMany relation with another model
+     *
+     * @param string $modelName
+     * @param string $modelRelation
+     *
+     * @return bool
      */
     public function hasHasMany(string! modelName, string! modelRelation) -> bool
     {
@@ -1610,13 +1737,24 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Checks whether a model has a hasManyToMany relation with another model
+     *
+     * @param string $modelName
+     * @param string $modelRelation
+     *
+     * @return bool
      */
     public function hasHasManyToMany(string! modelName, string! modelRelation) -> bool
     {
         return this->checkHasRelationship("hasManyToMany", modelName, modelRelation);
     }
+
     /**
      * Checks whether a model has a hasOne relation with another model
+     *
+     * @param string $modelName
+     * @param string $modelRelation
+     *
+     * @return bool
      */
     public function hasHasOne(string! modelName, string! modelRelation) -> bool
     {
@@ -1625,6 +1763,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Checks whether a model has a hasOneThrough relation with another model
+     *
+     * @param string $modelName
+     * @param string $modelRelation
+     *
+     * @return bool
      */
     public function hasHasOneThrough(string! modelName, string! modelRelation) -> bool
     {
@@ -1633,6 +1776,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Initializes a model in the model manager
+     *
+     * @param ModelInterface $model
+     *
+     * @return bool
      */
     public function initialize(<ModelInterface> model) -> bool
     {
@@ -1680,6 +1827,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Check whether a model is already initialized
+     *
+     * @param string $className
+     *
+     * @return bool
      */
     public function isInitialized(string! className) -> bool
     {
@@ -1688,6 +1839,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Checks if a model is keeping snapshots for the queried records
+     *
+     * @param ModelInterface $model
+     *
+     * @return bool
      */
     public function isKeepingSnapshots(<ModelInterface> model) -> bool
     {
@@ -1702,6 +1857,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Checks if a model is using dynamic update instead of all-field update
+     *
+     * @param ModelInterface $model
+     *
+     * @return bool
      */
     public function isUsingDynamicUpdate(<ModelInterface> model) -> bool
     {
@@ -1723,6 +1882,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *     "name"
      * );
      * ```
+     *
+     * @param ModelInterface $model
+     * @param string         $property
+     *
+     * @return bool
      */
     final public function isVisibleModelProperty(<ModelInterface> model, string property) -> bool
     {
@@ -1748,6 +1912,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets if a model must keep snapshots
+     *
+     * @param ModelInterface $model
+     * @param bool           $keepSnapshots
+     *
+     * @return void
      */
     public function keepSnapshots(<ModelInterface> model, bool keepSnapshots) -> void
     {
@@ -1756,6 +1925,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Loads a model throwing an exception if it doesn't exist
+     *
+     * @param string $modelName
+     *
+     * @return ModelInterface
      */
     public function load(string! modelName) -> <ModelInterface>
     {
@@ -1789,6 +1962,9 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Receives events generated in the models and dispatches them to an
      * events-manager if available. Notify the behaviors that are listening in
      * the model
+     *
+     * @param string         $eventName
+     * @param ModelInterface $model
      */
     public function notifyEvent(string! eventName, <ModelInterface> model)
     {
@@ -1850,6 +2026,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Dispatch an event to the listeners and behaviors
      * This method expects that the endpoint listeners/behaviors returns true
      * meaning that a least one was implemented
+     *
+     * @param ModelInterface $model
+     * @param string         $eventName
+     * @param mixed          $data
      */
     public function missingMethod(<ModelInterface> model, string! eventName, var data)
     {
@@ -1889,6 +2069,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets both write and read connection service for a model
+     *
+     * @param ModelInterface $model
+     * @param string         $connectionService
+     *
+     * @return void
      */
     public function setConnectionService(<ModelInterface> model, string! connectionService) -> void
     {
@@ -1898,6 +2083,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets a custom events manager for a specific model
+     *
+     * @param ModelInterface         $model
+     * @param EventsManagerInterface $eventsManager
+     *
+     * @return void
      */
     public function setCustomEventsManager(<ModelInterface> model, <EventsManagerInterface> eventsManager) -> void
     {
@@ -1906,6 +2096,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets the DependencyInjector container
+     *
+     * @param DiInterface $container
+     *
+     * @return void
      */
     public function setDI(<DiInterface> container) -> void
     {
@@ -1914,6 +2108,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets a global events manager
+     *
+     * @param EventsManagerInterface $eventsManager
+     *
+     * @return void
      */
     public function setEventsManager(<EventsManagerInterface> eventsManager) -> void
     {
@@ -1941,6 +2139,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * echo $robots->getSource(); // wp_robots
      * ```
+     *
+     * $param string $prefix
+     *
+     * @return void
      */
     public function setModelPrefix(string! prefix) -> void
     {
@@ -1949,6 +2151,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets the mapped schema for a model
+     *
+     * @param ModelInterface $model
+     * @param string         $schema
+     *
+     * @return void
      */
     public function setModelSchema(<ModelInterface> model, string! schema) -> void
     {
@@ -1957,6 +2164,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets the mapped source for a model
+     *
+     * @param ModelInterface $model
+     * @param string         $source
+     *
+     * @return void
      */
     public function setModelSource(<ModelInterface> model, string! source) -> void
     {
@@ -1965,6 +2177,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets read connection service for a model
+     *
+     * @param ModelInterface $model
+     * @param string         $connectionService
+     *
+     * @return void
      */
     public function setReadConnectionService(<ModelInterface> model, string! connectionService) -> void
     {
@@ -1973,6 +2190,12 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Stores a reusable record in the internal list
+     *
+     * @param ModelInterface $model
+     * @param string         $key
+     * @param mixed          $records
+     *
+     * @return void
      */
     public function setReusableRecords(string! modelName, string! key, var records) -> void
     {
@@ -1981,6 +2204,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets write connection service for a model
+     *
+     * @param ModelInterface $model
+     * @param string         $connectionService
+     *
+     * @return void
      */
     public function setWriteConnectionService(<ModelInterface> model, string! connectionService) -> void
     {
@@ -1989,6 +2217,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 
     /**
      * Sets if a model must use dynamic update instead of the all-field update
+     *
+     * @param ModelInterface $model
+     * @param bool           $dynamicUpdate
+     *
+     * @return void
      */
     public function useDynamicUpdate(<ModelInterface> model, bool dynamicUpdate) -> void
     {
@@ -2000,9 +2233,51 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Merge two arrays of find parameters
+     * Returns the connection to read or write data related to a model
+     * depending on the connection services.
+     *
+     * @param ModelInterface $model
+     * @param array          $connectionServices
+     *
+     * @return AdapterInterface
      */
-    final protected function _mergeFindParameters(var findParamsOne, var findParamsTwo) -> array
+    protected function getConnection(
+        <ModelInterface> model,
+        array connectionServices
+    ) -> <AdapterInterface> {
+        var container, service, connection;
+
+        let service = this->getConnectionService(model, connectionServices);
+
+        let container = <DiInterface> this->container;
+
+        if unlikely typeof container != "object" {
+            throw new Exception(
+                "A dependency injection container is required to access the services related to the ORM"
+            );
+        }
+
+        /**
+         * Request the connection service from the DI
+         */
+        let connection = <AdapterInterface> container->getShared(service);
+
+        if unlikely typeof connection != "object" {
+            throw new Exception("Invalid injected connection service");
+        }
+
+        return connection;
+    }
+
+    /**
+     * Merge two arrays of find parameters
+     *
+     * @param mixed $findParamsOne
+     * @param mixed $findParamsTwo
+     *
+     * @return array
+     */
+    final protected function mergeFindParameters(var findParamsOne, var findParamsTwo) -> array
     {
         var key, value;
         array findParams;
@@ -2064,36 +2339,12 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Returns the connection to read or write data related to a model depending on the connection services.
+     * @param string $collection
+     * @param string $modelName
+     * @param string $modelRelation
      *
-     * @return AdapterInterface
+     * @return bool
      */
-    protected function getConnection(<ModelInterface> model, connectionServices) -> <AdapterInterface>
-    {
-        var container, service, connection;
-
-        let service = this->getConnectionService(model, connectionServices);
-
-        let container = <DiInterface> this->container;
-
-        if unlikely typeof container != "object" {
-            throw new Exception(
-                "A dependency injection container is required to access the services related to the ORM"
-            );
-        }
-
-        /**
-         * Request the connection service from the DI
-         */
-        let connection = <AdapterInterface> container->getShared(service);
-
-        if unlikely typeof connection != "object" {
-            throw new Exception("Invalid injected connection service");
-        }
-
-        return connection;
-    }
-
     private function checkHasRelationship(
         string collection,
         string! modelName,

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -76,6 +76,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     protected belongsToSingle = [];
 
     /**
+     * @var BuilderInterface|null
+     */
+    protected builder = null;
+
+    /**
      * @var DiInterface|null
      */
     protected container = null;
@@ -217,482 +222,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     protected reusable = [];
 
     /**
-     * Sets the DependencyInjector container
+     * Destroys the current PHQL cache
      */
-    public function setDI(<DiInterface> container) -> void
+    public function __destruct()
     {
-        let this->container = container;
-    }
+        phalcon_orm_destroy_cache();
 
-    /**
-     * Returns the DependencyInjector container
-     */
-    public function getDI() -> <DiInterface>
-    {
-        return this->container;
-    }
-
-    /**
-     * Sets a global events manager
-     */
-    public function setEventsManager(<EventsManagerInterface> eventsManager) -> void
-    {
-        let this->eventsManager = eventsManager;
-    }
-
-    /**
-     * Returns the internal event manager
-     */
-    public function getEventsManager() -> <EventsManagerInterface> | null
-    {
-        return this->eventsManager;
-    }
-
-    /**
-     * Sets a custom events manager for a specific model
-     */
-    public function setCustomEventsManager(<ModelInterface> model, <EventsManagerInterface> eventsManager) -> void
-    {
-        let this->customEventsManager[get_class_lower(model)] = eventsManager;
-    }
-
-    /**
-     * Returns a custom events manager related to a model or null if there is no related events manager
-     */
-    public function getCustomEventsManager(<ModelInterface> model) -> <EventsManagerInterface> | null
-    {
-        var eventsManager;
-
-        if fetch eventsManager, this->customEventsManager[get_class_lower(model)] {
-            return eventsManager;
-        }
-
-        return null;
-    }
-
-    /**
-     * Initializes a model in the model manager
-     */
-    public function initialize(<ModelInterface> model) -> bool
-    {
-        var className, eventsManager;
-
-        let className = get_class_lower(model);
-
-        /**
-         * Models are just initialized once per request
-         */
-        if isset this->initialized[className] {
-            return false;
-        }
-
-        /**
-         * Update the model as initialized, this avoid cyclic initializations
-         */
-        let this->initialized[className] = true;
-
-        /**
-         * Call the 'initialize' method if it's implemented
-         */
-        if method_exists(model, "initialize") {
-            model->{"initialize"}();
-        }
-
-        /**
-         * Update the last initialized model, so it can be used in
-         * modelsManager:afterInitialize
-         */
-        let this->lastInitialized = model;
-
-        /**
-         * If an EventsManager is available we pass to it every initialized
-         * model
-         */
-        let eventsManager = <EventsManagerInterface> this->eventsManager;
-
-        if typeof eventsManager == "object" {
-            eventsManager->fire("modelsManager:afterInitialize", this, model);
-        }
-
-        return true;
-    }
-
-    /**
-     * Check whether a model is already initialized
-     */
-    public function isInitialized(string! className) -> bool
-    {
-        return isset this->initialized[strtolower(className)];
-    }
-
-    /**
-     * Get last initialized model
-     */
-    public function getLastInitialized() -> <ModelInterface>
-    {
-        return this->lastInitialized;
-    }
-
-    /**
-     * Loads a model throwing an exception if it doesn't exist
-     */
-    public function load(string! modelName) -> <ModelInterface>
-    {
-        var model;
-
-        /**
-         * The model doesn't exist throw an exception
-         */
-        if unlikely !class_exists(modelName) {
-            throw new Exception(
-                "Model '" . modelName . "' could not be loaded"
-            );
-        }
-
-        /**
-         * Load it using an autoloader
-         */
-        let model = create_instance_params(
-            modelName,
-            [
-                null,
-                this->container,
-                this
-            ]
-        );
-
-        return model;
-    }
-
-    /**
-     * Sets the prefix for all model sources.
-     *
-     * ```php
-     * use Phalcon\Mvc\Model\Manager;
-     *
-     * $di->set(
-     *     "modelsManager",
-     *     function () {
-     *         $modelsManager = new Manager();
-     *
-     *         $modelsManager->setModelPrefix("wp_");
-     *
-     *         return $modelsManager;
-     *     }
-     * );
-     *
-     * $robots = new Robots();
-     *
-     * echo $robots->getSource(); // wp_robots
-     * ```
-     */
-    public function setModelPrefix(string! prefix) -> void
-    {
-        let this->prefix = prefix;
-    }
-
-    /**
-     * Returns the prefix for all model sources.
-     */
-    public function getModelPrefix() -> string
-    {
-        return this->prefix;
-    }
-
-    /**
-     * Sets the mapped source for a model
-     */
-    public function setModelSource(<ModelInterface> model, string! source) -> void
-    {
-        let this->sources[get_class_lower(model)] = source;
-    }
-
-    /**
-     * Check whether a model property is declared as public.
-     *
-     * ```php
-     * $isPublic = $manager->isVisibleModelProperty(
-     *     new Robots(),
-     *     "name"
-     * );
-     * ```
-     */
-    final public function isVisibleModelProperty(<ModelInterface> model, string property) -> bool
-    {
-        var properties, className, publicProperties, classReflection,
-            reflectionProperties, reflectionProperty;
-
-        let className = get_class(model);
-
-        if !isset this->modelVisibility[className] {
-            let publicProperties = [];
-            let classReflection = new ReflectionClass(className);
-            let reflectionProperties = classReflection->getProperties(ReflectionProperty::IS_PUBLIC);
-            for reflectionProperty in reflectionProperties {
-                let publicProperties[reflectionProperty->name] = true;
-            }
-            let this->modelVisibility[className] = publicProperties;
-        }
-
-        let properties = this->modelVisibility[className];
-
-        return array_key_exists(property, properties);
-    }
-
-    /**
-     * Returns the mapped source for a model
-     */
-    public function getModelSource(<ModelInterface> model) -> string
-    {
-        var entityName;
-
-        let entityName = get_class_lower(model);
-
-        if !isset this->sources[entityName] {
-            this->setModelSource(
-                model,
-                uncamelize(
-                    get_class_ns(model)
-                )
-            );
-        }
-
-        return this->prefix . this->sources[entityName];
-    }
-
-    /**
-     * Sets the mapped schema for a model
-     */
-    public function setModelSchema(<ModelInterface> model, string! schema) -> void
-    {
-        let this->schemas[get_class_lower(model)] = schema;
-    }
-
-    /**
-     * Returns the mapped schema for a model
-     */
-    public function getModelSchema(<ModelInterface> model) -> string | null
-    {
-        var schema;
-
-        if !fetch schema, this->schemas[get_class_lower(model)] {
-            return null;
-        }
-
-        return schema;
-    }
-
-    /**
-     * Sets both write and read connection service for a model
-     */
-    public function setConnectionService(<ModelInterface> model, string! connectionService) -> void
-    {
-        this->setReadConnectionService(model, connectionService);
-        this->setWriteConnectionService(model, connectionService);
-    }
-
-    /**
-     * Sets write connection service for a model
-     */
-    public function setWriteConnectionService(<ModelInterface> model, string! connectionService) -> void
-    {
-        let this->writeConnectionServices[get_class_lower(model)] = connectionService;
-    }
-
-    /**
-     * Sets read connection service for a model
-     */
-    public function setReadConnectionService(<ModelInterface> model, string! connectionService) -> void
-    {
-        let this->readConnectionServices[get_class_lower(model)] = connectionService;
-    }
-
-    /**
-     * Returns the connection to read data related to a model
-     */
-    public function getReadConnection(<ModelInterface> model) -> <AdapterInterface>
-    {
-        return this->getConnection(model, this->readConnectionServices);
-    }
-
-    /**
-     * Returns the connection to write data related to a model
-     */
-    public function getWriteConnection(<ModelInterface> model) -> <AdapterInterface>
-    {
-        return this->getConnection(model, this->writeConnectionServices);
-    }
-
-    /**
-     * Returns the connection to read or write data related to a model depending on the connection services.
-     *
-     * @return AdapterInterface
-     */
-    protected function getConnection(<ModelInterface> model, connectionServices) -> <AdapterInterface>
-    {
-        var container, service, connection;
-
-        let service = this->getConnectionService(model, connectionServices);
-
-        let container = <DiInterface> this->container;
-
-        if unlikely typeof container != "object" {
-            throw new Exception(
-                "A dependency injection container is required to access the services related to the ORM"
-            );
-        }
-
-        /**
-         * Request the connection service from the DI
-         */
-        let connection = <AdapterInterface> container->getShared(service);
-
-        if unlikely typeof connection != "object" {
-            throw new Exception("Invalid injected connection service");
-        }
-
-        return connection;
-    }
-
-    /**
-     * Returns the connection service name used to read data related to a model
-     */
-    public function getReadConnectionService(<ModelInterface> model) -> string
-    {
-        return this->getConnectionService(
-            model,
-            this->readConnectionServices
-        );
-    }
-
-    /**
-     * Returns the connection service name used to write data related to a model
-     */
-    public function getWriteConnectionService(<ModelInterface> model) -> string
-    {
-        return this->getConnectionService(
-            model,
-            this->writeConnectionServices
-        );
-    }
-
-    /**
-     * Returns the connection service name used to read or write data related to
-     * a model depending on the connection services
-     *
-     * @return string
-     */
-    public function getConnectionService(<ModelInterface> model, connectionServices) -> string
-    {
-        var connection;
-
-        if !fetch connection, connectionServices[get_class_lower(model)] {
-            return "db";
-        }
-
-        return connection;
-    }
-
-    /**
-     * Receives events generated in the models and dispatches them to an
-     * events-manager if available. Notify the behaviors that are listening in
-     * the model
-     */
-    public function notifyEvent(string! eventName, <ModelInterface> model)
-    {
-        var status, behavior, modelsBehaviors, eventsManager,
-            customEventsManager;
-
-        let status = null;
-
-        /**
-         * Dispatch events to the global events manager
-         */
-        if fetch modelsBehaviors, this->behaviors[get_class_lower(model)] {
-            /**
-             * Notify all the events on the behavior
-             */
-            for behavior in modelsBehaviors {
-                let status = behavior->notify(eventName, model);
-
-                if status === false {
-                    return false;
-                }
-            }
-        }
-
-        /**
-         * Dispatch events to the global events manager
-         */
-        let eventsManager = this->eventsManager;
-
-        if typeof eventsManager == "object" {
-            let status = eventsManager->fire(
-                "model:" . eventName,
-                model
-            );
-
-            if status === false {
-                return status;
-            }
-        }
-
-        /**
-         * A model can has a specific events manager for it
-         */
-        if fetch customEventsManager, this->customEventsManager[get_class_lower(model)] {
-            let status = customEventsManager->fire(
-                "model:" . eventName,
-                model
-            );
-
-            if status === false {
-                return false;
-            }
-        }
-
-        return status;
-    }
-
-    /**
-     * Dispatch an event to the listeners and behaviors
-     * This method expects that the endpoint listeners/behaviors returns true
-     * meaning that a least one was implemented
-     */
-    public function missingMethod(<ModelInterface> model, string! eventName, var data)
-    {
-        var modelsBehaviors, result, eventsManager, behavior;
-
-        /**
-         * Dispatch events to the global events manager
-         */
-        if fetch modelsBehaviors, this->behaviors[get_class_lower(model)] {
-            /**
-             * Notify all the events on the behavior
-             */
-            for behavior in modelsBehaviors {
-                let result = behavior->missingMethod(model, eventName, data);
-
-                if result !== null {
-                    return result;
-                }
-            }
-        }
-
-        /**
-         * Dispatch events to the global events manager
-         */
-        let eventsManager = this->eventsManager;
-
-        if typeof eventsManager == "object" {
-            return eventsManager->fire(
-                "model:" . eventName,
-                model,
-                data
-            );
-        }
-
-        return null;
+        Query::clean();
     }
 
     /**
@@ -712,258 +248,6 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
          * Append the behavior to the list of behaviors
          */
         let this->behaviors[entityName][] = behavior;
-    }
-
-    /**
-     * Sets if a model must keep snapshots
-     */
-    public function keepSnapshots(<ModelInterface> model, bool keepSnapshots) -> void
-    {
-        let this->keepSnapshots[get_class_lower(model)] = keepSnapshots;
-    }
-
-    /**
-     * Checks if a model is keeping snapshots for the queried records
-     */
-    public function isKeepingSnapshots(<ModelInterface> model) -> bool
-    {
-        var isKeeping;
-
-        if !fetch isKeeping, this->keepSnapshots[get_class_lower(model)] {
-            return false;
-        }
-
-        return isKeeping;
-    }
-
-    /**
-     * Sets if a model must use dynamic update instead of the all-field update
-     */
-    public function useDynamicUpdate(<ModelInterface> model, bool dynamicUpdate) -> void
-    {
-        var entityName;
-
-        let entityName = get_class_lower(model),
-            this->dynamicUpdate[entityName] = dynamicUpdate,
-            this->keepSnapshots[entityName] = dynamicUpdate;
-    }
-
-    /**
-     * Checks if a model is using dynamic update instead of all-field update
-     */
-    public function isUsingDynamicUpdate(<ModelInterface> model) -> bool
-    {
-        var isUsing;
-
-        if !fetch isUsing, this->dynamicUpdate[get_class_lower(model)] {
-            return false;
-        }
-
-        return isUsing;
-    }
-
-    /**
-     * Setup a 1-1 relation between two models
-     *
-     * @param array options
-     */
-    public function addHasOne(<ModelInterface> model, var fields, string! referencedModel,
-        var referencedFields, array options = []) -> <RelationInterface>
-    {
-        var entityName, referencedEntity, relation, relations, alias,
-            lowerAlias, singleRelations;
-        string keyRelation;
-
-        let entityName = get_class_lower(model),
-            referencedEntity = strtolower(referencedModel);
-
-        let keyRelation = entityName . "$" . referencedEntity;
-
-        if !fetch relations, this->hasOne[keyRelation] {
-            let relations = [];
-        }
-
-        /**
-         * Check if the number of fields are the same
-         */
-        if typeof referencedFields == "array" {
-            if unlikely count(fields) != count(referencedFields) {
-                throw new Exception(
-                    "Number of referenced fields are not the same"
-                );
-            }
-        }
-
-        /**
-         * Create a relationship instance
-         */
-        let relation = new Relation(
-            Relation::HAS_ONE,
-            referencedModel,
-            fields,
-            referencedFields,
-            options
-        );
-
-        /**
-         * Check an alias for the relation
-         */
-        if fetch alias, options["alias"] {
-            if unlikely typeof alias != "string" {
-                throw new Exception("Relation alias must be a string");
-            }
-
-            let lowerAlias = strtolower(alias);
-        } else {
-            let lowerAlias = referencedEntity;
-        }
-
-        /**
-         * Append a new relationship
-         * Update the global alias
-         * Update the relations
-         */
-        let relations[] = relation,
-            this->aliases[entityName . "$" . lowerAlias] = relation,
-            this->hasOne[keyRelation] = relations;
-
-        /**
-         * Get existing relations by model
-         */
-        if !fetch singleRelations, this->hasOneSingle[entityName] {
-            let singleRelations = [];
-        }
-
-        /**
-         * Append a new relationship
-         */
-        let singleRelations[] = relation;
-
-        /**
-         * Update relations by model
-         */
-        let this->hasOneSingle[entityName] = singleRelations;
-
-        return relation;
-    }
-
-    /**
-     * Setups a relation 1-1 between two models using an intermediate model
-     *
-     * @param    string fields
-     * @param    string intermediateFields
-     * @param    string intermediateReferencedFields
-     * @param    string referencedFields
-     * @param   array options
-     */
-    public function addHasOneThrough(<ModelInterface> model, var fields, string! intermediateModel,
-        var intermediateFields, var intermediateReferencedFields, string! referencedModel, var referencedFields, array options = []) -> <RelationInterface>
-    {
-        var entityName, referencedEntity, hasOneThrough, relation, relations,
-            alias, lowerAlias, singleRelations, intermediateEntity;
-        string keyRelation;
-
-        let entityName = get_class_lower(model),
-            intermediateEntity = strtolower(intermediateModel),
-            referencedEntity = strtolower(referencedModel),
-            keyRelation = entityName . "$" . referencedEntity;
-
-        let hasOneThrough = this->hasOneThrough;
-
-        if !fetch relations, hasOneThrough[keyRelation] {
-            let relations = [];
-        }
-
-        /**
-         * Check if the number of fields are the same from the model to the
-         * intermediate model
-         */
-        if typeof intermediateFields == "array" {
-            if unlikely count(fields) != count(intermediateFields) {
-                throw new Exception(
-                    "Number of referenced fields are not the same"
-                );
-            }
-        }
-
-        /**
-         * Check if the number of fields are the same from the intermediate
-         * model to the referenced model
-         */
-        if typeof intermediateReferencedFields == "array" {
-            if unlikely count(fields) != count(intermediateFields) {
-                throw new Exception(
-                    "Number of referenced fields are not the same"
-                );
-            }
-        }
-
-        /**
-         * Create a relationship instance
-         */
-        let relation = new Relation(
-            Relation::HAS_ONE_THROUGH,
-            referencedModel,
-            fields,
-            referencedFields,
-            options
-        );
-
-        /**
-         * Set extended intermediate relation data
-         */
-        relation->setIntermediateRelation(
-            intermediateFields,
-            intermediateModel,
-            intermediateReferencedFields
-        );
-
-        /**
-         * Check an alias for the relation
-         */
-        if fetch alias, options["alias"] {
-            if typeof alias != "string" {
-                throw new Exception("Relation alias must be a string");
-            }
-
-            let lowerAlias = strtolower(alias);
-        } else {
-            let lowerAlias = referencedEntity;
-        }
-
-        /**
-         * Append a new relationship
-         */
-        let relations[] = relation;
-
-        /**
-         * Update the global alias
-         */
-        let this->aliases[entityName . "$" . lowerAlias] = relation;
-
-        /**
-         * Update the relations
-         */
-        let this->hasOneThrough[keyRelation] = relations;
-
-        /**
-         * Get existing relations by model
-         */
-        if !fetch singleRelations, this->hasOneThroughSingle[entityName] {
-            let singleRelations = [];
-        }
-
-        /**
-         * Append a new relationship
-         */
-        let singleRelations[] = relation;
-
-        /**
-         * Update relations by model
-         */
-        let this->hasOneThroughSingle[entityName] = singleRelations;
-
-        return relation;
     }
 
     /**
@@ -1258,6 +542,324 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
+     * Setup a 1-1 relation between two models
+     *
+     * @param array options
+     */
+    public function addHasOne(<ModelInterface> model, var fields, string! referencedModel,
+        var referencedFields, array options = []) -> <RelationInterface>
+    {
+        var entityName, referencedEntity, relation, relations, alias,
+            lowerAlias, singleRelations;
+        string keyRelation;
+
+        let entityName = get_class_lower(model),
+            referencedEntity = strtolower(referencedModel);
+
+        let keyRelation = entityName . "$" . referencedEntity;
+
+        if !fetch relations, this->hasOne[keyRelation] {
+            let relations = [];
+        }
+
+        /**
+         * Check if the number of fields are the same
+         */
+        if typeof referencedFields == "array" {
+            if unlikely count(fields) != count(referencedFields) {
+                throw new Exception(
+                    "Number of referenced fields are not the same"
+                );
+            }
+        }
+
+        /**
+         * Create a relationship instance
+         */
+        let relation = new Relation(
+            Relation::HAS_ONE,
+            referencedModel,
+            fields,
+            referencedFields,
+            options
+        );
+
+        /**
+         * Check an alias for the relation
+         */
+        if fetch alias, options["alias"] {
+            if unlikely typeof alias != "string" {
+                throw new Exception("Relation alias must be a string");
+            }
+
+            let lowerAlias = strtolower(alias);
+        } else {
+            let lowerAlias = referencedEntity;
+        }
+
+        /**
+         * Append a new relationship
+         * Update the global alias
+         * Update the relations
+         */
+        let relations[] = relation,
+            this->aliases[entityName . "$" . lowerAlias] = relation,
+            this->hasOne[keyRelation] = relations;
+
+        /**
+         * Get existing relations by model
+         */
+        if !fetch singleRelations, this->hasOneSingle[entityName] {
+            let singleRelations = [];
+        }
+
+        /**
+         * Append a new relationship
+         */
+        let singleRelations[] = relation;
+
+        /**
+         * Update relations by model
+         */
+        let this->hasOneSingle[entityName] = singleRelations;
+
+        return relation;
+    }
+
+    /**
+     * Setups a relation 1-1 between two models using an intermediate model
+     *
+     * @param    string fields
+     * @param    string intermediateFields
+     * @param    string intermediateReferencedFields
+     * @param    string referencedFields
+     * @param   array options
+     */
+    public function addHasOneThrough(<ModelInterface> model, var fields, string! intermediateModel,
+        var intermediateFields, var intermediateReferencedFields, string! referencedModel, var referencedFields, array options = []) -> <RelationInterface>
+    {
+        var entityName, referencedEntity, hasOneThrough, relation, relations,
+            alias, lowerAlias, singleRelations, intermediateEntity;
+        string keyRelation;
+
+        let entityName = get_class_lower(model),
+            intermediateEntity = strtolower(intermediateModel),
+            referencedEntity = strtolower(referencedModel),
+            keyRelation = entityName . "$" . referencedEntity;
+
+        let hasOneThrough = this->hasOneThrough;
+
+        if !fetch relations, hasOneThrough[keyRelation] {
+            let relations = [];
+        }
+
+        /**
+         * Check if the number of fields are the same from the model to the
+         * intermediate model
+         */
+        if typeof intermediateFields == "array" {
+            if unlikely count(fields) != count(intermediateFields) {
+                throw new Exception(
+                    "Number of referenced fields are not the same"
+                );
+            }
+        }
+
+        /**
+         * Check if the number of fields are the same from the intermediate
+         * model to the referenced model
+         */
+        if typeof intermediateReferencedFields == "array" {
+            if unlikely count(fields) != count(intermediateFields) {
+                throw new Exception(
+                    "Number of referenced fields are not the same"
+                );
+            }
+        }
+
+        /**
+         * Create a relationship instance
+         */
+        let relation = new Relation(
+            Relation::HAS_ONE_THROUGH,
+            referencedModel,
+            fields,
+            referencedFields,
+            options
+        );
+
+        /**
+         * Set extended intermediate relation data
+         */
+        relation->setIntermediateRelation(
+            intermediateFields,
+            intermediateModel,
+            intermediateReferencedFields
+        );
+
+        /**
+         * Check an alias for the relation
+         */
+        if fetch alias, options["alias"] {
+            if typeof alias != "string" {
+                throw new Exception("Relation alias must be a string");
+            }
+
+            let lowerAlias = strtolower(alias);
+        } else {
+            let lowerAlias = referencedEntity;
+        }
+
+        /**
+         * Append a new relationship
+         */
+        let relations[] = relation;
+
+        /**
+         * Update the global alias
+         */
+        let this->aliases[entityName . "$" . lowerAlias] = relation;
+
+        /**
+         * Update the relations
+         */
+        let this->hasOneThrough[keyRelation] = relations;
+
+        /**
+         * Get existing relations by model
+         */
+        if !fetch singleRelations, this->hasOneThroughSingle[entityName] {
+            let singleRelations = [];
+        }
+
+        /**
+         * Append a new relationship
+         */
+        let singleRelations[] = relation;
+
+        /**
+         * Update relations by model
+         */
+        let this->hasOneThroughSingle[entityName] = singleRelations;
+
+        return relation;
+    }
+
+    /**
+     * Clears the internal reusable list
+     */
+    public function clearReusableObjects() -> void
+    {
+        let this->reusable = [];
+    }
+
+    /**
+     * Creates a Phalcon\Mvc\Model\Query\Builder
+     *
+     * @param array|string|null params
+     */
+    public function createBuilder(var params = null) -> <BuilderInterface>
+    {
+        var container;
+
+        let container = <DiInterface> this->container;
+
+        if unlikely typeof container != "object" {
+            throw new Exception(
+                "A dependency injection container is required to access the services related to the ORM"
+            );
+        }
+
+        /**
+         * Gets Builder instance from DI container
+         */
+        let this->builder = <BuilderInterface> container->get(
+            "Phalcon\\Mvc\\Model\\Query\\Builder",
+            [
+                params,
+                container
+            ]
+        );
+
+        return this->builder;
+    }
+
+    /**
+     * Creates a Phalcon\Mvc\Model\Query without execute it
+     */
+    public function createQuery(string! phql) -> <QueryInterface>
+    {
+        var container, query;
+
+        let container = this->container;
+
+        if unlikely typeof container != "object" {
+            throw new Exception(
+                "A dependency injection container is required to access the services related to the ORM"
+            );
+        }
+
+        /**
+         * Create a query
+         */
+        let query = <QueryInterface> container->get(
+            "Phalcon\\Mvc\\Model\\Query",
+            [phql, container]
+        );
+
+        let this->lastQuery = query;
+
+        return query;
+    }
+
+    /**
+     * Creates a Phalcon\Mvc\Model\Query and execute it
+     *
+     * ```php
+     * $model = new Robots();
+     * $manager = $model->getModelsManager();
+     *
+     * // \Phalcon\Mvc\Model\Resultset\Simple
+     * $manager->executeQuery('SELECT * FROM Robots');
+     *
+     * // \Phalcon\Mvc\Model\Resultset\Complex
+     * $manager->executeQuery('SELECT COUNT(type) FROM Robots GROUP BY type');
+     *
+     * // \Phalcon\Mvc\Model\Query\StatusInterface
+     * $manager->executeQuery('INSERT INTO Robots (id) VALUES (1)');
+     *
+     * // \Phalcon\Mvc\Model\Query\StatusInterface
+     * $manager->executeQuery('UPDATE Robots SET id = 0 WHERE id = :id:', ['id' => 1]);
+     *
+     * // \Phalcon\Mvc\Model\Query\StatusInterface
+     * $manager->executeQuery('DELETE FROM Robots WHERE id = :id:', ['id' => 1]);
+     * ```
+     *
+     * @param array|null $placeholders
+     * @param array|null $types
+     * @return ResultsetInterface|StatusInterface
+     */
+    public function executeQuery(string! phql, var placeholders = null, var types = null) -> var
+    {
+        var query;
+
+        let query = this->createQuery(phql);
+
+        if typeof placeholders == "array" {
+            query->setBindParams(placeholders);
+        }
+
+        if typeof types == "array" {
+            query->setBindTypes(types);
+        }
+
+        /**
+         * Execute the query
+         */
+        return query->execute();
+    }
+
+    /**
      * Checks whether a model has a belongsTo relation with another model
      * @deprecated
      */
@@ -1273,6 +875,15 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     public function existsHasMany(string! modelName, string! modelRelation) -> bool
     {
         return this->hasHasMany(modelName, modelRelation);
+    }
+
+    /**
+     * Checks whether a model has a hasManyToMany relation with another model
+     * @deprecated
+     */
+    public function existsHasManyToMany(string! modelName, string! modelRelation) -> bool
+    {
+        return this->hasHasManyToMany(modelName, modelRelation);
     }
 
     /**
@@ -1294,12 +905,317 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Checks whether a model has a hasManyToMany relation with another model
-     * @deprecated
+     * Gets all the belongsTo relations defined in a model
+     *
+     *```php
+     * $relations = $modelsManager->getBelongsTo(
+     *     new Robots()
+     * );
+     *```
      */
-    public function existsHasManyToMany(string! modelName, string! modelRelation) -> bool
+    public function getBelongsTo(<ModelInterface> model) -> <RelationInterface[]> | array
     {
-        return this->hasHasManyToMany(modelName, modelRelation);
+        var relations;
+
+        if !fetch relations, this->belongsToSingle[get_class_lower(model)] {
+            return [];
+        }
+
+        return relations;
+    }
+
+    /**
+     * Gets belongsTo related records from a model
+     */
+    public function getBelongsToRecords(
+        string! modelName,
+        string! modelRelation,
+        <ModelInterface> record,
+        parameters = null,
+        string method = null
+    ) -> <ResultsetInterface> | bool {
+        var relations;
+        string keyRelation;
+
+        /**
+         * Check if there is a relation between them
+         */
+        let keyRelation = strtolower(modelName) . "$" . strtolower(modelRelation);
+
+        if !fetch relations, this->hasMany[keyRelation] {
+            return false;
+        }
+
+        /**
+         * "relations" is an array with all the belongsTo relationships to that model
+         * Perform the query
+         */
+        return this->getRelationRecords(
+            relations[0],
+            record,
+            parameters,
+            method
+        );
+    }
+
+    /**
+     * Returns the newly created Phalcon\Mvc\Model\Query\Builder or null
+     */
+    public function getBuilder() -> <BuilderInterface> | null
+    {
+        return this->builder;
+    }
+
+    /**
+     * Returns the connection service name used to read or write data related to
+     * a model depending on the connection services
+     *
+     * @return string
+     */
+    public function getConnectionService(<ModelInterface> model, connectionServices) -> string
+    {
+        var connection;
+
+        if !fetch connection, connectionServices[get_class_lower(model)] {
+            return "db";
+        }
+
+        return connection;
+    }
+
+    /**
+     * Returns a custom events manager related to a model or null if there is no related events manager
+     */
+    public function getCustomEventsManager(<ModelInterface> model) -> <EventsManagerInterface> | null
+    {
+        var eventsManager;
+
+        if fetch eventsManager, this->customEventsManager[get_class_lower(model)] {
+            return eventsManager;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the DependencyInjector container
+     */
+    public function getDI() -> <DiInterface>
+    {
+        return this->container;
+    }
+
+    /**
+     * Returns the internal event manager
+     */
+    public function getEventsManager() -> <EventsManagerInterface> | null
+    {
+        return this->eventsManager;
+    }
+
+    /**
+     * Gets hasMany relations defined on a model
+     */
+    public function getHasMany(<ModelInterface> model) -> <RelationInterface[]> | array
+    {
+        var relations;
+
+        if !fetch relations, this->hasManySingle[get_class_lower(model)] {
+            return [];
+        }
+
+        return relations;
+    }
+
+    /**
+     * Gets hasMany related records from a model
+     */
+    public function getHasManyRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
+        -> <ResultsetInterface> | bool
+    {
+        var relations;
+        string keyRelation;
+
+        /**
+         * Check if there is a relation between them
+         */
+        let keyRelation = strtolower(modelName) . "$" . strtolower(modelRelation);
+
+        if !fetch relations, this->hasMany[keyRelation] {
+            return false;
+        }
+
+        /**
+         * "relations" is an array with all the hasMany relationships to that model
+         * Perform the query
+         */
+        return this->getRelationRecords(
+            relations[0],
+            record,
+            parameters,
+            method
+        );
+    }
+
+    /**
+     * Gets hasManyToMany relations defined on a model
+     */
+    public function getHasManyToMany(<ModelInterface> model) -> <RelationInterface[]> | array
+    {
+        var relations;
+
+        if !fetch relations, this->hasManyToManySingle[get_class_lower(model)] {
+            return [];
+        }
+
+        return relations;
+    }
+
+    /**
+     * Gets hasOne relations defined on a model
+     */
+    public function getHasOne(<ModelInterface> model) -> array
+    {
+        var relations;
+
+        if !fetch relations, this->hasOneSingle[get_class_lower(model)] {
+            return [];
+        }
+
+        return relations;
+    }
+
+    /**
+     * Gets hasOne relations defined on a model
+     */
+    public function getHasOneAndHasMany(<ModelInterface> model) -> <RelationInterface[]>
+    {
+        return array_merge(
+            this->getHasOne(model),
+            this->getHasMany(model)
+        );
+    }
+
+    /**
+     * Gets belongsTo related records from a model
+     */
+    public function getHasOneRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
+        -> <ModelInterface> | bool
+    {
+        var relations;
+        string keyRelation;
+
+        /**
+         * Check if there is a relation between them
+         */
+        let keyRelation = strtolower(modelName) . "$" . strtolower(modelRelation);
+
+        if !fetch relations, this->hasOne[keyRelation] {
+            return false;
+        }
+
+        /**
+         * "relations" is an array with all the belongsTo relationships to that model
+         * Perform the query
+         */
+        return this->getRelationRecords(
+            relations[0],
+            record,
+            parameters,
+            method
+        );
+    }
+
+    /**
+     * Gets hasOneThrough relations defined on a model
+     */
+    public function getHasOneThrough(<ModelInterface> model) -> <RelationInterface[]> | array
+    {
+        var relations;
+
+        if !fetch relations, this->hasOneThroughSingle[get_class_lower(model)] {
+            return [];
+        }
+
+        return relations;
+    }
+
+    /**
+     * Get last initialized model
+     */
+    public function getLastInitialized() -> <ModelInterface>
+    {
+        return this->lastInitialized;
+    }
+
+    /**
+     * Returns the last query created or executed in the models manager
+     */
+    public function getLastQuery() -> <QueryInterface>
+    {
+        return this->lastQuery;
+    }
+
+    /**
+     * Returns the prefix for all model sources.
+     */
+    public function getModelPrefix() -> string
+    {
+        return this->prefix;
+    }
+
+    /**
+     * Returns the mapped schema for a model
+     */
+    public function getModelSchema(<ModelInterface> model) -> string | null
+    {
+        var schema;
+
+        if !fetch schema, this->schemas[get_class_lower(model)] {
+            return null;
+        }
+
+        return schema;
+    }
+
+    /**
+     * Returns the mapped source for a model
+     */
+    public function getModelSource(<ModelInterface> model) -> string
+    {
+        var entityName;
+
+        let entityName = get_class_lower(model);
+
+        if !isset this->sources[entityName] {
+            this->setModelSource(
+                model,
+                uncamelize(
+                    get_class_ns(model)
+                )
+            );
+        }
+
+        return this->prefix . this->sources[entityName];
+    }
+
+    /**
+     * Returns the connection to read data related to a model
+     */
+    public function getReadConnection(<ModelInterface> model) -> <AdapterInterface>
+    {
+        return this->getConnection(model, this->readConnectionServices);
+    }
+
+    /**
+     * Returns the connection service name used to read data related to a model
+     */
+    public function getReadConnectionService(<ModelInterface> model) -> string
+    {
+        return this->getConnectionService(
+            model,
+            this->readConnectionServices
+        );
     }
 
     /**
@@ -1319,70 +1235,6 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         }
 
         return relation;
-    }
-
-    /**
-     * Merge two arrays of find parameters
-     */
-    final protected function _mergeFindParameters(var findParamsOne, var findParamsTwo) -> array
-    {
-        var key, value;
-        array findParams;
-
-        let findParams = [];
-
-        if typeof findParamsOne == "string" {
-            let findParamsOne = [
-                "conditions": findParamsOne
-            ];
-        }
-
-        if typeof findParamsTwo == "string" {
-            let findParamsTwo = [
-                "conditions": findParamsTwo
-            ];
-        }
-
-        if typeof findParamsOne == "array"  {
-            for key, value in findParamsOne {
-                if key === 0 || key === "conditions" {
-                    if !isset findParams[0] {
-                        let findParams[0] = value;
-                    } else {
-                        let findParams[0] = "(" . findParams[0] . ") AND (" . value . ")";
-                    }
-                } else {
-                    let findParams[key] = value;
-                }
-            }
-        }
-
-        if typeof findParamsTwo == "array"  {
-            for key, value in findParamsTwo {
-                if key === 0 || key === "conditions" {
-                    if !isset findParams[0] {
-                        let findParams[0] = value;
-                    } else {
-                        let findParams[0] = "(" . findParams[0] . ") AND (" . value . ")";
-                    }
-                } elseif key === "bind" || key === "bindTypes" {
-                    if typeof value == "array" {
-                        if !isset findParams[key] {
-                            let findParams[key] = value;
-                        } else {
-                            let findParams[key] = array_merge(
-                                findParams[key],
-                                value
-                            );
-                        }
-                    }
-                } else {
-                    let findParams[key] = value;
-                }
-            }
-        }
-
-        return findParams;
     }
 
     /**
@@ -1601,252 +1453,6 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Returns a reusable object from the internal list
-     */
-    public function getReusableRecords(string! modelName, string! key)
-    {
-        var records;
-
-        if !fetch records, this->reusable[key] {
-            return null;
-        }
-
-        return records;
-    }
-
-    /**
-     * Checks whether a model has a belongsTo relation with another model
-     */
-    public function hasBelongsTo(string! modelName, string! modelRelation) -> bool
-    {
-        return this->checkHasRelationship("belongsTo", modelName, modelRelation);
-    }
-
-    /**
-     * Checks whether a model has a hasMany relation with another model
-     */
-    public function hasHasMany(string! modelName, string! modelRelation) -> bool
-    {
-        return this->checkHasRelationship("hasMany", modelName, modelRelation);
-    }
-
-    /**
-     * Checks whether a model has a hasOne relation with another model
-     */
-    public function hasHasOne(string! modelName, string! modelRelation) -> bool
-    {
-        return this->checkHasRelationship("hasOne", modelName, modelRelation);
-    }
-
-    /**
-     * Checks whether a model has a hasOneThrough relation with another model
-     */
-    public function hasHasOneThrough(string! modelName, string! modelRelation) -> bool
-    {
-        return this->checkHasRelationship("hasOneThrough", modelName, modelRelation);
-    }
-
-    /**
-     * Checks whether a model has a hasManyToMany relation with another model
-     */
-    public function hasHasManyToMany(string! modelName, string! modelRelation) -> bool
-    {
-        return this->checkHasRelationship("hasManyToMany", modelName, modelRelation);
-    }
-    /**
-     * Stores a reusable record in the internal list
-     */
-    public function setReusableRecords(string! modelName, string! key, var records) -> void
-    {
-        let this->reusable[key] = records;
-    }
-
-    /**
-     * Clears the internal reusable list
-     */
-    public function clearReusableObjects() -> void
-    {
-        let this->reusable = [];
-    }
-
-    /**
-     * Gets belongsTo related records from a model
-     */
-    public function getBelongsToRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
-        -> <ResultsetInterface> | bool
-    {
-        var relations;
-        string keyRelation;
-
-        /**
-         * Check if there is a relation between them
-         */
-        let keyRelation = strtolower(modelName) . "$" . strtolower(modelRelation);
-
-        if !fetch relations, this->hasMany[keyRelation] {
-            return false;
-        }
-
-        /**
-         * "relations" is an array with all the belongsTo relationships to that model
-         * Perform the query
-         */
-        return this->getRelationRecords(
-            relations[0],
-            record,
-            parameters,
-            method
-        );
-    }
-
-    /**
-     * Gets hasMany related records from a model
-     */
-    public function getHasManyRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
-        -> <ResultsetInterface> | bool
-    {
-        var relations;
-        string keyRelation;
-
-        /**
-         * Check if there is a relation between them
-         */
-        let keyRelation = strtolower(modelName) . "$" . strtolower(modelRelation);
-
-        if !fetch relations, this->hasMany[keyRelation] {
-            return false;
-        }
-
-        /**
-         * "relations" is an array with all the hasMany relationships to that model
-         * Perform the query
-         */
-        return this->getRelationRecords(
-            relations[0],
-            record,
-            parameters,
-            method
-        );
-    }
-
-    /**
-     * Gets belongsTo related records from a model
-     */
-    public function getHasOneRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
-        -> <ModelInterface> | bool
-    {
-        var relations;
-        string keyRelation;
-
-        /**
-         * Check if there is a relation between them
-         */
-        let keyRelation = strtolower(modelName) . "$" . strtolower(modelRelation);
-
-        if !fetch relations, this->hasOne[keyRelation] {
-            return false;
-        }
-
-        /**
-         * "relations" is an array with all the belongsTo relationships to that model
-         * Perform the query
-         */
-        return this->getRelationRecords(
-            relations[0],
-            record,
-            parameters,
-            method
-        );
-    }
-
-    /**
-     * Gets all the belongsTo relations defined in a model
-     *
-     *```php
-     * $relations = $modelsManager->getBelongsTo(
-     *     new Robots()
-     * );
-     *```
-     */
-    public function getBelongsTo(<ModelInterface> model) -> <RelationInterface[]> | array
-    {
-        var relations;
-
-        if !fetch relations, this->belongsToSingle[get_class_lower(model)] {
-            return [];
-        }
-
-        return relations;
-    }
-
-    /**
-     * Gets hasMany relations defined on a model
-     */
-    public function getHasMany(<ModelInterface> model) -> <RelationInterface[]> | array
-    {
-        var relations;
-
-        if !fetch relations, this->hasManySingle[get_class_lower(model)] {
-            return [];
-        }
-
-        return relations;
-    }
-
-    /**
-     * Gets hasOne relations defined on a model
-     */
-    public function getHasOne(<ModelInterface> model) -> array
-    {
-        var relations;
-
-        if !fetch relations, this->hasOneSingle[get_class_lower(model)] {
-            return [];
-        }
-
-        return relations;
-    }
-
-    /**
-     * Gets hasOneThrough relations defined on a model
-     */
-    public function getHasOneThrough(<ModelInterface> model) -> <RelationInterface[]> | array
-    {
-        var relations;
-
-        if !fetch relations, this->hasOneThroughSingle[get_class_lower(model)] {
-            return [];
-        }
-
-        return relations;
-    }
-
-    /**
-     * Gets hasManyToMany relations defined on a model
-     */
-    public function getHasManyToMany(<ModelInterface> model) -> <RelationInterface[]> | array
-    {
-        var relations;
-
-        if !fetch relations, this->hasManyToManySingle[get_class_lower(model)] {
-            return [];
-        }
-
-        return relations;
-    }
-
-    /**
-     * Gets hasOne relations defined on a model
-     */
-    public function getHasOneAndHasMany(<ModelInterface> model) -> <RelationInterface[]>
-    {
-        return array_merge(
-            this->getHasOne(model),
-            this->getHasMany(model)
-        );
-    }
-
-    /**
      * Query all the relationships defined on a model
      */
     public function getRelations(string! modelName) -> <RelationInterface[]>
@@ -1954,88 +1560,519 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     }
 
     /**
-     * Creates a Phalcon\Mvc\Model\Query without execute it
+     * Returns a reusable object from the internal list
      */
-    public function createQuery(string! phql) -> <QueryInterface>
+    public function getReusableRecords(string! modelName, string! key)
     {
-        var container, query;
+        var records;
 
-        let container = this->container;
+        if !fetch records, this->reusable[key] {
+            return null;
+        }
 
-        if unlikely typeof container != "object" {
+        return records;
+    }
+
+    /**
+     * Returns the connection to write data related to a model
+     */
+    public function getWriteConnection(<ModelInterface> model) -> <AdapterInterface>
+    {
+        return this->getConnection(model, this->writeConnectionServices);
+    }
+
+    /**
+     * Returns the connection service name used to write data related to a model
+     */
+    public function getWriteConnectionService(<ModelInterface> model) -> string
+    {
+        return this->getConnectionService(
+            model,
+            this->writeConnectionServices
+        );
+    }
+
+    /**
+     * Checks whether a model has a belongsTo relation with another model
+     */
+    public function hasBelongsTo(string! modelName, string! modelRelation) -> bool
+    {
+        return this->checkHasRelationship("belongsTo", modelName, modelRelation);
+    }
+
+    /**
+     * Checks whether a model has a hasMany relation with another model
+     */
+    public function hasHasMany(string! modelName, string! modelRelation) -> bool
+    {
+        return this->checkHasRelationship("hasMany", modelName, modelRelation);
+    }
+
+    /**
+     * Checks whether a model has a hasManyToMany relation with another model
+     */
+    public function hasHasManyToMany(string! modelName, string! modelRelation) -> bool
+    {
+        return this->checkHasRelationship("hasManyToMany", modelName, modelRelation);
+    }
+    /**
+     * Checks whether a model has a hasOne relation with another model
+     */
+    public function hasHasOne(string! modelName, string! modelRelation) -> bool
+    {
+        return this->checkHasRelationship("hasOne", modelName, modelRelation);
+    }
+
+    /**
+     * Checks whether a model has a hasOneThrough relation with another model
+     */
+    public function hasHasOneThrough(string! modelName, string! modelRelation) -> bool
+    {
+        return this->checkHasRelationship("hasOneThrough", modelName, modelRelation);
+    }
+
+    /**
+     * Initializes a model in the model manager
+     */
+    public function initialize(<ModelInterface> model) -> bool
+    {
+        var className, eventsManager;
+
+        let className = get_class_lower(model);
+
+        /**
+         * Models are just initialized once per request
+         */
+        if isset this->initialized[className] {
+            return false;
+        }
+
+        /**
+         * Update the model as initialized, this avoid cyclic initializations
+         */
+        let this->initialized[className] = true;
+
+        /**
+         * Call the 'initialize' method if it's implemented
+         */
+        if method_exists(model, "initialize") {
+            model->{"initialize"}();
+        }
+
+        /**
+         * Update the last initialized model, so it can be used in
+         * modelsManager:afterInitialize
+         */
+        let this->lastInitialized = model;
+
+        /**
+         * If an EventsManager is available we pass to it every initialized
+         * model
+         */
+        let eventsManager = <EventsManagerInterface> this->eventsManager;
+
+        if typeof eventsManager == "object" {
+            eventsManager->fire("modelsManager:afterInitialize", this, model);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check whether a model is already initialized
+     */
+    public function isInitialized(string! className) -> bool
+    {
+        return isset this->initialized[strtolower(className)];
+    }
+
+    /**
+     * Checks if a model is keeping snapshots for the queried records
+     */
+    public function isKeepingSnapshots(<ModelInterface> model) -> bool
+    {
+        var isKeeping;
+
+        if !fetch isKeeping, this->keepSnapshots[get_class_lower(model)] {
+            return false;
+        }
+
+        return isKeeping;
+    }
+
+    /**
+     * Checks if a model is using dynamic update instead of all-field update
+     */
+    public function isUsingDynamicUpdate(<ModelInterface> model) -> bool
+    {
+        var isUsing;
+
+        if !fetch isUsing, this->dynamicUpdate[get_class_lower(model)] {
+            return false;
+        }
+
+        return isUsing;
+    }
+
+    /**
+     * Check whether a model property is declared as public.
+     *
+     * ```php
+     * $isPublic = $manager->isVisibleModelProperty(
+     *     new Robots(),
+     *     "name"
+     * );
+     * ```
+     */
+    final public function isVisibleModelProperty(<ModelInterface> model, string property) -> bool
+    {
+        var properties, className, publicProperties, classReflection,
+            reflectionProperties, reflectionProperty;
+
+        let className = get_class(model);
+
+        if !isset this->modelVisibility[className] {
+            let publicProperties = [];
+            let classReflection = new ReflectionClass(className);
+            let reflectionProperties = classReflection->getProperties(ReflectionProperty::IS_PUBLIC);
+            for reflectionProperty in reflectionProperties {
+                let publicProperties[reflectionProperty->name] = true;
+            }
+            let this->modelVisibility[className] = publicProperties;
+        }
+
+        let properties = this->modelVisibility[className];
+
+        return array_key_exists(property, properties);
+    }
+
+    /**
+     * Sets if a model must keep snapshots
+     */
+    public function keepSnapshots(<ModelInterface> model, bool keepSnapshots) -> void
+    {
+        let this->keepSnapshots[get_class_lower(model)] = keepSnapshots;
+    }
+
+    /**
+     * Loads a model throwing an exception if it doesn't exist
+     */
+    public function load(string! modelName) -> <ModelInterface>
+    {
+        var model;
+
+        /**
+         * The model doesn't exist throw an exception
+         */
+        if unlikely !class_exists(modelName) {
             throw new Exception(
-                "A dependency injection container is required to access the services related to the ORM"
+                "Model '" . modelName . "' could not be loaded"
             );
         }
 
         /**
-         * Create a query
+         * Load it using an autoloader
          */
-        let query = <QueryInterface> container->get(
-            "Phalcon\\Mvc\\Model\\Query",
-            [phql, container]
+        let model = create_instance_params(
+            modelName,
+            [
+                null,
+                this->container,
+                this
+            ]
         );
 
-        let this->lastQuery = query;
-
-        return query;
+        return model;
     }
 
     /**
-     * Creates a Phalcon\Mvc\Model\Query and execute it
-     *
-     * ```php
-     * $model = new Robots();
-     * $manager = $model->getModelsManager();
-     *
-     * // \Phalcon\Mvc\Model\Resultset\Simple
-     * $manager->executeQuery('SELECT * FROM Robots');
-     *
-     * // \Phalcon\Mvc\Model\Resultset\Complex
-     * $manager->executeQuery('SELECT COUNT(type) FROM Robots GROUP BY type');
-     *
-     * // \Phalcon\Mvc\Model\Query\StatusInterface
-     * $manager->executeQuery('INSERT INTO Robots (id) VALUES (1)');
-     *
-     * // \Phalcon\Mvc\Model\Query\StatusInterface
-     * $manager->executeQuery('UPDATE Robots SET id = 0 WHERE id = :id:', ['id' => 1]);
-     *
-     * // \Phalcon\Mvc\Model\Query\StatusInterface
-     * $manager->executeQuery('DELETE FROM Robots WHERE id = :id:', ['id' => 1]);
-     * ```
-     *
-     * @param array|null $placeholders
-     * @param array|null $types
-     * @return ResultsetInterface|StatusInterface
+     * Receives events generated in the models and dispatches them to an
+     * events-manager if available. Notify the behaviors that are listening in
+     * the model
      */
-    public function executeQuery(string! phql, var placeholders = null, var types = null) -> var
+    public function notifyEvent(string! eventName, <ModelInterface> model)
     {
-        var query;
+        var status, behavior, modelsBehaviors, eventsManager,
+            customEventsManager;
 
-        let query = this->createQuery(phql);
+        let status = null;
 
-        if typeof placeholders == "array" {
-            query->setBindParams(placeholders);
-        }
+        /**
+         * Dispatch events to the global events manager
+         */
+        if fetch modelsBehaviors, this->behaviors[get_class_lower(model)] {
+            /**
+             * Notify all the events on the behavior
+             */
+            for behavior in modelsBehaviors {
+                let status = behavior->notify(eventName, model);
 
-        if typeof types == "array" {
-            query->setBindTypes(types);
+                if status === false {
+                    return false;
+                }
+            }
         }
 
         /**
-         * Execute the query
+         * Dispatch events to the global events manager
          */
-        return query->execute();
+        let eventsManager = this->eventsManager;
+
+        if typeof eventsManager == "object" {
+            let status = eventsManager->fire(
+                "model:" . eventName,
+                model
+            );
+
+            if status === false {
+                return status;
+            }
+        }
+
+        /**
+         * A model can has a specific events manager for it
+         */
+        if fetch customEventsManager, this->customEventsManager[get_class_lower(model)] {
+            let status = customEventsManager->fire(
+                "model:" . eventName,
+                model
+            );
+
+            if status === false {
+                return false;
+            }
+        }
+
+        return status;
     }
 
     /**
-     * Creates a Phalcon\Mvc\Model\Query\Builder
-     *
-     * @param array|string|null params
+     * Dispatch an event to the listeners and behaviors
+     * This method expects that the endpoint listeners/behaviors returns true
+     * meaning that a least one was implemented
      */
-    public function createBuilder(var params = null) -> <BuilderInterface>
+    public function missingMethod(<ModelInterface> model, string! eventName, var data)
     {
-        var container;
+        var modelsBehaviors, result, eventsManager, behavior;
+
+        /**
+         * Dispatch events to the global events manager
+         */
+        if fetch modelsBehaviors, this->behaviors[get_class_lower(model)] {
+            /**
+             * Notify all the events on the behavior
+             */
+            for behavior in modelsBehaviors {
+                let result = behavior->missingMethod(model, eventName, data);
+
+                if result !== null {
+                    return result;
+                }
+            }
+        }
+
+        /**
+         * Dispatch events to the global events manager
+         */
+        let eventsManager = this->eventsManager;
+
+        if typeof eventsManager == "object" {
+            return eventsManager->fire(
+                "model:" . eventName,
+                model,
+                data
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Sets both write and read connection service for a model
+     */
+    public function setConnectionService(<ModelInterface> model, string! connectionService) -> void
+    {
+        this->setReadConnectionService(model, connectionService);
+        this->setWriteConnectionService(model, connectionService);
+    }
+
+    /**
+     * Sets a custom events manager for a specific model
+     */
+    public function setCustomEventsManager(<ModelInterface> model, <EventsManagerInterface> eventsManager) -> void
+    {
+        let this->customEventsManager[get_class_lower(model)] = eventsManager;
+    }
+
+    /**
+     * Sets the DependencyInjector container
+     */
+    public function setDI(<DiInterface> container) -> void
+    {
+        let this->container = container;
+    }
+
+    /**
+     * Sets a global events manager
+     */
+    public function setEventsManager(<EventsManagerInterface> eventsManager) -> void
+    {
+        let this->eventsManager = eventsManager;
+    }
+
+    /**
+     * Sets the prefix for all model sources.
+     *
+     * ```php
+     * use Phalcon\Mvc\Model\Manager;
+     *
+     * $di->set(
+     *     "modelsManager",
+     *     function () {
+     *         $modelsManager = new Manager();
+     *
+     *         $modelsManager->setModelPrefix("wp_");
+     *
+     *         return $modelsManager;
+     *     }
+     * );
+     *
+     * $robots = new Robots();
+     *
+     * echo $robots->getSource(); // wp_robots
+     * ```
+     */
+    public function setModelPrefix(string! prefix) -> void
+    {
+        let this->prefix = prefix;
+    }
+
+    /**
+     * Sets the mapped schema for a model
+     */
+    public function setModelSchema(<ModelInterface> model, string! schema) -> void
+    {
+        let this->schemas[get_class_lower(model)] = schema;
+    }
+
+    /**
+     * Sets the mapped source for a model
+     */
+    public function setModelSource(<ModelInterface> model, string! source) -> void
+    {
+        let this->sources[get_class_lower(model)] = source;
+    }
+
+    /**
+     * Sets read connection service for a model
+     */
+    public function setReadConnectionService(<ModelInterface> model, string! connectionService) -> void
+    {
+        let this->readConnectionServices[get_class_lower(model)] = connectionService;
+    }
+
+    /**
+     * Stores a reusable record in the internal list
+     */
+    public function setReusableRecords(string! modelName, string! key, var records) -> void
+    {
+        let this->reusable[key] = records;
+    }
+
+    /**
+     * Sets write connection service for a model
+     */
+    public function setWriteConnectionService(<ModelInterface> model, string! connectionService) -> void
+    {
+        let this->writeConnectionServices[get_class_lower(model)] = connectionService;
+    }
+
+    /**
+     * Sets if a model must use dynamic update instead of the all-field update
+     */
+    public function useDynamicUpdate(<ModelInterface> model, bool dynamicUpdate) -> void
+    {
+        var entityName;
+
+        let entityName = get_class_lower(model),
+            this->dynamicUpdate[entityName] = dynamicUpdate,
+            this->keepSnapshots[entityName] = dynamicUpdate;
+    }
+
+    /**
+     * Merge two arrays of find parameters
+     */
+    final protected function _mergeFindParameters(var findParamsOne, var findParamsTwo) -> array
+    {
+        var key, value;
+        array findParams;
+
+        let findParams = [];
+
+        if typeof findParamsOne == "string" {
+            let findParamsOne = [
+                "conditions": findParamsOne
+            ];
+        }
+
+        if typeof findParamsTwo == "string" {
+            let findParamsTwo = [
+                "conditions": findParamsTwo
+            ];
+        }
+
+        if typeof findParamsOne == "array"  {
+            for key, value in findParamsOne {
+                if key === 0 || key === "conditions" {
+                    if !isset findParams[0] {
+                        let findParams[0] = value;
+                    } else {
+                        let findParams[0] = "(" . findParams[0] . ") AND (" . value . ")";
+                    }
+                } else {
+                    let findParams[key] = value;
+                }
+            }
+        }
+
+        if typeof findParamsTwo == "array"  {
+            for key, value in findParamsTwo {
+                if key === 0 || key === "conditions" {
+                    if !isset findParams[0] {
+                        let findParams[0] = value;
+                    } else {
+                        let findParams[0] = "(" . findParams[0] . ") AND (" . value . ")";
+                    }
+                } elseif key === "bind" || key === "bindTypes" {
+                    if typeof value == "array" {
+                        if !isset findParams[key] {
+                            let findParams[key] = value;
+                        } else {
+                            let findParams[key] = array_merge(
+                                findParams[key],
+                                value
+                            );
+                        }
+                    }
+                } else {
+                    let findParams[key] = value;
+                }
+            }
+        }
+
+        return findParams;
+    }
+
+    /**
+     * Returns the connection to read or write data related to a model depending on the connection services.
+     *
+     * @return AdapterInterface
+     */
+    protected function getConnection(<ModelInterface> model, connectionServices) -> <AdapterInterface>
+    {
+        var container, service, connection;
+
+        let service = this->getConnectionService(model, connectionServices);
 
         let container = <DiInterface> this->container;
 
@@ -2046,33 +2083,15 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         }
 
         /**
-         * Gets Builder instance from DI container
+         * Request the connection service from the DI
          */
-        return <BuilderInterface> container->get(
-            "Phalcon\\Mvc\\Model\\Query\\Builder",
-            [
-                params,
-                container
-            ]
-        );
-    }
+        let connection = <AdapterInterface> container->getShared(service);
 
-    /**
-     * Returns the last query created or executed in the models manager
-     */
-    public function getLastQuery() -> <QueryInterface>
-    {
-        return this->lastQuery;
-    }
+        if unlikely typeof connection != "object" {
+            throw new Exception("Invalid injected connection service");
+        }
 
-    /**
-     * Destroys the current PHQL cache
-     */
-    public function __destruct()
-    {
-        phalcon_orm_destroy_cache();
-
-        Query::clean();
+        return connection;
     }
 
     private function checkHasRelationship(

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -159,6 +159,11 @@ interface ManagerInterface
     ) -> <ResultsetInterface> | bool;
 
     /**
+     * Returns the newly created Phalcon\Mvc\Model\Query\Builder or null
+     */
+    public function getBuilder() -> <BuilderInterface> | null;
+
+    /**
      * Gets hasMany relations defined on a model
      */
     public function getHasMany(<ModelInterface> model) -> <RelationInterface[]> | array;

--- a/phalcon/Mvc/RouterInterface.zep
+++ b/phalcon/Mvc/RouterInterface.zep
@@ -27,17 +27,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function add(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>;
-
-    /**
-     * Attach Route object to the routes stack.
-     *
-     * @param RouteInterface route
-     * @param int position
-     *
-     * @return RouterInterface
-     */
-    public function attach(<RouteInterface> route, int position = Router::POSITION_LAST) -> <RouterInterface>;
+    public function add(string! pattern, var paths = null, var httpMethods = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is CONNECT
@@ -47,7 +37,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addConnect(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addConnect(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is DELETE
@@ -57,7 +47,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addDelete(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addDelete(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is HEAD
@@ -67,7 +57,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addHead(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addHead(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is GET
@@ -77,7 +67,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addGet(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addGet(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Add a route to the router that only match if the HTTP method is OPTIONS
@@ -87,7 +77,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addOptions(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addOptions(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PATCH
@@ -97,7 +87,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPatch(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPatch(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is POST
@@ -107,7 +97,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPost(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPost(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PURGE
@@ -118,7 +108,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPurge(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPurge(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PUT
@@ -128,7 +118,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPut(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPut(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is TRACE
@@ -138,7 +128,17 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addTrace(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addTrace(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+
+    /**
+     * Attach Route object to the routes stack.
+     *
+     * @param RouteInterface route
+     * @param int position
+     *
+     * @return RouterInterface
+     */
+    public function attach(<RouteInterface> route, int position = Router::POSITION_LAST) -> <RouterInterface>;
 
     /**
      * Removes all the defined routes

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -32,7 +32,19 @@ class Redis extends AbstractAdapter
      * Redis constructor.
      *
      * @param SerializerFactory $factory
-     * @param array             $options
+     * @param array             $options = [
+     *     "host"           => "127.0.0.1",
+     *     "port"           => 6379,
+     *     "index"          => 0,
+     *     "timeout"        => 0,
+     *     "persistent"     => false,
+     *     "persistentId"   => "",
+     *     "auth"           => "",
+     *     "socket"         => "",
+     *     "connectTimeout" => 0,
+     *     "retryInterval"  => 0,
+     *     "readTimeout"    => 0,
+     * ]
      *
      * @throws SupportException
      */

--- a/phalcon/Storage/Adapter/Stream.zep
+++ b/phalcon/Storage/Adapter/Stream.zep
@@ -17,9 +17,6 @@ use Phalcon\Storage\Exception;
 use Phalcon\Storage\SerializerFactory;
 use Phalcon\Storage\Traits\StorageErrorHandlerTrait;
 use Phalcon\Support\Exception as SupportException;
-use Phalcon\Traits\Helper\Str\DirFromFileTrait;
-use Phalcon\Traits\Helper\Str\DirSeparatorTrait;
-use Phalcon\Traits\Php\FileTrait;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 

--- a/tests/database/Mvc/Model/Manager/CreateBuilderCest.php
+++ b/tests/database/Mvc/Model/Manager/CreateBuilderCest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Mvc\Model\Manager;
+
+use DatabaseTester;
+use Phalcon\Mvc\Model\ManagerInterface;
+use Phalcon\Mvc\Model\Query\StatusInterface;
+use Phalcon\Mvc\Model\Resultset\Complex;
+use Phalcon\Mvc\Model\Resultset\Simple;
+use Phalcon\Storage\Exception;
+use Phalcon\Tests\Fixtures\Traits\DiTrait;
+use Phalcon\Tests\Models\Invoices;
+
+use function spl_object_hash;
+
+class CreateBuilderCest
+{
+    use DiTrait;
+
+    /**
+     * Tests Phalcon\Mvc\Model\Manager :: createBuilder()
+     *
+     * @param  DatabaseTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-07-04
+     *
+     * @group  mysql
+     * @group  pgsql
+     */
+    public function mvcModelManagerCreateBuilder(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model\Manager :: executeQuery() - #15024');
+
+        $this->setNewFactoryDefault();
+        $this->setDatabase($I);
+
+        /** @var ManagerInterface $manager */
+        $manager = $this->getService('modelsManager');
+
+        $actual = $manager->getBuilder();
+        $I->assertNull($actual);
+
+        $builder    = $manager->createBuilder();
+        $getBuilder = $manager->getBuilder();
+        $expected   = spl_object_hash($builder);
+        $actual     = spl_object_hash($getBuilder);
+        $I->assertSame($expected, $actual);
+
+        $builder    = $manager->createBuilder();
+        $expected   = spl_object_hash($builder);
+        $I->assertNotSame($expected, $actual);
+    }
+}

--- a/tests/unit/Encryption/Crypt/EncryptBase64Cest.php
+++ b/tests/unit/Encryption/Crypt/EncryptBase64Cest.php
@@ -105,33 +105,4 @@ class EncryptBase64Cest
         $decrypted = $crypt->decryptBase64($encrypted, $key, true);
         $I->assertSame($source, $decrypted);
     }
-
-    /**
-     * Tests Phalcon\Encryption\Crypt :: encryptBase64() - safe
-     *
-     * @param UnitTester $I
-     *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2022-07-05
-     */
-    public function encryptionCryptEncryptBase64PhpVersions(UnitTester $I)
-    {
-        $I->wantToTest('Encryption\Crypt - encryptBase64() - php versions');
-
-        $key    = substr(md5(uniqid()), 0, 16);
-        $source = 'BvQrk+D^b&saR/L#mQig+8V9v^W&S/&moY7';
-
-        $crypt = new Crypt();
-        $crypt->setKey($key);
-
-        $encrypted = $crypt->encryptBase64($source);
-
-        $expected = 'wwj9F2tFQPF81WXtEEZxymsv+QxnqCJc7yc1nUz8YB+vpj/b5BoTWQmazy2FxWAroiJJfA==';
-        $actual   = $expected;
-        $I->assertSame($expected, $actual);
-
-        $expected = $source;
-        $actual   = $crypt->decryptBase64($encrypted);
-        $I->assertSame($expected, $actual);
-    }
 }

--- a/tests/unit/Encryption/Crypt/EncryptBase64Cest.php
+++ b/tests/unit/Encryption/Crypt/EncryptBase64Cest.php
@@ -105,4 +105,33 @@ class EncryptBase64Cest
         $decrypted = $crypt->decryptBase64($encrypted, $key, true);
         $I->assertSame($source, $decrypted);
     }
+
+    /**
+     * Tests Phalcon\Encryption\Crypt :: encryptBase64() - safe
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-07-05
+     */
+    public function encryptionCryptEncryptBase64PhpVersions(UnitTester $I)
+    {
+        $I->wantToTest('Encryption\Crypt - encryptBase64() - php versions');
+
+        $key    = substr(md5(uniqid()), 0, 16);
+        $source = 'BvQrk+D^b&saR/L#mQig+8V9v^W&S/&moY7';
+
+        $crypt = new Crypt();
+        $crypt->setKey($key);
+
+        $encrypted = $crypt->encryptBase64($source);
+
+        $expected = 'wwj9F2tFQPF81WXtEEZxymsv+QxnqCJc7yc1nUz8YB+vpj/b5BoTWQmazy2FxWAroiJJfA==';
+        $actual   = $expected;
+        $I->assertSame($expected, $actual);
+
+        $expected = $source;
+        $actual   = $crypt->decryptBase64($encrypted);
+        $I->assertSame($expected, $actual);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #15966 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Mvc\Model\ManagerInterface::getBuilder()` to return the existing builder (created by `createBuilder()`)
Added `Phalcon\Mvc\Model\Manager::getBuilder()` to return the existing builder (created by `createBuilder()`)

Thanks

