### PR TITLE
Fix method checkCipherHashIsAvailable()

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -18,7 +18,8 @@
 - Fixed `Phalcon\Http\Request` method `getPostData()` when `Content-Type` header is not set [#16804](https://github.com/phalcon/cphalcon/issues/16804)
 - Fixed `Phalcon\Events\ManagerInterface` adding priority property [#16817](https://github.com/phalcon/cphalcon/issues/16817)
 - Fixed `Phalcon\Storage\Adapters\Libmemcached::getAdapter()` to correctly merge adapter options [#16818](https://github.com/phalcon/cphalcon/issues/16818)
- 
+- Fixed `Phalcon\Encryption\Crypt` method `checkCipherHashIsAvailable(string $cipher, string $type)` to correctly check the `cipher` or `hash` type [#16822](https://github.com/phalcon/cphalcon/issues/16822)
+
 ### Removed
 
 ## [5.9.3](https://github.com/phalcon/cphalcon/releases/tag/v5.9.3) (2025-04-19)

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -590,7 +590,7 @@ class Crypt implements CryptInterface
     {
         var available, lower, method;
 
-        if "hash" === cipher {
+        if "hash" === type {
             let method = "getAvailableHashAlgorithms";
         } else {
             let method = "getAvailableCiphers";

--- a/tests/unit/Encryption/Crypt/GetSetHashAlgorithmCest.php
+++ b/tests/unit/Encryption/Crypt/GetSetHashAlgorithmCest.php
@@ -35,7 +35,6 @@ class GetSetHashAlgorithmCest
     public function encryptionCryptGetSetHashAlgo(UnitTester $I)
     {
         $I->wantToTest('Encryption\Crypt - getHashAlgorithm() / setHashAlgorithm()');
-        $I->skipTest('TODO: Check this test with 8.2');
 
         $cipher = 'sha384';
         $crypt  = new Crypt();


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16822

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

A small mistake in the if clause, causing only ciphers types to be checked.

This should have been caught, not sure exactly why the test was skipped.

Thanks

