### PR TITLE
T16188 cannot fetch patch payload

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,9 +1,13 @@
-# [5.0.6](https://github.com/phalcon/cphalcon/releases/tag/v5.0.6) (xxxx-xx-xx)
+# [5.1.0](https://github.com/phalcon/cphalcon/releases/tag/v5.1.0) (2022-11-01)
 
 ## Fixed
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::isTagFactory` to correctly detect a `TagFactory` object without throwing an error [#16097](https://github.com/phalcon/cphalcon/issues/16097)
 - Fixed default values for `Phalcon\Cli`, `Phalcon\Dispatcher` and `Phalcon\Application` components to ensure not `null` values are passed to methods [#16186](https://github.com/phalcon/cphalcon/issues/16186)
 
+## Added
+- Added `Phalcon\Http\Request::getPatch()` to get a value from a PATCH request [#16188](https://github.com/phalcon/cphalcon/issues/16188)
+- Added `Phalcon\Http\Request::getFilteredPatch()` to get a value filtered from a PATCH request [#16188](https://github.com/phalcon/cphalcon/issues/16188)
+- Added `Phalcon\Http\Request::hasPatch()` to check if a value exist in a PATCH request [#16188](https://github.com/phalcon/cphalcon/issues/16188)
 
 # [5.0.5](https://github.com/phalcon/cphalcon/releases/tag/v5.0.5) (2022-10-24)
 

--- a/tests/unit/Http/Request/GetFilteredPatchCest.php
+++ b/tests/unit/Http/Request/GetFilteredPatchCest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Http\Request;
+
+use Phalcon\Http\Request;
+use Phalcon\Tests\Fixtures\Http\PhpStream;
+use Phalcon\Tests\Fixtures\Traits\DiTrait;
+use UnitTester;
+
+use function file_put_contents;
+use function stream_wrapper_register;
+use function stream_wrapper_restore;
+use function stream_wrapper_unregister;
+
+class GetFilteredPatchCest
+{
+    use DiTrait;
+
+    /**
+     * Tests Phalcon\Http\Request :: getFilteredPatch()
+     *
+     * @issue  16188
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-11-01
+     */
+    public function httpRequestGetFilteredPatch(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getFilteredPatch()');
+
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', PhpStream::class);
+
+        file_put_contents('php://input', 'no-id=24');
+
+        $store   = $_SERVER ?? [];
+        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT' => $time,
+            'REQUEST_METHOD'     => 'PATCH',
+        ];
+
+        $container = $this->newService('factoryDefault');
+        /** @var Request $request */
+        $request = $container->get('request');
+        $request
+            ->setParameterFilters('id', ['absint'], ['patch']);
+
+        $expected = 24;
+        $actual   = $request->getFilteredPut('id', 24);
+        $I->assertSame($expected, $actual);
+
+        stream_wrapper_restore('php');
+
+        $_SERVER = $store;
+    }
+}

--- a/tests/unit/Http/Request/GetPatchCest.php
+++ b/tests/unit/Http/Request/GetPatchCest.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Http\Request;
+
+use Phalcon\Http\Request;
+use Phalcon\Tests\Fixtures\Http\PhpStream;
+use UnitTester;
+
+use function file_get_contents;
+use function file_put_contents;
+use function json_decode;
+use function parse_str;
+use function stream_wrapper_register;
+use function stream_wrapper_restore;
+use function stream_wrapper_unregister;
+
+class GetPatchCest
+{
+    /**
+     * Tests Phalcon\Http\Request :: getPatch()
+     *
+     * @issue  16188
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-11-01
+     */
+    public function httpRequestGetPatch(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPatch()');
+
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', PhpStream::class);
+
+        file_put_contents('php://input', 'fruit=orange&quantity=4');
+
+        $store   = $_SERVER ?? [];
+        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT' => $time,
+            'REQUEST_METHOD'     => 'PATCH',
+        ];
+
+        $request = new Request();
+
+        $actual = $request->hasPatch('fruit');
+        $I->assertTrue($actual);
+        $actual = $request->hasPatch('quantity');
+        $I->assertTrue($actual);
+        $actual = $request->hasPatch('unknown');
+        $I->assertFalse($actual);
+
+        $data = file_get_contents('php://input');
+
+        $expected = [
+            'fruit'    => 'orange',
+            'quantity' => '4',
+        ];
+
+        parse_str($data, $actual);
+
+        $I->assertSame($expected, $actual);
+
+        $actual = $request->getPatch();
+        $I->assertSame($expected, $actual);
+
+        stream_wrapper_restore('php');
+
+        $_SERVER = $store;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getPatch() - json
+     *
+     * @issue  16188
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-11-01
+     */
+    public function httpRequestGetPatchJson(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPatch() - json');
+
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', PhpStream::class);
+
+        file_put_contents(
+            'php://input',
+            '{"fruit": "orange", "quantity": "4"}'
+        );
+
+        $store   = $_SERVER ?? [];
+        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT' => $time,
+            'REQUEST_METHOD'     => 'PATCH',
+            'CONTENT_TYPE'       => 'application/json',
+        ];
+
+        $request = new Request();
+
+        $expected = [
+            'fruit'    => 'orange',
+            'quantity' => '4',
+        ];
+
+        $actual = json_decode(
+            file_get_contents('php://input'),
+            true
+        );
+
+        $I->assertSame($expected, $actual);
+
+        $actual = $request->getPatch();
+        $I->assertSame($expected, $actual);
+
+        stream_wrapper_restore('php');
+
+        $_SERVER = $store;
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature 
* Link to issue: #16188 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Http\Request::getPatch()` to get a value from a PATCH request 
Added `Phalcon\Http\Request::getFilteredPatch()` to get a value filtered from a PATCH request
Added `Phalcon\Http\Request::hasPatch()` to check if a value exist in a PATCH request


Thanks

