### PR TITLE
Update AbstractAdapter.zep

### DIFF
--- a/phalcon/Image/Adapter/AbstractAdapter.zep
+++ b/phalcon/Image/Adapter/AbstractAdapter.zep
@@ -130,14 +130,14 @@ abstract class AbstractAdapter implements AdapterInterface
         int offsetX = null,
         int offsetY = null
     ) -> <AdapterInterface> {
-        if (null === offsetX) {
+        if (null === offsetX || 0 ===  offsetX) {
             let offsetX = ((this->width - width) / 2);
         } else {
             let offsetX = (offsetX < 0) ? this->width - width + offsetX : offsetX;
             let offsetX = (offsetX > this->width) ? this->width : offsetX;
         }
 
-        if (null === offsetY) {
+        if (null === offsetY || 0 ===  offsetY) {
             let offsetY = ((this->height - height) / 2);
         } else {
             let offsetY = (offsetY < 0) ? this->height - height + offsetY : offsetY;


### PR DESCRIPTION
Fix image crop bug

Hello!

* Type: bug fix 
* Link to issue:  [Crop image using offset = 0px](https://github.com/phalcon/cphalcon/issues/16156)

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of the change:

When I constrain the coordinate data for cropping points to numerical values, if no cropping point is set, the default position becomes (0,0), meaning:

```
$offsetX = 0;
$offsetY = 0;
```

And i found someone brought it up here: https://github.com/phalcon/cphalcon/issues/16156

You will notice that the default position for the cropping point is now the center of the image.

Thanks

