### PR TITLE
Fix passing null of type string is deprecated warning

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Http\Response\Cookies`, `Phalcon\Http\Response\CookiesInterface` and `Phalcon\Http\Cookie` to use correct cookie default arguments, avoid deprecated null assign warning when trying to assign the same cookie twice [#16649](https://github.com/phalcon/cphalcon/issues/16649)
 - Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)
 - Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)
 

--- a/phalcon/Http/Cookie.zep
+++ b/phalcon/Http/Cookie.zep
@@ -100,9 +100,9 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
         var value = null,
         int expire = 0,
         string path = "/",
-        bool secure = null,
-        string domain = null,
-        bool httpOnly = null,
+        bool secure = false,
+        string domain = "",
+        bool httpOnly = false,
         array options = []
     ) {
         let this->name     = name,

--- a/phalcon/Http/Response/Cookies.zep
+++ b/phalcon/Http/Response/Cookies.zep
@@ -251,9 +251,9 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
         var value = null,
         int expire = 0,
         string path = "/",
-        bool secure = null,
-        string! domain = null,
-        bool httpOnly = null,
+        bool secure = false,
+        string! domain = "",
+        bool httpOnly = false,
         array options = []
     ) -> <CookiesInterface> {
         var cookie, encryption, container, response;

--- a/phalcon/Http/Response/CookiesInterface.zep
+++ b/phalcon/Http/Response/CookiesInterface.zep
@@ -58,9 +58,9 @@ interface CookiesInterface
         var value = null,
         int expire = 0,
         string path = "/",
-        bool secure = null,
-        string! domain = null,
-        bool httpOnly = null,
+        bool secure = false,
+        string! domain = "",
+        bool httpOnly = false,
         array options = []
     ) -> <CookiesInterface>;
 


### PR DESCRIPTION
Hello!

*  Type: bug fix
*  Link to issue: https://github.com/phalcon/cphalcon/issues/16649

**In raising this pull request, I confirm the following:**

-  [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/phalcon/blob/master/CONTRIBUTING.md)
-  [x] I have checked that another pull request for this purpose does not exist
-  [ ] I wrote some tests for this PR
-  [ ] I have updated the relevant CHANGELOG
-  [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Ensure null type deprecation warnings are avoided, happens if someone creates the same cookie twice eg:
```
$this->cookies->set("test", "test value");
$this->cookies->set("test", "test value");
```
it will cause the deprecated warning message.

Thanks
