### PR TITLE
Update Postgresql.zep

### DIFF
--- a/phalcon/Db/Adapter/Pdo/Postgresql.zep
+++ b/phalcon/Db/Adapter/Pdo/Postgresql.zep
@@ -503,7 +503,7 @@ class Postgresql extends PdoAdapter
              */
             if field[9] !== null {
                 let definition["default"] = preg_replace(
-                    "/^'|'?::[[:alnum:]+[:space:]]+(\\[\\])?$/",
+                    "/^'|'?::[[:alnum:][:space:]]+(\\[\\])?$/",
                     "",
                     field[9]
                 );

--- a/phalcon/Db/Adapter/Pdo/Postgresql.zep
+++ b/phalcon/Db/Adapter/Pdo/Postgresql.zep
@@ -503,7 +503,7 @@ class Postgresql extends PdoAdapter
              */
             if field[9] !== null {
                 let definition["default"] = preg_replace(
-                    "/^'|'?::[[:alnum:][:space:]]+$/",
+                    "/^'|'?::[[:alnum:]+[:space:]]+(\\[\\])?$/",
                     "",
                     field[9]
                 );


### PR DESCRIPTION
// it gives "{}'::character varying[]"
when we must have
"'{}'::character varying[]"
because it gives an sql error

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

