### PR TITLE
T16308 di dynamic properties 4

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Tried to reproduce the behavior described in #16244 but had no success. [#16244](https://github.com/phalcon/cphalcon/issues/16244)
 - Added `getAdapter()` in `Phalcon\Mvc\Model\Metadata` to retrieve the internal cache adapter if necessary. [#16244](https://github.com/phalcon/cphalcon/issues/16244)
+- Extended `Phalcon\Di\Injectable` from `stdClass` to remove the deprecation warning (dynamic properties) for PHP 8.2 [#16308](https://github.com/phalcon/cphalcon/issues/16308)
 
 ## [5.2.2](https://github.com/phalcon/cphalcon/releases/tag/v5.2.2) (2023-06-18)
 

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -10,6 +10,7 @@
 
 namespace Phalcon\Di;
 
+use stdClass;
 use Phalcon\Di\Di;
 use Phalcon\Session\BagInterface;
 
@@ -42,7 +43,7 @@ use Phalcon\Session\BagInterface;
  * @property \Phalcon\Session\Bag|\Phalcon\Session\BagInterface $persistent
  * @property \Phalcon\Mvc\View|\Phalcon\Mvc\ViewInterface $view
  */
-abstract class Injectable implements InjectionAwareInterface
+abstract class Injectable extends stdClass implements InjectionAwareInterface
 {
     /**
      * Dependency Injector

--- a/tests/integration/Mvc/Micro/GetServiceCest.php
+++ b/tests/integration/Mvc/Micro/GetServiceCest.php
@@ -13,59 +13,83 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Integration\Mvc\Micro;
 
+use ErrorException;
 use IntegrationTester;
 use Phalcon\Di\Di;
+use Phalcon\Di\FactoryDefault;
 use Phalcon\Html\Escaper;
+use Phalcon\Http\Request;
 use Phalcon\Mvc\Dispatcher;
 use Phalcon\Mvc\Micro;
 use Phalcon\Mvc\Router;
+
+use function restore_error_handler;
+use function set_error_handler;
 
 class GetServiceCest
 {
     /**
      * Tests Phalcon\Mvc\Micro :: getService()
      *
-     * @author Sid Roberts <https://github.com/SidRoberts>
+     * @author Phalcon Team <team@phalcon.io>
      * @since  2019-05-22
      */
     public function mvcMicroGetService(IntegrationTester $I)
     {
         $I->wantToTest('Mvc\Micro - getService()');
 
-        $micro = new Micro();
-
-        $di = new Di();
-
-        $micro->setDi($di);
-
-
-        $escaper = new Escaper();
-
+        $micro     = new Micro();
+        $container = new Di();
+        $escaper   = new Escaper();
+        $micro->setDi($container);
         $micro->setService('escaper', $escaper);
 
-        $I->assertSame(
-            $escaper,
-            $micro->getService('escaper')
-        );
-
+        $expected = $escaper;
+        $actual   = $micro->getService('escaper');
+        $I->assertSame($expected, $actual);
 
         $dispatcher = new Dispatcher();
-
         $micro['dispatcher'] = $dispatcher;
 
-        $I->assertSame(
-            $dispatcher,
-            $micro->getService('dispatcher')
-        );
-
+        $expected = $dispatcher;
+        $actual   = $micro->getService('dispatcher');
+        $I->assertSame($expected, $actual);
 
         $router = new Router();
+        $container->set('router', $router);
 
-        $di->set('router', $router);
+        $expected = $router;
+        $actual   = $micro->getService('router');
+        $I->assertSame($expected, $actual);
+    }
+    /**
+     * Tests after binding event
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2023-07-03
+     */
+    public function mvcMicroGetServiceWithProperty(IntegrationTester $I)
+    {
+        $container = new FactoryDefault();
+        $micro     = new Micro($container);
+        $error     = '';
 
-        $I->assertSame(
-            $router,
-            $micro->getService('router')
+        set_error_handler(
+            function ($number, $message, $file, $line) {
+                throw new ErrorException($message, 0, $number, $file, $line);
+            }
         );
+
+        try {
+            $class   = Request::class;
+            $request = $micro->request;
+            $I->assertInstanceOf($class, $request);
+        } catch (ErrorException $ex) {
+            $error = $ex->getMessage();
+        }
+
+        restore_error_handler();
+
+        $I->assertEmpty($error);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16308 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Extended `Phalcon\Di\Injectable` from `stdClass` to remove the deprecation warning (dynamic properties) for PHP 8.2

Credit: @escribiendocodigo

Thanks

