### PR TITLE
setcookie() Passing null to parameter #2 ($value) of type string

### DIFF
--- a/phalcon/Http/Cookie.zep
+++ b/phalcon/Http/Cookie.zep
@@ -157,7 +157,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
             options["secure"]   = this->getArrVal(options, "secure", secure),
             options["httponly"] = this->getArrVal(options, "httponly", httpOnly);
 
-        setcookie(name, null, options);
+        setcookie(name, "", options);
     }
 
     /**


### PR DESCRIPTION
Hello!

Type: bug fix bug fix
Link to issue: [setcookie() Passing null to parameter #2 ($value) - issue 16053](https://github.com/phalcon/cphalcon/issues/16053)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change





setcookie() Passing null to parameter #2 ($value) of type string is deprecated

