### PR TITLE
The `escape` argument is explicitly required in PHP 8.4

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [5.9.2](https://github.com/phalcon/cphalcon/releases/tag/v5.9.2) (2025-XX-XX)
+
+### Changed
+
+### Added
+
+### Fixed
+
+- Fixed `Phalcon\Translate\Adapter\Csv` the `escape` argument is explicitly required in PHP 8.4  [#16733](https://github.com/phalcon/cphalcon/issues/16733)
+
+### Removed
+
 ## [5.9.1](https://github.com/phalcon/cphalcon/releases/tag/v5.9.1) (2025-03-31)
 
 ### Changed

--- a/phalcon/Translate/Adapter/Csv.zep
+++ b/phalcon/Translate/Adapter/Csv.zep
@@ -31,7 +31,7 @@ class Csv extends AbstractAdapter implements ArrayAccess
      * @param array               $options = [
      *                                       'content'   => '',
      *                                       'delimiter' => ';',
-     *                                       'enclosure' => '"'
+     *                                       'enclosure' => '"',
      *                                       'escape' => '\\'
      *                                       ]
      *

--- a/phalcon/Translate/Adapter/Csv.zep
+++ b/phalcon/Translate/Adapter/Csv.zep
@@ -32,6 +32,7 @@ class Csv extends AbstractAdapter implements ArrayAccess
      *                                       'content'   => '',
      *                                       'delimiter' => ';',
      *                                       'enclosure' => '"'
+     *                                       'escape' => '\\'
      *                                       ]
      *
      * @throws Exception
@@ -40,7 +41,7 @@ class Csv extends AbstractAdapter implements ArrayAccess
         <InterpolatorFactory> interpolator,
         array options
     ) {
-        var delimiter, enclosure;
+        var delimiter, enclosure, escape;
 
         parent::__construct(interpolator, options);
 
@@ -60,7 +61,13 @@ class Csv extends AbstractAdapter implements ArrayAccess
             let enclosure = "\"";
         }
 
-        this->load(options["content"], 0, delimiter, enclosure);
+        if isset options["escape"] {
+            let escape = options["escape"];
+        } else {
+            let escape = "\\";
+        }
+
+        this->load(options["content"], 0, delimiter, enclosure, escape);
     }
 
     /**
@@ -114,10 +121,11 @@ class Csv extends AbstractAdapter implements ArrayAccess
      * @param int    $length
      * @param string $separator
      * @param string $enclosure
+     * @param string $escape
      *
      * @throws Exception
      */
-    private function load(string file, int length, string delimiter, string enclosure) -> void
+    private function load(string file, int length, string delimiter, string enclosure, string escape) -> void
     {
         var data, fileHandler;
 
@@ -130,7 +138,7 @@ class Csv extends AbstractAdapter implements ArrayAccess
         }
 
         loop {
-            let data = fgetcsv(fileHandler, length, delimiter, enclosure);
+            let data = fgetcsv(fileHandler, length, delimiter, enclosure, escape);
 
             if data === false {
                 break;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16733

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Added default `escape` argument, now explicitly required, to `fgetcsv` method

Thanks

