### PR TITLE
[BUG]: RawValue no longer supports mysql functions

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,7 +9,7 @@
   - `Phalcon\Cli\RouterInterface::getMatchedRoute()`
   - `Phalcon\Mvc\Router::getMatchedRoute()`
   - `Phalcon\Mvc\RouterInterface::getMatchedRoute()` to return `RouterInterface` or `null` [#16030](https://github.com/phalcon/cphalcon/issues/16030)
-- Fixed `Phalcon\Html\Helper\Title` to properly use indent and delimiter [#16037](https://github.com/phalcon/cphalcon/issues/16037)
+- Fixed `Phalcon\Mvc\Model::doLowUpdate()` prevent RawValue getting overwritten [#16037](https://github.com/phalcon/cphalcon/issues/16037)
 
 # [5.0.0rc3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0RC3) (2022-07-12)
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
   - `Phalcon\Cli\RouterInterface::getMatchedRoute()`
   - `Phalcon\Mvc\Router::getMatchedRoute()`
   - `Phalcon\Mvc\RouterInterface::getMatchedRoute()` to return `RouterInterface` or `null` [#16030](https://github.com/phalcon/cphalcon/issues/16030)
+- Fixed `Phalcon\Html\Helper\Title` to properly use indent and delimiter [#16037](https://github.com/phalcon/cphalcon/issues/16037)
 
 # [5.0.0rc3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0RC3) (2022-07-12)
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -3919,7 +3919,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         var automaticAttributes, attributeField, bindSkip, bindDataTypes,
             bindType, bindTypes, columnMap, dataType, dataTypes, field, fields,
             manager, nonPrimary, newSnapshot, success, primaryKeys, snapshot,
-            snapshotValue, uniqueKey, uniqueParams, uniqueTypes, value, values;
+            snapshotValue, uniqueKey, uniqueParams, uniqueTypes, value, values,
+            updateValue;
         bool changed, useDynamicUpdate;
 
         let bindSkip    = Column::BIND_SKIP,
@@ -4027,19 +4028,21 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                     if is_object(snapshotValue) && snapshotValue instanceof RawValue {
                                         let snapshotValue = snapshotValue->getValue();
                                     }
+
+                                    let updateValue = value;
                                     if is_object(value) && value instanceof RawValue {
-                                        let value = value->getValue();
+                                        let updateValue = value->getValue();
                                     }
 
                                     switch dataType {
 
                                         case Column::TYPE_BOOLEAN:
-                                            let changed = (bool) snapshotValue !== (bool) value;
+                                            let changed = (bool) snapshotValue !== (bool) updateValue;
                                             break;
 
                                         case Column::TYPE_DECIMAL:
                                         case Column::TYPE_FLOAT:
-                                            let changed = floatval(snapshotValue) !== floatval(value);
+                                            let changed = floatval(snapshotValue) !== floatval(updateValue);
                                             break;
 
                                         case Column::TYPE_INTEGER:
@@ -4050,14 +4053,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                         case Column::TYPE_TEXT:
                                         case Column::TYPE_VARCHAR:
                                         case Column::TYPE_BIGINTEGER:
-                                            let changed = (string) snapshotValue !== (string) value;
+                                            let changed = (string) snapshotValue !== (string) updateValue;
                                             break;
 
                                         /**
                                          * Any other type is not really supported...
                                          */
                                         default:
-                                            let changed = value != snapshotValue;
+                                            let changed = updateValue != snapshotValue;
                                     }
                                 }
                             }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/cphalcon/issues/16037

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
I've updated the changed check on the Model.zep to have a separate comparison variable instead of overwriting the value, overwriting the value with the `value->getValue()` is turning it into a string and causing issues deeper in the update at `phalcon\Db\Adapter\AbstractAdapter.zep:1198-1202`

Instead of the placeholders[] being something like:
```'`last_updated` = now()'```

It's passing:
```'`last_updated` = ?'``` and then passing `'now()'` in the bind parameters 

Thanks

