### PR TITLE
New Workflow - Build Windows DLLs

### DIFF
--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -11,11 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.0"]
-#        php: ["8.0", "8.1", "8.2", "8.3"]
-        arch: [x64]
-        ts: [nts]
-#        ts: [nts, ts]
+        php: ["8.0", "8.1", "8.2", "8.3"]
+        arch: [x64, x86]
+        ts: [nts,ts]
         experimental: [false]
     steps:
       - name: Checkout Xdebug

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.0", "8.1", "8.2", "8.3"]
-        arch: [x64, x86]
-        ts: [nts,ts]
+        php: ["8.0"]
+        arch: [x64]
+        ts: [nts]
         experimental: [false]
     steps:
       - name: Checkout Xdebug
@@ -71,7 +71,7 @@ jobs:
           $phalconDllOpt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_phalcon.dll'
           echo $phalconDllOpt >> $env:GITHUB_ENV
 
-          $artifactName = 'php_phalcon-${{env.XDEBUG_VERSION}}-${{matrix.php}}'
+          $artifactName = 'php_phalcon-${{matrix.php}}'
 
           if ('8.0' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.1' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
@@ -85,7 +85,7 @@ jobs:
           echo $phalconArtifactName >> $env:GITHUB_ENV
 
           $from = $dir + '\php_phalcon.dll'
-          $to = $dir + '\' + $artifactName + ".dll"
+          $to = $dir + '\' + $artifactName + '\' + "php_phalcon.dll"
           Copy-Item $from -Destination $to
           $phalconArtifact = "ARTIFACT=" + $to
           echo $phalconArtifact >> $env:GITHUB_ENV

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.0", "8.1", "8.2", "8.3"]
-        arch: [x64, x86]
-        ts: [nts,ts]
+        php: ["8.0"]
+        arch: [x64]
+        ts: [nts]
         experimental: [false]
     steps:
       - name: Checkout Xdebug
@@ -71,7 +71,7 @@ jobs:
           $phalconDllOpt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_phalcon.dll'
           echo $phalconDllOpt >> $env:GITHUB_ENV
 
-          $artifactName = 'php_phalcon-${{env.XDEBUG_VERSION}}-${{matrix.php}}'
+          $artifactName = 'php_phalcon-${{matrix.php}}'
 
           if ('8.0' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.1' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -77,14 +77,13 @@ jobs:
           $phalconDllOpt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_phalcon.dll'
           echo $phalconDllOpt >> $env:GITHUB_ENV
 
-          $artifactName = 'php_phalcon-${{matrix.php}}'
-
+          $artifactName = 'phalcon-php${{matrix.php}}'
+          
+          if ('nts' -eq '${{matrix.ts}}') { $artifactName = $artifactName + '-nts' }
           if ('8.0' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.1' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.2' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.3' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
-
-          if ('nts' -eq '${{matrix.ts}}') { $artifactName = $artifactName + '-nts' }
           if ('x64' -eq '${{matrix.arch}}') { $artifactName = $artifactName + '-x86_64' }
 
           $phalconArtifactName = "ARTIFACT_NAME=" + $artifactName

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -1,22 +1,22 @@
-name: Compile on Windows
+name: "[Windows] Build Phalcon"
 on: [push, pull_request]
 
 jobs:
   windows:
     runs-on: windows-latest
-    name: "Windows: Build and test"
+    name: "Build Phalcon (PHP ${{matrix.php}}-${{matrix.ts}}-${{matrix.arch}})"
     defaults:
       run:
         shell: cmd
     strategy:
       fail-fast: false
       matrix:
-        php: ["8.0"]
-        arch: [x64]
-        ts: [nts]
+        php: ["8.0","8.1","8.2","8.3"]
+        arch: [x64,x86]
+        ts: [nts,ts]
         experimental: [false]
     steps:
-      - name: Checkout Xdebug
+      - name: Checkout Phalcon
         uses: actions/checkout@v4
 
       - name: Extract Phalcon Version

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -37,7 +37,7 @@ jobs:
           arch: ${{matrix.arch}}
           ts: ${{matrix.ts}}
           deps: zlib
-      
+
       - name: Generate build folder
         run: |
           cd build/
@@ -48,7 +48,6 @@ jobs:
         with:
           arch: ${{matrix.arch}}
           toolset: ${{steps.setup-php.outputs.toolset}}
-
 
       - name: Phpize
         run: |
@@ -77,14 +76,19 @@ jobs:
           $phalconDllOpt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_phalcon.dll'
           echo $phalconDllOpt >> $env:GITHUB_ENV
 
-          $artifactName = 'phalcon-php${{matrix.php}}'
-          
+          $artifactName = 'php_phalcon-php${{matrix.php}}'
+
+          if ('nts' -ne '${{matrix.ts}}') { $artifactName = $artifactName + '-ts' }
           if ('nts' -eq '${{matrix.ts}}') { $artifactName = $artifactName + '-nts' }
+
+          $artifactName = $artifactName + '-windows'
+
           if ('8.0' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.1' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.2' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
           if ('8.3' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
-          if ('x64' -eq '${{matrix.arch}}') { $artifactName = $artifactName + '-x86_64' }
+
+          if ('x64' -eq '${{matrix.arch}}') { $artifactName = $artifactName + '-x64' }
 
           $phalconArtifactName = "ARTIFACT_NAME=" + $artifactName
           echo $phalconArtifactName >> $env:GITHUB_ENV
@@ -96,9 +100,9 @@ jobs:
           echo $phalconArtifact >> $env:GITHUB_ENV
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-            name: ${{env.ARTIFACT_NAME}}
-            path: |
-              ${{env.ARTIFACT}}
-              LICENSE.txt
+          name: ${{env.ARTIFACT_NAME}}
+          path: |
+            ${{env.ARTIFACT}}
+            LICENSE.txt

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           cd build/phalcon/
           ./configure --enable-phalcon --with-prefix=${{steps.setup-php.outputs.prefix}}
-          nmake
 
       - name: Make
         run: |
@@ -67,7 +66,7 @@ jobs:
         run: |
           chcp 65001
 
-          $dir = (Get-Location).Path + '\'
+          $dir = (Get-Location).Path + '\phalcon\build\'
           if ('x64' -eq '${{matrix.arch}}') { $dir = $dir + 'x64\' }
           $dir = $dir + 'Release'
           if ('ts' -eq '${{matrix.ts}}') { $dir = $dir + '_TS' }

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -91,13 +91,15 @@ jobs:
           echo $phalconArtifactName >> $env:GITHUB_ENV
 
           $from = $dir + '\php_phalcon.dll'
-          $to = $dir + '\' + $artifactName + "\php_phalcon.dll"
+          $to = '.\php_phalcon.dll'
           Copy-Item $from -Destination $to
-          $phalconArtifact = "ARTIFACT=" + $to
+          $phalconArtifact = "ARTIFACT=" + '.\php_phalcon.dll'
           echo $phalconArtifact >> $env:GITHUB_ENV
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
             name: ${{env.ARTIFACT_NAME}}
-            path: ${{env.ARTIFACT}}
+            path: |
+              ${{env.ARTIFACT}}
+              LICENSE.txt

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           chcp 65001
 
-          $dir = (Get-Location).Path + '\phalcon\build\'
+          $dir = (Get-Location).Path + '\build\phalcon\'
           if ('x64' -eq '${{matrix.arch}}') { $dir = $dir + 'x64\' }
           $dir = $dir + 'Release'
           if ('ts' -eq '${{matrix.ts}}') { $dir = $dir + '_TS' }

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -85,7 +85,7 @@ jobs:
           echo $phalconArtifactName >> $env:GITHUB_ENV
 
           $from = $dir + '\php_phalcon.dll'
-          $to = $dir + '\' + $artifactName + '\' + "php_phalcon.dll"
+          $to = $dir + '\' + $artifactName + ".dll"
           Copy-Item $from -Destination $to
           $phalconArtifact = "ARTIFACT=" + $to
           echo $phalconArtifact >> $env:GITHUB_ENV

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -37,12 +37,18 @@ jobs:
           arch: ${{matrix.arch}}
           ts: ${{matrix.ts}}
           deps: zlib
+      
+      - name: Generate build folder
+        run: |
+          cd build/
+          php gen-build.php
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{matrix.arch}}
           toolset: ${{steps.setup-php.outputs.toolset}}
+
 
       - name: Phpize
         run: |

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -91,7 +91,7 @@ jobs:
           echo $phalconArtifactName >> $env:GITHUB_ENV
 
           $from = $dir + '\php_phalcon.dll'
-          $to = $dir + '\' + $artifactName + ".dll"
+          $to = $dir + '\' + $artifactName + "\php_phalcon.dll"
           Copy-Item $from -Destination $to
           $phalconArtifact = "ARTIFACT=" + $to
           echo $phalconArtifact >> $env:GITHUB_ENV

--- a/.github/workflows/compile-windows.yml
+++ b/.github/workflows/compile-windows.yml
@@ -1,0 +1,100 @@
+name: Compile on Windows
+on: [push, pull_request]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    name: "Windows: Build and test"
+    defaults:
+      run:
+        shell: cmd
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.0"]
+#        php: ["8.0", "8.1", "8.2", "8.3"]
+        arch: [x64]
+        ts: [nts]
+#        ts: [nts, ts]
+        experimental: [false]
+    steps:
+      - name: Checkout Xdebug
+        uses: actions/checkout@v4
+
+      - name: Extract Phalcon Version
+        shell: powershell
+        run: |
+          chcp 65001
+          $r = Select-String -Path build/phalcon/php_phalcon.h -Pattern 'PHP_PHALCON_VERSION\s+"(.*)"'
+          $s = $r.Matches[0].Groups[1]
+          echo "$s"
+          $PhalconVersion = 'PHALCON_VERSION=' + $s
+          echo $PhalconVersion >> $env:GITHUB_ENV
+
+      - name: Setup PHP
+        id: setup-php
+        uses: php/setup-php-sdk@v0.8
+        with:
+          version: ${{matrix.php}}
+          arch: ${{matrix.arch}}
+          ts: ${{matrix.ts}}
+          deps: zlib
+
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{matrix.arch}}
+          toolset: ${{steps.setup-php.outputs.toolset}}
+
+      - name: Phpize
+        run: |
+          cd build/phalcon/
+          phpize
+
+      - name: Configure
+        run: |
+          cd build/phalcon/
+          ./configure --enable-phalcon --with-prefix=${{steps.setup-php.outputs.prefix}}
+          nmake
+
+      - name: Make
+        run: |
+          cd build/phalcon/
+          nmake
+
+      - name: Define Phalcon Module Env
+        shell: powershell
+        run: |
+          chcp 65001
+
+          $dir = (Get-Location).Path + '\'
+          if ('x64' -eq '${{matrix.arch}}') { $dir = $dir + 'x64\' }
+          $dir = $dir + 'Release'
+          if ('ts' -eq '${{matrix.ts}}') { $dir = $dir + '_TS' }
+          $phalconDllOpt = 'TEST_PHP_ARGS=-n -d zend_extension=' + $dir + '\php_phalcon.dll'
+          echo $phalconDllOpt >> $env:GITHUB_ENV
+
+          $artifactName = 'php_phalcon-${{env.XDEBUG_VERSION}}-${{matrix.php}}'
+
+          if ('8.0' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
+          if ('8.1' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
+          if ('8.2' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
+          if ('8.3' -eq '${{matrix.php}}') { $artifactName = $artifactName + '-vs16' }
+
+          if ('nts' -eq '${{matrix.ts}}') { $artifactName = $artifactName + '-nts' }
+          if ('x64' -eq '${{matrix.arch}}') { $artifactName = $artifactName + '-x86_64' }
+
+          $phalconArtifactName = "ARTIFACT_NAME=" + $artifactName
+          echo $phalconArtifactName >> $env:GITHUB_ENV
+
+          $from = $dir + '\php_phalcon.dll'
+          $to = $dir + '\' + $artifactName + ".dll"
+          Copy-Item $from -Destination $to
+          $phalconArtifact = "ARTIFACT=" + $to
+          echo $phalconArtifact >> $env:GITHUB_ENV
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+            name: ${{env.ARTIFACT_NAME}}
+            path: ${{env.ARTIFACT}}


### PR DESCRIPTION
* Type: New Feature
* Link to issue: https://github.com/phalcon/cphalcon/issues/16318

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
I have created a new workflow that automatically builds the php_phalcon.dll files for use with all Windows PHP 8.x variants. The compiled extensions are appropriately named, bundled with ``License.txt`` and added as artifacts. The workflow has been tested and confirmed to be working.

Thanks to @niden for his base script as contribution for this fix as well as his guidance to help get this completed.

