### PR TITLE
Update Redis.zep

### DIFF
--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -68,6 +68,32 @@ class Redis extends AbstractAdapter
         parent::__construct(factory, options);
     }
 
+     /**
+     * Returns the time to live left for a given key in seconds
+     *
+     * @param string $key
+     * LONG: The time to live in seconds. If the key has no ttl, -1 will be returned, and -2 if the key doesn't exist.
+     * @return int 
+     * @throws StorageException
+     */
+     public function ttl($key) -> int
+     {
+        return this->getAdapter()->ttl(key);
+     }
+     
+     /**
+     * Returns the time to live left for a given key in milliseconds 
+     *
+     * @param string $key
+     * 
+     * @return int 
+     * @throws StorageException
+     */
+     public function pttl() -> int
+     {
+        return this->getAdapter()->pttl(key);
+     }
+     
     /**
      * Flushes/clears the cache
      *

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -69,13 +69,15 @@ class Redis extends AbstractAdapter
     }
 
      /**
-     * Returns the time to live left for a given key in seconds
+     * Returns the time to live left for a given key in seconds.
+     * If the key has no ttl, -1 will be returned, and -2 if the key doesn't exist.
      *
-     * @param string $key LONG: The time to live in seconds. If the key has no ttl, -1 will be returned, and -2 if the key doesn't exist.
+     * @param string $key
+     *
      * @return int 
      * @throws StorageException
      */
-     public function ttl($key) -> int
+     public function ttl(string! key) -> int
      {
         return this->getAdapter()->ttl(key);
      }
@@ -88,7 +90,7 @@ class Redis extends AbstractAdapter
      * @return int 
      * @throws StorageException
      */
-     public function pttl() -> int
+     public function pttl(string! key) -> int
      {
         return this->getAdapter()->pttl(key);
      }

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -71,8 +71,7 @@ class Redis extends AbstractAdapter
      /**
      * Returns the time to live left for a given key in seconds
      *
-     * @param string $key
-     * LONG: The time to live in seconds. If the key has no ttl, -1 will be returned, and -2 if the key doesn't exist.
+     * @param string $key LONG: The time to live in seconds. If the key has no ttl, -1 will be returned, and -2 if the key doesn't exist.
      * @return int 
      * @throws StorageException
      */


### PR DESCRIPTION
add ttl() and pttl() to that developer can get Redis TTL.

Hello!

* Type: new feature
* Link to issue: [https://github.com/phpredis/phpredis#ttl-pttl](https://github.com/phpredis/phpredis#ttl-pttl)

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR

Small description of change:
add ttl(), pttl() for Redis.
Thanks

