### PR TITLE
T16560 min max validator

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Mvc\Cli\Router` to extend the `Phalcon\Mvc\Cli\RouterInterface` [#16551](https://github.com/phalcon/cphalcon/issues/16551)
+- Fixed `Phalcon\Filter\Validation\Validator\StringLength::validate()` to correctly use the `include` parameter [#16560](https://github.com/phalcon/cphalcon/issues/16560)
 
 ### Removed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [5.7.0](https://github.com/phalcon/cphalcon/releases/tag/v5.7.0) (xxxx-xx-xx)
+
+### Changed
+ 
+### Added
+ 
+### Fixed
+
+- Fixed `Phalcon\Mvc\Cli\Router` to extend the `Phalcon\Mvc\Cli\RouterInterface` [#16551](https://github.com/phalcon/cphalcon/issues/16551)
+
+### Removed
+
+# Changelog
+
 ## [5.6.2](https://github.com/phalcon/cphalcon/releases/tag/v5.6.1) (2024-03-14)
 
 ### Changed

--- a/composer.lock
+++ b/composer.lock
@@ -1019,16 +1019,16 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace"
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/4775f35b2d70865807c89d32c8e7385b86eb0ace",
-                "reference": "4775f35b2d70865807c89d32c8e7385b86eb0ace",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
+                "reference": "5b16e25a5355f1f3afdfc2f954a0a80aec4826a8",
                 "shasum": ""
             },
             "require": {
@@ -1070,7 +1070,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.1.2"
+                "source": "https://github.com/composer/pcre/tree/3.1.3"
             },
             "funding": [
                 {
@@ -1086,7 +1086,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-07T15:38:35+00:00"
+            "time": "2024-03-19T10:26:25+00:00"
         },
         {
             "name": "composer/semver",
@@ -1553,16 +1553,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.51.0",
+            "version": "v3.52.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "127fa74f010da99053e3f5b62672615b72dd6efd"
+                "reference": "a3564bd66f4bce9bc871ef18b690e2dc67a7f969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/127fa74f010da99053e3f5b62672615b72dd6efd",
-                "reference": "127fa74f010da99053e3f5b62672615b72dd6efd",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a3564bd66f4bce9bc871ef18b690e2dc67a7f969",
+                "reference": "a3564bd66f4bce9bc871ef18b690e2dc67a7f969",
                 "shasum": ""
             },
             "require": {
@@ -1633,7 +1633,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.51.0"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.52.0"
             },
             "funding": [
                 {
@@ -1641,7 +1641,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-28T19:50:06+00:00"
+            "time": "2024-03-18T18:40:11+00:00"
         },
         {
             "name": "graham-campbell/result-type",
@@ -2294,21 +2294,21 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.18.0",
+            "version": "v4.19.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999"
+                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/1bcbb2179f97633e98bbbc87044ee2611c7d7999",
-                "reference": "1bcbb2179f97633e98bbbc87044ee2611c7d7999",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
@@ -2344,22 +2344,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.18.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
             },
-            "time": "2023-12-10T21:03:43+00:00"
+            "time": "2024-03-17T08:10:35+00:00"
         },
         {
             "name": "phalcon/ide-stubs",
-            "version": "v5.6.1",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phalcon/ide-stubs.git",
-                "reference": "59be72bc524967f522ad333f8b0d0017403395e3"
+                "reference": "509423a14c34ea40abb504ff937102ba8207a7b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phalcon/ide-stubs/zipball/59be72bc524967f522ad333f8b0d0017403395e3",
-                "reference": "59be72bc524967f522ad333f8b0d0017403395e3",
+                "url": "https://api.github.com/repos/phalcon/ide-stubs/zipball/509423a14c34ea40abb504ff937102ba8207a7b4",
+                "reference": "509423a14c34ea40abb504ff937102ba8207a7b4",
                 "shasum": ""
             },
             "require": {
@@ -2413,7 +2413,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-02-08T18:31:12+00:00"
+            "time": "2024-03-14T17:21:14+00:00"
         },
         {
             "name": "phalcon/zephir",
@@ -4557,16 +4557,16 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -4578,7 +4578,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -4599,8 +4599,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -4608,8 +4607,7 @@
                     "type": "github"
                 }
             ],
-            "abandoned": true,
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",

--- a/phalcon/Filter/Validation/Validator/StringLength/Max.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength/Max.zep
@@ -86,7 +86,7 @@ class Max extends AbstractValidator
      */
     public function validate(<Validation> validation, var field) -> bool
     {
-        var value, length, maximum, replacePairs, included, result;
+        var failed, included, length, maximum, replacePairs, value;
 
         let value = validation->getValue(field);
         if this->allowEmpty(field, value) {
@@ -115,12 +115,12 @@ class Max extends AbstractValidator
         }
 
         if included {
-            let result = length >= maximum;
+            let failed = length > maximum;
         } else {
-            let result = length > maximum;
+            let failed = length >= maximum;
         }
 
-        if result {
+        if failed {
             let replacePairs = [
                 ":max" : maximum
             ];

--- a/phalcon/Filter/Validation/Validator/StringLength/Min.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength/Min.zep
@@ -86,7 +86,7 @@ class Min extends AbstractValidator
      */
     public function validate(<Validation> validation, var field) -> bool
     {
-        var value, length, minimum, replacePairs, included, result;
+        var failed, included, length, minimum, replacePairs, value;
 
         let value = validation->getValue(field);
         if this->allowEmpty(field, value) {
@@ -115,12 +115,12 @@ class Min extends AbstractValidator
         }
 
         if included {
-            let result = length <= minimum;
+            let failed = length < minimum;
         } else {
-            let result = length < minimum;
+            let failed = length <= minimum;
         }
 
-        if result {
+        if failed {
             let replacePairs = [
                 ":min"   : minimum
             ];

--- a/tests/integration/Filter/Validation/Validator/Callback/ValidateCest.php
+++ b/tests/integration/Filter/Validation/Validator/Callback/ValidateCest.php
@@ -146,7 +146,7 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'user'  => 'user',
+                'user'  => '12345',
                 'admin' => null,
             ]
         );

--- a/tests/integration/Filter/Validation/Validator/StringLength/Max/ValidateCest.php
+++ b/tests/integration/Filter/Validation/Validator/StringLength/Max/ValidateCest.php
@@ -72,26 +72,23 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
+                'name' => '12345678',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
+                'name' => '123456789',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
     }
 
     /**
@@ -120,26 +117,23 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'short',
+                'name' => '12345',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
+                'name' => '1234567890',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
-
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
@@ -147,9 +141,8 @@ class ValidateCest
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
     }
 }

--- a/tests/integration/Filter/Validation/Validator/StringLength/Min/ValidateCest.php
+++ b/tests/integration/Filter/Validation/Validator/StringLength/Min/ValidateCest.php
@@ -43,8 +43,8 @@ class ValidateCest
         $entity->name = '';
 
         $validation->bind($entity, []);
-        $result = $validator->validate($validation, 'name');
-        $I->assertTrue($result);
+        $actual = $validator->validate($validation, 'name');
+        $I->assertTrue($actual);
     }
 
     /**
@@ -69,29 +69,26 @@ class ValidateCest
             )
         );
 
-
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
+                'name' => '1234567890',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
+                'name' => '123456789',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
     }
 
     /**
@@ -120,25 +117,23 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
+                'name' => '12345678',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
+                'name' => '1234567890',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
     }
 }

--- a/tests/integration/Filter/Validation/Validator/StringLength/ValidateCest.php
+++ b/tests/integration/Filter/Validation/Validator/StringLength/ValidateCest.php
@@ -49,29 +49,25 @@ class ValidateCest
             )
         );
 
-
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
+                'name' => '12345678',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
+                'name' => '123456789',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
     }
 
     /**
@@ -98,15 +94,13 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'Something',
+                'name' => '123456',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $expected = new Messages(
             [
@@ -121,7 +115,7 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'So',
+                'name' => '12',
             ]
         );
 
@@ -156,15 +150,13 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'message' => 'Something',
+                'message' => '123456',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $expected = new Messages(
             [
@@ -179,7 +171,7 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'message' => 'So',
+                'message' => '12',
             ]
         );
 
@@ -210,15 +202,13 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'John',
+                'name' => '123',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $expected = new Messages(
             [
@@ -233,7 +223,7 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'Johannes',
+                'name' => '1234',
             ]
         );
 
@@ -267,15 +257,13 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'message' => 'Pet',
+                'message' => '123',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $expected = new Messages(
             [
@@ -290,7 +278,7 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'message' => 'Validation',
+                'message' => '123456',
             ]
         );
 
@@ -340,28 +328,25 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
-                'type' => 'SomeValue',
+                'name' => '1234',
+                'type' => '1234',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
-                'type' => 'SomeValue',
+                'name' => '123456789',
+                'type' => '12345678',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $I->assertSame(
             $validationMaximumMessages['name'],
@@ -371,25 +356,22 @@ class ValidateCest
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
-                'type' => 'SomeValue123',
+                'name' => '123456789',
+                'type' => '123456789',
             ]
         );
 
-        $I->assertSame(
-            2,
-            $messages->count()
-        );
+        $expected = 2;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
-        $I->assertSame(
-            $validationMaximumMessages['name'],
-            $messages->offsetGet(0)->getMessage()
-        );
+        $expected = $validationMaximumMessages['name'];
+        $actual   = $messages->offsetGet(0)->getMessage();
+        $I->assertSame($expected, $actual);
 
-        $I->assertSame(
-            $validationMaximumMessages['type'],
-            $messages->offsetGet(1)->getMessage()
-        );
+        $expected = $validationMaximumMessages['type'];
+        $actual   = $messages->offsetGet(1)->getMessage();
+        $I->assertSame($expected, $actual);
     }
 
     /**
@@ -436,76 +418,118 @@ class ValidateCest
             )
         );
 
-
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
-                'type' => 'Some',
+                'name' => '12345678',
+                'type' => '123',
             ]
         );
 
-        $I->assertSame(
-            0,
-            $messages->count()
-        );
-
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
-                'type' => 'Some',
+                'name' => '1234567890',
+                'type' => '123',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
-        $I->assertSame(
-            $validationMaximumMessages['name'],
-            $messages->offsetGet(0)->getMessage()
-        );
-
+        $expected = $validationMaximumMessages['name'];
+        $actual   = $messages->offsetGet(0)->getMessage();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue',
-                'type' => 'SomeValue',
+                'name' => '12345678',
+                'type' => '12345',
             ]
         );
 
-        $I->assertSame(
-            1,
-            $messages->count()
-        );
+        $expected = 1;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
 
-        $I->assertSame(
-            $validationMaximumMessages['type'],
-            $messages->offsetGet(0)->getMessage()
-        );
-
+        $expected = $validationMaximumMessages['type'];
+        $actual   = $messages->offsetGet(0)->getMessage();
+        $I->assertSame($expected, $actual);
 
         $messages = $validation->validate(
             [
-                'name' => 'SomeValue123',
-                'type' => 'SomeValue',
+                'name' => '1234567890',
+                'type' => '12345',
             ]
         );
 
-        $I->assertSame(
-            2,
-            $messages->count()
+        $expected = 2;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
+
+        $expected = $validationMaximumMessages['name'];
+        $actual   = $messages->offsetGet(0)->getMessage();
+        $I->assertSame($expected, $actual);
+
+        $expected = $validationMaximumMessages['type'];
+        $actual   = $messages->offsetGet(1)->getMessage();
+        $I->assertSame($expected, $actual);
+    }
+
+
+    /**
+     * Tests Phalcon\Filter\Validation\Validator\StringLength :: validate() - 16560
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2024-04-03
+     * @issue  16560
+     */
+    public function filterValidationValidatorStringLengthValidate16560(IntegrationTester $I)
+    {
+        $I->wantToTest('Validation\Validator\StringLength :: validate() - 16560');
+
+        $data            = [];
+        $data['testMin'] = '12345678';
+        $data['testMax'] = '12345678901234567890';
+
+        $validation = new Validation();
+
+
+        $validation->add(
+            'testMin',
+            new StringLength(
+                [
+                    "min"             => 8,
+                    "max"             => 20,
+                    "messageMinimum"  => "minimum length requirement failed.",
+                    "messageMaximum"  => "maximum length requirement failed.",
+                    "includedMinimum" => true,
+                    "includedMaximum" => true
+                ]
+            )
         );
 
-        $I->assertSame(
-            $validationMaximumMessages['name'],
-            $messages->offsetGet(0)->getMessage()
+        $validation->add(
+            'testMax',
+            new StringLength(
+                [
+                    "min"             => 8,
+                    "max"             => 20,
+                    "messageMinimum"  => "minimum length requirement failed.",
+                    "messageMaximum"  => "maximum length requirement failed.",
+                    "includedMinimum" => true,
+                    "includedMaximum" => true
+                ]
+            )
         );
 
-        $I->assertSame(
-            $validationMaximumMessages['type'],
-            $messages->offsetGet(1)->getMessage()
-        );
+        $messages = $validation->validate($data);
+
+        $expected = 0;
+        $actual   = $messages->count();
+        $I->assertSame($expected, $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16560 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Filter\Validation\Validator\StringLength::validate()` to correctly use the `include` parameter

Thanks

