### PR TITLE
[#16637] - refactor: allow utf8 in email local part.

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [5.8.x](https://github.com/phalcon/cphalcon/releases/tag/v5.8.x) (xxxx-xx-xx)
+
+### Changed
+
+- Changed `Phalcon\Filter\Validation\Validator\Email` to allow UTF8 in local part. [#16637](https://github.com/phalcon/cphalcon/issues/16637)
+
 ## [5.8.0](https://github.com/phalcon/cphalcon/releases/tag/v5.8.0) (2024-07-09)
 
 ### Changed

--- a/phalcon/Filter/Validation/Validator/Email.zep
+++ b/phalcon/Filter/Validation/Validator/Email.zep
@@ -46,6 +46,16 @@ use Phalcon\Filter\Validation\AbstractValidator;
  *         ]
  *     )
  * );
+ *
+ * $validator->add(
+ *     "täst@example.com",
+ *     new EmailValidator(
+ *         [
+ *             "message" => "The e-mail is not valid",
+ *             "allowUTF8" => true,
+ *         ]
+ *     )
+ * );
  * ```
  */
 class Email extends AbstractValidator
@@ -58,7 +68,8 @@ class Email extends AbstractValidator
      * @param array options = [
      *     'message' => '',
      *     'template' => '',
-     *     'allowEmpty' => false
+     *     'allowEmpty' => false,
+     *     'allowUTF8' => false,
      * ]
      */
     public function __construct(array! options = [])
@@ -71,12 +82,19 @@ class Email extends AbstractValidator
      */
     public function validate(<Validation> validation, var field) -> bool
     {
-        var value = validation->getValue(field);
+        var value, flags;
+
+        let value = validation->getValue(field);
         if this->allowEmpty(field, value) {
             return true;
         }
 
-        if !filter_var(value, FILTER_VALIDATE_EMAIL) {
+        let flags = FILTER_DEFAULT;
+        if (this->getOption("allowUTF8")) {
+            let flags = FILTER_FLAG_EMAIL_UNICODE;
+        }
+
+        if !filter_var(value, FILTER_VALIDATE_EMAIL, flags) {
             validation->appendMessage(
                 this->messageFactory(validation, field)
             );

--- a/tests/unit/Filter/Validation/Validator/EmailCest.php
+++ b/tests/unit/Filter/Validation/Validator/EmailCest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Filter\Validation\Validator;
+
+use Phalcon\Filter\Validation;
+use UnitTester;
+
+class EmailCest
+{
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function validEmail(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - valid email');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email());
+        $I->assertEmpty($validation->validate(['email' => 'test@example.com']));
+    }
+
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function invalidEmail(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - invalid email');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email());
+        $I->assertNotEmpty($validation->validate(['email' => 'test@-example.com']));
+    }
+
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function emailWithoutUTF8Success(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - without utf8 is ok');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email());
+        $I->assertEmpty($validation->validate(['email' => 'test@example.com']));
+    }
+
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function emailAllowEmptyFails(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - empty is not ok');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email());
+        $I->assertNotEmpty($validation->validate(['email' => '']));
+    }
+
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function emailAllowEmptySuccess(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - empty is ok');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email(['allowEmpty' => true]));
+        $I->assertEmpty($validation->validate(['email' => '']));
+    }
+
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function emailWithUTF8Fail(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - with utf8 fails');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email());
+        $I->assertNotEmpty($validation->validate(['email' => 'täst@example.com']));
+    }
+
+    /**
+     * Tests Filter\Validation\Validator\Email :: validate
+     *
+     * @param UnitTester $I
+     *
+     * @author n[oO]ne <lominum@protonmail.com>
+     * @since  2024-08-19
+     */
+    public function emailWithUTF8Success(UnitTester $I)
+    {
+        $I->wantToTest('Filter\Validation\Validator\Email - with utf8 success');
+
+        $validation = new Validation();
+        $validation->add('email', new Validation\Validator\Email(['allowUTF8' => true]));
+        $I->assertEmpty($validation->validate(['email' => 'täst@example.com']));
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16637

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [X] I have updated the relevant CHANGELOG
- [X] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change: Allow UTF8 in local part of the email, if `allowUTF8` is `true`

Thanks

