### PR TITLE
Replaced deprecated Code Sniffer syntax

### DIFF
--- a/tests/integration/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
+++ b/tests/integration/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
@@ -20,8 +20,8 @@ use Phalcon\Mvc\Controller;
  */
 class DispatcherTestDefaultNoNamespaceController extends Controller
 {
-    const RETURN_VALUE_STRING = 'string';
-    const RETURN_VALUE_INT    = 5;
+    public const RETURN_VALUE_STRING = 'string';
+    public const RETURN_VALUE_INT    = 5;
 
     public function beforeExecuteRoute()
     {

--- a/tests/integration/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
+++ b/tests/integration/Mvc/Dispatcher/Helper/DispatcherTestDefaultNoNamespaceController.php
@@ -1,9 +1,6 @@
-<?php
+<?php // phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
 
-// @codingStandardsIgnoreStart
 use Phalcon\Mvc\Controller;
-
-// @codingStandardsIgnoreSEnd
 
 /**
  * \DispatcherTestDefaultNoNamespaceController


### PR DESCRIPTION
`@codingStandards` is deprecated in 3.2 and removed in version 4. It is replaced with `phpcs:` comments.

https://github.com/PHPCSStandards/PHP_CodeSniffer/pull/975