### PR TITLE
Improved typehint for method 'View::render'

### DIFF
--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -747,7 +747,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
         string! controllerName,
         string! actionName,
         array params = []
-    ) -> <View> | bool
+    ) -> <View> | false
     {
         var result;
 


### PR DESCRIPTION
Hello!

* Type: documentation

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist

Small description of change:
I noticed that the method `View::render` has a typehint of `View|bool`. The method never returns `true` so I changed the return type to `View|false`.

Change log:
Changed the return type of the method `View::render` to `View|false`.

Thanks

