### PR TITLE
added return type for getVar() in View

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,8 +5,10 @@
 ### Fixed
 - Tried to reproduce the behavior described in #16244 but had no success. [#16244](https://github.com/phalcon/cphalcon/issues/16244)
 - Added `getAdapter()` in `Phalcon\Mvc\Model\Metadata` to retrieve the internal cache adapter if necessary. [#16244](https://github.com/phalcon/cphalcon/issues/16244)
-- Added `Phalcon\Storage\Adapter\Weak` implemented with WeakReference has a cache/retrieval solution for objects not yet collected by the Garbage Collection. [#16372] (https://github.com/phalcon/cphalcon/issues/16372)
+- Added `Phalcon\Storage\Adapter\Weak` implemented with WeakReference has a cache/retrieval solution for objects not yet collected by the Garbage Collection. [#16372](https://github.com/phalcon/cphalcon/issues/16372)
 - Extended `Phalcon\Di\Injectable` from `stdClass` to remove the deprecation warning (dynamic properties) for PHP 8.2 [#16308](https://github.com/phalcon/cphalcon/issues/16308)
+- Corrected the return type of `Phalcon\Mvc\View::getVar()` so that stubs can be accurate. [#16276](https://github.com/phalcon/cphalcon/issues/16276)
+
 
 ## [5.2.2](https://github.com/phalcon/cphalcon/releases/tag/v5.2.2) (2023-06-18)
 

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -536,8 +536,10 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
 
     /**
      * Returns a parameter previously set in the view
+     *
+     * @return mixed|null
      */
-    public function getVar(string! key)
+    public function getVar(string! key) -> var | null
     {
         var value;
 


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16276 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Corrected the return type of `Phalcon\Mvc\View::getVar()` so that stubs can be accurate.

Thanks

