### PR TITLE
[BUG]: AbstractSerializer isSuccess never getting reset to true

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,7 +9,11 @@
   - `Phalcon\Cli\RouterInterface::getMatchedRoute()`
   - `Phalcon\Mvc\Router::getMatchedRoute()`
   - `Phalcon\Mvc\RouterInterface::getMatchedRoute()` to return `RouterInterface` or `null` [#16030](https://github.com/phalcon/cphalcon/issues/16030)
-
+- Fixed 
+  - `Phalcon/Storage/Serializer/Base64::unserialize()`
+  - `Phalcon/Storage/Serializer/Igbinary::unserialize()`
+  - `Phalcon/Storage/Serializer/Igbinary::serialize()`
+  - `Phalcon/Storage/Serializer/Php::unserialize()` to reset isSuccess value [#16040](https://github.com/phalcon/cphalcon/issues/16040)
 # [5.0.0rc3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0RC3) (2022-07-12)
 
 ## Fixed

--- a/phalcon/Storage/Serializer/Base64.zep
+++ b/phalcon/Storage/Serializer/Base64.zep
@@ -52,6 +52,8 @@ class Base64 extends AbstractSerializer
         if unlikely false === result {
             let this->isSuccess = false,
                 result          = "";
+        } else {
+            let this->isSuccess = true;
         }
 
         let this->data = result;

--- a/phalcon/Storage/Serializer/Igbinary.zep
+++ b/phalcon/Storage/Serializer/Igbinary.zep
@@ -30,6 +30,8 @@ class Igbinary extends AbstractSerializer
         if unlikely null === result {
             let this->isSuccess = false,
                 result          = "";
+        } else {
+            let this->isSuccess = true;
         }
 
         return result;
@@ -75,6 +77,8 @@ class Igbinary extends AbstractSerializer
             if unlikely globals_get("warning.enable") || false === result {
                 let this->isSuccess = false,
                     result          = "";
+            } else {
+                let this->isSuccess = true;
             }
 
             let this->data = result;

--- a/phalcon/Storage/Serializer/Php.zep
+++ b/phalcon/Storage/Serializer/Php.zep
@@ -70,6 +70,8 @@ class Php extends AbstractSerializer
         if unlikely globals_get("warning.enable") || result === false {
             let this->isSuccess = false,
                 result          = "";
+        } else {
+            let this->isSuccess = true;
         }
 
         let this->data = result;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16040

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Since AbstractSerializer isSuccess is initiated with the class and is set as true and is only is updated to false, if it fails to unserialize one bit of data the rest will also return isSuccess as false but getData will return valid data.

Thanks

