### PR TITLE
Bugfix in JWT "exp" (Expiration Time) Claim validation.

### DIFF
--- a/phalcon/Encryption/Security/JWT/Validator.zep
+++ b/phalcon/Encryption/Security/JWT/Validator.zep
@@ -145,7 +145,7 @@ class Validator
 
         if (
             this->token->getClaims()->has(Enum::EXPIRATION_TIME) &&
-            this->getTimestamp(timestamp) < $tokenExpirationTime
+            this->getTimestamp(timestamp) > $tokenExpirationTime
         ) {
             let this->errors[] = "Validation: the token has expired";
         }

--- a/tests/unit/Encryption/Security/JWT/Token/Token/ValidateCest.php
+++ b/tests/unit/Encryption/Security/JWT/Token/Token/ValidateCest.php
@@ -60,7 +60,7 @@ class ValidateCest
 
         $validator
             ->set(Enum::AUDIENCE, 'my-audience')
-            ->set(Enum::EXPIRATION_TIME, $expiry)
+            ->set(Enum::EXPIRATION_TIME, $now)
             ->set(Enum::ISSUER, 'Phalcon JWT')
             ->set(Enum::ISSUED_AT, $issued)
             ->set(Enum::ID, 'PH-JWT')

--- a/tests/unit/Encryption/Security/JWT/Validator/ValidateExpirationCest.php
+++ b/tests/unit/Encryption/Security/JWT/Validator/ValidateExpirationCest.php
@@ -38,7 +38,7 @@ class ValidateExpirationCest
         $I->wantToTest('Encryption\Security\JWT\Validator - validateExpiration()');
 
         $token = $this->newToken();
-        $timestamp = strtotime(("-2 days"));
+        $timestamp = strtotime(("+2 days"));
         $validator = new Validator($token);
         $I->assertInstanceOf(Validator::class, $validator);
 


### PR DESCRIPTION
Hello!

* Type: bug fix #16166 

Small description of change:

RFC 7519,  4.1.4.,  The processing of the "exp" claim requires that the current date/time MUST be before the expiration date/time listed in the "exp" claim. So Validator must produce an error if current timestamp is grater than "exp" claim.

Thanks

