### PR TITLE
Correctly return IP address when using trusted header

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -8,6 +8,8 @@
 ### Fixed
 
 - Fixed `Phalcon\Config\Adapter\Yaml` constructor to handle `null` return values from `yaml_parse_file()`, ensuring empty configuration files are treated as empty arrays instead of throwing errors.
+- Fixed `Phalcon\Http\Request` method `getClientAddress(true)` to return correct IP address from trusted forwarded proxy. [#16777](https://github.com/phalcon/cphalcon/issues/16777)
+
 ### Removed
 
 ## [5.9.3](https://github.com/phalcon/cphalcon/releases/tag/v5.9.3) (2025-04-19)

--- a/phalcon/Filter/Filter.zep
+++ b/phalcon/Filter/Filter.zep
@@ -20,6 +20,7 @@ namespace Phalcon\Filter;
  * @method string email(string $input)
  * @method float  float(mixed $input)
  * @method int    int(string $input)
+ * @method string ip(string $input, int $filter = FILTER_FLAG_NONE)
  * @method string lower(string $input)
  * @method string lowerfirst(string $input)
  * @method mixed  regex(mixed $input, mixed $pattern, mixed $replace)
@@ -48,6 +49,7 @@ class Filter implements FilterInterface
     const FILTER_EMAIL         = "email";
     const FILTER_FLOAT         = "float";
     const FILTER_INT           = "int";
+    const FILTER_IP            = "ip";
     const FILTER_LOWER         = "lower";
     const FILTER_LOWERFIRST    = "lowerfirst";
     const FILTER_REGEX         = "regex";

--- a/phalcon/Filter/FilterFactory.zep
+++ b/phalcon/Filter/FilterFactory.zep
@@ -45,6 +45,7 @@ class FilterFactory
             Filter::FILTER_EMAIL         : "Phalcon\\Filter\\Sanitize\\Email",
             Filter::FILTER_FLOAT         : "Phalcon\\Filter\\Sanitize\\FloatVal",
             Filter::FILTER_INT           : "Phalcon\\Filter\\Sanitize\\IntVal",
+            Filter::FILTER_IP            : "Phalcon\\Filter\\Sanitize\\Ip",
             Filter::FILTER_LOWER         : "Phalcon\\Filter\\Sanitize\\Lower",
             Filter::FILTER_LOWERFIRST    : "Phalcon\\Filter\\Sanitize\\LowerFirst",
             Filter::FILTER_REGEX         : "Phalcon\\Filter\\Sanitize\\Regex",

--- a/phalcon/Filter/Sanitize/Ip.zep
+++ b/phalcon/Filter/Sanitize/Ip.zep
@@ -1,0 +1,101 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Filter\Sanitize;
+
+/**
+ * Phalcon\Filter\Sanitize\AbsInt
+ *
+ * Sanitizes a value to absolute integer
+ */
+class Ip
+{
+    /**
+     * @param string $input
+     * @param int $protocol
+     * @param int $filter
+     * @return false|string
+     */
+    public function __invoke(string input, int filter = 0) -> string | false
+    {
+        var parts, ip, mask, protocol, filtered;
+
+        let protocol = this->getIpAddressProtocolVersion(input);
+        if (protocol === false) {
+            return false;
+        }
+
+        // CIDR notation (e.g., 192.168.1.0/24)
+        if memstr(input, "/") {
+            let parts       = explode("/", input, 2),
+                ip          = parts[0],
+                mask        = parts[1];
+
+            // Try IPv4 validation
+            if protocol === 4 {
+                let filtered = filter_var(ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | filter);
+                if filtered !== false {
+                    if is_numeric(mask) && mask >= 0 && mask <= 32 {
+                        return filtered . "/" . mask;
+                    }
+                }
+            }
+
+            // Try IPv6 validation
+            if protocol === 6 {
+                let filtered = filter_var(ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | filter);
+                if (filtered) {
+                    if is_numeric(mask) && mask >= 0 && mask <= 128 {
+                        return filtered . "/" . mask;
+                    }
+                }
+            }
+        } else {
+            // Single IP
+            if protocol === 4 {
+                return filter_var(input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | filter);
+            }
+
+            if (protocol === 6) {
+                return filter_var(input, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6 | filter);
+            }
+        }
+
+        // return false if nothing filtered.
+        return false;
+    }
+
+    /**
+     * Return the IP address protocol version
+     *
+     * @param $ip
+     * @return int
+     */
+    private function getIpAddressProtocolVersion(string input) -> int | false
+    {
+        var parts, ip;
+
+        let ip = input;
+        if (memstr(ip, "/")) {
+            let parts   = explode("/", ip, 2),
+                ip      = parts[0];
+        }
+
+        if (filter_var(ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return 4;
+        }
+
+        if (filter_var(ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return 6;
+        }
+
+        return false;
+    }
+}

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -211,7 +211,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      *
      * @param bool $trustForwardedHeader
      *
-     * @return string|bool
+     * @return string|false
      * @throws \Exception
      */
     public function getClientAddress(bool trustForwardedHeader = false) -> string | false
@@ -1431,9 +1431,9 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Check if an IP address exists in CIDR range
      *
-     * @param $ip
-     * @param $cidr
-     * @return bool
+     * @param string $ip The IP address to check.
+     * @param string $cidr The CIDR range to compare against.
+     * @return bool True if the IP is in range, false otherwise.
      */
     protected function isIpAddressInCIDR(string ip, string cidr) -> bool
     {

--- a/tests/unit/Filter/FilterFactory/NewInstanceCest.php
+++ b/tests/unit/Filter/FilterFactory/NewInstanceCest.php
@@ -24,6 +24,7 @@ use Phalcon\Filter\Sanitize\BoolVal;
 use Phalcon\Filter\Sanitize\Email;
 use Phalcon\Filter\Sanitize\FloatVal;
 use Phalcon\Filter\Sanitize\IntVal;
+use Phalcon\Filter\Sanitize\Ip;
 use Phalcon\Filter\Sanitize\Lower;
 use Phalcon\Filter\Sanitize\LowerFirst;
 use Phalcon\Filter\Sanitize\Regex;
@@ -99,6 +100,7 @@ class NewInstanceCest
             [Filter::FILTER_EMAIL, Email::class],
             [Filter::FILTER_FLOAT, FloatVal::class],
             [Filter::FILTER_INT, IntVal::class],
+            [Filter::FILTER_IP, Ip::class],
             [Filter::FILTER_LOWER, Lower::class],
             [Filter::FILTER_LOWERFIRST, LowerFirst::class],
             [Filter::FILTER_REGEX, Regex::class],

--- a/tests/unit/Filter/SanitizeCest.php
+++ b/tests/unit/Filter/SanitizeCest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Unit\Filter;
 
 use Codeception\Example;
+use Phalcon\Cache\Exception\InvalidArgumentException;
 use Phalcon\Filter\FilterFactory;
 use UnitTester;
 
@@ -1026,6 +1027,162 @@ class SanitizeCest
                 'method'   => 'url',
                 'source'   => ['https://pha�lc�on.i�o'],
                 'expected' => 'https://phalcon.io',
+            ],
+            // IPv4 Test dataset
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 1, valid private IP address, FILTER_FLAG_NONE / 0',
+                'method'   => '',
+                'source'   => ['192.168.0.10', 0],
+                'expected' => '192.168.0.10',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 2, valid reserved IP address, FILTER_FLAG_NONE / 0',
+                'method'   => '',
+                'source'   => ['255.255.255.255', 0],
+                'expected' => '255.255.255.255',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 3, valid CIDR IP address, FILTER_FLAG_NONE / 0',
+                'method'   => '',
+                'source'   => ['10.0.0.0/24', 0],
+                'expected' => '10.0.0.0/24',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: valid IP address, no filter',
+                'method'   => '',
+                'source'   => ['8.8.8.8'],
+                'expected' => '8.8.8.8',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 1, FILTER_FLAG_NO_PRIV_RANGE',
+                'method'   => '',
+                'source'   => ['192.168.1.1', FILTER_FLAG_NO_PRIV_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 2, FILTER_FLAG_NO_PRIV_RANGE',
+                'method'   => '',
+                'source'   => ['10.0.0.5', FILTER_FLAG_NO_PRIV_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 1, FILTER_FLAG_NO_RES_RANGE',
+                'method'   => '',
+                'source'   => ['0.0.0.0', FILTER_FLAG_NO_RES_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: test 2, FILTER_FLAG_NO_RES_RANGE 2',
+                'method'   => '',
+                'source'   => ['255.255.255.255', FILTER_FLAG_NO_RES_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: combined filter FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE',
+                'method'   => '',
+                'source'   => ['255.255.255.255', FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: invalid IPv4 address',
+                'method'   => '',
+                'source'   => ['999.999.999.999', FILTER_FLAG_IPV4],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv4: invalid IPv4 CIDR address',
+                'method'   => '',
+                'source'   => ['192.168.1.1/33', FILTER_FLAG_IPV4],
+                'expected' => false,
+            ],
+            // IPv6 Test dataset
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 1 Valid Public IPv6, FILTER_FLAG_NONE / 0',
+                'method'   => '',
+                'source'   => ['2001:4860:4860::8888', 0],
+                'expected' => '2001:4860:4860::8888',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 2 Valid Public IPv6, no filter',
+                'method'   => '',
+                'source'   => ['2001:db8::1', FILTER_FLAG_IPV6],
+                'expected' => '2001:db8::1',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 3, valid CIDR IP address, FILTER_FLAG_NONE / 0',
+                'method'   => '',
+                'source'   => ['2001:db8::/32', 0],
+                'expected' => '2001:db8::/32',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: valid IP address, no filter',
+                'method'   => '',
+                'source'   => ['2001:db8:85a3:8d3:1319:8a2e:370:7348'],
+                'expected' => '2001:db8:85a3:8d3:1319:8a2e:370:7348',
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 1, FILTER_FLAG_NO_PRIV_RANGE',
+                'method'   => '',
+                'source'   => ['fd12:3456:789a:1::1', FILTER_FLAG_NO_PRIV_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 2, FILTER_FLAG_NO_PRIV_RANGE',
+                'method'   => '',
+                'source'   => ['fc00::1', FILTER_FLAG_NO_PRIV_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 1, FILTER_FLAG_NO_RES_RANGE',
+                'method'   => '',
+                'source'   => ['fe80::1', FILTER_FLAG_NO_RES_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: test 2, FILTER_FLAG_NO_RES_RANGE 2',
+                'method'   => '',
+                'source'   => ['::1', FILTER_FLAG_NO_RES_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: combined filter FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE',
+                'method'   => '',
+                'source'   => ['fd00::1', FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: invalid IPv6 address',
+                'method'   => '',
+                'source'   => ['2001:db8:85a3::8a2e:370g:7334', FILTER_FLAG_IPV6],
+                'expected' => false,
+            ],
+            [
+                'class'    => 'ip',
+                'label'    => 'IPv6: invalid IPv6 CIDR address',
+                'method'   => '',
+                'source'   => ['2001:db8::/140', FILTER_FLAG_IPV6],
+                'expected' => false,
             ],
         ];
     }

--- a/tests/unit/Http/Request/GetClientAddressCest.php
+++ b/tests/unit/Http/Request/GetClientAddressCest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Http\Request;
 
+use Phalcon\Di\FactoryDefault;
 use Phalcon\Http\Request;
 use UnitTester;
 
@@ -27,20 +28,60 @@ class GetClientAddressCest
     public function httpRequestGetClientAddressTrustForwardedHeader(UnitTester $I)
     {
         $I->wantToTest('Http\Request - getClientAddress() - trustForwardedHeader');
+        $container = new FactoryDefault();
 
         $store   = $_SERVER ?? [];
         $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+        // skip private IP and return the first non-private and non-reserved IP
         $_SERVER = [
             'REQUEST_TIME_FLOAT'   => $time,
-            'HTTP_X_FORWARDED_FOR' => '10.4.6.1',
+            'HTTP_X_FORWARDED_FOR' => '10.4.6.1,25.25.25.25',
         ];
 
         $request = new Request();
+        $request->setDI($container);
 
-        $expected = '10.4.6.1';
+        $expected = '25.25.25.25';
         $actual   = $request->getClientAddress(true);
         $I->assertSame($expected, $actual);
 
+        // set correct IP with trusted proxy
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT'   => $time,
+            'HTTP_X_FORWARDED_FOR' => '8.8.8.8,25.25.25.1',
+        ];
+
+        $request = new Request();
+        $request->setDI($container);
+        $request->setTrustedProxies([
+            '25.25.25.0/24'
+        ]);
+
+        $expected = '8.8.8.8';
+        $actual   = $request->getClientAddress(true);
+        $I->assertSame($expected, $actual);
+
+        // verify proxy is trusted
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT'   => $time,
+            'HTTP_X_FORWARDED_FOR' => '8.8.8.8,1.1.1.1',
+        ];
+
+        $request = new Request();
+        $request->setDI($container);
+        $request->setTrustedProxies([
+            '25.25.25.0/24'
+        ]);
+
+        $expected = 'The forwarded proxy IP addresses are not trusted.';
+        try {
+            $request->getClientAddress(true);
+            $I->fail('Expected exception was not thrown.');
+        } catch (\Exception $e) {
+            $I->assertEquals($expected, $e->getMessage());
+        }
+
+        // Test HTTP_CLIENT_IP header
         $_SERVER = $store;
         $store   = $_SERVER ?? [];
         $time    = $_SERVER['REQUEST_TIME_FLOAT'];
@@ -50,6 +91,7 @@ class GetClientAddressCest
         ];
 
         $request = new Request();
+        $request->setDI($container);
 
         $expected = '10.4.6.2';
         $actual   = $request->getClientAddress(true);

--- a/tests/unit/Http/Request/GetClientAddressCest.php
+++ b/tests/unit/Http/Request/GetClientAddressCest.php
@@ -152,32 +152,6 @@ class GetClientAddressCest
     }
 
     /**
-     * Tests Phalcon\Http\Request :: getClientAddress() - multiple
-     *
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-03-17
-     */
-    public function httpRequestGetClientAddressMultiple(UnitTester $I)
-    {
-        $I->wantToTest('Http\Request - getClientAddress() - multiple');
-
-        $store   = $_SERVER ?? [];
-        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
-        $_SERVER = [
-            'REQUEST_TIME_FLOAT' => $time,
-            'REMOTE_ADDR'        => '10.4.6.4,10.4.6.5',
-        ];
-
-        $request = new Request();
-
-        $expected = '10.4.6.4';
-        $actual   = $request->getClientAddress();
-        $I->assertSame($expected, $actual);
-
-        $_SERVER = $store;
-    }
-
-    /**
      * Tests Phalcon\Http\Request :: getClientAddress() - ipv6
      *
      * @author Phalcon Team <team@phalcon.io>


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16777

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [X] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

When using `$this->request->getClientAddress(true);` to extract IP address from `X-Forwarded-For` header it needs to select the first left side IP that is not private or reserved IP address.

Added support for users to add their own `trustedProxies` via method, accepts array of IPs or range of IPs.
```
$this->request->setTrustedProxies(['1.1.1.1']);
```
This will trigger an `Exception("The forwarded proxy IP addresses are not trusted.")` if users mess up their proxy setup.

Thanks

