### PR TITLE
#16177 - Unify args of `fetchAll()` with `PDOStatement::fetchAll()`

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,7 @@
 - Fixed `Phalcon\Config\Config::setData` to pass the `insensitive` flag to child objects [#16171](https://github.com/phalcon/cphalcon/issues/16171)
 - Fixed `Phalcon\Config\Adapter\Groupped::__construct` to pass the `insensitive` flag to child objects [#16171](https://github.com/phalcon/cphalcon/issues/16171)
 - Fixed `Phalcon\Session\Manager::setName`, removing the regex check for the name for custom adapters to work with `create_sid()` [#16170](https://github.com/phalcon/cphalcon/issues/16170)
+- Fixed `PdoResult::fetchAll` when passed class name in 2nd argument [#16177](https://github.com/phalcon/cphalcon/issues/16177)
  
 # [5.0.4](https://github.com/phalcon/cphalcon/releases/tag/v5.0.4) (2022-10-17)
 

--- a/phalcon/Db/Result/PdoResult.zep
+++ b/phalcon/Db/Result/PdoResult.zep
@@ -211,29 +211,24 @@ class PdoResult implements ResultInterface
      * $robots = $result->fetchAll();
      *```
      *
-     * @param int|null            $fetchStyle
-     * @param int|string|callable $fetchArgument
-     * @param array|null          $constructorArgs
+     * @param int                      $mode
+     * @param int|string|callable|null $fetchArgument
+     * @param array|null               $constructorArgs
      */
     public function fetchAll(
-        int fetchStyle = null,
-        mixed fetchArgument = Pdo::FETCH_ORI_NEXT,
-        mixed constructorArgs = 0
+        int mode = Enum::FETCH_DEFAULT,
+        var fetchArgument = Pdo::FETCH_ORI_NEXT,
+        var constructorArgs = 0
     ) -> array {
-        var pdoStatement, mode;
-
-        let pdoStatement = this->pdoStatement;
-        let mode = typeof fetchStyle === "int" ? fetchStyle : this->fetchMode;
-
         if fetchStyle == Enum::FETCH_CLASS {
-            return pdoStatement->fetchAll(mode, fetchArgument, constructorArgs);
+            return this->pdoStatement->fetchAll(mode, fetchArgument, constructorArgs);
         }
 
         if fetchStyle == Enum::FETCH_COLUMN || fetchStyle == Enum::FETCH_FUNC {
-            return pdoStatement->fetchAll(fetchStyle, fetchArgument);
+            return this->pdoStatement->fetchAll(fetchStyle, fetchArgument);
         }
 
-        return pdoStatement->fetchAll(fetchStyle);
+        return this->pdoStatement->fetchAll(fetchStyle);
     }
 
     /**

--- a/phalcon/Db/Result/PdoResult.zep
+++ b/phalcon/Db/Result/PdoResult.zep
@@ -218,7 +218,7 @@ class PdoResult implements ResultInterface
     public function fetchAll(
         int mode = Enum::FETCH_DEFAULT,
         var fetchArgument = Pdo::FETCH_ORI_NEXT,
-        var constructorArgs = 0
+        var constructorArgs = null
     ) -> array {
         if mode == Enum::FETCH_CLASS {
             return this->pdoStatement->fetchAll(mode, fetchArgument, constructorArgs);

--- a/phalcon/Db/Result/PdoResult.zep
+++ b/phalcon/Db/Result/PdoResult.zep
@@ -220,15 +220,15 @@ class PdoResult implements ResultInterface
         var fetchArgument = Pdo::FETCH_ORI_NEXT,
         var constructorArgs = 0
     ) -> array {
-        if fetchStyle == Enum::FETCH_CLASS {
+        if mode == Enum::FETCH_CLASS {
             return this->pdoStatement->fetchAll(mode, fetchArgument, constructorArgs);
         }
 
-        if fetchStyle == Enum::FETCH_COLUMN || fetchStyle == Enum::FETCH_FUNC {
-            return this->pdoStatement->fetchAll(fetchStyle, fetchArgument);
+        if mode == Enum::FETCH_COLUMN || mode == Enum::FETCH_FUNC {
+            return this->pdoStatement->fetchAll(mode, fetchArgument);
         }
 
-        return this->pdoStatement->fetchAll(fetchStyle);
+        return this->pdoStatement->fetchAll(mode);
     }
 
     /**

--- a/phalcon/Db/Result/PdoResult.zep
+++ b/phalcon/Db/Result/PdoResult.zep
@@ -210,16 +210,23 @@ class PdoResult implements ResultInterface
      *
      * $robots = $result->fetchAll();
      *```
+     *
+     * @param int|null            $fetchStyle
+     * @param int|string|callable $fetchArgument
+     * @param int|array|null      $constructorArgs
      */
-    public function fetchAll(int fetchStyle = null, int fetchArgument = Pdo::FETCH_ORI_NEXT, int ctorArgs = 0) -> array
-    {
+    public function fetchAll(
+        int fetchStyle = null,
+        mixed fetchArgument = Pdo::FETCH_ORI_NEXT,
+        mixed constructorArgs = 0
+    ) -> array {
         var pdoStatement, mode;
 
         let pdoStatement = this->pdoStatement;
         let mode = typeof fetchStyle === "int" ? fetchStyle : this->fetchMode;
 
         if fetchStyle == Enum::FETCH_CLASS {
-            return pdoStatement->fetchAll(mode, fetchArgument, ctorArgs);
+            return pdoStatement->fetchAll(mode, fetchArgument, constructorArgs);
         }
 
         if fetchStyle == Enum::FETCH_COLUMN || fetchStyle == Enum::FETCH_FUNC {

--- a/phalcon/Db/Result/PdoResult.zep
+++ b/phalcon/Db/Result/PdoResult.zep
@@ -213,7 +213,7 @@ class PdoResult implements ResultInterface
      *
      * @param int|null            $fetchStyle
      * @param int|string|callable $fetchArgument
-     * @param int|array|null      $constructorArgs
+     * @param array|null          $constructorArgs
      */
     public function fetchAll(
         int fetchStyle = null,


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

