### PR TITLE
Refactored Model, added Loader::isRegistered, fixed Metadata behaviour

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,13 @@
 
 ## [5.2.4](https://github.com/phalcon/cphalcon/releases/tag/v5.2.4) (xxxx-xx-xx)
 
+### Added
+- Added `Phalcon\Mvc\Model::appendMessagedFrom` for code consistency and to add messages from another another model. [#16391](https://github.com/phalcon/cphalcon/issues/16391)
+- Added `Phalcon\Autoload\Loader::isRegistered` for debugging purposes [#16391](https://github.com/phalcon/cphalcon/issues/16391)
+
+### Changed
+- Refactored `Phalcon\Mvc\Model::doLowUpdate` and `Phalcon\Mvc\Model::postSaveRelatedRecords` for better code logic and a clearer seperation of behaviour although it lead to partially repeated code.[#16391](https://github.com/phalcon/cphalcon/issues/16391)
+
 ### Fixed
 
 - Parse multipart/form-data from PUT request [#16271](https://github.com/phalcon/cphalcon/issues/16271)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,9 +5,13 @@
 ### Added
 - Added `Phalcon\Mvc\Model::appendMessagedFrom` for code consistency and to add messages from another another model. [#16391](https://github.com/phalcon/cphalcon/issues/16391)
 - Added `Phalcon\Autoload\Loader::isRegistered` for debugging purposes [#16391](https://github.com/phalcon/cphalcon/issues/16391)
+- Added `Phalcon\Mvc\Model\Metadata::initializeMetadata` [#16393] (https://github.com/phalcon/cphalcon/issues/16393)
+- Added `Phalcon\Mvc\Model\Metadata::getMetaDataUniqueKey` [#16393] (https://github.com/phalcon/cphalcon/issues/16393)
+- Added `Phalcon\Mvc\Model\Metadata::getColumnMapUniqueKey` [#16393] (https://github.com/phalcon/cphalcon/issues/16393)
 
 ### Changed
 - Refactored `Phalcon\Mvc\Model::doLowUpdate` and `Phalcon\Mvc\Model::postSaveRelatedRecords` for better code logic and a clearer seperation of behaviour although it lead to partially repeated code.[#16391](https://github.com/phalcon/cphalcon/issues/16391)
+- Cleaned `Phalcon\Mvc\Model\Metadata::initialize` [#16393] (https://github.com/phalcon/cphalcon/issues/16393)
 
 ### Fixed
 

--- a/phalcon/Autoload/Loader.zep
+++ b/phalcon/Autoload/Loader.zep
@@ -511,6 +511,16 @@ class Loader extends AbstractEventsAware
     }
 
     /**
+     * returns isRegister
+     *
+     * @return bool
+     */
+     public function isRegistered() -> bool
+     {
+        return this->isRegistered;
+     }
+
+    /**
      * If the file exists, require it and return true; false otherwise
      *
      * @param string $file The file to require

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -178,7 +178,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if container === null {
             throw new Exception(
-                "A dependency injection container is required to access the services related to the ODM"
+                "A dependency injection container is required to access the services related to the ODM in '" . get_class(this) . "'"
             );
         }
 
@@ -191,7 +191,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let modelsManager = <ManagerInterface> container->getShared("modelsManager");
             if modelsManager === null {
                 throw new Exception(
-                    "The injected service 'modelsManager' is not valid"
+                    "The injected service 'modelsManager' is not valid in '" . get_class(this) . "'"
                 );
             }
         }
@@ -518,7 +518,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
             if unlikely !manager->isVisibleModelProperty(this, property) {
                 throw new Exception(
-                    "Cannot access property '" . property . "' (not public)."
+                    "Cannot access property '" . property . "' (not public) in '" . get_class(this) . "'"
                 );
             }
         }
@@ -547,7 +547,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         let container = Di::getDefault();
         if container === null {
             throw new Exception(
-                "A dependency injection container is required to access the services related to the ODM"
+                "A dependency injection container is required to access the services related to the ODM in '" . get_class(this) . "'"
             );
         }
 
@@ -562,7 +562,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         let manager = <ManagerInterface> container->getShared("modelsManager");
         if manager === null {
             throw new Exception(
-                "The injected service 'modelsManager' is not valid"
+                "The injected service 'modelsManager' is not valid in '" . get_class(this) . "'"
             );
         }
 
@@ -776,7 +776,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if !fetch attributeField, columnMap[attribute] {
                     if unlikely !globals_get("orm.ignore_unknown_columns") {
                         throw new Exception(
-                            "Column '" . attribute. "' doesn't make part of the column map"
+                            "Column '" . attribute. "' doesn't make part of the column map in '" . get_class(this) . "'"
                         );
                     }
 
@@ -882,7 +882,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         for key, value in data {
             if unlikely typeof key !== "string" {
                 throw new Exception(
-                    "Invalid key in array data provided to dumpResult()"
+                    "Invalid key in array data provided to dumpResult() in '" . get_class(base) . "'"
                 );
             }
 
@@ -952,7 +952,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     if !fetch attribute, reverseMap[key] {
                         if unlikely !globals_get("orm.ignore_unknown_columns") {
                             throw new Exception(
-                                "Column '" . key . "' doesn't make part of the column map"
+                                "Column '" . key . "' doesn't make part of the column map in '" . get_class(base) . "'"
                             );
                         }
 
@@ -961,7 +961,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 } else {
                     if unlikely !globals_get("orm.ignore_unknown_columns") {
                         throw new Exception(
-                            "Column '" . key . "' doesn't make part of the column map"
+                            "Column '" . key . "' doesn't make part of the column map in '" . get_class(base) . "'"
                         );
                     }
 
@@ -1087,6 +1087,9 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                  */
                 if !fetch attribute, columnMap[key] {
                     if unlikely !globals_get("orm.ignore_unknown_columns") {
+                        /**
+                         * @todo unless we pass the model name in the funciton we cannot tell what model has this problem
+                         */
                         throw new Exception(
                             "Column '" . key . "' doesn't make part of the column map"
                         );
@@ -1232,7 +1235,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 new Message(
                     "Record cannot be created because it already exists",
                     null,
-                    "InvalidCreateAttempt"
+                    "InvalidCreateAttempt",
+                    0,
+                    [
+                        "model": get_class(this)
+                    ]
                 )
             ];
 
@@ -1303,7 +1310,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          */
         if unlikely !count(primaryKeys) {
             throw new Exception(
-                "A primary key must be defined in the model in order to perform the operation"
+                "A primary key must be defined in the model in order to perform the operation in '" . get_class(this) . "'"
             );
         }
 
@@ -1317,7 +1324,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             if unlikely !fetch bindType, bindDataTypes[primaryKey] {
                 throw new Exception(
-                    "Column '" . primaryKey . "' have not defined a bind data type"
+                    "Column '" . primaryKey . "' have not defined a bind data type in '" . get_class(this) . "'"
                 );
             }
 
@@ -1327,7 +1334,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if typeof columnMap == "array" {
                 if unlikely !fetch attributeField, columnMap[primaryKey] {
                     throw new Exception(
-                        "Column '" . primaryKey . "' isn't part of the column map"
+                        "Column '" . primaryKey . "' isn't part of the column map in '" . get_class(this) . "'"
                     );
                 }
             } else {
@@ -1341,7 +1348,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if unlikely !fetch value, this->{attributeField} {
                 throw new Exception(
                     "Cannot delete the record because the primary key attribute: '"
-                    . attributeField . "' was not set"
+                    . attributeField . "' was not set in '" . get_class(this) . "'"
                 );
             }
 
@@ -1746,7 +1753,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let params = [parameters];
         } else {
             throw new Exception(
-                "Parameters passed must be of type array, string, numeric or null"
+                "Parameters passed must be of type array, string, numeric or null in '" . get_called_class() . "'"
             );
         }
 
@@ -1832,7 +1839,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if unlikely typeof snapshot !== "array" {
             throw new Exception(
-                "The 'keepSnapshots' option must be enabled to track changes"
+                "The 'keepSnapshots' option must be enabled to track changes in '" . get_class(this) . "'"
             );
         }
 
@@ -1981,7 +1988,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
             if unlikely typeof metaData != "object" {
                 throw new Exception(
-                    "The injected service 'modelsMetadata' is not valid"
+                    "The injected service 'modelsMetadata' is not valid in '" . get_class(this) . "'"
                 );
             }
 
@@ -2181,7 +2188,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if unlikely !globals_get("orm.update_snapshot_on_save") {
             throw new Exception(
-                "The 'updateSnapshotOnSave' option must be enabled for this method to work properly"
+                "The 'updateSnapshotOnSave' option must be enabled for this method to work properly in '" . get_class(this) . "'"
             );
         }
 
@@ -2196,7 +2203,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          */
         if unlikely this->dirtyState != self::DIRTY_STATE_PERSISTENT {
             throw new Exception(
-                "Change checking cannot be performed because the object has not been persisted or is deleted"
+                "Change checking cannot be performed because the object has not been persisted or is deleted in '" . get_class(this) . "'"
             );
         }
 
@@ -2462,7 +2469,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if unlikely this->dirtyState != self::DIRTY_STATE_PERSISTENT {
             throw new Exception(
-                "The record cannot be refreshed because it does not exist or is deleted"
+                "The record cannot be refreshed because it does not exist or is deleted in '" . get_class(this) . "'"
             );
         }
 
@@ -2487,7 +2494,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             if unlikely !this->has(metaData, readConnection) {
                 throw new Exception(
-                    "The record cannot be refreshed because it does not exist or is deleted"
+                    "The record cannot be refreshed because it does not exist or is deleted in '" . get_class(this) . "'"
                 );
             }
 
@@ -2498,7 +2505,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if unlikely typeof uniqueParams != "array" {
             throw new Exception(
-                "The record cannot be refreshed because it does not exist or is deleted"
+                "The record cannot be refreshed because it does not exist or is deleted in '" . get_class(this) . "'"
             );
         }
 
@@ -2783,7 +2790,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let container = Di::getDefault();
             if container === null {
                 throw new Exception(
-                    "A dependency injection container is required to access the services related to the ODM"
+                    "A dependency injection container is required to access the services related to the ODM in '" . get_class(this) . "'"
                 );
             }
 
@@ -2799,7 +2806,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
             if unlikely typeof manager !== "object" {
                 throw new Exception(
-                    "The injected service 'modelsManager' is not valid"
+                    "The injected service 'modelsManager' is not valid in '" . get_class(this) . "'"
                 );
             }
 
@@ -2920,7 +2927,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if !fetch attribute, columnMap[key] {
                     if unlikely !globals_get("orm.ignore_unknown_columns") {
                         throw new Exception(
-                            "Column '" . key . "' doesn't make part of the column map"
+                            "Column '" . key . "' doesn't make part of the column map in '" . get_class(this) . "'"
                         );
                     }
 
@@ -2931,7 +2938,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     if !fetch attribute, attribute[0] {
                         if unlikely !globals_get("orm.ignore_unknown_columns") {
                             throw new Exception(
-                                "Column '" . key . "' doesn't make part of the column map"
+                                "Column '" . key . "' doesn't make part of the column map in '" . get_class(this) . "'"
                             );
                         }
 
@@ -2985,7 +2992,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if !fetch attribute, columnMap[key] {
                     if unlikely !globals_get("orm.ignore_unknown_columns") {
                         throw new Exception(
-                            "Column '" . key . "' doesn't make part of the column map"
+                            "Column '" . key . "' doesn't make part of the column map in '" . get_class(this) . "'"
                         );
                     }
 
@@ -2996,7 +3003,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     if !fetch attribute, attribute[0] {
                         if unlikely !globals_get("orm.ignore_unknown_columns") {
                             throw new Exception(
-                                "Column '" . key . "' doesn't make part of the column map"
+                                "Column '" . key . "' doesn't make part of the column map in '" . get_class(this) . "'"
                             );
                         }
 
@@ -3260,7 +3267,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if !fetch attributeField, columnMap[attribute] {
                     if unlikely !globals_get("orm.ignore_unknown_columns") {
                         throw new Exception(
-                            "Column '" . attribute . "' doesn't make part of the column map"
+                            "Column '" . attribute . "' doesn't make part of the column map in '" . get_class(this) . "'"
                         );
                     }
 
@@ -3315,7 +3322,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     new Message(
                         "Record cannot be updated because it does not exist",
                         null,
-                        "InvalidUpdateAttempt"
+                        "InvalidUpdateAttempt",
+                        0,
+                        [
+                            "model": get_class(this)
+                        ]
                     )
                 ];
 
@@ -3481,7 +3492,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     new Message(
                         message,
                         fields,
-                        "ConstraintViolation"
+                        "ConstraintViolation",
+                        0,
+                        [
+                            "model": get_class(this),
+                            "referenceModel" : relation->getReferencedModel()
+                        ]
                     )
                 );
 
@@ -3643,7 +3659,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     new Message(
                         message,
                         fields,
-                        "ConstraintViolation"
+                        "ConstraintViolation",
+                        0,
+                        [
+                            "model": get_class(this),
+                            "referenceModel" : relationClass
+                        ]
                     )
                 );
 
@@ -3711,7 +3732,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if typeof columnMap === "array" {
                 if unlikely !fetch attributeField, columnMap[field] {
                     throw new Exception(
-                        "Column '" . field . "' isn't part of the column map"
+                        "Column '" . field . "' in '" . get_class(this) . "' isn't part of the column map"
                     );
                 }
             } else {
@@ -3746,7 +3767,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                          */
                         if unlikely !fetch bindType, bindDataTypes[field] {
                             throw new Exception(
-                                "Column '" . field . "' have not defined a bind data type"
+                                "Column '" . field . "' in '" . get_class(this) . "' have not defined a bind data type"
                             );
                         }
 
@@ -3797,7 +3818,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if typeof columnMap == "array" {
                 if unlikely !fetch attributeField, columnMap[identityField] {
                     throw new Exception(
-                        "Identity column '" . identityField . "' isn't part of the column map"
+                        "Identity column '" . identityField . "' isn't part of the column map in '" . get_class(this) . "'"
                     );
                 }
             } else {
@@ -3826,7 +3847,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                      */
                     if unlikely !fetch bindType, bindDataTypes[identityField] {
                         throw new Exception(
-                            "Identity column '" . identityField . "' isn\'t part of the table columns"
+                            "Identity column '" . identityField . "' isn\'t part of the table columns in '" . get_class(this) . "'"
                         );
                     }
 
@@ -3941,12 +3962,6 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         let useDynamicUpdate = (bool) manager->isUsingDynamicUpdate(this),
             snapshot         = this->snapshot;
 
-        if useDynamicUpdate {
-            if typeof snapshot !== "array" {
-                let useDynamicUpdate = false;
-            }
-        }
-
         let dataTypes           = metaData->getDataTypes(this),
             bindDataTypes       = metaData->getBindTypes(this),
             nonPrimary          = metaData->getNonPrimaryKeyAttributes(this),
@@ -3958,52 +3973,37 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let columnMap = null;
         }
 
-        /**
-         * We only make the update based on the non-primary attributes, values
-         * in primary key attributes are ignored
-         */
-        for field in nonPrimary {
-            /**
-             * Check if the model has a column map
-             */
-            if typeof columnMap === "array" {
-                if unlikely !fetch attributeField, columnMap[field] {
-                    if unlikely !globals_get("orm.ignore_unknown_columns") {
+        if useDynamicUpdate && typeof snapshot !== "array" {
+            for field in nonPrimary {
+                let changed = false;
+                if typeof columnMap === "array" {
+                    if unlikely !fetch attributeField, columnMap[field] {
+                        if unlikely !globals_get("orm.ignore_unknown_columns") {
+                            throw new Exception(
+                                "Column '" . field . "' in '" . get_class(this) . "' isn't part of the column map"
+                            );
+                        }
+                    }
+                } else {
+                    let attributeField = field;
+                }
+                if !isset automaticAttributes[attributeField] {
+                    /**
+                     * Check a bind type for field to update
+                     */
+                    if unlikely !fetch bindType, bindDataTypes[field] {
                         throw new Exception(
-                            "Column '" . field . "' isn't part of the column map"
+                            "Column '" . field . "' in '" . get_class(this) . "' have not defined a bind data type"
                         );
                     }
-                }
-            } else {
-                let attributeField = field;
-            }
-
-            if !isset automaticAttributes[attributeField] {
-                /**
-                 * Check a bind type for field to update
-                 */
-                if unlikely !fetch bindType, bindDataTypes[field] {
-                    throw new Exception(
-                        "Column '" . field . "' have not defined a bind data type"
-                    );
-                }
-
-                /**
-                 * Get the field's value
-                 * If a field isn't set we pass a null value
-                 */
-                if fetch value, this->{attributeField} {
                     /**
-                     * When dynamic update is not used we pass every field to the update
+                     * Get the field's value
+                     * If a field isn't set there was no change
                      */
-                    if !useDynamicUpdate {
-                        let fields[] = field,
-                            values[] = value;
-                        let bindTypes[] = bindType;
-                    } else {
+                    if fetch value, this->{attributeField} {
                         /**
-                         * If the field is not part of the snapshot we add them as changed
-                         */
+                        * If the field is not part of the snapshot we add them as changed
+                        */
                         if !fetch snapshotValue, snapshot[attributeField] {
                             let changed = true;
                         } else {
@@ -4023,13 +4023,13 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                 } else {
                                     if unlikely !fetch dataType, dataTypes[field] {
                                         throw new Exception(
-                                           "Column '" . field . "' have not defined a data type"
+                                            "Column '" . field . "' in '" . get_class(this) . "' have not defined a data type"
                                         );
                                     }
 
                                     /**
-                                     * Get actual values before comparison
-                                     */
+                                    * Get actual values before comparison
+                                    */
                                     if is_object(snapshotValue) && snapshotValue instanceof RawValue {
                                         let snapshotValue = snapshotValue->getValue();
                                     }
@@ -4062,44 +4062,91 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                             break;
 
                                         /**
-                                         * Any other type is not really supported...
-                                         */
+                                        * Any other type is not really supported...
+                                        */
                                         default:
                                             let changed = updateValue != snapshotValue;
                                     }
                                 }
                             }
                         }
-
                         /**
-                         * Only changed values are added to the SQL Update
-                         */
+                        * Only changed values are added to the SQL Update
+                        */
                         if changed {
                             let fields[]    = field,
                                 values[]    = value,
                                 bindTypes[] = bindType;
                         }
+                        let newSnapshot[attributeField] = value;
+                    } else {
+                        let newSnapshot[attributeField] = null;
                     }
-                   let newSnapshot[attributeField] = value;
-
+                }
+            }
+            /**
+             * If there is no fields to update we return true
+             */
+            if !count(fields) {
+                let this->oldSnapshot = snapshot;
+                return true;
+            }
+        } else {
+            /**
+             * We only make the update based on the non-primary attributes, values
+             * in primary key attributes are ignored
+             */
+            for field in nonPrimary {
+                /**
+                 * Check if the model has a column map
+                 */
+                if typeof columnMap === "array" {
+                    if unlikely !fetch attributeField, columnMap[field] {
+                        if unlikely !globals_get("orm.ignore_unknown_columns") {
+                            throw new Exception(
+                                "Column '" . field . "' in '" . get_class(this) . "' isn't part of the column map"
+                            );
+                        }
+                    }
                 } else {
-                    let newSnapshot[attributeField] = null;
+                    let attributeField = field;
+                }
 
-                    let fields[]    = field,
-                        values[]    = null,
-                        bindTypes[] = bindSkip;
+                if !isset automaticAttributes[attributeField] {
+                    /**
+                     * Check a bind type for field to update
+                     */
+                    if unlikely !fetch bindType, bindDataTypes[field] {
+                        throw new Exception(
+                            "Column '" . field . "' in '" . get_class(this) . "' have not defined a bind data type"
+                        );
+                    }
+
+                    /**
+                     * Get the field's value
+                     * If a field isn't set we pass a null value
+                     */
+                    if fetch value, this->{attributeField} {
+                        /**
+                         * When dynamic update is not used we pass every field to the update
+                         */
+                        let fields[] = field,
+                            values[] = value;
+                        let bindTypes[] = bindType;
+                        let newSnapshot[attributeField] = value;
+                    } else {
+                        let newSnapshot[attributeField] = null;
+                        let fields[]    = field,
+                            values[]    = null,
+                            bindTypes[] = bindSkip;
+                    }
                 }
             }
         }
-
         /**
          * If there is no fields to update we return true
          */
         if !count(fields) {
-            if useDynamicUpdate {
-                let this->oldSnapshot = snapshot;
-            }
-
             return true;
         }
 
@@ -4117,7 +4164,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             if unlikely !count(primaryKeys) {
                 throw new Exception(
-                    "A primary key must be defined in the model in order to perform the operation"
+                    "A primary key must be defined in the model in order to perform the operation in '" . get_class(this) . "'"
                 );
             }
 
@@ -4130,7 +4177,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if typeof columnMap == "array" {
                     if unlikely !fetch attributeField, columnMap[field] {
                         throw new Exception(
-                           "Column '" . field . "' isn't part of the column map"
+                           "Column '" . field . "' in '" . get_class(this) . "' isn't part of the column map"
                         );
                     }
                 } else {
@@ -4233,7 +4280,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if typeof columnMap === "array" {
                     if unlikely !fetch attributeField, columnMap[field] {
                         throw new Exception(
-                            "Column '" . field . "' isn't part of the column map"
+                            "Column '" . field . "' in '" . get_class(this) . "' isn't part of the column map"
                         );
                     }
                 } else {
@@ -4263,7 +4310,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
                 if unlikely !fetch type, bindDataTypes[field] {
                     throw new Exception(
-                        "Column '" . field . "' isn't part of the table columns"
+                        "Column '" . field . "' in '" . get_class(this) . "' isn't part of the table columns"
                     );
                 }
 
@@ -4558,7 +4605,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if unlikely !isset arguments[0] {
             throw new Exception(
-                "The static method '" . method . "' requires one argument"
+                "The static method '" . method . "' in '" . get_called_class() . "' requires one argument"
             );
         }
 
@@ -4595,7 +4642,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
                 if unlikely !isset attributes[field] {
                     throw new Exception(
-                        "Cannot resolve attribute '" . extraMethod . "' in the model"
+                        "Cannot resolve attribute '" . extraMethod . "' in the model '" . get_called_class() . "'"
                     );
                 }
             }
@@ -4756,7 +4803,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                         if unlikely !fetch attributeField, columnMap[field] {
                             if unlikely !globals_get("orm.ignore_unknown_columns") {
                                 throw new Exception(
-                                    "Column '" . field . "' isn't part of the column map"
+                                    "Column '" . field . "' in '" . get_class(this) . "' isn't part of the column map"
                                 );
                             }
                         }
@@ -4825,7 +4872,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                             let this->errorMessages[] = new Message(
                                 attributeField . " is required",
                                 attributeField,
-                                "PresenceOf"
+                                "PresenceOf",
+                                0,
+                                [
+                                    "model": get_class(this)
+                                ]
                             );
 
                             let error = true;
@@ -4917,8 +4968,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      */
     protected function preSaveRelatedRecords(<AdapterInterface> connection, related) -> bool
     {
-        var className, manager, type, relation, columns, referencedFields,
-            message, nesting, name, record;
+        var className, manager, type, relation, columns, referencedFields, nesting, name, record;
 
         let nesting = false;
 
@@ -4953,7 +5003,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                         connection->rollback(nesting);
 
                         throw new Exception(
-                            "Only objects can be stored as part of belongs-to relations"
+                            "Only objects can be stored as part of belongs-to relations in '" . get_class(this) . "' Relation " . name
                         );
                     }
 
@@ -4966,7 +5016,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     if unlikely typeof columns === "array" {
                         connection->rollback(nesting);
 
-                        throw new Exception("Not implemented");
+                        throw new Exception("Not implemented in '" . get_class(this) . "' Relation " . name);
                     }
 
                     /**
@@ -4978,23 +5028,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                          * Get the validation messages generated by the
                          * referenced model
                          */
-                        for message in record->getMessages() {
-                            /**
-                             * Set the related model
-                             */
-                            if typeof message == "object" {
-                                message->setMetaData(
-                                    [
-                                        "model": record
-                                    ]
-                                );
-                            }
-
-                            /**
-                             * Appends the messages to the current model
-                             */
-                            this->appendMessage(message);
-                        }
+                        this->appendMessagesFrom(record);
 
                         /**
                          * Rollback the implicit transaction
@@ -5042,7 +5076,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      */
     protected function postSaveRelatedRecords(<AdapterInterface> connection, related) -> bool
     {
-        var nesting, className, manager, relation, name, record, message,
+        var nesting, className, manager, relation, name, record,
             columns, referencedModel, referencedFields, relatedRecords, value,
             recordAfter, intermediateModel, intermediateFields,
             intermediateValue, intermediateModelName,
@@ -5074,7 +5108,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     connection->rollback(nesting);
 
                     throw new Exception(
-                        "Only objects/arrays can be stored as part of has-many/has-one/has-one-through/has-many-to-many relations"
+                        "Only objects/arrays can be stored as part of has-many/has-one/has-one-through/has-many-to-many relations on model " . className . " on Relation " . name
                     );
                 }
 
@@ -5085,7 +5119,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if unlikely typeof columns === "array" {
                     connection->rollback(nesting);
 
-                    throw new Exception("Not implemented");
+                    throw new Exception("Not implemented in '" . className . "' on Relation " . name);
                 }
 
                 /**
@@ -5101,7 +5135,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     connection->rollback(nesting);
 
                     throw new Exception(
-                        "The column '" . columns . "' needs to be present in the model"
+                        "The column '" . columns . "' needs to be present in the model '" . className . "'"
                     );
                 }
 
@@ -5112,61 +5146,31 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 let isThrough = (bool) relation->isThrough();
 
                 /**
-                 * Get the rest of intermediate model info
+                 * Many-to-Many 
                  */
                 if isThrough {
                     let intermediateModelName = relation->getIntermediateModel(),
                         intermediateFields = relation->getIntermediateFields(),
                         intermediateReferencedFields = relation->getIntermediateReferencedFields();
-                }
 
-                for recordAfter in relatedRecords {
-                    /**
-                     * For non has-many-to-many relations just assign the local
-                     * value in the referenced model
-                     */
-                    if !isThrough {
+                    for recordAfter in relatedRecords {
                         /**
-                         * Assign the value to the
+                         * Save the record and get messages
                          */
-                        recordAfter->writeAttribute(referencedFields, value);
-                    }
-
-                    /**
-                     * Save the record and get messages
-                     */
-                    if !recordAfter->save() {
-                        /**
-                         * Get the validation messages generated by the
-                         * referenced model
-                         */
-                        for message in recordAfter->getMessages() {
+                        if !recordAfter->save() {
                             /**
-                             * Set the related model
+                             * Get the validation messages generated by the
+                             * referenced model
                              */
-                            if typeof message === "object" {
-                                message->setMetaData(
-                                    [
-                                        "model": recordAfter
-                                    ]
-                                );
-                            }
-
+                            this->appendMessagesFrom(recordAfter);
+    
                             /**
-                             * Appends the messages to the current model
+                             * Rollback the implicit transaction
                              */
-                            this->appendMessage(message);
+                            connection->rollback(nesting);
+    
+                            return false;
                         }
-
-                        /**
-                         * Rollback the implicit transaction
-                         */
-                        connection->rollback(nesting);
-
-                        return false;
-                    }
-
-                    if isThrough {
                         /**
                          * Create a new instance of the intermediate model
                          */
@@ -5221,24 +5225,32 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                             /**
                              * Get the validation messages generated by the referenced model
                              */
-                            for message in intermediateModel->getMessages() {
-                                /**
-                                 * Set the related model
-                                 */
-                                if typeof message === "object" {
-                                    message->setMetaData(
-                                        [
-                                            "model": intermediateModel
-                                        ]
-                                    );
-                                }
+                            this->appendMessagesFrom(intermediateModel);
 
-                                /**
-                                 * Appends the messages to the current model
-                                 */
-                                this->appendMessage(message);
-                            }
+                            /**
+                             * Rollback the implicit transaction
+                             */
+                            connection->rollback(nesting);
 
+                            return false;
+                        }
+                    }
+                } else {
+                    for recordAfter in relatedRecords {
+                        /**
+                         * Assign the value to the
+                         */
+                        recordAfter->writeAttribute(referencedFields, value);
+                        /**
+                         * Save the record and get messages
+                         */
+                        if !recordAfter->save() {
+                            /**
+                             * Get the validation messages generated by the
+                             * referenced model
+                             */
+                            this->appendMessagesFrom(recordAfter);
+    
                             /**
                              * Rollback the implicit transaction
                              */
@@ -5867,7 +5879,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                     message->getMessage(),
                     message->getField(),
                     message->getType(),
-                    message->getCode()
+                    message->getCode(),
+                    message->getMetaData()
                 )
             );
         }
@@ -5926,5 +5939,29 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         }
 
         return key;
+    }
+
+    /***
+     * Append messages to this model from another Model.
+     */
+    public inline function appendMessagesFrom(var model) -> void
+    {
+        var messages, message;
+        let messages = model->getMessages();
+        if false === empty(messages) {
+            for message in messages {
+                if typeof message == "object" {
+                    message->setMetaData(
+                        [
+                            "model": model
+                        ]
+                    );
+                }
+                /**
+                 * Appends the messages to the current model
+                 */
+                this->appendMessage(message);
+            }
+        }
     }
 }

--- a/phalcon/Mvc/Model/MetaDataInterface.zep
+++ b/phalcon/Mvc/Model/MetaDataInterface.zep
@@ -118,17 +118,17 @@ interface MetaDataInterface
     /**
      * Reads column-map information for certain model using a MODEL_* constant
      */
-    public function readColumnMapIndex(<ModelInterface> model, int index);
+    public function readColumnMapIndex(<ModelInterface> model, int index) -> array | null;
 
     /**
      * Reads meta-data for certain model
      */
-    public function readMetaData(<ModelInterface> model) -> array;
+    public function readMetaData(<ModelInterface> model) -> array | null;
 
     /**
      * Reads meta-data for certain model using a MODEL_* constant
      */
-    public function readMetaDataIndex(<ModelInterface> model, int index) -> var;
+    public function readMetaDataIndex(<ModelInterface> model, int index) -> array | null;
 
     /**
      * Resets internal meta-data in order to regenerate it

--- a/tests/database/Mvc/Model/FindFirstCest.php
+++ b/tests/database/Mvc/Model/FindFirstCest.php
@@ -264,7 +264,7 @@ class FindFirstCest
 
         $I->expectThrowable(
             new Exception(
-                'Parameters passed must be of type array, string, numeric or null'
+                "Parameters passed must be of type array, string, numeric or null in '" . Invoices::class . "'"
             ),
             function () {
                 Invoices::findFirst(false);

--- a/tests/database/Mvc/Model/MetaData/Adapter/ReadMetadataCest.php
+++ b/tests/database/Mvc/Model/MetaData/Adapter/ReadMetadataCest.php
@@ -87,6 +87,7 @@ class ReadMetadataCest
             'photo_id',
         ];
         $actual = $metadata->getAttributes($model);
+        $columnMap = $metadata->getColumnMap($model);
         $I->assertEquals($expected, $actual);
 
         $model = new AlbumPhoto();
@@ -97,6 +98,7 @@ class ReadMetadataCest
             'position',
         ];
         $actual = $metadata->getAttributes($model);
+        $columnMap = $metadata->getColumnMap($model);
         $I->assertEquals($expected, $actual);
 
         $model = new Photo();
@@ -120,6 +122,7 @@ class ReadMetadataCest
             'wins',
         ];
         $actual = $metadata->getAttributes($model);
+        $columnMap = $metadata->getColumnMap($model);
         $I->assertEquals($expected, $actual);
 
         $service = $adapter->getAdapter();
@@ -165,7 +168,7 @@ class ReadMetadataCest
     private function getKeyData(): array
     {
         return [
-        'meta-phalcon\tests\fixtures\models\albumphoto-album_photo' => [
+        'meta-phalcon\tests\fixtures\models\albumphoto' => [
             0 => [
                 'id',
                 'photo_id',
@@ -220,7 +223,7 @@ class ReadMetadataCest
             0 => null,
             1 => null,
         ],
-        'meta-phalcon\tests\fixtures\models\photo-photo' => [
+        'meta-phalcon\tests\fixtures\models\photo' => [
             0 => [
                 'id',
                 'date_uploaded',
@@ -345,7 +348,7 @@ class ReadMetadataCest
             0 => null,
             1 => null,
         ],
-        'meta-phalcon\tests\fixtures\models\album-album' => [
+        'meta-phalcon\tests\fixtures\models\album' => [
             0 => [
                 'id',
                 'name',

--- a/tests/database/Mvc/Model/UnderscoreCallStaticCest.php
+++ b/tests/database/Mvc/Model/UnderscoreCallStaticCest.php
@@ -167,7 +167,7 @@ class UnderscoreCallStaticCest
          */
         $I->expectThrowable(
             new Exception(
-                "Cannot resolve attribute 'UnknownField' in the model"
+                "Cannot resolve attribute 'UnknownField' in the model '" . Models\Invoices::class . "'"
             ),
             function () {
                 Models\Invoices::findFirstByUnknownField(1);
@@ -179,7 +179,7 @@ class UnderscoreCallStaticCest
          */
         $I->expectThrowable(
             new Exception(
-                "Cannot resolve attribute 'UnknownField' in the model"
+                "Cannot resolve attribute 'UnknownField' in the model '" . Models\Invoices::class . "'"
             ),
             function () {
                 Models\Invoices::countByUnknownField(1);

--- a/tests/database/Mvc/Model/UnderscoreGetCest.php
+++ b/tests/database/Mvc/Model/UnderscoreGetCest.php
@@ -302,7 +302,7 @@ class UnderscoreGetCest
 
         $I->expectThrowable(
             new Exception(
-                "Cannot access property 'superSecret' (not public)."
+                "Cannot access property 'superSecret' (not public) in '" . Invoices::class . "'"
             ),
             function () {
                 $model              = new Invoices();


### PR DESCRIPTION
Hello!

* Type: new feature | code quality
* Link to issue: [#16391]

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Refactored the Model::doLowUpdate for better seperation of dynamicUpdate from normal full update.
Added better error reporting adding the class on which it happened.
Added Model::appendMessagesFrom for code quality and added the model name to the message MetaData
Added Model and relatedName to Message MetaData in several lines where there was no reference to model and/or relation where the non-exception failure occurred.


Thanks

