### PR TITLE
T16202 - Escape::html zero string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '7.4', '8.0', '8.1' ]
-        ts: [ 'nts', 'ts' ] // disabling TS for the release
+        ts: [ 'nts', 'ts' ]
         arch: [ 'x64' ]
 
         name:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,8 +86,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '7.4', '8.0', '8.1' ]
-        ts: [ 'nts' ]
-#        ts: [ 'nts', 'ts' ] // disabling TS for the release
+        ts: [ 'nts', 'ts' ] // disabling TS for the release
         arch: [ 'x64' ]
 
         name:

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,3 +1,8 @@
+# [5.1.1](https://github.com/phalcon/cphalcon/releases/tag/v5.1.1) (xxxx-xx-xx)
+
+## Fixed
+- Fixed `Phalcon\Filter::sanitize` to return correct data when `noRecursive` is `true` [#16199](https://github.com/phalcon/cphalcon/issues/16199)
+
 # [5.1.0](https://github.com/phalcon/cphalcon/releases/tag/v5.1.0) (2022-11-01)
 
 ## Fixed

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 - Fixed `Phalcon\Filter::sanitize` to return correct data when `noRecursive` is `true` [#16199](https://github.com/phalcon/cphalcon/issues/16199)
+- Fixed `Phalcon\Html\Escaper::html` to not return `null` when a zero string is passed [#16202](https://github.com/phalcon/cphalcon/issues/16202)
 
 # [5.1.0](https://github.com/phalcon/cphalcon/releases/tag/v5.1.0) (2022-11-01)
 

--- a/phalcon/Html/Escaper.zep
+++ b/phalcon/Html/Escaper.zep
@@ -250,7 +250,7 @@ class Escaper implements EscaperInterface
      */
     public function html(string input = null) -> string
     {
-        if !input {
+        if null === input {
             return "";
         }
         return htmlspecialchars(

--- a/tests/integration/Filter/Validation/ConstructCest.php
+++ b/tests/integration/Filter/Validation/ConstructCest.php
@@ -41,9 +41,8 @@ class ConstructCest
 
         $validation = new Validation($validators);
 
-        $I->assertEquals(
-            $validators,
-            $validation->getValidators()
-        );
+        $expected = $validators;
+        $actual   = $validation->getValidators();
+        $I->assertSame($expected, $actual);
     }
 }

--- a/tests/integration/Filter/Validation/ValidateCest.php
+++ b/tests/integration/Filter/Validation/ValidateCest.php
@@ -57,7 +57,7 @@ class ValidateCest
             [
                 'day'   => date('d'),
                 'month' => date('m'),
-                'year'  => date('Y') + 1,
+                'year'  => (string) (intval(date('Y')) + 1),
             ]
         );
 

--- a/tests/unit/Html/Escaper/HtmlCest.php
+++ b/tests/unit/Html/Escaper/HtmlCest.php
@@ -52,11 +52,14 @@ class HtmlCest
     {
         $I->wantToTest('Escaper - html() - null');
 
-        $escaper = new Escaper();
-
         $escaper  = new Escaper();
         $expected = '';
         $actual   = $escaper->html(null);
+        $I->assertSame($expected, $actual);
+
+        $escaper  = new Escaper();
+        $expected = '0';
+        $actual   = $escaper->html('0');
         $I->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16202 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Html\Escaper::html` to not return `null` when a zero string is passed

Thanks

