### PR TITLE
T16348 cache stream

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -6,6 +6,7 @@
  
 - Fixed `Encryption\Crypt::checkCipherHashIsAvailable` to allow proper setting of the hash [#16314](https://github.com/phalcon/cphalcon/issues/16314) 
 - Removed `unlikely` from `if` statements from the Stream storage adapter and Json serializer [#16339](https://github.com/phalcon/cphalcon/issues/16339)
+- Fixed `Storage\Adapter\Stream::get()/set()` to correctly calculate the path if the prefix is present in the key [#16348](https://github.com/phalcon/cphalcon/issues/16348)
 
 ## [5.2.1](https://github.com/phalcon/cphalcon/releases/tag/v5.2.1) (2023-02-28)
 

--- a/phalcon/Storage/Adapter/Stream.zep
+++ b/phalcon/Storage/Adapter/Stream.zep
@@ -314,9 +314,7 @@ class Stream extends AbstractAdapter
         var dirFromFile, dirPrefix;
 
         let dirPrefix   = this->getDirSeparator(this->storageDir . this->prefix),
-            dirFromFile = this->getDirFromFile(
-                str_replace(this->prefix, "", key)
-            );
+            dirFromFile = $this->getDirFromFile($this->getKeyWithoutPrefix($key));
 
         return this->getDirSeparator(dirPrefix . dirFromFile);
     }
@@ -328,9 +326,26 @@ class Stream extends AbstractAdapter
      *
      * @return string
      */
-    private function getFilepath(string! key) -> string
+    private function getFilepath(string key) -> string
     {
-        return this->getDir(key) . str_replace(this->prefix, "", key);
+        return this->getDir(key) . this->getKeyWithoutPrefix(key);
+    }
+
+    /**
+     * Check if the key has the prefix and remove it, otherwise just return the
+     * key unaltered
+     *
+     * @param string $key
+     *
+     * @return string
+     */
+    private function getKeyWithoutPrefix(string key) -> string
+    {
+        if (starts_with(key, this->prefix)) {
+            return substr(key, strlen(this->prefix));
+        }
+
+        return key;
     }
 
     /**

--- a/tests/integration/Cache/Adapter/Apcu/GetKeysCest.php
+++ b/tests/integration/Cache/Adapter/Apcu/GetKeysCest.php
@@ -34,7 +34,7 @@ class GetKeysCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterApcuGetKeys(IntegrationTester $I)
+    public function cacheAdapterApcuGetKeys(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Apcu - getKeys()');
 
@@ -82,7 +82,7 @@ class GetKeysCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterApcuGetKeysIteratorError(IntegrationTester $I)
+    public function cacheAdapterApcuGetKeysIteratorError(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Apcu - getKeys() - iterator error');
 

--- a/tests/integration/Cache/Adapter/Apcu/GetSetCest.php
+++ b/tests/integration/Cache/Adapter/Apcu/GetSetCest.php
@@ -38,7 +38,7 @@ class GetSetCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterApcuGetSet(IntegrationTester $I, Example $example)
+    public function cacheAdapterApcuGetSet(IntegrationTester $I, Example $example)
     {
         $I->wantToTest('Cache\Adapter\Apcu - get()/set() - ' . $example[0]);
 

--- a/tests/integration/Cache/Adapter/ClearCest.php
+++ b/tests/integration/Cache/Adapter/ClearCest.php
@@ -40,7 +40,7 @@ class ClearCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterApcuClearIteratorError(IntegrationTester $I)
+    public function cacheAdapterApcuClearIteratorError(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Apcu - clear() - iterator error');
 
@@ -81,7 +81,7 @@ class ClearCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterApcuClearDeleteError(IntegrationTester $I)
+    public function cacheAdapterApcuClearDeleteError(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Apcu - clear() - delete error');
 
@@ -123,7 +123,7 @@ class ClearCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamClearCannotDeleteFile(IntegrationTester $I)
+    public function cacheAdapterStreamClearCannotDeleteFile(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - clear() - cannot delete file');
 
@@ -165,7 +165,7 @@ class ClearCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterClear(IntegrationTester $I, Example $example)
+    public function cacheAdapterClear(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/ConstructCest.php
+++ b/tests/integration/Cache/Adapter/ConstructCest.php
@@ -42,7 +42,7 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamConstructException(IntegrationTester $I)
+    public function cacheAdapterStreamConstructException(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - __construct() - exception');
 
@@ -66,7 +66,7 @@ class ConstructCest
      *
      * @throws SupportException
      */
-    public function storageAdapterLibmemcachedConstructEmptyOptions(IntegrationTester $I)
+    public function cacheAdapterLibmemcachedConstructEmptyOptions(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Libmemcached - __construct() - empty options');
 
@@ -98,7 +98,7 @@ class ConstructCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterLibmemcachedConstructGetTtl(IntegrationTester $I)
+    public function cacheAdapterLibmemcachedConstructGetTtl(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Libmemcached - __construct() - getTtl');
 
@@ -131,7 +131,7 @@ class ConstructCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterConstruct(IntegrationTester $I, Example $example)
+    public function cacheAdapterConstruct(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/DecrementCest.php
+++ b/tests/integration/Cache/Adapter/DecrementCest.php
@@ -37,7 +37,7 @@ class DecrementCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterClear(IntegrationTester $I, Example $example)
+    public function cacheAdapterClear(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/DeleteCest.php
+++ b/tests/integration/Cache/Adapter/DeleteCest.php
@@ -38,7 +38,7 @@ class DeleteCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterDelete(IntegrationTester $I, Example $example)
+    public function cacheAdapterDelete(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/GetAdapterCest.php
+++ b/tests/integration/Cache/Adapter/GetAdapterCest.php
@@ -39,7 +39,7 @@ class GetAdapterCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterGetAdapter(IntegrationTester $I, Example $example)
+    public function cacheAdapterGetAdapter(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/GetPrefixCest.php
+++ b/tests/integration/Cache/Adapter/GetPrefixCest.php
@@ -37,7 +37,7 @@ class GetPrefixCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterGetSetPrefix(IntegrationTester $I, Example $example)
+    public function cacheAdapterGetSetPrefix(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/GetSetCest.php
+++ b/tests/integration/Cache/Adapter/GetSetCest.php
@@ -40,7 +40,7 @@ class GetSetCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterGetSetWithZeroTtl(IntegrationTester $I, Example $example)
+    public function cacheAdapterGetSetWithZeroTtl(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/GetSetDefaultSerializerCest.php
+++ b/tests/integration/Cache/Adapter/GetSetDefaultSerializerCest.php
@@ -37,7 +37,7 @@ class GetSetDefaultSerializerCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterGetSetDefaultSerializer(IntegrationTester $I, Example $example)
+    public function cacheAdapterGetSetDefaultSerializer(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/GetSetForeverCest.php
+++ b/tests/integration/Cache/Adapter/GetSetForeverCest.php
@@ -41,7 +41,7 @@ class GetSetForeverCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterGetSetForever(IntegrationTester $I, Example $example)
+    public function cacheAdapterGetSetForever(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/HasCest.php
+++ b/tests/integration/Cache/Adapter/HasCest.php
@@ -39,7 +39,7 @@ class HasCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamHasCannotOpenFile(IntegrationTester $I)
+    public function cacheAdapterStreamHasCannotOpenFile(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - has() - cannot open file');
 
@@ -76,7 +76,7 @@ class HasCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamHasEmptyPayload(IntegrationTester $I)
+    public function cacheAdapterStreamHasEmptyPayload(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - has() - empty payload');
 
@@ -110,7 +110,7 @@ class HasCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterHas(IntegrationTester $I, Example $example)
+    public function cacheAdapterHas(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/IncrementCest.php
+++ b/tests/integration/Cache/Adapter/IncrementCest.php
@@ -37,7 +37,7 @@ class IncrementCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterClear(IntegrationTester $I, Example $example)
+    public function cacheAdapterClear(IntegrationTester $I, Example $example)
     {
         $I->wantToTest(
             sprintf(

--- a/tests/integration/Cache/Adapter/Libmemcached/GetKeysCest.php
+++ b/tests/integration/Cache/Adapter/Libmemcached/GetKeysCest.php
@@ -37,7 +37,7 @@ class GetKeysCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterLibmemcachedGetKeys(IntegrationTester $I)
+    public function cacheAdapterLibmemcachedGetKeys(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Libmemcached - getKeys()');
 

--- a/tests/integration/Cache/Adapter/Libmemcached/GetSetCest.php
+++ b/tests/integration/Cache/Adapter/Libmemcached/GetSetCest.php
@@ -41,7 +41,7 @@ class GetSetCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterLibmemcachedGetSet(IntegrationTester $I, Example $example)
+    public function cacheAdapterLibmemcachedGetSet(IntegrationTester $I, Example $example)
     {
         $I->wantToTest('Cache\Adapter\Libmemcached - get()/set() - ' . $example[0]);
 
@@ -72,7 +72,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterLibmemcachedGetSetCustomSerializer(IntegrationTester $I)
+    public function cacheAdapterLibmemcachedGetSetCustomSerializer(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Libmemcached - get()/set() - custom serializer');
 

--- a/tests/integration/Cache/Adapter/Memory/GetKeysCest.php
+++ b/tests/integration/Cache/Adapter/Memory/GetKeysCest.php
@@ -30,7 +30,7 @@ class GetKeysCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterMemoryGetKeys(IntegrationTester $I)
+    public function cacheAdapterMemoryGetKeys(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Memory - getKeys()');
 

--- a/tests/integration/Cache/Adapter/Memory/GetSetCest.php
+++ b/tests/integration/Cache/Adapter/Memory/GetSetCest.php
@@ -35,7 +35,7 @@ class GetSetCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterMemoryGetSet(IntegrationTester $I, Example $example)
+    public function cacheAdapterMemoryGetSet(IntegrationTester $I, Example $example)
     {
         $I->wantToTest('Cache\Adapter\Memory - get()/set() - ' . $example[0]);
 

--- a/tests/integration/Cache/Adapter/Redis/DecrementCest.php
+++ b/tests/integration/Cache/Adapter/Redis/DecrementCest.php
@@ -38,7 +38,7 @@ class DecrementCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisDecrement(IntegrationTester $I)
+    public function cacheAdapterRedisDecrement(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - decrement()');
 

--- a/tests/integration/Cache/Adapter/Redis/GetKeysCest.php
+++ b/tests/integration/Cache/Adapter/Redis/GetKeysCest.php
@@ -37,7 +37,7 @@ class GetKeysCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisGetKeys(IntegrationTester $I)
+    public function cacheAdapterRedisGetKeys(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - getKeys()');
 

--- a/tests/integration/Cache/Adapter/Redis/GetSetCest.php
+++ b/tests/integration/Cache/Adapter/Redis/GetSetCest.php
@@ -44,7 +44,7 @@ class GetSetCest
      * @author       Phalcon Team <team@phalcon.io>
      * @since        2020-09-09
      */
-    public function storageAdapterRedisGetSet(IntegrationTester $I, Example $example)
+    public function cacheAdapterRedisGetSet(IntegrationTester $I, Example $example)
     {
         $I->wantToTest('Cache\Adapter\Redis - get()/set() - ' . $example[0]);
 
@@ -71,7 +71,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisGetSetPersistent(IntegrationTester $I)
+    public function cacheAdapterRedisGetSetPersistent(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - get()/set() - persistent');
 
@@ -103,7 +103,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisGetSetWrongIndex(IntegrationTester $I)
+    public function cacheAdapterRedisGetSetWrongIndex(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - get()/set() - wrong index');
 
@@ -134,7 +134,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisGetSetFailedAuth(IntegrationTester $I)
+    public function cacheAdapterRedisGetSetFailedAuth(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - get()/set() - failed auth');
 
@@ -168,7 +168,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisGetSetCustomSerializer(IntegrationTester $I)
+    public function cacheAdapterRedisGetSetCustomSerializer(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - get()/set() - custom serializer');
 

--- a/tests/integration/Cache/Adapter/Redis/IncrementCest.php
+++ b/tests/integration/Cache/Adapter/Redis/IncrementCest.php
@@ -38,7 +38,7 @@ class IncrementCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterRedisIncrement(IntegrationTester $I)
+    public function cacheAdapterRedisIncrement(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Redis - increment()');
 

--- a/tests/integration/Cache/Adapter/Stream/GetKeysCest.php
+++ b/tests/integration/Cache/Adapter/Stream/GetKeysCest.php
@@ -36,7 +36,7 @@ class GetKeysCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamGetKeys(IntegrationTester $I)
+    public function cacheAdapterStreamGetKeys(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - getKeys()');
 
@@ -102,7 +102,7 @@ class GetKeysCest
      * @since  2020-09-09
      * @issue  cphalcon/#14190
      */
-    public function storageAdapterStreamGetKeysIssue14190(IntegrationTester $I)
+    public function cacheAdapterStreamGetKeysIssue14190(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - getKeys() - issue 14190');
 
@@ -152,7 +152,7 @@ class GetKeysCest
      * @since  2020-09-09
      * @issue  cphalcon/#14190
      */
-    public function storageAdapterStreamGetKeysPrefix(IntegrationTester $I)
+    public function cacheAdapterStreamGetKeysPrefix(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - getKeys() - prefix');
 

--- a/tests/integration/Cache/Adapter/Stream/GetSetCest.php
+++ b/tests/integration/Cache/Adapter/Stream/GetSetCest.php
@@ -39,7 +39,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamSet(IntegrationTester $I)
+    public function cacheAdapterStreamSet(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - set()');
 
@@ -75,7 +75,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamGet(IntegrationTester $I)
+    public function cacheAdapterStreamGet(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - get()');
 
@@ -111,6 +111,73 @@ class GetSetCest
     }
 
     /**
+     * Tests Phalcon\Cache\Adapter\Stream :: get() - with prefix
+     *
+     * @param IntegrationTester $I
+     *
+     * @throws HelperException
+     * @throws CacheException
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2023-06-01
+     * @issue  16348
+     */
+    public function cacheAdapterStreamGetWithPrefix(IntegrationTester $I)
+    {
+        $I->wantToTest('Cache\Adapter\Stream - get() with prefix');
+
+        $serializer = new SerializerFactory();
+        $adapter    = new Stream(
+            $serializer,
+            [
+                'storageDir' => outputDir(),
+                'prefix'     => 'en',
+            ]
+        );
+
+        $target = outputDir() . 'en/';
+
+        $data   = 123;
+        $actual = $adapter->set('men', $data);
+        $I->assertTrue($actual);
+
+        $expected = 123;
+        $actual   = $adapter->get('men');
+        $I->assertNotNull($actual);
+        $I->assertEquals($expected, $actual);
+
+
+        $data   = 'abc';
+        $actual = $adapter->set('barmen', $data);
+        $I->assertTrue($actual);
+
+        $expected = 'abc';
+        $actual   = $adapter->get('barmen');
+        $I->assertNotNull($actual);
+        $I->assertEquals($expected, $actual);
+
+        $data   = 'xyz';
+        $actual = $adapter->set('bar', $data);
+        $I->assertTrue($actual);
+
+        $expected = 'xyz';
+        $actual   = $adapter->get('bar');
+        $I->assertNotNull($actual);
+        $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'enbar',
+            'enbarmen',
+            'enmen',
+        ];
+        $actual   = $adapter->getKeys();
+        sort($actual);
+        $I->assertEquals($expected, $actual);
+
+        $I->safeDeleteFile($target);
+    }
+
+    /**
      * Tests Phalcon\Cache\Adapter\Stream :: get() - errors
      *
      * @param IntegrationTester $I
@@ -121,7 +188,7 @@ class GetSetCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageAdapterStreamGetErrors(IntegrationTester $I)
+    public function cacheAdapterStreamGetErrors(IntegrationTester $I)
     {
         $I->wantToTest('Cache\Adapter\Stream - get() - errors');
 

--- a/tests/integration/Cache/AdapterFactory/NewInstanceCest.php
+++ b/tests/integration/Cache/AdapterFactory/NewInstanceCest.php
@@ -66,7 +66,7 @@ class NewInstanceCest
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */
-    public function storageSerializerFactoryNewInstanceException(IntegrationTester $I)
+    public function cacheSerializerFactoryNewInstanceException(IntegrationTester $I)
     {
         $I->wantToTest('Storage\SerializerFactory - newInstance() - exception');
 


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16348 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Storage\Adapter\Stream::get()/set()` to correctly calculate the path if the prefix is present in the key

Thanks

