### PR TITLE
fixed skipping application/x-www-form-urlencoded in getPut()

### DIFF
--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -1721,7 +1721,9 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
         if null === cached {
             let contentType = this->getContentType();
 
-            if typeof contentType == "string" {
+            if typeof contentType == "string" &&
+            (stripos(contentType, "json") != false ||
+                stripos(contentType, "multipart/form-data") !== false) {
 
                 if (stripos(contentType, "json") != false) {
                     let cached = this->getJsonRawBody(true);

--- a/tests/unit/Http/Request/GetPutCest.php
+++ b/tests/unit/Http/Request/GetPutCest.php
@@ -189,4 +189,49 @@ class GetPutCest
 
         $_SERVER = $store;
     }
+
+    /**
+     * Tests Phalcon\Http\Request :: getPut() - x-www-form-urlencoded
+     *
+     * @issue  @16519
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2024-01-29
+     */
+    public function httpRequestGetPutApplicationtXWwwFormUrlencoded(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPut() - x-www-form-urlencoded');
+
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', PhpStream::class);
+
+        file_put_contents('php://input', 'fruit=orange&quantity=4');
+
+        $store   = $_SERVER ?? [];
+        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT' => $time,
+            'REQUEST_METHOD'     => 'PUT',
+            'CONTENT_TYPE'       => "application/x-www-form-urlencoded",
+        ];
+
+        $request = new Request();
+
+        $expected = [
+            'fruit'    => 'orange',
+            'quantity' => '4',
+        ];
+
+        $actual = file_get_contents('php://input');
+
+        $I->assertSame("fruit=orange&quantity=4", $actual);
+
+        $I->assertSame(
+            $expected,
+            $request->getPut()
+        );
+
+        stream_wrapper_restore('php');
+
+        $_SERVER = $store;
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/cphalcon/issues/16519

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

I have fixed it, it doesn't look as nice as before, but it works any content type now :)

Thanks

