### PR TITLE
Model::toArray added parameter to ignore getters

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [5.5.0](https://github.com/phalcon/cphalcon/releases/tag/v5.5.1) (xxxx-xx-xx)
+## [5.5.1](https://github.com/phalcon/cphalcon/releases/tag/v5.5.1) (xxxx-xx-xx)
 
 ### Changed
  
@@ -12,6 +12,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Mvc\Model::count` to ignore the `order` parameter (needed for Posgresql) [#16471](https://github.com/phalcon/cphalcon/issues/16471)
+- Fixed `Phalcon\Mvc\Model::toArray` added parameter to ignore getters in order not to break serialize. [#16490](https://github.com/phalcon/cphalcon/issues/16490)
 
 ### Removed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -390,7 +390,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          */
         var attributes, manager, dirtyState, snapshot = null;
 
-        let attributes = this->toArray(),
+        let attributes = this->toArray(null, false),
             dirtyState = this->dirtyState,
             manager = <ManagerInterface> this->getModelsManager();
 
@@ -2791,7 +2791,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
          */
         var attributes, manager, dirtyState, snapshot = null;
 
-        let attributes = this->toArray(),
+        let attributes = this->toArray(null, false),
             dirtyState = this->dirtyState,
             manager = <ManagerInterface> this->getModelsManager();
 
@@ -3282,7 +3282,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @param array $columns
      */
-    public function toArray(columns = null) -> array
+    public function toArray(columns = null, useGetter = true) -> array
     {
         var attribute, attributeField, columnMap, metaData, method, value;
         array data;
@@ -3328,7 +3328,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             let method = "get" . camelize(attributeField);
 
-            if method_exists(this, method) {
+            if true === useGetter && method_exists(this, method) {
                 let data[attributeField] = this->{method}();
             } elseif fetch value, this->{attributeField} {
                 let data[attributeField] = value;

--- a/tests/database/Mvc/Model/ToArrayCest.php
+++ b/tests/database/Mvc/Model/ToArrayCest.php
@@ -407,5 +407,58 @@ class ToArrayCest
          * PHP versions
          */
         $I->assertEquals($expected, $actual);
+
+        $expected = [
+            'inv_id'          => '4',
+            'inv_cst_id'      => '1',
+            'inv_status_flag' => '0',
+            'inv_title'       => $title,
+            'inv_total'       => '111.26',
+            'inv_created_at'  => $date,
+        ];
+        $actual = $model->toArray(null, false);
+        $I->assertEquals($expected, $actual);
+    }
+
+        /**
+     * Tests Phalcon\Mvc\Model\ :: save() with property source
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2019-11-16
+     * @issue  #11922
+     *
+     * @group  mysql
+     * @group  sqlite
+     */
+    public function mvcModelToArrayModelWithGettersSerialize(DatabaseTester $I)
+    {
+        $I->wantToTest('Mvc\Model - toArray - model with getters serialize');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+        $title      = uniqid('inv-');
+        $date       = date('Y-m-d H:i:s');
+
+        $migration = new InvoicesMigration($connection);
+        $migration->insert(4, 1, 0, $title, 111.26, $date);
+
+        $model = InvoicesGetters::findFirst(4);
+
+        $class = InvoicesGetters::class;
+        $I->assertInstanceOf($class, $model);
+
+        $expected = 4;
+        $actual   = $model->inv_id;
+        $I->assertEquals($expected, $actual);
+
+        /**
+         * assertEquals here because sqlite returns strings in different
+         * PHP versions
+         */
+
+        $serialize = $model->serialize();
+        $unserialize = new InvoicesGetters();
+        $unserialize->unserialize($serialize);
+        $I->assertEquals($title, $unserialize->inv_title);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16490

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Added parameter to Model::toArray to ignore getters in order not to break serialize.

Thanks

