### PR TITLE
The ext/json is always available since PHP 8.0

### DIFF
--- a/build/config/config.m4
+++ b/build/config/config.m4
@@ -7,7 +7,7 @@ if test "$PHP_PHALCON" = "yes"; then
     PHP_STRING=$($PHP_CONFIG --version)
     AC_MSG_CHECKING(PHP version)
 
-    if test $PHP_VERSION -lt 70401; then
+    if test $PHP_VERSION -lt 80000; then
       AC_MSG_ERROR(PHP version $PHP_STRING is not supported)
     fi
 
@@ -30,23 +30,6 @@ if test "$PHP_PHALCON" = "yes"; then
 				[
 					PHP_ADD_EXTENSION_DEP([phalcon], [pcre])
 					AC_DEFINE([ZEPHIR_USE_PHP_PCRE], [1], [Whether PHP pcre extension is present at compile time])
-				],
-				,
-				[[#include "main/php.h"]]
-			)
-		],
-		,
-		[[#include "php_config.h"]]
-	)
-
-	AC_CHECK_DECL(
-		[HAVE_JSON],
-		[
-			AC_CHECK_HEADERS(
-				[ext/json/php_json.h],
-				[
-					PHP_ADD_EXTENSION_DEP([phalcon], [json])
-					AC_DEFINE([ZEPHIR_USE_PHP_JSON], [1], [Whether PHP json extension is present at compile time])
 				],
 				,
 				[[#include "main/php.h"]]

--- a/build/phalcon/config.m4
+++ b/build/phalcon/config.m4
@@ -7,7 +7,7 @@ if test "$PHP_PHALCON" = "yes"; then
     PHP_STRING=$($PHP_CONFIG --version)
     AC_MSG_CHECKING(PHP version)
 
-    if test $PHP_VERSION -lt 70401; then
+    if test $PHP_VERSION -lt 80000; then
       AC_MSG_ERROR(PHP version $PHP_STRING is not supported)
     fi
 
@@ -30,23 +30,6 @@ if test "$PHP_PHALCON" = "yes"; then
 				[
 					PHP_ADD_EXTENSION_DEP([phalcon], [pcre])
 					AC_DEFINE([ZEPHIR_USE_PHP_PCRE], [1], [Whether PHP pcre extension is present at compile time])
-				],
-				,
-				[[#include "main/php.h"]]
-			)
-		],
-		,
-		[[#include "php_config.h"]]
-	)
-
-	AC_CHECK_DECL(
-		[HAVE_JSON],
-		[
-			AC_CHECK_HEADERS(
-				[ext/json/php_json.h],
-				[
-					PHP_ADD_EXTENSION_DEP([phalcon], [json])
-					AC_DEFINE([ZEPHIR_USE_PHP_JSON], [1], [Whether PHP json extension is present at compile time])
 				],
 				,
 				[[#include "main/php.h"]]

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
     "ext-igbinary": "*",
     "ext-imagick": "*",
     "ext-intl": "*",
-    "ext-json": "*",
     "ext-libxml": "*",
     "ext-mbstring": "*",
     "ext-msgpack": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b72d11dba93423cc6d6c77c01c90896e",
+    "content-hash": "99f80ef25314b9904f4b2ca3a94b392d",
     "packages": [],
     "packages-dev": [
         {
@@ -6924,7 +6924,6 @@
         "ext-igbinary": "*",
         "ext-imagick": "*",
         "ext-intl": "*",
-        "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-msgpack": "*",

--- a/ext/config.m4
+++ b/ext/config.m4
@@ -660,23 +660,6 @@ if test "$PHP_PHALCON" = "yes"; then
 		[[#include "php_config.h"]]
 	)
 
-	AC_CHECK_DECL(
-		[HAVE_JSON],
-		[
-			AC_CHECK_HEADERS(
-				[ext/json/php_json.h],
-				[
-					PHP_ADD_EXTENSION_DEP([phalcon], [json])
-					AC_DEFINE([ZEPHIR_USE_PHP_JSON], [1], [Whether PHP json extension is present at compile time])
-				],
-				,
-				[[#include "main/php.h"]]
-			)
-		],
-		,
-		[[#include "php_config.h"]]
-	)
-
 	CPPFLAGS=$old_CPPFLAGS
 
 	PHP_INSTALL_HEADERS([ext/phalcon], [php_PHALCON.h])

--- a/ext/config.w32
+++ b/ext/config.w32
@@ -5,10 +5,6 @@ if (PHP_PHALCON != "no") {
   ADD_SOURCES(configure_module_dirname + "/kernel", "main.c memory.c exception.c debug.c backtrace.c object.c array.c string.c fcall.c require.c file.c operators.c math.c concat.c variables.c filter.c iterator.c exit.c time.c", "phalcon");
   /* PCRE is always included on WIN32 */
   AC_DEFINE("ZEPHIR_USE_PHP_PCRE", 1, "Whether PHP pcre extension is present at compile time");
-  if (PHP_JSON != "no") {
-    ADD_EXTENSION_DEP("phalcon", "json");
-    AC_DEFINE("ZEPHIR_USE_PHP_JSON", 1, "Whether PHP json extension is present at compile time");
-  }
   ADD_SOURCES(configure_module_dirname + "/phalcon/annotations", "scanner.c parser.c", "phalcon");
 	ADD_SOURCES(configure_module_dirname + "/phalcon/mvc/model", "orm.c", "phalcon");
 	ADD_SOURCES(configure_module_dirname + "/phalcon/mvc/model/query", "scanner.c parser.c", "phalcon");

--- a/ext/kernel/string.c
+++ b/ext/kernel/string.c
@@ -35,9 +35,7 @@
 #include <ext/pcre/php_pcre.h>
 #endif
 
-#if defined ZEPHIR_USE_PHP_JSON && ZEPHIR_USE_PHP_JSON
 #include <ext/json/php_json.h>
-#endif
 
 #include "kernel/main.h"
 #include "kernel/memory.h"
@@ -1128,8 +1126,6 @@ void zephir_preg_match(zval *return_value, zval *regex, zval *subject, zval *mat
 
 #endif /* ZEPHIR_USE_PHP_PCRE */
 
-#if defined ZEPHIR_USE_PHP_JSON && ZEPHIR_USE_PHP_JSON
-
 int zephir_json_encode(zval *return_value, zval *v, int opts)
 {
 	smart_str buf = { 0 };
@@ -1161,38 +1157,6 @@ int zephir_json_decode(zval *return_value, zval *v, zend_bool assoc)
 
 	return SUCCESS;
 }
-
-#else
-
-int zephir_json_encode(zval *return_value, zval *v, int opts)
-{
-	zval zopts;
-	zval *params[2];
-
-	ZVAL_NULL(&zopts);
-	ZVAL_LONG(&zopts, opts);
-
-	params[0] = v;
-	params[1] = &zopts;
-
-	return zephir_return_call_function(return_value, SL("json_encode"), NULL, 0, 2, params);
-}
-
-int zephir_json_decode(zval *return_value, zval *v, zend_bool assoc)
-{
-	zval zassoc;
-	zval *params[2];
-
-	ZVAL_NULL(&zassoc);
-	ZVAL_BOOL(&zassoc, assoc);
-
-	params[0] = v;
-	params[1] = &zassoc;
-
-	return zephir_return_call_function(return_value, SL("json_decode"), NULL, 0, 2, params);
-}
-
-#endif /* ZEPHIR_USE_PHP_JSON */
 
 void zephir_md5(zval *return_value, zval *str)
 {


### PR DESCRIPTION
The HAVE_JSON symbol is removed with PHP 8.4.0+.

Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16523

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

The HAVE_JSON symbol is removed with PHP 8.4.0+ in php_config.h. Perhaps fixing this can be done something like in the pull request, since the PHP 8.0 is the minimum required version for Phalcon since Phalcon 5.6.

Otherwise, PR needs to be adjusted further.

Thanks

