### PR TITLE
Fix Request::getPostData() when Content-Type is null

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -15,6 +15,7 @@
 - Fixed `Phalcon\Http\Request` method `getClientAddress(true)` to return correct IP address from trusted forwarded proxy. [#16777](https://github.com/phalcon/cphalcon/issues/16777)
 - Fixed `Phalcon\Http\Request` method `getPost()` to correctly return json data as well and unified both `getPut()` and `getPatch()` to go through the same parsing method. [#16792](https://github.com/phalcon/cphalcon/issues/16792)
 - Fixed `Phalcon\Filter\Validation` method `bind()` and `validate()` to correctly bind data when using entity as well as skip binding of fields not included in `$whitelist` [#16800](https://github.com/phalcon/cphalcon/issues/16800)
+- Fixed `Phalcon\Http\Request` method `getPostData()` when `Content-Type` header is not set [#16804](https://github.com/phalcon/cphalcon/issues/16804)
 
 ### Removed
 

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -1852,7 +1852,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
         if empty data {
             if this->isJson() {
                 let result = this->getJsonRawBody(true);
-            } elseif stripos(this->getContentType(), "multipart/form-data") !== false {
+            } elseif this->getContentType() && stripos(this->getContentType(), "multipart/form-data") !== false {
                 let result = this->getFormData();
             } else {
                 // this is more like a fallback to application/x-www-form-urlencoded parsing raw body


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16804

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Added a check to ensure getContentType() is not null

Thanks

