### PR TITLE
Fix #[16222], Added Model::setRelated()

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## [5.4.0](https://github.com/phalcon/cphalcon/releases/tag/v5.3.1) (xxxx-xx-xx)
+## [5.4.0](https://github.com/phalcon/cphalcon/releases/tag/v5.4.0) (xxxx-xx-xx)
+
+### Added
+- Added `Phalcon\Mvc\Model::setRelated()` to allow setting related models and automaticly de added to the dirtyRelated list [#16222] (https://github.com/phalcon/cphalcon/issues/16222)
 
 ### Fixed
 - Model Annotation strategy did not work with empty_string [#16426] (https://github.com/phalcon/cphalcon/issues/16426)

--- a/tests/database/Mvc/Model/SetRelatedCest.php
+++ b/tests/database/Mvc/Model/SetRelatedCest.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Mvc\Model;
+
+use DatabaseTester;
+use PDO;
+use Phalcon\Tests\Fixtures\Migrations\CustomersMigration;
+use Phalcon\Tests\Fixtures\Migrations\InvoicesMigration;
+use Phalcon\Tests\Fixtures\Traits\DiTrait;
+use Phalcon\Tests\Models\Customers;
+use Phalcon\Tests\Models\Invoices;
+
+use function uniqid;
+
+/**
+ * Class GetRelatedCest
+ */
+class SetRelatedCest
+{
+    use DiTrait;
+
+    /**
+     * @param DatabaseTester $I
+     */
+    public function _before(DatabaseTester $I)
+    {
+        $this->setNewFactoryDefault();
+        $this->setDatabase($I);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: getRelated()
+     *
+     * @param DatabaseTester $I
+     *
+     * @since  2023-08-15
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelSetRelated(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - setRelated()');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+
+        $custId = 2;
+
+        $firstName = uniqid('cust-', true);
+        $lastName  = uniqid('cust-', true);
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->insert($custId, 0, $firstName, $lastName);
+
+        $paidInvoiceId   = 4;
+        $unpaidInvoiceId = 5;
+
+        $title = uniqid('inv-');
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert(
+            $paidInvoiceId,
+            $custId,
+            Invoices::STATUS_PAID,
+            $title . '-paid'
+        );
+        $invoicesMigration->insert(
+            $unpaidInvoiceId,
+            $custId,
+            Invoices::STATUS_UNPAID,
+            $title . '-unpaid'
+        );
+
+        /**
+         * @var Customers $customer
+         */
+        $customer = Customers::findFirst($custId);
+
+        $invoices = [];
+        $expectedTitle = [];
+        foreach ($customer->Invoices as $invoice) {
+            $invoices[] = $invoice;
+            $expectedTitle[] = $invoice->inv_title . 'updated';
+            $invoice->inv_title = $invoice->inv_title . 'updated';
+        }
+
+        $customer->setRelated('Invoices', $invoices);
+
+        $invoices = $customer->Invoices;
+
+        $I->assertIsArray($invoices);
+
+        $expected = 2;
+        $actual   = count($invoices);
+        $I->assertEquals($expected, $actual);
+
+        $actual = $customer->save();
+
+        $I->assertTrue($actual);
+
+        $invoice = $invoices[0];
+        $actual = $invoice->getDirtyState();
+
+        $I->assertEquals(0, $actual);
+
+        $expected = $expectedTitle[0];
+        $actual = $invoice->inv_title;
+        $I->assertSame($expected, $actual);
+
+        $invoice = $invoices[1];
+        $actual = $invoice->getDirtyState();
+        $expected = 0;
+        $I->assertEquals($expected, $actual);
+
+        $expected = $expectedTitle[1];
+        $actual = $invoice->inv_title;
+        $I->assertSame($expected, $actual);
+
+        $actual = $customer->getDirtyState();
+        $expected = 0;
+        $I->assertEquals($expected, $actual);
+
+        $invoice->Customer = $customer;
+        $actual = $invoice->getDirtyState();
+        $expected = 1;
+        $I->assertEquals($expected, $actual);
+
+        $actual = $customer->getDirtyState();
+        $expected = 1;
+        $I->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16222

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Added Model::setRelated() for those who want to make a setter for relations or avoid magic __set(), changed the magical __set() to use setRelated()

Thanks

