### PR TITLE
T16161 mvc model fireevent return value must be of type bool null returned

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,7 +5,6 @@
 - Removed double unserializing during Model caching [#16035](https://github.com/phalcon/cphalcon/issues/16035), [#16131](https://github.com/phalcon/cphalcon/issues/16131)
 - Fixed `Phalcon\Db\Adapter\Pdo\Mysql::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
 - Fixed `Phalcon\Db\Adapter\Pdo\Sqlite::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
-- Fixed `Phalcon\Db\Adapter\Pdo\Sqlite::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
 - Fixed `Phalcon\Mvc\Model\Manager::notifyEvent` to return `true` instead of `null` on success [#16161](https://github.com/phalcon/cphalcon/issues/16161)
 
 # [5.0.3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.3) (2022-10-06)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,6 +5,8 @@
 - Removed double unserializing during Model caching [#16035](https://github.com/phalcon/cphalcon/issues/16035), [#16131](https://github.com/phalcon/cphalcon/issues/16131)
 - Fixed `Phalcon\Db\Adapter\Pdo\Mysql::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
 - Fixed `Phalcon\Db\Adapter\Pdo\Sqlite::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
+- Fixed `Phalcon\Db\Adapter\Pdo\Sqlite::describeIndexes` to assign an empty string in the index type of `null` and remove warnings [#16157](https://github.com/phalcon/cphalcon/issues/16157)
+- Fixed `Phalcon\Mvc\Model\Manager::notifyEvent` to return `true` instead of `null` on success [#16161](https://github.com/phalcon/cphalcon/issues/16161)
 
 # [5.0.3](https://github.com/phalcon/cphalcon/releases/tag/v5.0.3) (2022-10-06)
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1971,7 +1971,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         var status, behavior, modelsBehaviors, eventsManager,
             customEventsManager;
 
-        let status = null;
+        let status = true;
 
         /**
          * Dispatch events to the global events manager

--- a/tests/_data/fixtures/Di/InitializationAwareComponent.php
+++ b/tests/_data/fixtures/Di/InitializationAwareComponent.php
@@ -17,8 +17,6 @@ use Phalcon\Di\InitializationAwareInterface;
 
 /**
  * Class InitializationAwareComponent
- *
- * @package Phalcon\Tests\Fixtures\Di
  */
 class InitializationAwareComponent implements InitializationAwareInterface
 {

--- a/tests/_data/fixtures/Di/ServiceComponent.php
+++ b/tests/_data/fixtures/Di/ServiceComponent.php
@@ -20,8 +20,8 @@ use Phalcon\Html\EscaperInterface;
  *
  * @package Phalcon\Tests\Fixtures\Di
  *
- * @property string           $name
- * @property int              $type
+ * @property string $name
+ * @property int    $type
  */
 class ServiceComponent
 {

--- a/tests/_data/fixtures/Messages/MessageFixture.php
+++ b/tests/_data/fixtures/Messages/MessageFixture.php
@@ -117,6 +117,7 @@ class MessageFixture implements MessageInterface
      * Sets code for the message
      *
      * @param int $code
+     *
      * @return $this|MessageInterface
      */
     public function setCode(int $code): MessageInterface
@@ -130,6 +131,7 @@ class MessageFixture implements MessageInterface
      * Sets field name related to message
      *
      * @param string $field
+     *
      * @return $this|MessageInterface
      */
     public function setField(string $field): MessageInterface
@@ -143,6 +145,7 @@ class MessageFixture implements MessageInterface
      * Sets verbose message
      *
      * @param string $message
+     *
      * @return $this|MessageInterface
      */
     public function setMessage(string $message): MessageInterface
@@ -156,6 +159,7 @@ class MessageFixture implements MessageInterface
      * Sets message metadata
      *
      * @param array $metaData
+     *
      * @return $this|MessageInterface
      */
     public function setMetaData(array $metaData): MessageInterface
@@ -169,6 +173,7 @@ class MessageFixture implements MessageInterface
      * Sets message type
      *
      * @param string $type
+     *
      * @return $this|MessageInterface
      */
     public function setType(string $type): MessageInterface

--- a/tests/_data/fixtures/Session/ExtendedManager.php
+++ b/tests/_data/fixtures/Session/ExtendedManager.php
@@ -15,8 +15,6 @@ namespace Phalcon\Tests\Fixtures\Session;
 
 use Phalcon\Session\Adapter\Noop;
 use Phalcon\Session\Manager;
-use Phalcon\Storage\SerializerFactory;
-use Phalcon\Storage\AdapterFactory;
 
 class ExtendedManager extends Manager
 {

--- a/tests/_data/fixtures/Tasks/EchoTask.php
+++ b/tests/_data/fixtures/Tasks/EchoTask.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Fixtures\Tasks;
 
-class EchoTask extends \Phalcon\Cli\Task
+use Phalcon\Cli\Task;
+
+class EchoTask extends Task
 {
     public function mainAction()
     {

--- a/tests/_data/fixtures/Tasks/MainTask.php
+++ b/tests/_data/fixtures/Tasks/MainTask.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Fixtures\Tasks;
 
-class MainTask extends \Phalcon\Cli\Task
+use Phalcon\Cli\Task;
+
+class MainTask extends Task
 {
     public function mainAction()
     {

--- a/tests/_data/fixtures/Tasks/OnConstructTask.php
+++ b/tests/_data/fixtures/Tasks/OnConstructTask.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Fixtures\Tasks;
 
-class OnConstructTask extends \Phalcon\Cli\Task
+use Phalcon\Cli\Task;
+
+class OnConstructTask extends Task
 {
     public $onConstructExecuted = false;
 

--- a/tests/_data/fixtures/Tasks/ParamsTask.php
+++ b/tests/_data/fixtures/Tasks/ParamsTask.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Fixtures\Tasks;
 
-class ParamsTask extends \Phalcon\Cli\Task
+use Phalcon\Cli\Task;
+
+class ParamsTask extends Task
 {
     public function paramsAction()
     {

--- a/tests/_data/fixtures/Traits/ConfigTrait.php
+++ b/tests/_data/fixtures/Traits/ConfigTrait.php
@@ -129,7 +129,9 @@ trait ConfigTrait
         $config = $this->getConfig($adapter);
 
         $expected = 'memory';
-        $actual   = $config->get('models')->get('metadata');
+        $actual   = $config->get('models')
+                           ->get('metadata')
+        ;
         $I->assertEquals($expected, $actual);
     }
 
@@ -230,7 +232,9 @@ trait ConfigTrait
         $config = $this->getConfig($adapter);
 
         $expected = 'memory';
-        $actual   = $config->offsetGet('models')->offsetGet('metadata');
+        $actual   = $config->offsetGet('models')
+                           ->offsetGet('metadata')
+        ;
         $I->assertEquals($expected, $actual);
     }
 

--- a/tests/_data/fixtures/Traits/FactoryTrait.php
+++ b/tests/_data/fixtures/Traits/FactoryTrait.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Fixtures\Traits;
 
-use Phalcon\Config\Config;
 use Phalcon\Config\Adapter\Ini;
+use Phalcon\Config\Config;
 
 use function dataDir;
 use function outputDir;

--- a/tests/_data/fixtures/Traits/GdTrait.php
+++ b/tests/_data/fixtures/Traits/GdTrait.php
@@ -236,7 +236,7 @@ trait GdTrait
     /**
      * @author https://github.com/xwiz/phash
      *
-     * @param $img
+     * @param     $img
      * @param int $thumbwidth
      * @param int $thumbheight
      * @param int $width

--- a/tests/_data/fixtures/Traits/TranslateGettextTrait.php
+++ b/tests/_data/fixtures/Traits/TranslateGettextTrait.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Fixtures\Traits;
 
 use UnitTester;
+
 use function dataDir;
 
 trait TranslateGettextTrait


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16161 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Manager::notifyEvent` to return `true` instead of `null` on success

Thanks

