### PR TITLE
Removed property comments in Select Helper

### DIFF
--- a/phalcon/Html/Helper/Input/Select.zep
+++ b/phalcon/Html/Helper/Input/Select.zep
@@ -14,10 +14,6 @@ use Phalcon\Html\Helper\AbstractList;
 
 /**
  * Class Select
- *
- * @property string $elementTag
- * @property bool   $inOptGroup
- * @property string $selected
  */
 class Select extends AbstractList
 {


### PR DESCRIPTION
Hello!

* Type: documentation

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist

Small description of change:
My IDE (phpstorm) was getting confused because inside the IDE stubs for the `Phalcon\Html\Helper\Input\Select` class there are `@property` comments for the class fields (`elementTag`, `inOptGroup` and `selected`) as well as the class fields themselves. My IDE was thinking that each of the fields are actually two fields with the same name but one public and one protected. \
This is why I deleted the `@property` comments to solve this confusion of my IDE.

Thanks

