### PR TITLE
T16157 mysql descripe indexes

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,8 @@
 ## Fixed
 - Fixed `Phalcon\Encryption\Security` to take into account the `workFactor` in the cost calculation [#16153](https://github.com/phalcon/cphalcon/issues/16153)
 - Removed double unserializing during Model caching [#16035](https://github.com/phalcon/cphalcon/issues/16035), [#16131](https://github.com/phalcon/cphalcon/issues/16131)
+- Fixed `Phalcon\Db\Adapter\Pdo\Mysql::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
+- Fixed `Phalcon\Db\Adapter\Pdo\Sqlite::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
 
 # [5.0.3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.3) (2022-10-06)
 

--- a/phalcon/Db/Adapter/Pdo/Mysql.zep
+++ b/phalcon/Db/Adapter/Pdo/Mysql.zep
@@ -539,7 +539,7 @@ class Mysql extends PdoAdapter
             } elseif index["Non_unique"] == 0 {
                 let indexes[keyName]["type"] = "UNIQUE";
             } else {
-                let indexes[keyName]["type"] = null;
+                let indexes[keyName]["type"] = "";
             }
         }
 

--- a/phalcon/Db/Adapter/Pdo/Sqlite.zep
+++ b/phalcon/Db/Adapter/Pdo/Sqlite.zep
@@ -362,7 +362,7 @@ class Sqlite extends PdoAdapter
                     let indexes[keyName]["type"] = "PRIMARY";
                 }
             } else {
-                let indexes[keyName]["type"] = null;
+                let indexes[keyName]["type"] = "";
             }
         }
 


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16157 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Db\Adapter\Pdo\Mysql::describeIndexes` to assign an empty string in the index type of `null` and remove warnings 
Fixed `Phalcon\Db\Adapter\Pdo\Sqlite::describeIndexes` to assign an empty string in the index type of `null` and remove warnings 


Thanks

