### PR TITLE
T16123 html attributes

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,3 +1,9 @@
+# [5.0.2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.2) (2022-09-27)
+
+## Fixed
+- Fixed `Phalcon\Html\Escaper::attributes()` to accept any value and transform it to string [#16123](https://github.com/phalcon/cphalcon/issues/16123)
+- Fixed `Phalcon\Logger\AbstractLogger::getLevelNumber()` to better check for string levels [#16123](https://github.com/phalcon/cphalcon/issues/16123)
+
 # [5.0.1](https://github.com/phalcon/cphalcon/releases/tag/v5.0.1) (2022-09-23)
 
 ## Fixed

--- a/phalcon/Html/Escaper.zep
+++ b/phalcon/Html/Escaper.zep
@@ -66,12 +66,8 @@ class Escaper implements EscaperInterface
     {
         var key, result, value;
 
-        if (typeof input !== "string" && typeof input !== "array") {
-            throw new Exception("Input must be an array or a string");
-        }
-
-        if (typeof input === "string") {
-            return this->phpHtmlSpecialChars(input);
+        if likely (typeof input !== "array") {
+            return this->phpHtmlSpecialChars((string) input);
         }
 
         let result = "";
@@ -86,11 +82,11 @@ class Escaper implements EscaperInterface
                 let value = implode(" ", value);
             }
 
-            let result .= this->phpHtmlSpecialChars(key);
+            let result .= this->phpHtmlSpecialChars((string) key);
 
             if (true !== value) {
                 let result .= "=\""
-                    . this->phpHtmlSpecialChars(value)
+                    . this->phpHtmlSpecialChars((string) value)
                     . "\"";
             }
 

--- a/phalcon/Logger/AbstractLogger.zep
+++ b/phalcon/Logger/AbstractLogger.zep
@@ -313,14 +313,14 @@ abstract class AbstractLogger
      *
      * @return int
      */
-    protected function getLevelNumber(level) -> int
+    protected function getLevelNumber(var level) -> int
     {
         var levelName, levels;
 
         /**
          * If someone uses "critical" as the level (string)
          */
-        if (true === is_string(level)) {
+        if (typeof level === "string") {
             let levelName = strtoupper(level),
                 levels    = array_flip(this->getLevels());
 

--- a/tests/unit/Html/Escaper/AttributesCest.php
+++ b/tests/unit/Html/Escaper/AttributesCest.php
@@ -79,6 +79,24 @@ class AttributesCest
             ],
             [
                 'htmlQuoteType' => ENT_HTML5,
+                'expected'      => '10',
+                'text'          => 10,
+            ],
+            [
+                'htmlQuoteType' => ENT_HTML5,
+                'expected'      => 'maxlength="10" cols="5" rows="3" min="1" max="100"',
+                'text'          => [
+                    'maxlength'  => 10,
+                    'cols'       => 5,
+                    'rows'       => 3,
+                    'min'        => 1,
+                    'max'        => 100,
+                    'notPrinted'  => false,
+                    'notPrinted2' => null,
+                ],
+            ],
+            [
+                'htmlQuoteType' => ENT_HTML5,
                 'expected'      => 'text="Ferrari Ford Dodge"',
                 'text'          => [
                     'text' => [


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16123 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Html\Escaper::attributes()` to accept any value and transform it to string 
Fixed `Phalcon\Logger\AbstractLogger::getLevelNumber()` to better check for string levels

Thanks

