### PR TITLE
Fix argument mismatch in PHP8 in set_error_handler()

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Support\Debug` to use correct passed arguments in `set_error_handler` callback. PHP v7.2.0 deprecated `errcontext` and has been removed since php v8.0.0 [#16649](https://github.com/phalcon/cphalcon/issues/16686)
 - Fixed `Phalcon\Http\Response\Cookies`, `Phalcon\Http\Response\CookiesInterface` and `Phalcon\Http\Cookie` to use correct cookie default arguments, avoid deprecated null assign warning when trying to assign the same cookie twice [#16649](https://github.com/phalcon/cphalcon/issues/16649)
 - Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)
 - Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)

--- a/phalcon/Support/Debug.zep
+++ b/phalcon/Support/Debug.zep
@@ -262,7 +262,7 @@ class Debug
     /**
      * Throws an exception when a notice or warning is raised
      */
-    public function onUncaughtLowSeverity(severity, message, file, line, context) -> void
+    public function onUncaughtLowSeverity(severity, message, file, line) -> void
     {
         if unlikely error_reporting() & severity {
             throw new ErrorException(message, 0, severity, file, line);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16686

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
PHP v7.2.0 deprecated `errcontext` in `set_error_handler()` and has been removed since php v8.0.0. The callback no longer passes `errcontext`, leading to the method definition of `onUncaughtLowSeverity(severity, message, file, line, context)` in `Phalcon\Support\Debug` to no longer be valid. The fix removes the unused deprecated argument.

Thanks

