### PR TITLE
Removed method getPatchPut() and passed post|patch|put to new parsing method

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 - Fixed `Phalcon\Config\Adapter\Yaml` constructor to handle `null` return values from `yaml_parse_file()`, ensuring empty configuration files are treated as empty arrays instead of throwing errors.
 - Fixed `Phalcon\Http\Request` method `getClientAddress(true)` to return correct IP address from trusted forwarded proxy. [#16777](https://github.com/phalcon/cphalcon/issues/16777)
+- Fixed `Phalcon\Http\Request` method `getPost()` to correctly return json data as well and unified both `getPut()` and `getPatch()` to go through the same parsing method. [#16792](https://github.com/phalcon/cphalcon/issues/16792)
 
 ### Removed
 

--- a/tests/unit/Http/Request/GetPostCest.php
+++ b/tests/unit/Http/Request/GetPostCest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Tests\Unit\Http\Request;
 
 use Phalcon\Http\Request;
 use Phalcon\Storage\Exception;
+use Phalcon\Tests\Fixtures\Http\PhpStream;
 use Phalcon\Tests\Fixtures\Traits\DiTrait;
 use UnitTester;
 
@@ -44,6 +45,50 @@ class GetPostCest //extends HttpBase
         $I->assertSame('two', $request->getPost('one'));
 
         $_POST = $store;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getPost() - json
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-07-22
+     */
+    public function httpRequestGetPostJson(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getPost() - json');
+
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', PhpStream::class);
+
+        file_put_contents(
+            'php://input',
+            '{"fruit": "orange", "quantity": "4"}'
+        );
+
+        $store   = $_SERVER ?? [];
+        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+        $_POST = [];
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT' => $time,
+            'REQUEST_METHOD'     => 'POST',
+            'CONTENT_TYPE'       => 'application/json',
+        ];
+
+        $request = new Request();
+
+        $expected = [
+            'fruit'    => 'orange',
+            'quantity' => '4',
+        ];
+
+        $I->assertSame(
+            $expected,
+            $request->getPost()
+        );
+
+        stream_wrapper_restore('php');
+
+        $_SERVER = $store;
     }
 
     /**

--- a/tests/unit/Http/Request/IsCest.php
+++ b/tests/unit/Http/Request/IsCest.php
@@ -224,6 +224,14 @@ class IsCest
                 true,
                 'isSoap',
             ],
+            [
+                'json',
+                [
+                    'CONTENT_TYPE' => 'application/json',
+                ],
+                true,
+                'isJson',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16792

**In raising this pull request, I confirm the following:**

- [X] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [X] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

I removed private method getPatchPut() and created a new one for parsing the post data / raw body data and passed post|patch|put through the new parsing method.

This ensure that for all requests methods some form of data is returned, be it json, form-data or x-www-form-urlencoded

Technically users can just use `$request->getPost()` to return their data now, and the `getPut()` and `getPatch()` can be used to have a more semantic understanding through which type of request method the request is being sent.

Thanks

