### PR TITLE
T16170 strict session id syntax

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,7 +3,8 @@
 ## Fixed
 - Fixed `Phalcon\Config\Config::setData` to pass the `insensitive` flag to child objects [#16171](https://github.com/phalcon/cphalcon/issues/16171)
 - Fixed `Phalcon\Config\Adapter\Groupped::__construct` to pass the `insensitive` flag to child objects [#16171](https://github.com/phalcon/cphalcon/issues/16171)
-
+- Fixed `Phalcon\Session\Manager::setName`, removing the regex check for the name for custom adapters to work with `create_sid()` [#16170](https://github.com/phalcon/cphalcon/issues/16170)
+ 
 # [5.0.4](https://github.com/phalcon/cphalcon/releases/tag/v5.0.4) (2022-10-17)
 
 ## Fixed

--- a/phalcon/Session/Manager.zep
+++ b/phalcon/Session/Manager.zep
@@ -294,12 +294,6 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
             );
         }
 
-        if unlikely !preg_match("/^[\p{L}\p{N}_-]+$/u", name) {
-            throw new Exception(
-                "The name contains non alphanum characters"
-            );
-        }
-
         let this->name = name;
 
         session_name(name);

--- a/tests/integration/Session/Manager/GetSetNameCest.php
+++ b/tests/integration/Session/Manager/GetSetNameCest.php
@@ -51,29 +51,6 @@ class GetSetNameCest
     }
 
     /**
-     * Tests Phalcon\Session\Manager :: getName()/setName() - not valid name
-     *
-     * @param IntegrationTester $I
-     *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-09-09
-     */
-    public function sessionManagerGetNameNotValidName(IntegrationTester $I)
-    {
-        $I->wantToTest('Session\Manager - getName()/setName() - not valid name');
-        $I->expectThrowable(
-            new Exception('The name contains non alphanum characters'),
-            function () {
-                $manager = new Manager();
-                $files   = $this->newService('sessionStream');
-                $manager->setAdapter($files);
-
-                $manager->setName('%-gga34');
-            }
-        );
-    }
-
-    /**
      * Tests Phalcon\Session\Manager :: getName()/setName() - session started
      *
      * @param IntegrationTester $I

--- a/tests/integration/Session/Manager/StartCest.php
+++ b/tests/integration/Session/Manager/StartCest.php
@@ -19,8 +19,6 @@ use Phalcon\Session\Manager;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 
 /**
- * Class StartCest
- *
  * @package Phalcon\Tests\Integration\Session\Manager
  */
 class StartCest


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16170 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Session\Manager::setName`, removing the regex check for the name for custom adapters to work with `create_sid()` 

Thanks

