### PR TITLE
[BUG]: Paginator Model Adapter Incorrect total items when grouped

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
   - `Phalcon\Cli\RouterInterface::getMatchedRoute()`
   - `Phalcon\Mvc\Router::getMatchedRoute()`
   - `Phalcon\Mvc\RouterInterface::getMatchedRoute()` to return `RouterInterface` or `null` [#16030](https://github.com/phalcon/cphalcon/issues/16030)
+- Fixed `Phalcon\Paginator\Adapter\Model::paginate()` fix group parameter breaking total items [#16042](https://github.com/phalcon/cphalcon/issues/16042)
 
 # [5.0.0rc3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0RC3) (2022-07-12)
 

--- a/phalcon/Paginator/Adapter/Model.zep
+++ b/phalcon/Paginator/Adapter/Model.zep
@@ -89,7 +89,8 @@ class Model extends AbstractAdapter
      */
     public function paginate() -> <RepositoryInterface>
     {
-        var config, modelClass, parameters, pageItems = [];
+        var config, modelClass, parameters, rowCountResult,
+         pageItems = [];
         int pageNumber, limit, rowcount, next, totalPages,
             previous;
 
@@ -111,7 +112,14 @@ class Model extends AbstractAdapter
             let pageNumber = 1;
         }
 
-        let rowcount = (int) call_user_func([modelClass, "count"], parameters);
+        // This can return int or ResultsetInterface if it's grouped
+        let rowCountResult = call_user_func([modelClass, "count"], parameters);
+
+        if typeof rowCountResult == "object" {
+            let rowcount = (int) rowCountResult->count();
+        } else {
+            let rowcount = (int) rowCountResult;
+        }
 
         if rowcount % limit != 0 {
             let totalPages = (int) (rowcount / limit + 1);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16042

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
when the parameters include a group, it will return a simple result instead of an int.

This is currently getting type cast to int which will return 1 for simple result.
`call_user_func([modelClass, "count"], parameters);`

Now it will check if it's an object and if it is get the count from that.

Thanks

