### PR TITLE
Update docs links to current working URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -13,7 +13,7 @@ Questions? Forum: https://phalcon.io/forum or Discord: https://phalcon.io/discor
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-> Provide output if related. Provide coredump if any. Use https://docs.phalcon.io/en/latest/generating-backtrace as reference.
+> Provide output if related. Provide coredump if any. Use https://docs.phalcon.io/latest/generating-backtrace as reference.
 
 Steps to reproduce the behavior:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,9 +34,9 @@ Please report bugs when you've exhausted all of the above options.
 ## Bug Report Checklist
 
 * Make sure you are using the latest released version of Phalcon before submitting a bug report. Bugs in versions older than the latest released one will not be addressed by the core team (so long as the version is not LTS).
-* If you have found a bug it is important to add relevant reproducibility information to your issue to allow us to reproduce the bug and fix it quicker. Add a script, small program or repository providing the necessary code to make everyone reproduce the issue reported easily. If a bug cannot be reproduced by the development it would be difficult provide corrections and solutions. [Submit Reproducible Test](https://docs.phalcon.io/en/latest/reproducible-tests) for more information
+* If you have found a bug it is important to add relevant reproducibility information to your issue to allow us to reproduce the bug and fix it quicker. Add a script, small program or repository providing the necessary code to make everyone reproduce the issue reported easily. If a bug cannot be reproduced by the development it would be difficult provide corrections and solutions. [Submit Reproducible Test](https://docs.phalcon.io/latest/reproducible-tests/) for more information
 * Be sure that information such as OS, Phalcon version and PHP version are part of the bug report
-* If you're submitting a [Segmentation Fault](https://en.wikipedia.org/wiki/Segmentation_fault) error, we would require a backtrace, please see [Generating a Backtrace](https://docs.phalcon.io/en/latest/generating-backtrace)
+* If you're submitting a [Segmentation Fault](https://en.wikipedia.org/wiki/Segmentation_fault) error, we would require a backtrace, please see [Generating a Backtrace](https://docs.phalcon.io/latest/generating-backtrace)
 
 ## Pull Request Checklist
 
@@ -48,7 +48,7 @@ Please report bugs when you've exhausted all of the above options.
 
 ## Requesting Features
 
-If you have a change or new feature in mind, please fill a [NFR](https://docs.phalcon.io/en/latest/new-feature-request) on the GitHub. Alternatively you may also request features via [the FeatHub page](https://feathub.com/phalcon/cphalcon).
+If you have a change or new feature in mind, please fill a [NFR](https://docs.phalcon.io/latest/new-feature-request) on the GitHub. Alternatively you may also request features via [the FeatHub page](https://feathub.com/phalcon/cphalcon).
 
 
 Thanks! 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can either download a binary package for the system of your choice or build 
 
 ## Installation
 
-For detailed installation instructions you can check our [installation](https://docs.phalcon.io/5.0/en/installation) page in the docs.
+For detailed installation instructions you can check our [installation](https://docs.phalcon.io/latest/installation/) page in the docs.
 
 ## Generating API Documentation
 

--- a/ext/phalcon/di/di.zep.c
+++ b/ext/phalcon/di/di.zep.c
@@ -650,7 +650,7 @@ PHP_METHOD(Phalcon_Di_Di, loadFromConfig)
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&services), _2, _3, _0)
 		{
 			ZEPHIR_INIT_NVAR(&name);
-			if (_3 != NULL) { 
+			if (_3 != NULL) {
 				ZVAL_STR_COPY(&name, _3);
 			} else {
 				ZVAL_LONG(&name, _2);
@@ -728,7 +728,7 @@ PHP_METHOD(Phalcon_Di_Di, loadFromConfig)
  * ];
  * ```
  *
- * @link https://docs.phalcon.io/en/latest/reference/di.html
+ * @link https://docs.phalcon.io/latest/di/
  */
 PHP_METHOD(Phalcon_Di_Di, loadFromPhp)
 {
@@ -795,7 +795,7 @@ PHP_METHOD(Phalcon_Di_Di, loadFromPhp)
  *    className: \Acme\User
  * ```
  *
- * @link https://docs.phalcon.io/en/latest/reference/di.html
+ * @link https://docs.phalcon.io/latest/di/
  */
 PHP_METHOD(Phalcon_Di_Di, loadFromYaml)
 {
@@ -1230,11 +1230,11 @@ zend_object *zephir_init_properties_Phalcon_Di_Di(zend_class_entry *class_type)
 	ZVAL_UNDEF(&_2);
 	ZVAL_UNDEF(&_1$$3);
 	ZVAL_UNDEF(&_3$$4);
-	
+
 
 		ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 		zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
-	
+
 	{
 		zval local_this_ptr, *this_ptr = &local_this_ptr;
 		ZEPHIR_CREATE_OBJECT(this_ptr, class_type);

--- a/phalcon/Di/Di.zep
+++ b/phalcon/Di/Di.zep
@@ -388,7 +388,7 @@ class Di implements DiInterface
      * ];
      * ```
      *
-     * @link https://docs.phalcon.io/en/latest/reference/di.html
+     * @link https://docs.phalcon.io/latest/di/
      */
     public function loadFromPhp(string! filePath) -> void
     {
@@ -430,7 +430,7 @@ class Di implements DiInterface
      *    className: \Acme\User
      * ```
      *
-     * @link https://docs.phalcon.io/en/latest/reference/di.html
+     * @link https://docs.phalcon.io/latest/di/
      */
     public function loadFromYaml(string! filePath, array! callbacks = null) -> void
     {


### PR DESCRIPTION
Hello!

* Type: documentation

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

These links redirect to never ending loop.


