### PR TITLE
Fix beforeValidation() event in class validation

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Forms\Form` and `Phalcon\Filter\Validation` to correctly handle the `validate()` response when using validation class `beforeValidate()` [#16702](https://github.com/phalcon/cphalcon/issues/16702)
 - Fixed `Phalcon\Support\Debug` to use correct passed arguments in `set_error_handler` callback. PHP v7.2.0 deprecated `errcontext` and has been removed since php v8.0.0 [#16649](https://github.com/phalcon/cphalcon/issues/16686)
 - Fixed `Phalcon\Http\Response\Cookies`, `Phalcon\Http\Response\CookiesInterface` and `Phalcon\Http\Cookie` to use correct cookie default arguments, avoid deprecated null assign warning when trying to assign the same cookie twice [#16649](https://github.com/phalcon/cphalcon/issues/16649)
 - Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)

--- a/phalcon/Filter/Validation.zep
+++ b/phalcon/Filter/Validation.zep
@@ -483,7 +483,7 @@ class Validation extends Injectable implements ValidationInterface
      */
     public function validate(var data = null, var entity = null) -> <Messages> | bool
     {
-        var combinedFieldsValidators, field, messages, scope, status, validator,
+        var combinedFieldsValidators, field, scope, status, validator,
             validatorData, validators;
 
         let validatorData            = this->validators,
@@ -501,7 +501,7 @@ class Validation extends Injectable implements ValidationInterface
         /**
          * Implicitly creates a Phalcon\Messages\Messages object
          */
-        let messages = new Messages();
+        let this->messages = new Messages();
 
         if entity !== null {
             this->setEntity(entity);
@@ -511,14 +511,12 @@ class Validation extends Injectable implements ValidationInterface
          * Validation classes can implement the 'beforeValidation' callback
          */
         if method_exists(this, "beforeValidation") {
-            let status = this->{"beforeValidation"}(data, entity, messages);
+            let status = this->{"beforeValidation"}(data, entity, this->messages);
 
             if status === false {
                 return status;
             }
         }
-
-        let this->messages = messages;
 
         if data !== null {
             if unlikely (typeof data != "array" && typeof data != "object") {

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -639,7 +639,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     public function isValid(var data = null, var entity = null, array whitelist = []) -> bool
     {
         var messages, element, validators, name, filters, validator, validation,
-            elementMessage, result;
+            elementMessage;
         bool validationStatus;
 
         if empty this->elements {

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -719,12 +719,8 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         /**
         * Perform the validation
         */
-        let result = validation->validate(data, entity);
-        if result === false {
-            let messages = validation->getMessages();
-        } else {
-            let messages = result;
-        }
+        validation->validate(data, entity);
+        let messages = validation->getMessages();
         if messages->count() {
             // Add validation messages to relevant elements
             for elementMessage in iterator(messages) {

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -639,7 +639,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     public function isValid(var data = null, var entity = null, array whitelist = []) -> bool
     {
         var messages, element, validators, name, filters, validator, validation,
-            elementMessage;
+            elementMessage, result;
         bool validationStatus;
 
         if empty this->elements {
@@ -719,7 +719,12 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
         /**
         * Perform the validation
         */
-        let messages = validation->validate(data, entity);
+        let result = validation->validate(data, entity);
+        if result === false {
+            let messages = validation->getMessages();
+        } else {
+            let messages = result;
+        }
         if messages->count() {
             // Add validation messages to relevant elements
             for elementMessage in iterator(messages) {


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16702

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
I'm not satisfied with this fix, I personally would not like to have the argument $messages passed to the event method, it is redundant and you can just use `$this->appendMessage()`, but it is what it is and its non-breaking for previous code.

**Please review before doing any approval.**

Thanks

