### PR TITLE
T16134 escaper flags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,8 @@ jobs:
         include:
           # Linux
           - { name: ubuntu-gcc, os: ubuntu-18.04, compiler: gcc }
-          # macOS
-          - { name: macos-clang, os: macos-11, compiler: clang }
+#          # macOS
+#          - { name: macos-clang, os: macos-11, compiler: clang }
           # Windows
           - { php: '7.4', ts: 'ts',  arch: 'x64', name: 'windows2019-vc15', os: 'windows-2019', compiler: 'vc15' }
           - { php: '7.4', ts: 'nts', arch: 'x64', name: 'windows2019-vc15', os: 'windows-2019', compiler: 'vc15' }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
 
         name:
           - ubuntu-gcc
-          - macos-clang
+#          - macos-clang
 
         # matrix names should be in next format:
         #     {php}-{ts}-{os.name}-{compiler}-{arch}
@@ -142,11 +142,11 @@ jobs:
         with:
           pecl: ./phalcon-pecl/phalcon-pecl.tgz
 
-      - name: Build Phalcon Extension (macOS)
-        uses: ./.github/actions/build-phalcon-mac
-        if: runner.os == 'macOS'
-        with:
-          pecl: ./phalcon-pecl/phalcon-pecl.tgz
+#      - name: Build Phalcon Extension (macOS)
+#        uses: ./.github/actions/build-phalcon-mac
+#        if: runner.os == 'macOS'
+#        with:
+#          pecl: ./phalcon-pecl/phalcon-pecl.tgz
 
       - name: Build Phalcon Extension (Windows)
         uses: ./.github/actions/build-phalcon-win

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ on:
 
 env:
   # All versions should be declared here
-  PHALCON_VERSION: 5.0.1
+  PHALCON_VERSION: 5.0.2
   ZEPHIR_PARSER_VERSION: 1.5.1
   ZEPHIR_VERSION: 0.16.3
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,3 +1,8 @@
+# [5.0.3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.3) (xxxx-xx-xx)
+
+## Fixed
+- Fixed `Phalcon\Html\Escaper::attributes()` to honor the `$flags` set for `htmlspecialchars()` [#16134](https://github.com/phalcon/cphalcon/issues/16134)
+
 # [5.0.2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.2) (2022-09-27)
 
 ## Fixed

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,3 +1,9 @@
+# [5.0.2](https://github.com/phalcon/cphalcon/releases/tag/v5.0.2) (2022-09-27)
+
+## Fixed
+- Fixed `Phalcon\Html\Escaper::attributes()` to accept any value and transform it to string [#16123](https://github.com/phalcon/cphalcon/issues/16123)
+- Fixed `Phalcon\Logger\AbstractLogger::getLevelNumber()` to better check for string levels [#16123](https://github.com/phalcon/cphalcon/issues/16123)
+
 # [5.0.1](https://github.com/phalcon/cphalcon/releases/tag/v5.0.1) (2022-09-23)
 
 ## Fixed

--- a/build/phalcon/php_phalcon.h
+++ b/build/phalcon/php_phalcon.h
@@ -103,7 +103,7 @@ typedef zend_function zephir_fcall_cache_entry;
 
 
 #define PHP_PHALCON_NAME        "phalcon"
-#define PHP_PHALCON_VERSION     "5.0.1"
+#define PHP_PHALCON_VERSION     "5.0.2"
 #define PHP_PHALCON_EXTNAME     "phalcon"
 #define PHP_PHALCON_AUTHOR      "Phalcon Team and contributors"
 #define PHP_PHALCON_ZEPVERSION  "0.16.3-5099f34"

--- a/composer.lock
+++ b/composer.lock
@@ -3339,16 +3339,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.24",
+            "version": "9.5.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5"
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
-                "reference": "d0aa6097bef9fd42458a9b3c49da32c6ce6129c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
                 "shasum": ""
             },
             "require": {
@@ -3370,14 +3370,14 @@
                 "phpunit/php-timer": "^5.0.2",
                 "sebastian/cli-parser": "^1.0.1",
                 "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.5",
+                "sebastian/comparator": "^4.0.8",
                 "sebastian/diff": "^4.0.3",
                 "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.3",
+                "sebastian/exporter": "^4.0.5",
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.1",
+                "sebastian/type": "^3.2",
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
@@ -3421,7 +3421,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.24"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
             },
             "funding": [
                 {
@@ -3431,9 +3431,13 @@
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-08-30T07:42:16+00:00"
+            "time": "2022-09-25T03:44:45+00:00"
         },
         {
             "name": "predis/predis",
@@ -4996,16 +5000,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.12",
+            "version": "v5.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c072aa8f724c3af64e2c7a96b796a4863d24dba1"
+                "reference": "3f97f6c7b7e26848a90c0c0cfb91eeb2bb8618be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c072aa8f724c3af64e2c7a96b796a4863d24dba1",
-                "reference": "c072aa8f724c3af64e2c7a96b796a4863d24dba1",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3f97f6c7b7e26848a90c0c0cfb91eeb2bb8618be",
+                "reference": "3f97f6c7b7e26848a90c0c0cfb91eeb2bb8618be",
                 "shasum": ""
             },
             "require": {
@@ -5075,7 +5079,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.12"
+                "source": "https://github.com/symfony/console/tree/v5.4.13"
             },
             "funding": [
                 {
@@ -5091,7 +5095,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-17T13:18:05+00:00"
+            "time": "2022-08-26T13:50:20+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -5467,16 +5471,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.12",
+            "version": "v5.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "2d67c1f9a1937406a9be3171b4b22250c0a11447"
+                "reference": "ac09569844a9109a5966b9438fc29113ce77cf51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2d67c1f9a1937406a9be3171b4b22250c0a11447",
-                "reference": "2d67c1f9a1937406a9be3171b4b22250c0a11447",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ac09569844a9109a5966b9438fc29113ce77cf51",
+                "reference": "ac09569844a9109a5966b9438fc29113ce77cf51",
                 "shasum": ""
             },
             "require": {
@@ -5511,7 +5515,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.12"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.13"
             },
             "funding": [
                 {
@@ -5527,7 +5531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-02T13:48:16+00:00"
+            "time": "2022-09-21T19:53:16+00:00"
         },
         {
             "name": "symfony/finder",
@@ -6379,16 +6383,16 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v5.4.5",
+            "version": "v5.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "4d04b5c24f3c9a1a168a131f6cbe297155bc0d30"
+                "reference": "6df7a3effde34d81717bbef4591e5ffe32226d69"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/4d04b5c24f3c9a1a168a131f6cbe297155bc0d30",
-                "reference": "4d04b5c24f3c9a1a168a131f6cbe297155bc0d30",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/6df7a3effde34d81717bbef4591e5ffe32226d69",
+                "reference": "6df7a3effde34d81717bbef4591e5ffe32226d69",
                 "shasum": ""
             },
             "require": {
@@ -6421,7 +6425,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v5.4.5"
+                "source": "https://github.com/symfony/stopwatch/tree/v5.4.13"
             },
             "funding": [
                 {
@@ -6437,20 +6441,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-02-18T16:06:09+00:00"
+            "time": "2022-09-28T13:19:49+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.4.12",
+            "version": "v5.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "2fc515e512d721bf31ea76bd02fe23ada4640058"
+                "reference": "2900c668a32138a34118740de3e4d5a701801f53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/2fc515e512d721bf31ea76bd02fe23ada4640058",
-                "reference": "2fc515e512d721bf31ea76bd02fe23ada4640058",
+                "url": "https://api.github.com/repos/symfony/string/zipball/2900c668a32138a34118740de3e4d5a701801f53",
+                "reference": "2900c668a32138a34118740de3e4d5a701801f53",
                 "shasum": ""
             },
             "require": {
@@ -6507,7 +6511,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v5.4.12"
+                "source": "https://github.com/symfony/string/tree/v5.4.13"
             },
             "funding": [
                 {
@@ -6523,7 +6527,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-12T17:03:11+00:00"
+            "time": "2022-09-01T01:52:16+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -6652,16 +6656,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.44.6",
+            "version": "v1.44.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "ae39480f010ef88adc7938503c9b02d3baf2f3b3"
+                "reference": "0887422319889e442458e48e2f3d9add1a172ad5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ae39480f010ef88adc7938503c9b02d3baf2f3b3",
-                "reference": "ae39480f010ef88adc7938503c9b02d3baf2f3b3",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/0887422319889e442458e48e2f3d9add1a172ad5",
+                "reference": "0887422319889e442458e48e2f3d9add1a172ad5",
                 "shasum": ""
             },
             "require": {
@@ -6714,7 +6718,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v1.44.6"
+                "source": "https://github.com/twigphp/Twig/tree/v1.44.7"
             },
             "funding": [
                 {
@@ -6726,7 +6730,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-11-25T13:31:46+00:00"
+            "time": "2022-09-28T08:38:36+00:00"
         },
         {
             "name": "vimeo/psalm",

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "name": "phalcon",
   "description": "Phalcon is a full stack PHP framework, delivered as a PHP extension, offering lower resource consumption and high performance.",
   "author": "Phalcon Team and contributors",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "verbose": false,
   "stubs": {
     "path": "ide\/%version%\/%namespace%\/",

--- a/ext/phalcon/html/escaper.zep.c
+++ b/ext/phalcon/html/escaper.zep.c
@@ -12,10 +12,9 @@
 #include <Zend/zend_interfaces.h>
 
 #include "kernel/main.h"
-#include "kernel/exception.h"
 #include "kernel/fcall.h"
-#include "kernel/memory.h"
 #include "kernel/operators.h"
+#include "kernel/memory.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
 #include "kernel/object.h"
@@ -86,12 +85,13 @@ ZEPHIR_INIT_CLASS(Phalcon_Html_Escaper)
  */
 PHP_METHOD(Phalcon_Html_Escaper, attributes)
 {
+	zend_bool _5$$4, _13$$8;
+	zval _0$$3, _9$$4, _11$$7, _17$$8, _19$$11;
 	zend_string *_4;
 	zend_ulong _3;
-	zend_bool _0, _5$$5, _11$$9;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *input, input_sub, key, result, value, *_1, _2, _6$$5, _8$$5, _7$$7, _9$$8, _10$$8, _12$$9, _14$$9, _13$$11, _15$$12, _16$$12;
+	zval *input, input_sub, key, result, value, *_1, _2, _6$$4, _8$$4, _7$$6, _10$$7, _12$$7, _14$$8, _16$$8, _15$$10, _18$$11, _20$$11;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&input_sub);
@@ -99,16 +99,21 @@ PHP_METHOD(Phalcon_Html_Escaper, attributes)
 	ZVAL_UNDEF(&result);
 	ZVAL_UNDEF(&value);
 	ZVAL_UNDEF(&_2);
-	ZVAL_UNDEF(&_6$$5);
-	ZVAL_UNDEF(&_8$$5);
-	ZVAL_UNDEF(&_7$$7);
-	ZVAL_UNDEF(&_9$$8);
-	ZVAL_UNDEF(&_10$$8);
-	ZVAL_UNDEF(&_12$$9);
-	ZVAL_UNDEF(&_14$$9);
-	ZVAL_UNDEF(&_13$$11);
-	ZVAL_UNDEF(&_15$$12);
-	ZVAL_UNDEF(&_16$$12);
+	ZVAL_UNDEF(&_6$$4);
+	ZVAL_UNDEF(&_8$$4);
+	ZVAL_UNDEF(&_7$$6);
+	ZVAL_UNDEF(&_10$$7);
+	ZVAL_UNDEF(&_12$$7);
+	ZVAL_UNDEF(&_14$$8);
+	ZVAL_UNDEF(&_16$$8);
+	ZVAL_UNDEF(&_15$$10);
+	ZVAL_UNDEF(&_18$$11);
+	ZVAL_UNDEF(&_20$$11);
+	ZVAL_UNDEF(&_0$$3);
+	ZVAL_UNDEF(&_9$$4);
+	ZVAL_UNDEF(&_11$$7);
+	ZVAL_UNDEF(&_17$$8);
+	ZVAL_UNDEF(&_19$$11);
 #if PHP_VERSION_ID >= 80000
 	bool is_null_true = 1;
 	ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -121,22 +126,15 @@ PHP_METHOD(Phalcon_Html_Escaper, attributes)
 	zephir_fetch_params(1, 1, 0, &input);
 
 
-	_0 = Z_TYPE_P(input) != IS_STRING;
-	if (_0) {
-		_0 = Z_TYPE_P(input) != IS_ARRAY;
-	}
-	if (_0) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_html_exception_ce, "Input must be an array or a string", "phalcon/Html/Escaper.zep", 70);
-		return;
-	}
-	if (Z_TYPE_P(input) == IS_STRING) {
-		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "phphtmlspecialchars", NULL, 0, input);
+	if (EXPECTED((Z_TYPE_P(input) != IS_ARRAY))) {
+		zephir_cast_to_string(&_0$$3, input);
+		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "phphtmlspecialchars", NULL, 0, &_0$$3);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
 	ZEPHIR_INIT_VAR(&result);
 	ZVAL_STRING(&result, "");
-	zephir_is_iterable(input, 0, "phalcon/Html/Escaper.zep", 100);
+	zephir_is_iterable(input, 0, "phalcon/Html/Escaper.zep", 96);
 	if (Z_TYPE_P(input) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(input), _3, _4, _1)
 		{
@@ -148,30 +146,32 @@ PHP_METHOD(Phalcon_Html_Escaper, attributes)
 			}
 			ZEPHIR_INIT_NVAR(&value);
 			ZVAL_COPY(&value, _1);
-			_5$$5 = Z_TYPE_P(&value) == IS_NULL;
-			if (!(_5$$5)) {
-				_5$$5 = ZEPHIR_IS_FALSE_IDENTICAL(&value);
+			_5$$4 = Z_TYPE_P(&value) == IS_NULL;
+			if (!(_5$$4)) {
+				_5$$4 = ZEPHIR_IS_FALSE_IDENTICAL(&value);
 			}
-			if (_5$$5) {
+			if (_5$$4) {
 				continue;
 			}
-			ZEPHIR_INIT_NVAR(&_6$$5);
-			zephir_fast_trim(&_6$$5, &key, NULL , ZEPHIR_TRIM_BOTH);
-			ZEPHIR_CPY_WRT(&key, &_6$$5);
+			ZEPHIR_INIT_NVAR(&_6$$4);
+			zephir_fast_trim(&_6$$4, &key, NULL , ZEPHIR_TRIM_BOTH);
+			ZEPHIR_CPY_WRT(&key, &_6$$4);
 			if (Z_TYPE_P(&value) == IS_ARRAY) {
-				ZEPHIR_INIT_NVAR(&_7$$7);
-				zephir_fast_join_str(&_7$$7, SL(" "), &value);
-				ZEPHIR_CPY_WRT(&value, &_7$$7);
+				ZEPHIR_INIT_NVAR(&_7$$6);
+				zephir_fast_join_str(&_7$$6, SL(" "), &value);
+				ZEPHIR_CPY_WRT(&value, &_7$$6);
 			}
-			ZEPHIR_CALL_METHOD(&_8$$5, this_ptr, "phphtmlspecialchars", NULL, 0, &key);
+			zephir_cast_to_string(&_9$$4, &key);
+			ZEPHIR_CALL_METHOD(&_8$$4, this_ptr, "phphtmlspecialchars", NULL, 0, &_9$$4);
 			zephir_check_call_status();
-			zephir_concat_self(&result, &_8$$5);
+			zephir_concat_self(&result, &_8$$4);
 			if (!ZEPHIR_IS_TRUE_IDENTICAL(&value)) {
-				ZEPHIR_CALL_METHOD(&_9$$8, this_ptr, "phphtmlspecialchars", NULL, 0, &value);
+				zephir_cast_to_string(&_11$$7, &value);
+				ZEPHIR_CALL_METHOD(&_10$$7, this_ptr, "phphtmlspecialchars", NULL, 0, &_11$$7);
 				zephir_check_call_status();
-				ZEPHIR_INIT_NVAR(&_10$$8);
-				ZEPHIR_CONCAT_SVS(&_10$$8, "=\"", &_9$$8, "\"");
-				zephir_concat_self(&result, &_10$$8);
+				ZEPHIR_INIT_NVAR(&_12$$7);
+				ZEPHIR_CONCAT_SVS(&_12$$7, "=\"", &_10$$7, "\"");
+				zephir_concat_self(&result, &_12$$7);
 			}
 			zephir_concat_self_str(&result, SL(" "));
 		} ZEND_HASH_FOREACH_END();
@@ -188,30 +188,32 @@ PHP_METHOD(Phalcon_Html_Escaper, attributes)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&value, input, "current", NULL, 0);
 			zephir_check_call_status();
-				_11$$9 = Z_TYPE_P(&value) == IS_NULL;
-				if (!(_11$$9)) {
-					_11$$9 = ZEPHIR_IS_FALSE_IDENTICAL(&value);
+				_13$$8 = Z_TYPE_P(&value) == IS_NULL;
+				if (!(_13$$8)) {
+					_13$$8 = ZEPHIR_IS_FALSE_IDENTICAL(&value);
 				}
-				if (_11$$9) {
+				if (_13$$8) {
 					continue;
 				}
-				ZEPHIR_INIT_NVAR(&_12$$9);
-				zephir_fast_trim(&_12$$9, &key, NULL , ZEPHIR_TRIM_BOTH);
-				ZEPHIR_CPY_WRT(&key, &_12$$9);
+				ZEPHIR_INIT_NVAR(&_14$$8);
+				zephir_fast_trim(&_14$$8, &key, NULL , ZEPHIR_TRIM_BOTH);
+				ZEPHIR_CPY_WRT(&key, &_14$$8);
 				if (Z_TYPE_P(&value) == IS_ARRAY) {
-					ZEPHIR_INIT_NVAR(&_13$$11);
-					zephir_fast_join_str(&_13$$11, SL(" "), &value);
-					ZEPHIR_CPY_WRT(&value, &_13$$11);
+					ZEPHIR_INIT_NVAR(&_15$$10);
+					zephir_fast_join_str(&_15$$10, SL(" "), &value);
+					ZEPHIR_CPY_WRT(&value, &_15$$10);
 				}
-				ZEPHIR_CALL_METHOD(&_14$$9, this_ptr, "phphtmlspecialchars", NULL, 0, &key);
+				zephir_cast_to_string(&_17$$8, &key);
+				ZEPHIR_CALL_METHOD(&_16$$8, this_ptr, "phphtmlspecialchars", NULL, 0, &_17$$8);
 				zephir_check_call_status();
-				zephir_concat_self(&result, &_14$$9);
+				zephir_concat_self(&result, &_16$$8);
 				if (!ZEPHIR_IS_TRUE_IDENTICAL(&value)) {
-					ZEPHIR_CALL_METHOD(&_15$$12, this_ptr, "phphtmlspecialchars", NULL, 0, &value);
+					zephir_cast_to_string(&_19$$11, &value);
+					ZEPHIR_CALL_METHOD(&_18$$11, this_ptr, "phphtmlspecialchars", NULL, 0, &_19$$11);
 					zephir_check_call_status();
-					ZEPHIR_INIT_NVAR(&_16$$12);
-					ZEPHIR_CONCAT_SVS(&_16$$12, "=\"", &_15$$12, "\"");
-					zephir_concat_self(&result, &_16$$12);
+					ZEPHIR_INIT_NVAR(&_20$$11);
+					ZEPHIR_CONCAT_SVS(&_20$$11, "=\"", &_18$$11, "\"");
+					zephir_concat_self(&result, &_20$$11);
 				}
 				zephir_concat_self_str(&result, SL(" "));
 			ZEPHIR_CALL_METHOD(NULL, input, "next", NULL, 0);
@@ -324,7 +326,7 @@ PHP_METHOD(Phalcon_Html_Escaper, detectEncoding)
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "ASCII");
 	zephir_array_fast_append(&_0, &_1);
-	zephir_is_iterable(&_0, 0, "phalcon/Html/Escaper.zep", 162);
+	zephir_is_iterable(&_0, 0, "phalcon/Html/Escaper.zep", 158);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _2)
 		{

--- a/ext/phalcon/logger/abstractlogger.zep.c
+++ b/ext/phalcon/logger/abstractlogger.zep.c
@@ -645,7 +645,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, getLevelNumber)
 	zephir_fetch_params(1, 1, 0, &level);
 
 
-	if (1 == Z_TYPE_P(level) == IS_STRING) {
+	if (Z_TYPE_P(level) == IS_STRING) {
 		ZEPHIR_INIT_VAR(&levelName);
 		zephir_fast_strtoupper(&levelName, level);
 		ZEPHIR_CALL_METHOD(&_0$$3, this_ptr, "getlevels", NULL, 0);

--- a/ext/phalcon/support/version.zep.c
+++ b/ext/phalcon/support/version.zep.c
@@ -117,7 +117,7 @@ PHP_METHOD(Phalcon_Support_Version, getVersion)
 	ZVAL_LONG(&_0, 0);
 	zephir_array_fast_append(return_value, &_0);
 	ZEPHIR_INIT_NVAR(&_0);
-	ZVAL_LONG(&_0, 1);
+	ZVAL_LONG(&_0, 2);
 	zephir_array_fast_append(return_value, &_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_LONG(&_0, 4);

--- a/ext/php_phalcon.h
+++ b/ext/php_phalcon.h
@@ -11,7 +11,7 @@
 #include "kernel/globals.h"
 
 #define PHP_PHALCON_NAME        "phalcon"
-#define PHP_PHALCON_VERSION     "5.0.1"
+#define PHP_PHALCON_VERSION     "5.0.2"
 #define PHP_PHALCON_EXTNAME     "phalcon"
 #define PHP_PHALCON_AUTHOR      "Phalcon Team and contributors"
 #define PHP_PHALCON_ZEPVERSION  "0.16.3-5099f34"

--- a/package.xml
+++ b/package.xml
@@ -22,11 +22,11 @@
     <email>nikos@phalcon.io</email>
     <active>yes</active>
   </lead>
-  <date>2022-09-22</date>
+  <date>2022-09-27</date>
   <time>17:00:00</time>
   <version>
-    <release>5.0.1</release>
-    <api>5.0.1</api>
+    <release>5.0.2</release>
+    <api>5.0.2</api>
   </version>
   <stability>
     <release>stable</release>
@@ -37,10 +37,8 @@
     Full changelog can be found at: https://github.com/phalcon/cphalcon/blob/master/CHANGELOG-5.0.md
 
     ## Fixed
-    - Fixed `Phalcon\Encryption\Security\JWT\Token\Token::validate()` to correctly call validator methods [#16115](https://github.com/phalcon/cphalcon/issues/16115)
-
-    ## Added
-    - Added `Phalcon\Encryption\Security\JWT\Validator::get()` and `Phalcon\Encryption\Security\JWT\Validator::set()` for validation data [#16115](https://github.com/phalcon/cphalcon/issues/16115)
+    - Fixed `Phalcon\Html\Escaper::attributes()` to accept any value and transform it to string [#16123](https://github.com/phalcon/cphalcon/issues/16123)
+    - Fixed `Phalcon\Logger\AbstractLogger::getLevelNumber()` to better check for string levels [#16123](https://github.com/phalcon/cphalcon/issues/16123)
 
   </notes>
   <contents>

--- a/phalcon/Html/Escaper.zep
+++ b/phalcon/Html/Escaper.zep
@@ -66,12 +66,8 @@ class Escaper implements EscaperInterface
     {
         var key, result, value;
 
-        if (typeof input !== "string" && typeof input !== "array") {
-            throw new Exception("Input must be an array or a string");
-        }
-
-        if (typeof input === "string") {
-            return this->phpHtmlSpecialChars(input);
+        if likely (typeof input !== "array") {
+            return this->phpHtmlSpecialChars((string) input);
         }
 
         let result = "";
@@ -86,11 +82,11 @@ class Escaper implements EscaperInterface
                 let value = implode(" ", value);
             }
 
-            let result .= this->phpHtmlSpecialChars(key);
+            let result .= this->phpHtmlSpecialChars((string) key);
 
             if (true !== value) {
                 let result .= "=\""
-                    . this->phpHtmlSpecialChars(value)
+                    . this->phpHtmlSpecialChars((string) value)
                     . "\"";
             }
 

--- a/phalcon/Html/Escaper.zep
+++ b/phalcon/Html/Escaper.zep
@@ -384,7 +384,7 @@ class Escaper implements EscaperInterface
     {
         return htmlspecialchars(
             input,
-            ENT_QUOTES,
+            this->flags,
             this->encoding,
             this->doubleEncode
         );

--- a/phalcon/Logger/AbstractLogger.zep
+++ b/phalcon/Logger/AbstractLogger.zep
@@ -313,14 +313,14 @@ abstract class AbstractLogger
      *
      * @return int
      */
-    protected function getLevelNumber(level) -> int
+    protected function getLevelNumber(var level) -> int
     {
         var levelName, levels;
 
         /**
          * If someone uses "critical" as the level (string)
          */
-        if (true === is_string(level)) {
+        if (typeof level === "string") {
             let levelName = strtoupper(level),
                 levels    = array_flip(this->getLevels());
 

--- a/phalcon/Support/Version.zep
+++ b/phalcon/Support/Version.zep
@@ -77,7 +77,7 @@ class Version
      */
     protected function getVersion() -> array
     {
-        return [5, 0, 1, 4, 0];
+        return [5, 0, 2, 4, 0];
     }
 
     /**

--- a/tests/unit/Html/Escaper/AttributesCest.php
+++ b/tests/unit/Html/Escaper/AttributesCest.php
@@ -19,6 +19,8 @@ use UnitTester;
 
 use const ENT_HTML401;
 use const ENT_HTML5;
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
 use const ENT_XHTML;
 use const ENT_XML1;
 
@@ -59,22 +61,27 @@ class AttributesCest
         return [
             [
                 'htmlQuoteType' => ENT_HTML401,
-                'expected'      => 'That&#039;s right',
+                'expected'      => "That's right",
                 'text'          => "That's right",
             ],
             [
                 'htmlQuoteType' => ENT_XML1,
-                'expected'      => 'That&#039;s right',
+                'expected'      => "That's right",
                 'text'          => "That's right",
             ],
             [
                 'htmlQuoteType' => ENT_XHTML,
-                'expected'      => 'That&#039;s right',
+                'expected'      => "That's right",
                 'text'          => "That's right",
             ],
             [
                 'htmlQuoteType' => ENT_HTML5,
-                'expected'      => 'That&#039;s right',
+                'expected'      => "That's right",
+                'text'          => "That's right",
+            ],
+            [
+                'htmlQuoteType' => ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401,
+                'expected'      => "That&#039;s right",
                 'text'          => "That's right",
             ],
             [

--- a/tests/unit/Html/Escaper/AttributesCest.php
+++ b/tests/unit/Html/Escaper/AttributesCest.php
@@ -79,6 +79,24 @@ class AttributesCest
             ],
             [
                 'htmlQuoteType' => ENT_HTML5,
+                'expected'      => '10',
+                'text'          => 10,
+            ],
+            [
+                'htmlQuoteType' => ENT_HTML5,
+                'expected'      => 'maxlength="10" cols="5" rows="3" min="1" max="100"',
+                'text'          => [
+                    'maxlength'  => 10,
+                    'cols'       => 5,
+                    'rows'       => 3,
+                    'min'        => 1,
+                    'max'        => 100,
+                    'notPrinted'  => false,
+                    'notPrinted2' => null,
+                ],
+            ],
+            [
+                'htmlQuoteType' => ENT_HTML5,
                 'expected'      => 'text="Ferrari Ford Dodge"',
                 'text'          => [
                     'text' => [

--- a/tests/unit/Html/Escaper/GetSetFlagsCest.php
+++ b/tests/unit/Html/Escaper/GetSetFlagsCest.php
@@ -51,6 +51,7 @@ class GetSetFlagsCest
         $actual   = $escaper->getFlags();
         $I->assertSame($expected, $actual);
 
+        $escaper->setFlags(ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401);
         $expected = 'That&#039;s right';
         $actual   = $escaper->attributes("That's right");
         $I->assertSame($expected, $actual);


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16134 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Escaper::attributes()` to take into account the `$flags` property

Thanks

