### PR TITLE
fix #16818: override memcached options correctly

### DIFF
--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -136,7 +136,7 @@ class Libmemcached extends AbstractAdapter
                         \Memcached::OPT_REMOVE_FAILED_SERVERS : true,
                         \Memcached::OPT_RETRY_TIMEOUT         : 1
                     ],
-                    client   = array_merge(failover, client);
+                    client   = array_replace(failover, client);
 
                 this
                     ->setOptions(connection, client)


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: https://github.com/phalcon/cphalcon/issues/16818

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:
Fixes merging numeric arrays keeping keys safe for \Memcached options constants

Thanks

Natalya