### PR TITLE
use ReflectionParameter::getType()

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -10,6 +10,7 @@
 
 - Fixed `Phalcon\Translate\Adapter\Csv` the `escape` argument is explicitly required in PHP 8.4  [#16733](https://github.com/phalcon/cphalcon/issues/16733)
 - Fixed `Phalcon\Mvc\Model\Query` to use the cacheOptions lifetime over the "cache" service lifetime
+- Fixed `Phalcon\Mvc\Model\Binder` to use ReflectionParameter::getType() instead of deprecated method, PHP 8.0 or higher issue. [#16742](https://github.com/phalcon/cphalcon/issues/16742)
 
 ### Removed
 

--- a/phalcon/Mvc/Model/Binder.zep
+++ b/phalcon/Mvc/Model/Binder.zep
@@ -183,7 +183,7 @@ class Binder implements BinderInterface
         let paramsKeys = array_keys(params);
 
         for paramKey, methodParam in methodParams {
-            let reflectionClass = methodParam->getClass();
+            let reflectionClass = methodParam->getType();
 
             if !reflectionClass {
                 continue;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16742

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Update `Phalcon\Mvc\Model\Binder` to use `ReflectionParameter::getType()` instead of `ReflectionParameter::getClass()`, PHP 8.0 or higher issue.

Thanks

