### PR TITLE
Correctly match route when using query string

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -12,6 +12,7 @@
 
 - Fixed `Phalcon\Mvc\Router` to correctly handle numeric URI parts as it was in v3 [#16741](https://github.com/phalcon/cphalcon/issues/16741)
 - Fixed `Phalcon\Mvc\Model\Binder` to use ReflectionParameter::getType() instead of deprecated method, PHP 8.0 or higher issue. [#16742](https://github.com/phalcon/cphalcon/issues/16742)
+- Fixed `Phalcon\Mvc\Router` to correctly match route when using query string URIs. [#16749](https://github.com/phalcon/cphalcon/issues/16749)
 
 ### Removed
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -613,7 +613,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      */
     public function getRewriteUri() -> string
     {
-		var url, urlParts, realUri;
+		var url;
 
 		/**
 		 * By default we use $_GET["url"] to obtain the rewrite information
@@ -621,7 +621,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 		if (self::URI_SOURCE_GET_URL === this->uriSource) {
 			if fetch url, _GET["_url"] {
 				if !empty url {
-					return url;
+					return this->extractRealUri(url);
 				}
 			}
 		} else {
@@ -629,15 +629,23 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 			 * Otherwise use the standard $_SERVER["REQUEST_URI"]
 			 */
 			if fetch url, _SERVER["REQUEST_URI"] {
-				let urlParts = explode("?", url),
-					realUri  = urlParts[0];
-				if !empty realUri {
-					return realUri;
-				}
+				if !empty url {
+                    return this->extractRealUri(url);
+                }
 			}
 		}
 
 		return "/";
+    }
+
+    public function extractRealUri(string! uri) -> string
+    {
+        var urlParts, realUri;
+
+        let urlParts = explode("?", uri, 2),
+            realUri  = urlParts[0];
+
+        return realUri;
     }
 
     /**
@@ -727,13 +735,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             paramsStr, part, parts, paths, pattern, position, realUri,
             regexHostName, request, route, routeFound, strParams, vnamespace;
 
-        let realUri = uri;
-
-		if !realUri {
+		if !uri {
 			/**
 			 * If 'uri' isn't passed as parameter it reads _GET["_url"]
 			 */
 			let realUri = this->getRewriteUri();
+		} else {
+		    let realUri = this->extractRealUri(uri);
 		}
 
         /**

--- a/tests/integration/Mvc/Router/ExtractRealUriCest.php
+++ b/tests/integration/Mvc/Router/ExtractRealUriCest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Integration\Mvc\Router;
+
+use IntegrationTester;
+use Phalcon\Di\FactoryDefault;
+use Phalcon\Mvc\Router;
+
+class ExtractRealUriCest
+{
+    /**
+     * Tests Phalcon\Mvc\Router :: extractRealUri()
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2025-04-11
+     * @issue        16749
+     */
+    public function testExtractRealUri(IntegrationTester $I): void
+    {
+        $router = new Router(false);
+        $router->setDI(new FactoryDefault());
+
+        $realUri = $router->extractRealUri(
+            '/admin/private/businesses/list/my/123?query=string'
+        );
+        $I->assertSame('/admin/private/businesses/list/my/123', $realUri);
+
+        $realUri = $router->extractRealUri(
+            '/admin/private/businesses/list/my/123'
+        );
+        $I->assertSame('/admin/private/businesses/list/my/123', $realUri);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16749

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
The recent fix for issue https://github.com/phalcon/cphalcon/issues/16741 has introduced this current bug. Missed one place to extract the correct URI for route matching when the `route->handle()` receives the `uri`.

Added a new reusable method `extractRealUri` to avoid replicating the same code in all 3 needed places.

Thanks

