### PR TITLE
T16414 route routeid type error

### DIFF
--- a/.github/actions/pack-phalcon-ext/action.yml
+++ b/.github/actions/pack-phalcon-ext/action.yml
@@ -25,7 +25,7 @@ runs:
         & 7z a "${{ inputs.target-name }}.zip" *
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.target-name }}.zip
         path: ./build-artifacts/phalcon*.zip

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -23,6 +23,13 @@
 - Fixed memory leak in Micro application [#16404](https://github.com/phalcon/cphalcon/pull/16404)
 
 
+## [5.3.1](https://github.com/phalcon/cphalcon/releases/tag/v5.3.1) (xxxx-xx-xx)
+
+### Fixed
+
+- Forced `routeId` in `Phalcon\Mvc\Router\Route` to always return a string [#16414](https://github.com/phalcon/cphalcon/pull/16414)
+
+
 ## [5.2.3](https://github.com/phalcon/cphalcon/releases/tag/v5.2.3) (2023-07-26)
 
 ### Fixed

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -43,9 +43,9 @@ class Route implements RouteInterface
     protected hostname = null;
 
     /**
-     * @var string|null
+     * @var string
      */
-    protected id = null;
+    protected id = "";
 
     /**
      * @var array|string
@@ -94,8 +94,8 @@ class Route implements RouteInterface
         let uniqueId = self::uniqueId;
 
         // TODO: Add a function that increase static members
-        let routeId = uniqueId,
-            this->id = routeId,
+        let routeId        = uniqueId,
+            this->id       = (string) routeId,
             self::uniqueId = uniqueId + 1;
     }
 
@@ -383,9 +383,9 @@ class Route implements RouteInterface
     }
 
     /**
-     * @return string | null
+     * @return string
      */
-    public function getId() -> string | null
+    public function getId() -> string
     {
         return this->id;
     }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16414 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Forced `routeId` in `Phalcon\Mvc\Router\Route` to always return a string

Thanks

