### PR TITLE
Fix checked attribute if « empty »

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -97,8 +97,11 @@ Thanks for the support
 
 <a href="https://github.com/niden"><img src="https://avatars2.githubusercontent.com/u/1073784?s=460&v=4" title="Nikolaos Dimopoulos" width="60" height="60"></a>
 <a href="https://github.com/Brade"><img src="https://avatars.githubusercontent.com/u/46009?v=4" title="N. Brad Garrett" width="60" height="60"></a>
+<a href="https://github.com/DestinyMKas"><img src="https://avatars.githubusercontent.com/u/170159?v=4" title="Karolis Mačiulskis" width="60" height="60"></a>
 <a href="https://github.com/andresgutierrez"><img src="https://avatars.githubusercontent.com/u/213590?v=4" title="Andres Gutierrez" width="60" height="60"></a>
+<a href="https://github.com/pyatin"><img src="https://avatars.githubusercontent.com/u/296939?v=4" title="Glib Pyatin" width="60" height="60"></a>
 <a href="https://github.com/alrieckert"><img src="https://avatars1.githubusercontent.com/u/452786?s=460&v=4" title="Anton Rieckert" width="60" height="60"></a>
+<a href="https://github.com/yannux"><img src="https://avatars.githubusercontent.com/u/533125?s=460&u=4f1e888783d1faafaa76282e5c388501c2b2df83&v=4" title="Yann" width="60" height="60"></a>
 <a href="https://github.com/elcreator"><img src="https://avatars.githubusercontent.com/u/974975?v=4" title="Artur Kyryliuk" width="60" height="60"></a>
 <a href="https://github.com/Ultimater"><img src="https://avatars.githubusercontent.com/u/1922199?v=4" title="Kevin Yarmak" width="60" height="60"></a>
 <a href="https://github.com/Ruzgfpegk"><img src="https://avatars1.githubusercontent.com/u/3818364?s=460&v=4" title="Ruzgfpegk" width="60" height="60"></a>
@@ -106,16 +109,20 @@ Thanks for the support
 <a href="https://github.com/f-do"><img src="https://avatars.githubusercontent.com/u/4299065?v=4" title="Florian" width="60" height="60"></a>
 <a href="https://github.com/borisdelev"><img src="https://avatars.githubusercontent.com/u/4441663?s=460&u=be604c39153e26326f2123c6e1bfe880d5ec0947&v=4" title="Boris Delev" width="60" height="60"></a>
 <a href="https://github.com/stdnk"><img src="https://avatars.githubusercontent.com/u/5130969?v=4" title="Vasily Stadnik" width="60" height="60"></a>
+<a href="https://github.com/educury"><img src="https://avatars2.githubusercontent.com/u/5339278?s=460&v=4" title="educury" width="60" height="60"></a>
 <a href="https://github.com/emagus"><img src="https://avatars.githubusercontent.com/u/5857789?v=4" title="maGus Informática" width="60" height="60"></a>
 <a href="https://github.com/tztztztz"><img src="https://avatars.githubusercontent.com/u/7032308?v=4" title="Tomasz Zadora" width="60" height="60"></a>
+<a href="https://github.com/ruudboon"><img src="https://avatars3.githubusercontent.com/u/7444246?s=460&v=4" title="Ruud Boon" width="60" height="60"></a>
 <a href="https://github.com/sitchi"><img src="https://avatars.githubusercontent.com/u/11546683?v=4" title="Nikoloz Sitchinava" width="60" height="60"></a>
 <a href="https://github.com/6trading"><img src="https://avatars.githubusercontent.com/u/12135941?v=4" title="Chris" width="60" height="60"></a>
+<a href="https://github.com/aircodepl"><img src="https://avatars.githubusercontent.com/u/17483386?v=4" title="Mateusz" width="60" height="60"></a>
 <a href="https://github.com/fvromera"><img src="https://avatars.githubusercontent.com/u/32909196?s=460&u=a4a6d765c836be52ab247354399d0ed1a49224fa&v=4" title="fvromera" width="60" height="60"></a>
 <a href="https://github.com/ak1113"><img src="https://avatars0.githubusercontent.com/u/38716832?s=460&v=4" title="Akira Kato" width="60" height="60"></a>
 <a href="https://github.com/dredasss"><img src="https://avatars1.githubusercontent.com/u/38747389?s=460&u=ee99a8bb28ee6bedbbea6325d49d4eb99080d421&v=4" title="Nerijus Alex" width="60" height="60"></a>
-<a href="https://github.com/housesigma"><img src="https://avatars.githubusercontent.com/u/50630040?s=200&v=4" title="HouseSigma" width="60" height="60"></a>
+<a href="https://github.com/RaulRaf95"><img src="https://avatars.githubusercontent.com/u/63474503?v=4" title="RaulRaf95" width="60" height="60"></a>
 <a href="https://github.com/levertr"><img src="https://avatars.githubusercontent.com/u/78140431?v=4" title="Rayan Levert" width="60" height="60"></a>
 <a href="https://github.com/iogates"><img src="https://avatars.githubusercontent.com/u/86652317?s=200&v=4" title="iogates" width="60" height="60"></a>
+<a href="https://github.com/super-dmitriy"><img src="https://avatars.githubusercontent.com/u/5605919?v=4" title="Dmitriy" width="60" height="60"></a>
 
 [//]: github-sponsors
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## [5.2.2](https://github.com/phalcon/cphalcon/releases/tag/v5.2.2) (xxxx-xx-xx)
-
-### Fixed
- 
-- Fixed `Encryption\Crypt::checkCipherHashIsAvailable` to allow proper setting of the hash [#16314](https://github.com/phalcon/cphalcon/issues/16314) 
-- Removed `unlikely` from `if` statements from the Stream storage adapter and Json serializer [#16339](https://github.com/phalcon/cphalcon/issues/16339)
-
 ## [5.2.1](https://github.com/phalcon/cphalcon/releases/tag/v5.2.1) (2023-02-28)
 
 ### Fixed

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -38,7 +38,7 @@ use Phalcon\Session\BagInterface;
  * @property \Phalcon\Mvc\Model\MetaData\Memory|\Phalcon\Mvc\Model\MetadataInterface $modelsMetadata
  * @property \Phalcon\Mvc\Model\Transaction\Manager|\Phalcon\Mvc\Model\Transaction\ManagerInterface $transactionManager
  * @property \Phalcon\Assets\Manager $assets
- * @property \Phalcon\Di\Di|\Phalcon\Di\DiInterface $di
+ * @property \Phalcon\Di\Di|\Phalcon\Di\Di\DiInterface $di
  * @property \Phalcon\Session\Bag|\Phalcon\Session\BagInterface $persistent
  * @property \Phalcon\Mvc\View|\Phalcon\Mvc\ViewInterface $view
  */

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -590,7 +590,7 @@ class Crypt implements CryptInterface
     {
         var available, lower, method;
 
-        if "hash" === type {
+        if "hash" === cipher {
             let method = "getAvailableHashAlgorithms";
         } else {
             let method = "getAvailableCiphers";

--- a/phalcon/Html/Helper/Input/Checkbox.zep
+++ b/phalcon/Html/Helper/Input/Checkbox.zep
@@ -115,14 +115,14 @@ class Checkbox extends AbstractInput
 
         let attributes = this->attributes;
         if !fetch checked, attributes["checked"] {
-            let checked = "";
+            let checked = null;
         }
 
         unset attributes["checked"];
 
-        if !empty checked {
+        if checked !== null {
             if !fetch value, attributes["value"] {
-                let value = "";
+                let value = null;
             }
             if checked === value {
                 let attributes["checked"] = "checked";

--- a/phalcon/Storage/Adapter/Stream.zep
+++ b/phalcon/Storage/Adapter/Stream.zep
@@ -83,7 +83,7 @@ class Stream extends AbstractAdapter
             iterator  = this->getIterator(directory);
 
         for file in iterator {
-            if true === file->isFile() && true !== this->phpUnlink(file->getPathName()) {
+            if unlikely true === file->isFile() && true !== this->phpUnlink(file->getPathName()) {
                 let result = false;
             }
         }
@@ -103,7 +103,7 @@ class Stream extends AbstractAdapter
     {
         var data, result;
 
-        if true !== this->has(key) {
+        if unlikely true !== this->has(key) {
             return false;
         }
 
@@ -235,7 +235,7 @@ class Stream extends AbstractAdapter
     {
         var data, result;
 
-        if true !== this->has(key) {
+        if unlikely true !== this->has(key) {
             return false;
         }
 

--- a/phalcon/Storage/Serializer/Json.zep
+++ b/phalcon/Storage/Serializer/Json.zep
@@ -65,7 +65,7 @@ class Json extends AbstractSerializer
 
         let decoded = json_decode(data, associative, depth, options);
 
-        if JSON_ERROR_NONE !== json_last_error() {
+        if unlikely JSON_ERROR_NONE !== json_last_error() {
             throw new InvalidArgumentException(
                 "json_decode error: " . json_last_error_msg()
             );
@@ -86,7 +86,7 @@ class Json extends AbstractSerializer
 
         let encoded = json_encode(data, options, depth);
 
-        if JSON_ERROR_NONE !== json_last_error() {
+        if unlikely JSON_ERROR_NONE !== json_last_error() {
             throw new InvalidArgumentException(
                 "json_encode error: " . json_last_error_msg()
             );

--- a/tests/unit/Encryption/Crypt/GetSetHashAlgorithmCest.php
+++ b/tests/unit/Encryption/Crypt/GetSetHashAlgorithmCest.php
@@ -35,6 +35,7 @@ class GetSetHashAlgorithmCest
     public function encryptionCryptGetSetHashAlgo(UnitTester $I)
     {
         $I->wantToTest('Encryption\Crypt - getHashAlgorithm() / setHashAlgorithm()');
+        $I->skipTest('TODO: Check this test with 8.2');
 
         $cipher = 'sha384';
         $crypt  = new Crypt();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15959

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Setting `checked` attribute to an « empty » value doesn't check the checkbox/radio input. « empty » is understand as the return of « empty() » PHP function.

For example `0` and the `empty string` are considered empty, but `<input type="checkbox" name="test" value="0" checked="checked"/>` is a valid option that Phalcon 5 doesn't allow.

Thanks