### PR TITLE
T16072 logger stream no lock

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,8 @@
 # [x.x.x](https://github.com/phalcon/cphalcon/releases/tag/vx.x.x) (xxxx-xx-xx)
 
+## Changed
+- Changed `Phalcon\Logger\Adapter\Stream::process` to open the log file, check for locks, write contents and close the stream [#16072](https://github.com/phalcon/cphalcon/issues/16072) 
+
 ## Fixed
 - Fixed and improved return type of `object` & `?object` [#16023](https://github.com/phalcon/cphalcon/issues/16023)
 - Fixed `Phalcon\Filter\Validation\Validator\Digit` to use only strings for `ctype_*` calls [#16064](https://github.com/phalcon/cphalcon/issues/16064)

--- a/phalcon/Logger/Adapter/Stream.zep
+++ b/phalcon/Logger/Adapter/Stream.zep
@@ -29,20 +29,12 @@ use Phalcon\Logger\Item;
  * $logger->close();
  *```
  *
- * @property resource|null $handler
  * @property string        $mode
  * @property string        $name
  * @property array         $options
  */
 class Stream extends AbstractAdapter
 {
-    /**
-     * Stream handler resource
-     *
-     * @var resource|null
-     */
-    protected handler = null;
-
     /**
      * The file open mode. Defaults to 'ab'
      *
@@ -93,15 +85,7 @@ class Stream extends AbstractAdapter
      */
     public function close() -> bool
     {
-        bool result = true;
-
-        if is_resource(this->handler) {
-            let result = fclose(this->handler);
-        }
-
-        let this->handler = null;
-
-        return result;
+        return true;
     }
 
     /**
@@ -111,27 +95,26 @@ class Stream extends AbstractAdapter
      */
     public function process(<Item> item) -> void
     {
-        var message;
+        var handler, message;
 
-        if !is_resource(this->handler) {
-            let this->handler = this->phpFopen(this->name, this->mode);
+        let handler = this->phpFopen(this->name, this->mode);
 
-            if !is_resource(this->handler) {
-                let this->handler = null;
-
-                throw new LogicException(
-                    "The file '" .
-                    this->name .
-                    "' cannot be opened with mode '" .
-                    this->mode .
-                    "'"
-                );
-            }
+        if !is_resource(handler) {
+            throw new LogicException(
+                "The file '" .
+                this->name .
+                "' cannot be opened with mode '" .
+                this->mode .
+                "'"
+            );
         }
 
-        let message = this->getFormattedItem(item) . PHP_EOL;
+        if (flock(handler, LOCK_SH)) {
+            let message = this->getFormattedItem(item) . PHP_EOL;
+            fwrite(handler, message);
+        }
 
-        fwrite(this->handler, message);
+        fclose(handler);
     }
 
     /**

--- a/phalcon/Logger/Adapter/Stream.zep
+++ b/phalcon/Logger/Adapter/Stream.zep
@@ -109,10 +109,12 @@ class Stream extends AbstractAdapter
             );
         }
 
-        if (flock(handler, LOCK_SH)) {
-            let message = this->getFormattedItem(item) . PHP_EOL;
-            fwrite(handler, message);
-        }
+        /**
+         * Not much we can do about locking
+         */
+        flock(handler, LOCK_EX);
+        let message = this->getFormattedItem(item) . PHP_EOL;
+        fwrite(handler, message);
 
         fclose(handler);
     }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #16072 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Logger\Adapter\Stream::process` to open the log file, check for locks, write contents and close the stream

Thanks

