### PR TITLE
T16467 column 0 to array

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Filter\Validation\Validator\Numericality` to return false when input has spaces [#16461](https://github.com/phalcon/cphalcon/issues/16461)
+- Fixed `Phalcon\Mvc\Model\ResultsetSimple::toArray` to ignore numeric indexes in case results come as not `fetch_assoc` [#16467](https://github.com/phalcon/cphalcon/issues/16467)
 
 ### Removed
 

--- a/phalcon/Mvc/Model/Resultset/Simple.zep
+++ b/phalcon/Mvc/Model/Resultset/Simple.zep
@@ -212,24 +212,26 @@ class Simple extends Resultset
                     let renamed = [];
 
                     for key, value in record {
-                        /**
-                         * Check if the key is part of the column map
-                         */
-                        if unlikely !fetch renamedKey, columnMap[key] {
-                            throw new Exception(
-                                "Column '" . key . "' is not part of the column map"
-                            );
-                        }
-
-                        if typeof renamedKey == "array" {
-                            if unlikely !fetch renamedKey, renamedKey[0] {
+                        if (typeof key === "string") {
+                            /**
+                             * Check if the key is part of the column map
+                             */
+                            if unlikely !fetch renamedKey, columnMap[key] {
                                 throw new Exception(
                                     "Column '" . key . "' is not part of the column map"
                                 );
                             }
-                        }
 
-                        let renamed[renamedKey] = value;
+                            if typeof renamedKey == "array" {
+                                if unlikely !fetch renamedKey, renamedKey[0] {
+                                    throw new Exception(
+                                        "Column '" . key . "' is not part of the column map"
+                                    );
+                                }
+                            }
+
+                            let renamed[renamedKey] = value;
+                        }
                     }
 
                     /**

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -22,7 +22,6 @@ use Phalcon\Tests\Models\Invoices;
 use Phalcon\Tests\Models\InvoicesMap;
 
 use function uniqid;
-use function var_dump;
 
 class ToArrayCest
 {
@@ -249,7 +248,7 @@ class ToArrayCest
                 'inv_title'       => $title,
                 'inv_total'       => 222.19,
                 'inv_created_at'  => $date,
-            ]
+            ],
         ];
         $actual   = $invoices->toArray();
         $I->assertSame($expected, $actual);
@@ -295,7 +294,8 @@ class ToArrayCest
             ->addFrom(InvoicesMap::class, 'i')
             ->limit(10)
             ->getQuery()
-            ->execute();
+            ->execute()
+        ;
 
         $result->rewind();
         $result->next();
@@ -319,7 +319,7 @@ class ToArrayCest
                 'created_at'  => $date,
             ],
         ];
-        $actual = $result->toArray();
+        $actual   = $result->toArray();
         $I->assertSame($expected, $actual);
     }
 }

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -15,12 +15,14 @@ namespace Phalcon\Tests\Database\Mvc\Model;
 
 use DatabaseTester;
 use PDO;
+use Phalcon\Mvc\Model\Manager;
 use Phalcon\Tests\Fixtures\Migrations\InvoicesMigration;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use Phalcon\Tests\Models\Invoices;
 use Phalcon\Tests\Models\InvoicesMap;
 
 use function uniqid;
+use function var_dump;
 
 class ToArrayCest
 {
@@ -258,5 +260,66 @@ class ToArrayCest
                 'castOnHydrate' => false,
             ]
         );
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: toArray() - execute column not in columnMap
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2022-11-21
+     *
+     * @issue https://github.com/phalcon/cphalcon/issues/16467
+     *
+     * @group  mysql
+     */
+    public function mvcModelToArrayExecuteColumnNotInColumnMap(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - toArray() - execute - column not in columnMap');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $title      = uniqid('inv-');
+        $date       = date('Y-m-d H:i:s');
+
+        $migration = new InvoicesMigration($connection);
+        $migration->insert(4, 1, 0, $title, 111.26, $date);
+        $migration->insert(5, 2, 1, $title, 222.19, $date);
+
+        $manager = $this->getService('modelsManager');
+        $class   = Manager::class;
+        $I->assertInstanceOf($class, $manager);
+
+
+        $result = $manager
+            ->createBuilder()
+            ->addFrom(InvoicesMap::class, 'i')
+            ->limit(10)
+            ->getQuery()
+            ->execute();
+
+        $result->rewind();
+        $result->next();
+        $result->rewind();
+
+        $expected = [
+            [
+                'id'          => 4,
+                'cst_id'      => 1,
+                'status_flag' => 0,
+                'title'       => $title,
+                'total'       => 111.26,
+                'created_at'  => $date,
+            ],
+            [
+                'id'          => 5,
+                'cst_id'      => 2,
+                'status_flag' => 1,
+                'title'       => $title,
+                'total'       => 222.19,
+                'created_at'  => $date,
+            ],
+        ];
+        $actual = $result->toArray();
+        $I->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16467 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\ResultsetSimple::toArray` to ignore numeric indexes in case results come as not `fetch_assoc`

Thanks

