### PR TITLE
Resolving Issue With Named Parameters and Dispatcher

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -7,7 +7,7 @@
 - Changed `Phalcon\Filter\Validation\Validator\Email` to allow UTF8 in local part. [#16637](https://github.com/phalcon/cphalcon/issues/16637)
 
 ### Added
-
+- Added `dispatch:beforeCallAction` and `dispatch:afterCallAction` to last-minute modifications to handler and method (mostly for debugging).
 
 ### Fixed
 
@@ -17,6 +17,7 @@
 - Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)
 - Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to explicitly set the `referencedModel` in the conditions along with the `referencedFields` [#16655](https://github.com/phalcon/cphalcon/pull/16655)
 - Fixed `Phalcon\Image\Adapters\AbstractAdapter::watermark` to correctly calculate the Y offset [#16658](https://github.com/phalcon/cphalcon/issues/16658)
+- Fixed `Phalcon\Dispatcher\AbstractDispatcher` when calling action methods that do not define parameters to prevent `Unknown named parameter` error.
 
 ### Removed
 

--- a/tests/unit/Dispatcher/CallActionMethodCest.php
+++ b/tests/unit/Dispatcher/CallActionMethodCest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Dispatcher;
+
+use Phalcon\Di\Di;
+use Phalcon\Events\Event;
+use Phalcon\Events\Manager;
+use Phalcon\Mvc\Dispatcher;
+use Phalcon\Support\Collection;
+use UnitTester;
+
+class CallActionMethodCest
+{
+    private bool $wasCalled = false;
+    private bool $altCalled = false;
+    private string $paramCalled = '';
+
+    public function _before(UnitTester $I)
+    {
+        $this->wasCalled = false;
+        $this->altCalled = false;
+        $this->paramCalled = '';
+    }
+
+    /**
+     * Tests Phalcon\Dispatcher :: callActionMethod()
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2025-01-06
+     */
+    public function dispatcherCallActionMethod(UnitTester $I)
+    {
+        $I->wantToTest('Dispatcher - callActionMethod()');
+
+        $dispatcher = new Dispatcher();
+
+        $dispatcher->callActionMethod(
+            $this,
+            '_wasCalled'
+        );
+
+        $I->assertTrue($this->wasCalled);
+        $I->assertFalse($this->altCalled);
+    }
+
+    /**
+     * Tests Phalcon\Dispatcher :: callActionMethod()
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2025-01-06
+     */
+    public function dispatcherCallActionMethodWithParams(UnitTester $I)
+    {
+        $I->wantToTest('Dispatcher - callActionMethod() - Params');
+
+        $dispatcher = new Dispatcher();
+
+        $dispatcher->callActionMethod(
+            $this,
+            '_paramCalled',
+            [
+                'something' => 'else'
+            ]
+        );
+
+        $I->assertFalse($this->wasCalled);
+        $I->assertFalse($this->altCalled);
+        $I->assertEquals('else', $this->paramCalled);
+
+        $dispatcher->callActionMethod(
+            $this,
+            '_paramCalled',
+            [
+                'something'
+            ]
+        );
+
+        $I->assertFalse($this->wasCalled);
+        $I->assertFalse($this->altCalled);
+        $I->assertEquals('something', $this->paramCalled);
+    }
+
+    /**
+     * Tests Phalcon\Dispatcher :: callActionMethod() Events
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2025-01-06
+     */
+    public function dispatcherCallActionMethodWithEvents(UnitTester $I)
+    {
+        $I->wantToTest('Dispatcher - callActionMethod() - Events');
+
+        $eventsManager = new Manager();
+        $eventsManager->attach(
+            'dispatch:beforeCallAction',
+            function (Event $event, Dispatcher $dispatcher, Collection $observer) {
+                $observer->action = "_altCalled";
+            }
+        );
+
+        $dispatcher = new Dispatcher();
+        $dispatcher->setEventsManager($eventsManager);
+        $dispatcher->setDi(new Di());
+
+        $dispatcher->callActionMethod(
+            $this,
+            '_wasCalled'
+        );
+
+        $I->assertTrue($this->altCalled);
+        $I->assertFalse($this->wasCalled);
+    }
+
+    public function _wasCalled(): void
+    {
+        $this->wasCalled = true;
+    }
+
+    public function _altCalled(): void
+    {
+        $this->altCalled = true;
+    }
+
+    public function _paramCalled(string $param): void
+    {
+        $this->paramCalled = $param;
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: N/A

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Since PHP 8.0, `call_user_func_array` now uses arrays with non-numeric keys as named parameters. If you have an action that does not use/define properties, this causes the error `Unknown named parameter`. While this can be avoided by adding the parameters, this change fixes it so this is no longer an issue. It also adds in the ability to hook into an event for the calling of the handler, though that was originally just confirmation of the bug. Just making the change to call `array_values` is enough otherwise.

Thanks

