### PR TITLE
Refactor Request::getClientAddress() when using trustForwardedHeader

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,4 +1,17 @@
 # Changelog
+## 5.11.0 (2026-XX-XX)
+
+### Changed
+
+### Added
+
+### Fixed
+
+- Fixed `Phalcon\Http\Request` method `getClientAddress()` when using `trustForwardedHeader`.[#16836](https://github.com/phalcon/cphalcon/issues/16836)
+
+### Removed
+
+# Changelog
 ## 5.10.0 (2025-12-25)
 
 ### Changed

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -86,6 +86,11 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     protected trustedProxies = [];
 
     /**
+     * @var string
+     */
+    protected trustedProxyHeader = "";
+
+    /**
      * Gets a variable from the $_REQUEST superglobal applying filters if
      * needed. If no parameters are given the $_REQUEST superglobal is returned
      *
@@ -204,6 +209,22 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      * `$_SERVER["REMOTE_ADDR"]` and optionally in
      * `$_SERVER["HTTP_X_FORWARDED_FOR"]` and returns the first non-private or non-reserved IP address
      *
+     * The user provided trusted header takes priority before checking X-Forwarded-For header.
+     *
+     * Using trusted proxies list, user has to provide a trusted list of proxy IPs
+     * ```
+     * $request
+     *     ->setTrustedProxies($trustedProxies)
+     *     ->getClientAddress(true);
+     * ```
+     * Using user provided trusted header, header should only ever contain 1 IP address, eg. HTTP_CLIENT_IP
+     * ```
+     * $request
+     *     ->setTrustedProxyHeader('HTTP_CLIENT_IP')
+     *     ->setTrustedProxies($trustedProxies)
+     *     ->getClientAddress(true);
+     * ```
+     *
      * @param bool $trustForwardedHeader
      *
      * @return string|false
@@ -211,75 +232,50 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      */
     public function getClientAddress(bool trustForwardedHeader = false) -> string | false
     {
-        var address, server,
-            forwardedIps, forwardedIp, invertForwardedIp, trustedForwardedIp,
-            filtered, trustedProxies, filterService, isTrusted, isIpAddressInCIDR;
+        var server, address, trustedProxyHeaderIp,
+            forwarded, forwardedIps, reverseForwardedIps, forwardedIp,
+            filteredIp;
 
         let server = this->getServerArray();
 
-        if trustForwardedHeader {
-            fetch address, server["HTTP_X_FORWARDED_FOR"];
-
-            if address === null {
-                fetch address, server["HTTP_CLIENT_IP"];
-            }
-
-            if (null !== address && memstr(address, ',')) {
-                /**
-                 * The client address has multiples parts,
-                 * only return the first non-private/non-reserved IP
-                 */
-                let trustedProxies = this->trustedProxies;
-                let forwardedIps = explode(',', address);
-                if !empty(trustedProxies) {
-                    // verify if we trust the forwarded proxy
-                    let isTrusted          = false;
-                    for invertForwardedIp in reverse forwardedIps {
-                        if isTrusted === true {
-                            break;
-                        }
-                        for trustedForwardedIp in trustedProxies {
-                            if (memstr(trustedForwardedIp, "/")) {
-                                let isIpAddressInCIDR = this->isIpAddressInCIDR(invertForwardedIp, trustedForwardedIp);
-                                if isIpAddressInCIDR === true {
-                                    let isTrusted = true;
-                                    break;
-                                }
-                            } else {
-                                if (invertForwardedIp === trustedForwardedIp) {
-                                    let isTrusted = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    if !isTrusted {
-                        throw new \Exception("The forwarded proxy IP addresses are not trusted.");
-                    }
-                }
-
-                // retrieve the first valid IP that is not reserved or private
-                let filterService = this->getFilterService();
-                for forwardedIp in forwardedIps {
-                    let filtered = filterService->sanitize(forwardedIp, [
-                        "ip" : [
-                            "filter" : FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
-                        ]
-                    ]);
-                    if filtered {
-                        return filtered;
-                    }
-                }
-
-                return false;
-            }
-        } else {
-            fetch address, server["REMOTE_ADDR"];
-        }
+        fetch address, server["REMOTE_ADDR"];
 
         if !is_string(address) {
             return false;
+        }
+
+        // if trustForwardedHeader == true, the $address is deemed a proxy IP, or we get it from a trusted header
+        if trustForwardedHeader {
+            // If trustedProxyHeader is not empty, it takes priority before we check for X-Forwarded-For
+            if this->trustedProxyHeader !== "" {
+                if fetch trustedProxyHeaderIp, server[this->trustedProxyHeader] {
+                    return trustedProxyHeaderIp;
+                }
+            }
+            // if $this->trustedProxies is not empty, we verify if the REMOTE_ADDR is a trusted proxy,
+            // and if not, we do not parse the X-Forwarded-For proxy header, return REMOTE_ADDR directly
+            if !empty(this->trustedProxies) && !this->isProxyTrusted(address) {
+                return address;
+            }
+            // if either trustedProxies are empty or we trust the proxy, parse the header HTTP_X_FORWARDED_FOR
+            fetch forwarded, server["HTTP_X_FORWARDED_FOR"];
+            if !empty(forwarded) {
+                // X-Forwarded-For contains ips, we continue parsing the header
+                let forwardedIps        = array_map("trim", explode(",", forwarded));
+                let reverseForwardedIps = array_reverse(forwardedIps);
+                for forwardedIp in reverseForwardedIps {
+                    // skip if the IP is one of our own trusted proxy
+                    if !empty(this->trustedProxies) && this->isProxyTrusted(forwardedIp) {
+                        continue;
+                    }
+
+                    // return the first public, non-private and non-reserved IP
+                    let filteredIp = this->isValidPublicIp(forwardedIp);
+                    if filteredIp {
+                        return filteredIp;
+                    }
+                }
+            }
         }
 
         return address;
@@ -1421,7 +1417,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     }
 
     /**
-     * Set trusted proxy
+     * Set a trusted proxy list for X-Forwarded-For header
      *
      * @param array $trustedProxies
      * @return RequestInterface
@@ -1445,6 +1441,27 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     }
 
     /**
+     * This header takes priority when parsing HTTP headers
+     * The header return only 1 single IP address, prefixed with HTTP_ eg. HTTP_CLIENT_IP.
+     *
+     * @param  string $trustedProxyHeader
+     * @return RequestInterface
+     */
+    public function setTrustedProxyHeader(string trustedProxyHeader) -> <RequestInterface>
+    {
+        var trustedHeader;
+
+        let trustedHeader = strtoupper(str_replace("-", "_", trustedProxyHeader));
+        if (!str_starts_with(trustedHeader, "HTTP_")) {
+            let trustedHeader = "HTTP_" . trustedHeader;
+        }
+
+        let this->trustedProxyHeader = trustedHeader;
+
+        return this;
+    }
+
+    /**
      * Check if an IP address exists in CIDR range
      *
      * @param string $ip The IP address to check.
@@ -1463,7 +1480,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
         let ipBin     = inet_pton(ip),
             subnetBin = inet_pton(subnet);
 
-        if ipBin === false || subnetBin === false {
+        if ipBin === false || subnetBin === false || strlen(ipBin) !== strlen(subnetBin) {
             return false; // Invalid IP
         }
 
@@ -1837,6 +1854,48 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
             notAllowEmpty,
             noRecursive
         );
+    }
+
+    /**
+     * Verify if given IP address is trusted
+     *
+     * @param string $ip
+     * @return bool
+     */
+    private function isProxyTrusted(string $ip) -> bool
+    {
+        var trusted;
+
+        for trusted in this->trustedProxies {
+            if (strpos(trusted, '/') !== false) {
+                return this->isIpAddressInCIDR(ip, trusted);
+            } else {
+                return ip === trusted;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Verify if given IP address is public, eg. not private or reserved IP
+     *
+     * @param string $forwardedIp
+     * @return string|false
+     * @throws \Phalcon\Filter\Exception
+     */
+    private function isValidPublicIp(string forwardedIp) -> string | false
+    {
+        var filterService, filtered;
+
+        let filterService = this->getFilterService();
+        let filtered = filterService->sanitize(forwardedIp, [
+            "ip" : [
+                "filter" : FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+            ]
+        ]);
+
+        return filtered;
     }
 
      /**

--- a/tests/unit/Http/Request/GetClientAddressCest.php
+++ b/tests/unit/Http/Request/GetClientAddressCest.php
@@ -36,6 +36,7 @@ class GetClientAddressCest
         // skip private IP and return the first non-private and non-reserved IP
         $_SERVER = [
             'REQUEST_TIME_FLOAT'   => $time,
+            'REMOTE_ADDR'          => '25.25.25.25',
             'HTTP_X_FORWARDED_FOR' => '10.4.6.1,25.25.25.25',
         ];
 
@@ -89,6 +90,7 @@ class GetClientAddressCest
         // set correct IP with trusted proxy
         $_SERVER = [
             'REQUEST_TIME_FLOAT'   => $time,
+            'REMOTE_ADDR'          => '25.25.25.1',
             'HTTP_X_FORWARDED_FOR' => '8.8.8.8,25.25.25.1',
         ];
 
@@ -122,6 +124,7 @@ class GetClientAddressCest
         // verify proxy is trusted
         $_SERVER = [
             'REQUEST_TIME_FLOAT'   => $time,
+            'REMOTE_ADDR'          => '1.1.1.1',
             'HTTP_X_FORWARDED_FOR' => '8.8.8.8,1.1.1.1',
         ];
 
@@ -131,13 +134,43 @@ class GetClientAddressCest
             '25.25.25.0/24'
         ]);
 
-        $expected = 'The forwarded proxy IP addresses are not trusted.';
-        try {
-            $request->getClientAddress(true);
-            $I->fail('Expected exception was not thrown.');
-        } catch (\Exception $e) {
-            $I->assertEquals($expected, $e->getMessage());
-        }
+        $expected = '1.1.1.1';
+        $actual   = $request->getClientAddress(true);
+        $I->assertSame($expected, $actual);
+
+        $_SERVER = $store;
+    }
+
+    /**
+     * Tests Phalcon\Http\Request :: getClientAddress() - trustForwardedHeader - with non-public proxy IPs
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-07-11
+     */
+    public function httpRequestGetClientAddressTrustForwardedHeaderWithNonPublicProxyIps(UnitTester $I)
+    {
+        $I->wantToTest('Http\Request - getClientAddress() - trustForwardedHeader - with non-public proxy IPs');
+        $container = new FactoryDefault();
+
+        $store   = $_SERVER ?? [];
+        $time    = $_SERVER['REQUEST_TIME_FLOAT'];
+
+        // verify proxy is trusted
+        $_SERVER = [
+            'REQUEST_TIME_FLOAT'   => $time,
+            'REMOTE_ADDR'          => '192.168.0.10',
+            'HTTP_X_FORWARDED_FOR' => '10.4.5.3,192.168.0.10',
+        ];
+
+        $request = new Request();
+        $request->setDI($container);
+        $request->setTrustedProxies([
+            '192.168.0.10'
+        ]);
+
+        $expected = '192.168.0.10';
+        $actual   = $request->getClientAddress(true);
+        $I->assertSame($expected, $actual);
 
         $_SERVER = $store;
     }
@@ -159,11 +192,13 @@ class GetClientAddressCest
         // Test HTTP_CLIENT_IP header
         $_SERVER = [
             'REQUEST_TIME_FLOAT' => $time,
+            'REMOTE_ADDR'        => '10.1.2.3',
             'HTTP_CLIENT_IP'     => '10.4.6.2',
         ];
 
         $request = new Request();
         $request->setDI($container);
+        $request->setTrustedProxyHeader('HTTP_CLIENT_IP');
 
         $expected = '10.4.6.2';
         $actual   = $request->getClientAddress(true);


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/16836

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

Two changes introduced, to support fallback to `REMOTE_ADDR` when invalid proxy IP was used, and introduced a new  setter `setTrustedProxyHeader` to retrieve the IP address from a user provided header eg. `HTTP_CLIENT_IP`. The user provided trusted header takes priority before checking `X-Forwarded-For` header.

The way it works is ...
1. Using trusted proxies list.
```
$request
    ->setTrustedProxies($trustedProxies)
    ->getClientAddress(true);
```
You can also not use a trusted proxies list, though I recommend using a trusted list for security reasons. It will parse the forwarded header, but may not be as reliable as with a trusted list.

2. Using user provided trusted header,  the header should only ever contain 1 IP address
```
$request
    ->setTrustedProxyHeader('HTTP_CLIENT_IP')
    ->getClientAddress(true);
```
If the `trustedProxyHeader` is empty, it will fallback to x-forwarded-for, in which case I would again recommend setting a proper trusted proxy list.

Using the proxy method should be used in careful controlled environment.

Requesting a review before merging please.

Thanks