### PR TITLE
Fix « empty » checkbox value

### DIFF
--- a/phalcon/Html/Helper/Input/Checkbox.zep
+++ b/phalcon/Html/Helper/Input/Checkbox.zep
@@ -115,14 +115,14 @@ class Checkbox extends AbstractInput
 
         let attributes = this->attributes;
         if !fetch checked, attributes["checked"] {
-            let checked = "";
+            let checked = null;
         }
 
         unset attributes["checked"];
 
-        if !empty checked {
+        if checked !== null {
             if !fetch value, attributes["value"] {
-                let value = "";
+                let value = null;
             }
             if checked === value {
                 let attributes["checked"] = "checked";


### PR DESCRIPTION
Hello!

(new PR to use the 5.0.x branch)

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15959

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Setting `checked` attribute to an « empty » value doesn't check the checkbox/radio input. « empty » is understand as the return of « empty() » PHP function.

For example `0` and the `empty string` are considered empty, but `<input type="checkbox" name="test" value="0" checked="checked"/>` is a valid option that Phalcon 5 doesn't allow.

Thanks