### PR TITLE
#16489 - Remove usage of 2nd argument of `apcu_fetch()` function

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -13,6 +13,7 @@
 
 - Fixed `Phalcon\Mvc\Model::count` to ignore the `order` parameter (needed for Posgresql) [#16471](https://github.com/phalcon/cphalcon/issues/16471)
 - Fixed `Phalcon\Mvc\Model::toArray` added parameter to ignore getters in order not to break serialize. [#16490](https://github.com/phalcon/cphalcon/issues/16490)
+- Fixed PHP Warning when using Apcu Cache Adapter [#16489](https://github.com/phalcon/cphalcon/issues/16489)
 
 ### Removed
 

--- a/phalcon/Storage/Adapter/Apcu.zep
+++ b/phalcon/Storage/Adapter/Apcu.zep
@@ -208,7 +208,7 @@ class Apcu extends AbstractAdapter
      */
     protected function doGet(string key)
     {
-        return this->phpApcuFetch(this->getPrefixedKey(key));
+        return apcu_fetch(this->getPrefixedKey(key));
     }
 
     /**
@@ -232,11 +232,6 @@ class Apcu extends AbstractAdapter
     protected function phpApcuInc(var key, int step = 1, var success = null, int ttl = 0) -> bool | int
     {
         return apcu_inc(key, step, success, ttl);
-    }
-
-    protected function phpApcuFetch(var key, var success = null) -> var
-    {
-        return apcu_fetch(key, success);
     }
 
     protected function phpApcuIterator(string pattern) -> <APCUIterator> | bool


### PR DESCRIPTION
Hello!

* Type: bug fix

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Thanks

