### PR TITLE
Fix no recursive array value with multiple sanitizers in Filter

### DIFF
--- a/phalcon/Filter/Filter.zep
+++ b/phalcon/Filter/Filter.zep
@@ -286,18 +286,20 @@ class Filter implements FilterInterface
              * has been defined it is a straight up; otherwise recursion is
              * required
              */
-            let value = this->processValueIsArray(
-                value,
-                sanitizerName,
-                sanitizerParams,
-                noRecursive
-            );
-
-            let value = this->processValueIsNotArray(
-                value,
-                sanitizerName,
-                sanitizerParams
-            );
+             if typeof value === "array" {
+                let value = this->processValueIsArray(
+                    value,
+                    sanitizerName,
+                    sanitizerParams,
+                    noRecursive
+                );
+             } else {
+                 let value = this->processValueIsNotArray(
+                     value,
+                     sanitizerName,
+                     sanitizerParams
+                 );
+             }
         }
 
         return value;
@@ -381,14 +383,14 @@ class Filter implements FilterInterface
         array sanitizerParams,
         bool noRecursive
     ) {
-        if typeof value === "array" && !noRecursive {
-            let value = this->processArrayValues(
+        if noRecursive {
+            let value = this->sanitizer(
                 value,
                 sanitizerName,
                 sanitizerParams
             );
         } else {
-            let value = this->sanitizer(
+            let value = this->processArrayValues(
                 value,
                 sanitizerName,
                 sanitizerParams

--- a/phalcon/Filter/Filter.zep
+++ b/phalcon/Filter/Filter.zep
@@ -387,6 +387,12 @@ class Filter implements FilterInterface
                 sanitizerName,
                 sanitizerParams
             );
+        } else {
+            let value = this->sanitizer(
+                value,
+                sanitizerName,
+                sanitizerParams
+            );
         }
 
         return value;

--- a/tests/unit/Filter/Filter/SanitizeMultipleCest.php
+++ b/tests/unit/Filter/Filter/SanitizeMultipleCest.php
@@ -27,7 +27,7 @@ class SanitizeMultipleCest
     /**
      * Tests sanitizing values
      *
-     * @dataProvider getExamples
+     * @dataProvider getFilterSanitizeExamples
      *
      * @param UnitTester $I
      * @param Example    $example
@@ -42,10 +42,13 @@ class SanitizeMultipleCest
         $locator = new FilterFactory();
         $filter  = $locator->newInstance();
 
-        $source   = $example['source'];
-        $expected = $example['expected'];
-        $filters  = $example['filters'];
-        $actual   = $filter->sanitize($source, $filters);
+        $source      = $example['source'];
+        $expected    = $example['expected'];
+        $filters     = $example['filters'];
+        $noRecursive = $example['noRecursive'];
+
+        $actual   = $filter->sanitize($source, $filters, $noRecursive);
+
         $I->assertSame($expected, $actual);
     }
 
@@ -91,9 +94,38 @@ class SanitizeMultipleCest
     }
 
     /**
+     * Tests filter sanitize on custom filters
+     *
+     * @dataProvider getFilterSanitizeCustomFiltersExamples
+     *
+     * @param UnitTester $I
+     * @param Example    $example
+     */
+    public function filterFilterSanitizeCustomFilters(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Filter\Filter - sanitize() - ' . $example['label']);
+
+        $locator = new FilterFactory();
+        $filter  = $locator->newInstance();
+
+        $source      = $example['source'];
+        $expected    = $example['expected'];
+        $filters     = $example['filters'];
+        $noRecursive = $example['noRecursive'];
+
+        foreach ($filters as $name => $testFilter) {
+            $filter->set($name, $testFilter);
+        }
+
+        $actual   = $filter->sanitize($source, array_keys($filters), $noRecursive);
+
+        $I->assertSame($expected, $actual);
+    }
+
+    /**
      * @return array<array-key, array<string, mixed>>
      */
-    private function getExamples(): array
+    private function getFilterSanitizeExamples(): array
     {
         return [
             [
@@ -103,6 +135,7 @@ class SanitizeMultipleCest
                     'string',
                     'trim',
                 ],
+                'noRecursive' => false,
                 'expected' => null,
             ],
             [
@@ -112,18 +145,21 @@ class SanitizeMultipleCest
                     'string',
                     'trim',
                 ],
+                'noRecursive' => false,
                 'expected' => 'lol&lt;&lt;&lt;',
             ],
             [
                 'label' => 'array with filters',
                 'source' => [' 1 ', '  2', '3  '],
                 'filters' => 'trim',
+                'noRecursive' => false,
                 'expected' => ['1', '2', '3'],
             ],
             [
                 'label' => 'array with multiple filters',
                 'source' => [' <a href="a">1</a> ', '  <h1>2</h1>', '<p>3</p>'],
                 'filters' => ['striptags', 'trim'],
+                'noRecursive' => false,
                 'expected' => ['1', '2', '3'],
             ],
             [
@@ -134,7 +170,37 @@ class SanitizeMultipleCest
                     'replace' => [' ', '-'],
                     'remove'  => ['mary'],
                 ],
+                'noRecursive' => false,
                 'expected' => '-had-a-little-lamb',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<array-key, array<string, mixed>>
+     */
+    private function getFilterSanitizeCustomFiltersExamples(): array
+    {
+        return [
+            [
+                'label' => 'no recursive array value with multiple sanitizers',
+                'source' => [4, 2, 0],
+                'filters' => [
+                    'sum' => fn ($input) => array_sum($input),
+                    'half' => fn ($input) => $input / 2,
+                ],
+                'noRecursive' => true,
+                'expected' => 3,
+            ],
+            [
+                'label' => 'recursive array value with multiple sanitizers',
+                'source' => [4, 2, 0],
+                'filters' => [
+                    'double' => fn ($input) => $input * 2,
+                    'inverse' => fn ($input) => 0 - $input,
+                ],
+                'noRecursive' => false,
+                'expected' => [-8, -4, 0],
             ],
         ];
     }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: -

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Hey, I was going after the new version and found that there seems to be an bug when we call `sanitize` with an array `value`, array `sanitizers` and `noRecursive = true`. **The output is always the same as the initial value**.
I think this change should do it as it goes to a [previous way](https://github.com/phalcon/cphalcon/pull/15734/files#diff-c589afb489a0f55dca8b29abf141bcf4d31783462ab3bd4e1780a4a86c8d5f7aL173-L179) to handle this.

Thanks

