### PR TITLE
Update Resultset.zep

### DIFF
--- a/phalcon/Mvc/Model/Resultset.zep
+++ b/phalcon/Mvc/Model/Resultset.zep
@@ -305,6 +305,9 @@ abstract class Resultset
      *     }
      * );
      *```
+     *
+     * @param \Closure(TValue|ModelInterface $record): bool $filter
+     * @return TValue[]|ModelInterface[]
      */
     public function filter(callable filter) -> <ModelInterface[]>
     {
@@ -373,7 +376,7 @@ abstract class Resultset
      *         ->getFirst();
      * ```
      *
-     * @return ModelInterface|Row|null
+     * @return TValue|ModelInterface|Row|null
      */
     public function getFirst() -> var | null
     {
@@ -396,6 +399,8 @@ abstract class Resultset
 
     /**
      * Get last row in the resultset
+     *
+     * @return TValue|ModelInterface|null
      */
     public function getLast() -> <ModelInterface> | null
     {

--- a/phalcon/Mvc/Model/Resultset.zep
+++ b/phalcon/Mvc/Model/Resultset.zep
@@ -68,6 +68,7 @@ use Serializable;
  * @template TValue
  * @implements Iterator<TKey, TValue>
  * @implements ArrayAccess<TKey, TValue>
+ * @implements ResultsetInterface<TValue>
  */
 abstract class Resultset
     implements ResultsetInterface, Iterator, SeekableIterator, Countable, ArrayAccess, Serializable, JsonSerializable

--- a/phalcon/Mvc/Model/Resultset.zep
+++ b/phalcon/Mvc/Model/Resultset.zep
@@ -65,7 +65,7 @@ use Serializable;
  * }
  * ```
  * @template TKey
- * @template TValue
+ * @template TValue of ModelInterface
  * @implements Iterator<TKey, TValue>
  * @implements ArrayAccess<TKey, TValue>
  * @implements ResultsetInterface<TValue>

--- a/phalcon/Mvc/Model/ResultsetInterface.zep
+++ b/phalcon/Mvc/Model/ResultsetInterface.zep
@@ -18,6 +18,8 @@ use Phalcon\Mvc\ModelInterface;
  * Phalcon\Mvc\Model\ResultsetInterface
  *
  * Interface for Phalcon\Mvc\Model\Resultset
+ *
+ * @template TValue
  */
 interface ResultsetInterface
 {
@@ -49,7 +51,7 @@ interface ResultsetInterface
     /**
      * Get first row in the resultset
      *
-     * @return ModelInterface|Row|null
+     * @return TValue|ModelInterface|Row|null
      */
     public function getFirst() -> var | null;
 
@@ -60,6 +62,7 @@ interface ResultsetInterface
 
     /**
      * Get last row in the resultset
+     * @return TValue|ModelInterface|Row|null
      */
     public function getLast() -> <ModelInterface> | null;
 

--- a/phalcon/Mvc/Model/ResultsetInterface.zep
+++ b/phalcon/Mvc/Model/ResultsetInterface.zep
@@ -19,7 +19,7 @@ use Phalcon\Mvc\ModelInterface;
  *
  * Interface for Phalcon\Mvc\Model\Resultset
  *
- * @template TValue
+ * @template TValue of ModelInterface
  */
 interface ResultsetInterface
 {


### PR DESCRIPTION
Add generic PHPDOC support for: `getLast`, `getFirst`, `filter`

Hello!

* Type: new feature

**In raising this pull request, I confirm the following:**

- [ ] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [ ] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Add generic support for `getLast`, `getFirst`, `filter`.

Thanks

