### PR TITLE
T16171 config insensitive

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,3 +1,9 @@
+# [5.0.5](https://github.com/phalcon/cphalcon/releases/tag/v5.0.5) (xxxx-xx-xx)
+
+## Fixed
+- Fixed `Phalcon\Config\Config::setData` to pass the `insensitive` flag to child objects [#16171](https://github.com/phalcon/cphalcon/issues/16171)
+- Fixed `Phalcon\Config\Adapter\Groupped::__construct` to pass the `insensitive` flag to child objects [#16171](https://github.com/phalcon/cphalcon/issues/16171)
+
 # [5.0.4](https://github.com/phalcon/cphalcon/releases/tag/v5.0.4) (2022-10-17)
 
 ## Fixed

--- a/phalcon/Config/Adapter/Grouped.zep
+++ b/phalcon/Config/Adapter/Grouped.zep
@@ -111,7 +111,7 @@ class Grouped extends Config
                 }
 
                 let configArray    = configInstance["config"],
-                    configInstance = new Config(configArray);
+                    configInstance = new Config(configArray, this->insensitive);
             } else {
                 let configInstance = (new ConfigFactory())->load(configInstance);
             }

--- a/phalcon/Config/Config.zep
+++ b/phalcon/Config/Config.zep
@@ -250,7 +250,7 @@ class Config extends Collection implements ConfigInterface
         let this->lowerKeys[key] = element;
 
         if typeof value === "array" {
-            let data[element] = new Config(value);
+            let data[element] = new Config(value, this->insensitive);
         } else {
             let data[element] = value;
         }

--- a/tests/unit/Config/Config/ConfigCest.php
+++ b/tests/unit/Config/Config/ConfigCest.php
@@ -83,4 +83,42 @@ class ConfigCest
         $actual   = new Config($settings);
         $I->assertEquals($expected, $actual);
     }
+
+    /**
+     * Test insensitive in sub arrays
+     *
+     * @param UnitTester $I
+     *
+     * @return void
+     *
+     * @issue  16171
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-10-19
+     */
+    public function configConfigConfigInsensitive(UnitTester $I)
+    {
+        $settings = [
+            'database' => [
+                'adapter'  => 'Mysql',
+                'host'     => 'localhost',
+                'username' => 'scott',
+                'password' => 'cheetah',
+                'name'     => 'test_db',
+            ],
+            'other'    => [1, 2, 3, 4],
+        ];
+        $config = new Config($settings, false);
+
+        /** @var Config $database */
+        $database = $config->get('database');
+
+        $class = Config::class;
+        $I->assertInstanceOf($class, $database);
+
+        $actual = $database->has('adapter');
+        $I->assertTrue($actual);
+
+        $actual = $database->has('ADAPTER');
+        $I->assertFalse($actual);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16171 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Config\Config::setData` to pass the `insensitive` flag to child objects
Fixed `Phalcon\Config\Adapter\Groupped::__construct` to pass the `insensitive` flag to child objects


Thanks

