### PR TITLE
T16135 stringval flags

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,8 @@
 # [5.0.3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.3) (xxxx-xx-xx)
 
+## Changed
+- Fixed `Phalcon\Filter\Sanitize\StringVal` to accept flags for `htmlspecialchars()` [#16135](https://github.com/phalcon/cphalcon/issues/16135)
+
 ## Fixed
 - Fixed `Phalcon\Html\Escaper::attributes()` to honor the `$flags` set for `htmlspecialchars()` [#16134](https://github.com/phalcon/cphalcon/issues/16134)
 

--- a/phalcon/Filter/Sanitize/StringVal.zep
+++ b/phalcon/Filter/Sanitize/StringVal.zep
@@ -17,11 +17,12 @@ class StringVal
 {
     /**
      * @param string $input The text to sanitize
+     * @param int    $flags The flags for `htmlspecialchars()`
      *
      * @return string
      */
-    public function __invoke(string input) -> string
+    public function __invoke(string input, int flags = 11) -> string
     {
-        return htmlspecialchars(input);
+        return htmlspecialchars(input, flags);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16135 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added flags for `htmlspecialchars()` for the StringVal filter.

Thanks

