### PR TITLE
Include the reference model name in the build query when getting rela…

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -13,6 +13,7 @@
 
 - Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)
 - Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)
+- Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to explicitly set the `referencedModel` in the contitions along with the `referencedFields` [#16655](https://github.com/phalcon/cphalcon/pull/16655)
 
 ### Removed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -13,7 +13,7 @@
 
 - Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)
 - Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)
-- Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to explicitly set the `referencedModel` in the contitions along with the `referencedFields` [#16655](https://github.com/phalcon/cphalcon/pull/16655)
+- Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to explicitly set the `referencedModel` in the conditions along with the `referencedFields` [#16655](https://github.com/phalcon/cphalcon/pull/16655)
 
 ### Removed
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1460,11 +1460,11 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
         let referencedFields = relation->getReferencedFields();
 
         if typeof fields != "array" {
-            let conditions[] = "[". referencedFields . "] = :APR0:",
+            let conditions[] = "[" . referencedModel . "].[". referencedFields . "] = :APR0:",
                 placeholders["APR0"] = record->readAttribute(fields);
         } else {
             for refPosition, field in relation->getFields() {
-                let conditions[] = "[". referencedFields[refPosition] . "] = :APR" . refPosition . ":",
+                let conditions[] = "[" . referencedModel . "].[". referencedFields[refPosition] . "] = :APR" . refPosition . ":",
                     placeholders["APR" . refPosition] = record->readAttribute(field);
             }
         }


### PR DESCRIPTION
…ted records

When we overload the getRelated function and join more tables, it can happen that the referencedField/s can't be mapped back correctly to the referenceModel it not specified

Hello!

* Type: bug fix | new feature | code quality | documentation
* Link to issue:

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Thanks

