### PR TITLE
Fix bug with cache lifetime priority inside Phalcon\Mvc\Model\Query

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Translate\Adapter\Csv` the `escape` argument is explicitly required in PHP 8.4  [#16733](https://github.com/phalcon/cphalcon/issues/16733)
+- Fixed `Phalcon\Mvc\Model\Query` to use the cacheOptions lifetime over the "cache" service lifetime
 
 ### Removed
 

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -283,13 +283,6 @@ class Query implements QueryInterface, InjectionAwareInterface
                 );
             }
 
-            /**
-             * By default use use 3600 seconds (1 hour) as cache lifetime
-             */
-            if !fetch lifetime, cacheOptions["lifetime"] {
-                let lifetime = 3600;
-            }
-
             if !fetch cacheService, cacheOptions["service"] {
                 let cacheService = "modelsCache";
             }
@@ -309,7 +302,8 @@ class Query implements QueryInterface, InjectionAwareInterface
              */
             let adapter       = cache->getAdapter();
             let cacheLifetime = adapter->getLifetime();
-            if (lifetime !== cacheLifetime) {
+
+            if !fetch lifetime, cacheOptions["lifetime"] {
                 let lifetime = cacheLifetime;
             }
 

--- a/tests/database/Mvc/Model/FindCest.php
+++ b/tests/database/Mvc/Model/FindCest.php
@@ -538,4 +538,76 @@ class FindCest
         $expected = 'Use of "static" in callables in deprecated';
         $I->assertStringNotContainsString($expected, $actual);
     }
+
+    public function testMvcModelFindWithCacheOptionsLifetimePriorityOverCacheService(DatabaseTester $I): void
+    {
+        $I->wantToTest('Mvc\Model - find() - cache options lifetime priority over adapter lifetime');
+
+        /** @var PDO $connection */
+        $connection = $I->getConnection();
+
+        $migration  = new ObjectsMigration($connection);
+        $migration->insert(1, 'random data', 1);
+
+        $options = [
+            'defaultSerializer' => 'Json',
+            'lifetime'          => 2,
+            'prefix'            => 'data-',
+        ];
+
+        /**
+         * Models Cache setup. Adapter's lifetime is 2 seconds
+         */
+        $serializerFactory = new SerializerFactory();
+        $adapterFactory    = new AdapterFactory($serializerFactory);
+        $adapter           = $adapterFactory->newInstance('apcu', $options);
+        $cache             = new Cache($adapter);
+
+        $this->container->setShared('modelsCache', $cache);
+
+        /**
+         * Find records with lifetime 5 sec
+         */
+        $data = Objects::find(
+            [
+                'cache' => [
+                    'key' => 'my-cache',
+                    'lifetime' => 5,
+                ],
+            ]
+        );
+
+        $I->assertEquals(1, count($data));
+
+        $record = $data[0];
+        $I->assertEquals(1, $record->obj_id);
+        $I->assertEquals('random data', $record->obj_name);
+
+        /**
+         * Get the models cache
+         */
+        $modelsCache = $this->container->get('modelsCache');
+
+        $exists = $modelsCache->has('my-cache');
+        $I->assertTrue($exists);
+
+        /**
+         * Wait for 3 seconds for the cache to check
+         * that we still have our cache and it wasn't taken
+         * from adapter's lifetime
+         */
+        sleep(3);
+
+        $data = $modelsCache->get('my-cache');
+        $I->assertNotNull($data);
+
+        /**
+         * Wait extra 3 seconds for the cache to check
+         * that our cache is expired
+         */
+        sleep(3);
+
+        $data = $modelsCache->get('my-cache');
+        $I->assertNull($data);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/pull/16714/files

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
After https://github.com/phalcon/cphalcon/pull/16714 there occurs bug with priority inside the Phalcon\Mvc\Model\Query. Inside the method "execute" there is overriding cacheOptions by adapter default lifetime. So it leads to just ignoring the cacheOptions['lifetime'] at all.
This PR uses cacheOptions['lifetime'] as first priority and the adapter's lifetime as second priority

Thanks

