### PR TITLE
adjust default for form::label attributes

### DIFF
--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -754,7 +754,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Generate the label of an element added to the form including HTML
      */
-    public function label(string! name, array attributes = null) -> string
+    public function label(string! name, array attributes = []) -> string
     {
         var element;
 


### PR DESCRIPTION
Hello!

* Type: bug fix / code quality

Small description of change:
since element::label is updated from `array attributes = null` to `array attributes = []` using this method with the default secondary argument will now cause an "Fatal error: Uncaught TypeError" to be thrown

Thanks