### PR TITLE
T16214 delete getrelated

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1267,7 +1267,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             success;
         array values, bindTypes, conditions;
 
-        let metaData = this->getModelsMetaData(),
+        let metaData        = this->getModelsMetaData(),
             writeConnection = this->getWriteConnection();
 
         /**
@@ -1285,11 +1285,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
         }
 
-        let values = [],
-            bindTypes = [],
+        let values     = [],
+            bindTypes  = [],
             conditions = [];
 
-        let primaryKeys = metaData->getPrimaryKeyAttributes(this),
+        let primaryKeys   = metaData->getPrimaryKeyAttributes(this),
             bindDataTypes = metaData->getBindTypes(this);
 
         if globals_get("orm.column_renaming") {
@@ -1340,7 +1340,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             if unlikely !fetch value, this->{attributeField} {
                 throw new Exception(
-                    "Cannot delete the record because the primary key attribute: '" . attributeField . "' was not set"
+                    "Cannot delete the record because the primary key attribute: '"
+                    . attributeField . "' was not set"
                 );
             }
 
@@ -1403,6 +1404,15 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if success {
                 this->fireEvent("afterDelete");
             }
+        }
+
+        /**
+         * Clear related records from the internal cache so that next time
+         * we can get proper counts.
+         */
+        if (success) {
+            let this->related = [];
+            this->modelsManager->clearReusableObjects();
         }
 
         /**
@@ -2046,7 +2056,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if unlikely typeof relation !== "object" {
             throw new Exception(
-                "There is no defined relations for the model '" . className . "' using alias '" . alias . "'"
+                "There is no defined relations for the model '"
+                . className . "' using alias '" . alias . "'"
             );
         }
 

--- a/tests/_data/fixtures/Traits/CliTrait.php
+++ b/tests/_data/fixtures/Traits/CliTrait.php
@@ -13,12 +13,16 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Fixtures\Traits;
 
+use Phalcon\Annotations\Adapter\Memory;
 use Phalcon\Cli\Dispatcher;
 use Phalcon\Cli\Router;
 use Phalcon\Encryption\Security;
 use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Filter\Filter;
 use Phalcon\Html\Escaper;
+use Phalcon\Mvc\Model\Manager;
+use Phalcon\Mvc\Model\MetaData\Memory as MetadataMemory;
+use Phalcon\Mvc\Model\Transaction\Manager as TransactionManager;
 use Phalcon\Support\HelperFactory;
 
 trait CliTrait
@@ -81,6 +85,10 @@ trait CliTrait
     {
         return [
             [
+                'service' => 'annotations',
+                'class'   => Memory::class,
+            ],
+            [
                 'service' => 'dispatcher',
                 'class'   => Dispatcher::class,
             ],
@@ -101,12 +109,24 @@ trait CliTrait
                 'class'   => HelperFactory::class,
             ],
             [
+                'service' => 'modelsManager',
+                'class'   => Manager::class,
+            ],
+            [
+                'service' => 'modelsMetadata',
+                'class'   => MetadataMemory::class,
+            ],
+            [
                 'service' => 'router',
                 'class'   => Router::class,
             ],
             [
                 'service' => 'security',
                 'class'   => Security::class,
+            ],
+            [
+                'service' => 'transactionManager',
+                'class'   => TransactionManager::class,
             ],
         ];
     }

--- a/tests/_data/fixtures/Traits/CliTrait.php
+++ b/tests/_data/fixtures/Traits/CliTrait.php
@@ -20,6 +20,7 @@ use Phalcon\Encryption\Security;
 use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Filter\Filter;
 use Phalcon\Html\Escaper;
+use Phalcon\Html\TagFactory;
 use Phalcon\Mvc\Model\Manager;
 use Phalcon\Mvc\Model\MetaData\Memory as MetadataMemory;
 use Phalcon\Mvc\Model\Transaction\Manager as TransactionManager;
@@ -123,6 +124,10 @@ trait CliTrait
             [
                 'service' => 'security',
                 'class'   => Security::class,
+            ],
+            [
+                'service' => 'tag',
+                'class'   => TagFactory::class,
             ],
             [
                 'service' => 'transactionManager',

--- a/tests/database/Mvc/Model/DeleteCest.php
+++ b/tests/database/Mvc/Model/DeleteCest.php
@@ -123,15 +123,15 @@ class DeleteCest
 
         $expected = 2;
         $actual   = $customer->invoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         $expected = 1;
         $actual   = $customer->paidInvoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         $expected = 1;
         $actual   = $customer->unpaidInvoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         $actual = $customer->delete();
         $I->assertTrue($actual);
@@ -140,11 +140,11 @@ class DeleteCest
 
         $expected = 1;
         $actual   = $invoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         $expected = $unpaidInvoiceId;
         $actual   = $invoices[0]->inv_id;
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
     }
 
     /**
@@ -230,7 +230,7 @@ class DeleteCest
          */
         $expected = 5;
         $actual   = $customer->invoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         /**
          * Get paid invoices using the property
@@ -256,7 +256,7 @@ class DeleteCest
          */
         $expected = 3;
         $actual   = $customer->invoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         /**
          * Get unpaid invoices using getRelated()
@@ -273,7 +273,7 @@ class DeleteCest
          */
         $expected = 0;
         $actual   = $customer->invoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
     }
 
     /**
@@ -318,7 +318,7 @@ class DeleteCest
 
         $expected = 1;
         $actual   = $customer->inactiveInvoices->count();
-        $I->assertSame($expected, $actual);
+        $I->assertEquals($expected, $actual);
 
         $actual = $customer->delete();
         $I->assertFalse($actual);

--- a/tests/database/Mvc/Model/GetRelatedCest.php
+++ b/tests/database/Mvc/Model/GetRelatedCest.php
@@ -221,22 +221,5 @@ class GetRelatedCest
         $expected = $custIdTwo;
         $actual   = $customer->cst_id;
         $I->assertEquals($expected, $actual);
-
-        /**
-         * Delete Customer Two and call getRelated again. We should get
-         * the cached copy
-         */
-        $result = $customer->delete();
-        $I->assertTrue($result);
-
-        /** @var Customers $customer */
-        $customer = $invoice->getRelated('customer');
-
-        $class = Customers::class;
-        $I->assertInstanceOf($class, $customer);
-
-        $expected = $custIdTwo;
-        $actual   = $customer->cst_id;
-        $I->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Di/FactoryDefault/Cli/ConstructCest.php
+++ b/tests/unit/Di/FactoryDefault/Cli/ConstructCest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Di\FactoryDefault\Cli;
+
+use Codeception\Example;
+use Phalcon\Di\Exception;
+use Phalcon\Di\FactoryDefault\Cli;
+use Phalcon\Tests\Fixtures\Traits\CliTrait;
+use UnitTester;
+
+/**
+ * Class ConstructCest
+ *
+ * @package Phalcon\Tests\Unit\Di\FactoryDefault\Cli
+ */
+class ConstructCest
+{
+    use CliTrait;
+
+    /**
+     * Tests Phalcon\Di\FactoryDefault\Cli :: __construct()
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-09-09
+     */
+    public function diFactoryDefaultCliConstruct(UnitTester $I)
+    {
+        $I->wantToTest('Di\FactoryDefault\Cli - __construct()');
+
+        $container = new Cli();
+        $services  = $this->getServices();
+
+        $expected = count($services);
+        $actual   = count($container->getServices());
+        $I->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Di\FactoryDefault\Cli :: __construct() - Check services
+     *
+     * @dataProvider getServices
+     *
+     * @param UnitTester $I
+     * @param Example    $example
+     *
+     * @throws Exception
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2019-09-09
+     */
+    public function diFactoryDefaultCliConstructServices(UnitTester $I, Example $example)
+    {
+        $I->wantToTest('Di\FactoryDefault\Cli - __construct() - Check services');
+
+        $container = new Cli();
+
+        $class  = $example['class'];
+        $actual = $container->get($example['service']);
+        $I->assertInstanceOf($class, $actual);
+    }
+}

--- a/tests/unit/Di/FactoryDefault/Cli/SetServiceCest.php
+++ b/tests/unit/Di/FactoryDefault/Cli/SetServiceCest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Di\FactoryDefault\Cli;
+
+use Phalcon\Di\FactoryDefault;
+use Phalcon\Di\Service;
+use Phalcon\Html\Escaper;
+use UnitTester;
+
+/**
+ * Class SetServiceCest
+ *
+ * @package Phalcon\Tests\Unit\Di\FactoryDefault\Cli
+ */
+class SetServiceCest
+{
+    /**
+     * Unit Tests Phalcon\Di\FactoryDefault\Cli :: setService()
+     *
+     * @param UnitTester $I
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-09-09
+     */
+    public function diFactoryDefaultCliSetRaw(UnitTester $I)
+    {
+        $I->wantToTest('Di\FactoryDefault\Cli - setService()');
+
+        $container = new FactoryDefault\Cli();
+
+        $expected = new Service(Escaper::class);
+        $actual   = $container->setService('escaper', $expected);
+        $I->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16214 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::delete` to clear the reusable cache when deleting records using `getRelated()`

Thanks

