### PR TITLE
[#16567] - Fix for Form::bind deprecated warnings.

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -7,12 +7,15 @@
 - Changed `Phalcon\Support\HelperFactory` to use the internal mapper for better memory management [#16571](https://github.com/phalcon/cphalcon/issues/16571)
 
 ### Added
+
+- New ini setting `phalcon.form.strict_entity_property_check` for `Phalcon\Forms\Form` to enable strict entity property checking. [#16567](https://github.com/phalcon/cphalcon/issues/16567)
  
 ### Fixed
 
 - Fixed `Phalcon\Mvc\Cli\Router` to extend the `Phalcon\Mvc\Cli\RouterInterface` [#16551](https://github.com/phalcon/cphalcon/issues/16551)
 - Fixed `Phalcon\Filter\Validation\Validator\StringLength::validate()` to correctly use the `include` parameter [#16560](https://github.com/phalcon/cphalcon/issues/16560)
 - Fixed `Phalcon\Db\Column::TYPE_BINARY` and `Phalcon\Db\Column::TYPE_TINYINTEGER` to have unique values [#16532](https://github.com/phalcon/cphalcon/issues/16532)
+- Fixed `Phalcon\Forms\Form` to bind only existing properties on entities, based on `phalcon.form.strict_entity_property_check` setting. [#16567](https://github.com/phalcon/cphalcon/issues/16567)
 
 ### Removed
 

--- a/config.json
+++ b/config.json
@@ -69,6 +69,10 @@
       "type": "bool",
       "default": false
     },
+    "form.strict_entity_property_check": {
+      "type": "bool",
+      "default": false
+    },
     "orm.ast_cache": {
       "type": "hash",
       "default": "NULL"

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -254,7 +254,15 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
                 /**
                  * Use the public property if it doesn't have a setter
                  */
-                let entity->{key} = filteredValue;
+                if (!globals_get("form.strict_entity_property_check")) {
+                    let entity->{key} = filteredValue;
+
+                    continue;
+                }
+
+                if (property_exists(entity, key)) {
+                    let entity->{key} = filteredValue;
+                }
             }
         }
 

--- a/tests/unit/Forms/FormEntityCest.php
+++ b/tests/unit/Forms/FormEntityCest.php
@@ -96,6 +96,7 @@ class FormEntityCest
 
         $I->assertFalse(property_exists($product, 'prd_not_exists'));
 
+        // Set setting for GlobalsCest.php
         ini_set('phalcon.form.strict_entity_property_check', '1');
 
         $form = new Form($product);
@@ -105,6 +106,9 @@ class FormEntityCest
         $exists = new Text('prd_name');
         $form->add($exists);
         $form->bind(['prd_name' => 'Test', 'prd_not_exists' => 'TestValue'], $product);
+
+        // Reset setting for GlobalsCest.php
+        ini_set('phalcon.form.strict_entity_property_check', '0');
 
         $I->assertEquals('Test', $product->prd_name);
         $I->assertFalse(property_exists($product, "prd_not_exists"));

--- a/tests/unit/Forms/FormEntityCest.php
+++ b/tests/unit/Forms/FormEntityCest.php
@@ -51,4 +51,62 @@ class FormEntityCest
         $I->assertNotNull($validator->getEntity());
         $I->assertSame($product->prd_name, $validator->getEntity()->prd_name);
     }
+
+    /**
+     * Tests Phalcon\Forms\Form :: bind()
+     *
+     * @author noone-silent <lominum@protonmail.com>
+     * @since  2024-05-01
+     */
+    public function bindDisabledStrictCheck(UnitTester $I): void
+    {
+        $I->wantToTest('Phalcon\Forms\Form - bind() with disabled strict property check');
+
+        $this->setNewFactoryDefault(); //create default DI
+
+        $product = new Products();
+
+        $I->assertFalse(property_exists($product, 'prd_not_exists'));
+
+        $form = new Form($product);
+        $form->setTagFactory($this->container->get("tag"));
+        $dynamic = new Text('prd_not_exists');
+        $form->add($dynamic);
+        $exists = new Text('prd_name');
+        $form->add($exists);
+        $form->bind(['prd_name' => 'Test', 'prd_not_exists' => 'TestValue'], $product);
+
+        $I->assertEquals('Test', $product->prd_name);
+        $I->assertEquals('TestValue', $product->prd_not_exists);
+    }
+
+    /**
+     * Tests Phalcon\Forms\Form :: bind()
+     *
+     * @author noone-silent <lominum@protonmail.com>
+     * @since  2024-05-01
+     */
+    public function bindEnabledStrictCheck(UnitTester $I): void
+    {
+        $I->wantToTest('Phalcon\Forms\Form - bind() with enabled strict property check');
+
+        $this->setNewFactoryDefault(); //create default DI
+
+        $product = new Products();
+
+        $I->assertFalse(property_exists($product, 'prd_not_exists'));
+
+        ini_set('phalcon.form.strict_entity_property_check', '1');
+
+        $form = new Form($product);
+        $form->setTagFactory($this->container->get("tag"));
+        $dynamic = new Text('prd_not_exists');
+        $form->add($dynamic);
+        $exists = new Text('prd_name');
+        $form->add($exists);
+        $form->bind(['prd_name' => 'Test', 'prd_not_exists' => 'TestValue'], $product);
+
+        $I->assertEquals('Test', $product->prd_name);
+        $I->assertFalse(property_exists($product, "prd_not_exists"));
+    }
 }

--- a/tests/unit/Mvc/GlobalsCest.php
+++ b/tests/unit/Mvc/GlobalsCest.php
@@ -58,6 +58,10 @@ class GlobalsCest
                 'value'   => '0',
             ],
             [
+                'setting' => 'phalcon.form.strict_entity_property_check',
+                'value'   => '0',
+            ],
+            [
                 'setting' => 'phalcon.orm.cast_last_insert_id_to_int',
                 'value'   => '0',
             ],


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16567

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

`Form:bind` raises `Deprecated: Creation of dynamic property Model::$attribute is deprecated` warnings on PHP 8.2+. A new PHP-ini setting `phalcon.form.strict_entity_property_check` has been introduced to change the default behavior. 

Documentation PR: https://github.com/phalcon/documentation/pull/132

Thanks

