### PR TITLE
T16030 router getmatchedroute

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,11 @@
 - Reverted to single quotes when volt code generates PHP code.
 - Any `tag` helpers only accept parameters with double quotes
 - Renamed `Phalcon\Tag::form()` to `Phalcon\Tag::formLegacy` (helper `form_legacy`) [#16019](https://github.com/phalcon/cphalcon/issues/16019)
+- Fixed
+  - `Phalcon\Cli\Router::getMatchedRoute()`
+  - `Phalcon\Cli\RouterInterface::getMatchedRoute()`
+  - `Phalcon\Mvc\Router::getMatchedRoute()`
+  - `Phalcon\Mvc\RouterInterface::getMatchedRoute()` to return `RouterInterface` or `null` [#16030](https://github.com/phalcon/cphalcon/issues/16030)
 
 # [5.0.0rc3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0RC3) (2022-07-12)
 

--- a/phalcon/Cli/Router.zep
+++ b/phalcon/Cli/Router.zep
@@ -162,7 +162,7 @@ class Router extends AbstractInjectionAware
     /**
      * Returns the route that matches the handled URI
      */
-    public function getMatchedRoute() -> <RouteInterface>
+    public function getMatchedRoute() -> <RouteInterface> | null
     {
         return this->matchedRoute;
     }

--- a/phalcon/Cli/RouterInterface.zep
+++ b/phalcon/Cli/RouterInterface.zep
@@ -30,7 +30,7 @@ interface RouterInterface
     /**
      * Returns the route that matches the handled URI
      */
-    public function getMatchedRoute() -> <RouteInterface>;
+    public function getMatchedRoute() -> <RouteInterface> | null;
 
     /**
      * Return the sub expressions in the regular expression matched

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -497,7 +497,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     /**
      * Returns the route that matches the handled URI
      */
-    public function getMatchedRoute() -> <RouteInterface>
+    public function getMatchedRoute() -> <RouteInterface> | null
     {
         return this->matchedRoute;
     }

--- a/phalcon/Mvc/RouterInterface.zep
+++ b/phalcon/Mvc/RouterInterface.zep
@@ -158,7 +158,7 @@ interface RouterInterface
     /**
      * Returns the route that matches the handled URI
      */
-    public function getMatchedRoute() -> <RouteInterface>;
+    public function getMatchedRoute() -> <RouteInterface> | null;
 
     /**
      * Return the sub expressions in the regular expression matched


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16030 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed 
  - `Phalcon\Cli\Router::getMatchedRoute()` 
  - `Phalcon\Cli\RouterInterface::getMatchedRoute()` 
  - `Phalcon\Mvc\Router::getMatchedRoute()` 
  - `Phalcon\Mvc\RouterInterface::getMatchedRoute()` to return `RouterInterface` or `null` 


Thanks

