### PR TITLE
T16108 escaper attributes

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,7 @@
 - Changed `Phalcon\Logger\Adapter\Stream::process` to open the log file, check for locks, write contents and close the stream [#16072](https://github.com/phalcon/cphalcon/issues/16072) 
 - Changed getters and setters from shorthand format to full methods [#16102](https://github.com/phalcon/cphalcon/issues/16102)
 - Changed return types to `array` in `Phalcon\Annotations\Reflection` class methods [#16106](https://github.com/phalcon/cphalcon/issues/16106)
+- Changed `Phalcon\Html\Escaper::attributes()` to also accept an array of attributes [#16108](https://github.com/phalcon/cphalcon/issues/16108)
 
 ## Fixed
 - Fixed and improved return type of `object` & `?object` [#16023](https://github.com/phalcon/cphalcon/issues/16023)

--- a/phalcon/Html/Escaper.zep
+++ b/phalcon/Html/Escaper.zep
@@ -49,20 +49,55 @@ class Escaper implements EscaperInterface
     protected flags = 11;
 
     /**
-     * Escapes a HTML attribute string
+     * Escapes a HTML attribute string or array
      *
-     * @param string $input
+     * If the input is an array, the keys are the attribute names and the
+     * values are attribute values. If a value is boolean (true/false) then
+     * the attribute will have no value:
+     * `['disabled' => true]` -> `'disabled``
+     *
+     * The resulting string will have attribute pairs separated by a space.
+     *
+     * @param array|string $input
      *
      * @return string
      */
-    public function attributes(string input) -> string
+    public function attributes(var input) -> string
     {
-        return htmlspecialchars(
-            input,
-            ENT_QUOTES,
-            this->encoding,
-            this->doubleEncode
-        );
+        var key, result, value;
+
+        if (typeof input !== "string" && typeof input !== "array") {
+            throw new Exception("Input must be an array or a string");
+        }
+
+        if (typeof input === "string") {
+            return this->phpHtmlSpecialChars(input);
+        }
+
+        let result = "";
+        for key, value in input {
+            if (null === value || false === value) {
+                continue;
+            }
+
+            let key = trim(key);
+
+            if (typeof value === "array") {
+                let value = implode(" ", value);
+            }
+
+            let result .= this->phpHtmlSpecialChars(key);
+
+            if (true !== value) {
+                let result .= "=\""
+                    . this->phpHtmlSpecialChars(value)
+                    . "\"";
+            }
+
+            let result .= " ";
+        }
+
+        return rtrim(result);
     }
 
     /**
@@ -340,6 +375,23 @@ class Escaper implements EscaperInterface
     public function url(string input) -> string
     {
         return rawurlencode(input);
+    }
+
+    /**
+     * Proxy method for testing
+     *
+     * @param string $input
+     *
+     * @return string
+     */
+    protected function phpHtmlSpecialChars(string input) -> string
+    {
+        return htmlspecialchars(
+            input,
+            ENT_QUOTES,
+            this->encoding,
+            this->doubleEncode
+        );
     }
 
     /**

--- a/tests/_config/generate-api-docs.php
+++ b/tests/_config/generate-api-docs.php
@@ -49,8 +49,6 @@ foreach ($documents as $document) {
     echo 'Processing: ' . $document['title'] . PHP_EOL;
     $output = "---
 layout: default
-language: 'en'
-version: '4.0'
 title: '{$document['title']}'
 ---
 ";
@@ -88,7 +86,7 @@ title: '{$document['title']}'
 
 <h1 id=\"{$href}\">{$signature}</h1>
 
-[Source on GitHub](https://github.com/phalcon/cphalcon/blob/v{{ page.version }}.0/phalcon/{$github})
+[Source on GitHub](https://github.com/phalcon/cphalcon/blob/v{{ pageVersion }}.0/phalcon/{$github})
 ";
 
         if (!empty($namespace)) {

--- a/tests/unit/Html/Escaper/AttributesCest.php
+++ b/tests/unit/Html/Escaper/AttributesCest.php
@@ -25,7 +25,7 @@ use const ENT_XML1;
 class AttributesCest
 {
     /**
-     * Tests Phalcon\Escaper :: escapeHtmlAttr()
+     * Tests Phalcon\Escaper :: attributes()
      *
      * @dataProvider escaperEscapeHtmlAttrProvider
      *
@@ -44,13 +44,10 @@ class AttributesCest
         $text  = $example['text'];
         $flags = $example['htmlQuoteType'];
 
-        $escaper->setHtmlQuoteType($flags);
+        $escaper->setFlags($flags);
 
         $expected = $example['expected'];
         $actual   = $escaper->attributes($text);
-        $I->assertSame($expected, $actual);
-
-        $actual = $escaper->escapeHtmlAttr($text);
         $I->assertSame($expected, $actual);
     }
 
@@ -65,23 +62,31 @@ class AttributesCest
                 'expected'      => 'That&#039;s right',
                 'text'          => "That's right",
             ],
-
             [
                 'htmlQuoteType' => ENT_XML1,
                 'expected'      => 'That&#039;s right',
                 'text'          => "That's right",
             ],
-
             [
                 'htmlQuoteType' => ENT_XHTML,
                 'expected'      => 'That&#039;s right',
                 'text'          => "That's right",
             ],
-
             [
                 'htmlQuoteType' => ENT_HTML5,
                 'expected'      => 'That&#039;s right',
                 'text'          => "That's right",
+            ],
+            [
+                'htmlQuoteType' => ENT_HTML5,
+                'expected'      => 'text="Ferrari Ford Dodge"',
+                'text'          => [
+                    'text' => [
+                        'Ferrari',
+                        'Ford',
+                        'Dodge',
+                    ],
+                ],
             ],
         ];
     }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #16108 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Html\Escaper::attributes()` to also accept an array of attributes

Thanks

