### PR TITLE
Add ignoreCheckUploadedFile option to File validator (Fixes #16710)

### DIFF
--- a/phalcon/Filter/Validation/Validator/File.zep
+++ b/phalcon/Filter/Validation/Validator/File.zep
@@ -111,7 +111,7 @@ class File extends AbstractValidatorComposite
      *     'maxResolution' => '1000x1000',
      *     'messageMaxResolution' => '',
      *     'includedMaxResolution' => false,
-     *     'minResolution => '500x500',
+     *     'minResolution' => '500x500',
      *     'includedMinResolution' => false,
      *     'messageMinResolution' => '',
      *     'equalResolution' => '1000x1000',
@@ -119,14 +119,15 @@ class File extends AbstractValidatorComposite
      *     'allowEmpty' => false,
      *     'messageFileEmpty' => '',
      *     'messageIniSize' => '',
-     *     'messageValid' => ''
+     *     'messageValid' => '',
+     *     'ignoreCheckUploadedFile' => false
      * ]
      */
     public function __construct(array! options = [])
     {
         var helper, included = null, key, message = null,
             messageFileEmpty = null, messageIniSize = null, messageValid = null,
-            validator, value;
+            validator, value, ignoreFlag;
 
         let helper = new Get();
 
@@ -145,7 +146,15 @@ class File extends AbstractValidatorComposite
             unset options["messageValid"];
         }
 
-        // create individual validators
+        /**
+         * Store ignoreCheckUploadedFile option internally
+         */
+        if isset options["ignoreCheckUploadedFile"] {
+            let this->options["ignoreCheckUploadedFile"] = options["ignoreCheckUploadedFile"];
+            unset options["ignoreCheckUploadedFile"];
+        }
+
+        // Create individual validators
         for key, value in options {
             // min file size
             if strcasecmp(key, "minSize") === 0 {
@@ -278,6 +287,15 @@ class File extends AbstractValidatorComposite
             }
 
             let this->validators[] = validator;
+        }
+
+        /**
+         * Propagate ignoreCheckUploadedFile option to all sub-validators
+         */
+        if fetch ignoreFlag, this->options["ignoreCheckUploadedFile"] {
+            for validator in this->validators {
+                validator->setOption("ignoreCheckUploadedFile", ignoreFlag);
+            }
         }
 
         parent::__construct(options);

--- a/phalcon/Filter/Validation/Validator/File/AbstractFile.zep
+++ b/phalcon/Filter/Validation/Validator/File/AbstractFile.zep
@@ -1,4 +1,3 @@
-
 /**
  * This file is part of the Phalcon Framework.
  *
@@ -229,33 +228,33 @@ abstract class AbstractFile extends AbstractValidator
     ) -> bool {
         var files, label, length, method, post, replacePairs, server, value;
 
-    let value  = validation->getValue(field);
-    let server = [];
-    let post   = [];
-    let files  = [];
-    let method = "GET";
-    let length = 0;
+        let value  = validation->getValue(field);
+        let server = [];
+        let post   = [];
+        let files  = [];
+        let method = "GET";
+        let length = 0;
 
-    // Skip all max size and POST-size checks when ignoreCheckUploadedFile is true
-    if this->getOption("ignoreCheckUploadedFile") {
-        return true;
-    }
+        // Skip all max size and POST-size checks when ignoreCheckUploadedFile is true
+        if this->getOption("ignoreCheckUploadedFile") {
+            return true;
+        }
 
-    if _SERVER {
-        let server = _SERVER;
-    }
-    if _POST {
-        let post = _POST;
-    }
-    if _FILES {
-        let files = _FILES;
-    }
-    if isset(server["REQUEST_METHOD"]) {
-        let method = server["REQUEST_METHOD"];
-    }
-    if isset(server["CONTENT_LENGTH"]) {
-        let length = server["CONTENT_LENGTH"];
-    }
+        if _SERVER {
+            let server = _SERVER;
+        }
+        if _POST {
+            let post = _POST;
+        }
+        if _FILES {
+            let files = _FILES;
+        }
+        if isset(server["REQUEST_METHOD"]) {
+            let method = server["REQUEST_METHOD"];
+        }
+        if isset(server["CONTENT_LENGTH"]) {
+            let length = server["CONTENT_LENGTH"];
+        }
 
         // Upload is larger than PHP allowed size (post_max_size or upload_max_filesize)
         if (
@@ -272,20 +271,20 @@ abstract class AbstractFile extends AbstractValidator
                 ":field" : label
             ];
 
-        validation->appendMessage(
-            new Message(
-                strtr(this->getMessageIniSize(), replacePairs),
-                field,
-                get_class(this),
-                this->prepareCode(field)
-            )
-        );
+            validation->appendMessage(
+                new Message(
+                    strtr(this->getMessageIniSize(), replacePairs),
+                    field,
+                    get_class(this),
+                    this->prepareCode(field)
+                )
+            );
 
-        return false;
+            return false;
+        }
+
+        return true;
     }
-
-    return true;
-}
 
     /**
      * Convert a string like "2.5MB" in bytes

--- a/tests/unit/Filter/Validation/Validator/FileCest.php
+++ b/tests/unit/Filter/Validation/Validator/FileCest.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Filter\Validation\Validator;
+
+use Phalcon\Filter\Validation;
+use Phalcon\Filter\Validation\Validator\File;
+use UnitTester;
+
+class FileCest
+{
+    /**
+     * Tests File validator with `ignoreCheckUploadedFile = true`
+     *
+     * This test creates a temporary file instead of relying on
+     * a static file under `tests/_data` to make it fully
+     * self-contained and environment independent.
+     *
+     * @param UnitTester $I
+     */
+    public function fileIgnoreCheckUploadedFile(UnitTester $I): void
+    {
+        $I->wantToTest('Filter\Validation\Validator\File - ignoreCheckUploadedFile works');
+
+        $validation = new Validation();
+        $validation->add(
+            'file',
+            new File([
+                'maxSize'                 => '2M',
+                'ignoreCheckUploadedFile' => true,
+                'allowEmpty'              => false,
+                'types'                   => ['text/plain'],
+            ])
+        );
+
+        // Create a temporary file to simulate an uploaded file
+        $tmpFile = tempnam(sys_get_temp_dir(), 'phalcon_test_');
+        file_put_contents($tmpFile, 'dummy content');
+
+        // Fake uploaded file array
+        $fakeFile = [
+            'name'     => 'test.txt',
+            'type'     => 'text/plain',
+            'tmp_name' => $tmpFile,
+            'error'    => 0,
+            'size'     => filesize($tmpFile),
+        ];
+
+        $messages = $validation->validate([
+            'file' => $fakeFile,
+        ]);
+
+        $I->assertEmpty($messages);
+
+        // Clean up the temporary file
+        @unlink($tmpFile);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature | bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16710

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the Contributing Guidelines
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the documentation about this change

---

### Small description of change:

This PR implements the `ignoreCheckUploadedFile` option in the `File` validator, allowing
developers to bypass the internal `is_uploaded_file()` check. This option is particularly
useful when mocking uploaded files in unit tests.

Additionally, when `ignoreCheckUploadedFile` is set to `true`, empty upload arrays
(e.g. `[]`) are now treated as valid rather than causing a validation failure.

This update improves testability while maintaining backwards compatibility.  
A unit test has been added to verify this behavior.

Note: I did not update the CHANGELOG because Phalcon maintainers usually handle it on merge. 
If it is preferred that contributors update it, I’m happy to add it.

Thanks



