### PR TITLE
Fix for #16437

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Model Annotation strategy did not work with empty_string [#16426] (https://github.com/phalcon/cphalcon/issues/16426)
+- View::reset() sets content to null instead of default empty string [#16437] (https://github.com/phalcon/cphalcon/issues/16437)
 
 
 ## [5.3.1](https://github.com/phalcon/cphalcon/releases/tag/v5.3.1) (2023-09-12)

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -768,7 +768,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
         let this->disabled        = false,
             this->engines         = false,
             this->renderLevel     = self::LEVEL_MAIN_LAYOUT,
-            this->content         = null,
+            this->content         = "",
             this->templatesBefore = [],
             this->templatesAfter  = [];
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16437

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
View on reset() now sets content to the default ("") empty string.

Thanks

