### PR TITLE
T16265 getmessages array

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,11 +4,11 @@
 
 ### Changed
 
+- Changed `Phalcon\Mvc\Model::getMessages()` to also filter with an array of fields [#16265](https://github.com/phalcon/cphalcon/issues/16265)
 
 ### Added
 
 - Added the ability to define interpolator characters for the `Phalcon\Logger\Formatter\Line` [#16430](https://github.com/phalcon/cphalcon/issues/16430)
-- Added the ability filter with an array of fields when using `Phalcon\Mvc\Model::getMessages()` [#16265](https://github.com/phalcon/cphalcon/issues/16265)
 
 ### Fixed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -8,6 +8,7 @@
 ### Added
 
 - Added the ability to define interpolator characters for the `Phalcon\Logger\Formatter\Line` [#16430](https://github.com/phalcon/cphalcon/issues/16430)
+- Added the ability filter with an array of fields when using `Phalcon\Mvc\Model::getMessages()` [#16265](https://github.com/phalcon/cphalcon/issues/16265)
 
 ### Fixed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1948,11 +1948,18 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         var message;
         array filtered;
 
-        if typeof filter === "string" && !empty filter {
+        if (
+            typeof filter === "string" ||
+            typeof filter === "array") && !empty filter
+        {
             let filtered = [];
 
+            if typeof filter === "string" {
+                let filter = [filter];
+            }
+
             for message in this->errorMessages {
-                if message->getField() == filter {
+                if in_array(message->getField(), filter) {
                     let filtered[] = message;
                 }
             }
@@ -5174,7 +5181,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 let isThrough = (bool) relation->isThrough();
 
                 /**
-                 * Many-to-Many 
+                 * Many-to-Many
                  */
                 if isThrough {
                     let intermediateModelName = relation->getIntermediateModel(),
@@ -5191,12 +5198,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                              * referenced model
                              */
                             this->appendMessagesFrom(recordAfter);
-    
+
                             /**
                              * Rollback the implicit transaction
                              */
                             connection->rollback(nesting);
-    
+
                             return false;
                         }
                         /**
@@ -5278,7 +5285,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                              * referenced model
                              */
                             this->appendMessagesFrom(recordAfter);
-    
+
                             /**
                              * Rollback the implicit transaction
                              */

--- a/tests/database/Mvc/Model/GetMessagesCest.php
+++ b/tests/database/Mvc/Model/GetMessagesCest.php
@@ -95,18 +95,6 @@ class GetMessagesCest
         $I->assertCount($expectedCount, $messages);
 
         /**
-         * Filter by field obj_id
-         */
-        $messages = $record->getMessages('obj_id');
-
-        $expectedCount = 1;
-        $I->assertCount($expectedCount, $messages);
-
-        $expected = 'obj_name is required';
-        $actual   = $messages[0]->getMessage();
-        $I->assertSame($expected, $actual);
-
-        /**
          * Filter by field obj_name
          */
         $messages = $record->getMessages('obj_name');
@@ -119,23 +107,31 @@ class GetMessagesCest
         $I->assertSame($expected, $actual);
 
         /**
+         * Filter by field obj_type
+         */
+        $messages = $record->getMessages('obj_type');
+
+        $expectedCount = 1;
+        $I->assertCount($expectedCount, $messages);
+
+        $expected = 'obj_type is required';
+        $actual   = $messages[0]->getMessage();
+        $I->assertSame($expected, $actual);
+
+        /**
          * Filter by both fields
          */
+        $messages = $record->getMessages(['obj_name', 'obj_type']);
 
+        $expectedCount = 2;
+        $I->assertCount($expectedCount, $messages);
+
+        $expected = 'obj_name is required';
+        $actual   = $messages[0]->getMessage();
+        $I->assertSame($expected, $actual);
 
         $expected = 'obj_type is required';
         $actual   = $messages[1]->getMessage();
         $I->assertSame($expected, $actual);
-
-
-
-        $I->assertEquals(
-            'obj_name is required',
-            $messages[0]->getMessage()
-        );
-        $I->assertEquals(
-            'obj_type is required',
-            $messages[1]->getMessage()
-        );
     }
 }

--- a/tests/database/Mvc/Model/GetMessagesCest.php
+++ b/tests/database/Mvc/Model/GetMessagesCest.php
@@ -58,7 +58,77 @@ class GetMessagesCest
 
         $messages = $record->getMessages();
 
-        $I->assertCount(2, $messages);
+        $expectedCount = 2;
+        $I->assertCount($expectedCount, $messages);
+
+        $expected = 'obj_name is required';
+        $actual   = $messages[0]->getMessage();
+        $I->assertSame($expected, $actual);
+
+        $expected = 'obj_type is required';
+        $actual   = $messages[1]->getMessage();
+        $I->assertSame($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: getMessages() - filtered
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2023-09-30
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function mvcModelGetMessagesFiltered(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - getMessages() - filtered');
+
+        $record         = new Objects();
+        $record->obj_id = 1;
+        $result         = $record->save();
+        $I->assertFalse($result);
+
+        $messages = $record->getMessages();
+
+        $expectedCount = 2;
+        $I->assertCount($expectedCount, $messages);
+
+        /**
+         * Filter by field obj_id
+         */
+        $messages = $record->getMessages('obj_id');
+
+        $expectedCount = 1;
+        $I->assertCount($expectedCount, $messages);
+
+        $expected = 'obj_name is required';
+        $actual   = $messages[0]->getMessage();
+        $I->assertSame($expected, $actual);
+
+        /**
+         * Filter by field obj_name
+         */
+        $messages = $record->getMessages('obj_name');
+
+        $expectedCount = 1;
+        $I->assertCount($expectedCount, $messages);
+
+        $expected = 'obj_name is required';
+        $actual   = $messages[0]->getMessage();
+        $I->assertSame($expected, $actual);
+
+        /**
+         * Filter by both fields
+         */
+
+
+        $expected = 'obj_type is required';
+        $actual   = $messages[1]->getMessage();
+        $I->assertSame($expected, $actual);
+
+
+
         $I->assertEquals(
             'obj_name is required',
             $messages[0]->getMessage()


### PR DESCRIPTION
Hello!

* Type: bug
* Link to issue: #16265 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Mvc\Model::getMessages()` to also filter with an array of fields

Thanks

