### PR TITLE
5.0.x

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -22,6 +22,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Encryption\Security::computeHmac()` to catch `\ValueError` thrown by PHP 8.1+ when an unknown hashing algorithm is passed [#16893](https://github.com/phalcon/cphalcon/issues/16893)
+- Fixed `Phalcon\Translate\Adapter\Gettext::setLocale()` to call `setlocale` when it is available, removing warnings in PHP 8.5 [#16886](https://github.com/phalcon/cphalcon/issues/16886)
 
 ### Removed
 

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -288,8 +288,13 @@ class Crypt implements CryptInterface
         this->checkCipherHashIsAvailable(cipher, "cipher");
 
         let mode      = this->getMode(),
-            blockSize = this->getBlockSize(mode),
-            iv        = this->phpOpensslRandomPseudoBytes(ivLength);
+            blockSize = this->getBlockSize(mode);
+
+        try {
+            let iv = this->phpOpensslRandomPseudoBytes(ivLength);
+        } catch \ValueError {
+            throw new Exception("Cannot calculate Random Pseudo Bytes");
+        }
 
         if false === iv {
             throw new Exception("Cannot calculate Random Pseudo Bytes");

--- a/phalcon/Translate/Adapter/Gettext.zep
+++ b/phalcon/Translate/Adapter/Gettext.zep
@@ -287,10 +287,12 @@ class Gettext extends AbstractAdapter implements ArrayAccess
         let this->locale   = setlocale(category, localeArray),
             this->category = category;
 
-        putenv("LC_ALL=" . this->locale);
-        putenv("LANG=" . this->locale);
-        putenv("LANGUAGE=" . this->locale);
-        setlocale(LC_ALL, this->locale);
+        if (false !== this->locale) {
+            putenv("LC_ALL=" . this->locale);
+            putenv("LANG=" . this->locale);
+            putenv("LANGUAGE=" . this->locale);
+            setlocale(LC_ALL, this->locale);
+        }
 
         return this->locale;
     }

--- a/tests/database/DataMapper/Fake/FakeConnection.php
+++ b/tests/database/DataMapper/Fake/FakeConnection.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Fixtures\DataMapper\Fake;
+namespace Phalcon\Tests\Support\DataMapper\Fake;
 
 use Phalcon\DataMapper\Pdo\Connection;
 use Phalcon\DataMapper\Pdo\Profiler\ProfilerInterface;

--- a/tests/database/DataMapper/Fake/PdoFixture.php
+++ b/tests/database/DataMapper/Fake/PdoFixture.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Phalcon\Tests\Fixtures\DataMapper\Fake;
+namespace Phalcon\Tests\Support\DataMapper\Fake;
 
 class PdoFixture
 {

--- a/tests/database/Mvc/Model/Query/Builder/MemoryUsageCest.php
+++ b/tests/database/Mvc/Model/Query/Builder/MemoryUsageCest.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Database\Mvc\Model\Query\Builder;
 
 use DatabaseTester;
-use Phalcon\Tests\Fixtures\Migrations\InvoicesMigration;
-use Phalcon\Tests\Fixtures\Traits\DiTrait;
+use Phalcon\Tests\Support\Migrations\InvoicesMigration;
+use Phalcon\Tests\Support\Traits\DiTrait;
 use Phalcon\Tests\Models\Invoices;
 
 class MemoryUsageCest

--- a/tests/database/Mvc/Model/RefactorModelsEventsTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsEventsTest.php
@@ -62,7 +62,7 @@ final class RefactorModelsEventsTest extends AbstractDatabaseTestCase
 //
 // use IntegrationTester;
 // use Phalcon\Mvc\Model\Manager as ModelManager;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\GossipRobots;
 //
 // class ModelsEventsCest

--- a/tests/database/Mvc/Model/RefactorModelsForeignKeysTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsForeignKeysTest.php
@@ -45,7 +45,7 @@ final class RefactorModelsForeignKeysTest extends AbstractDatabaseTestCase
 // use Codeception\Example;
 // use IntegrationTester;
 // use Phalcon\Messages\Message;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Deles;
 // use Phalcon\Tests\Support\Models\Parts;
 // use Phalcon\Tests\Support\Models\Robots;

--- a/tests/database/Mvc/Model/RefactorModelsMetadataStrategyTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsMetadataStrategyTest.php
@@ -46,7 +46,7 @@ final class RefactorModelsMetadataStrategyTest extends AbstractDatabaseTestCase
 // use Phalcon\Mvc\Model\MetaData\Memory;
 // use Phalcon\Mvc\Model\MetaData\Strategy\Annotations;
 // use Phalcon\Mvc\Model\MetaData\Strategy\Introspection;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Boutique\Robots as BoutiqueRobots;
 // use Phalcon\Tests\Support\Models\Robots;
 //

--- a/tests/database/Mvc/Model/RefactorModelsMetadataTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsMetadataTest.php
@@ -52,7 +52,7 @@ final class RefactorModelsMetadataTest extends AbstractDatabaseTestCase
 // namespace Phalcon\Tests\Integration\Mvc\Model;
 //
 // use IntegrationTester;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Personas;
 // use Phalcon\Tests\Support\Models\Robots;
 //

--- a/tests/database/Mvc/Model/RefactorModelsQueryExecuteTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsQueryExecuteTest.php
@@ -52,7 +52,7 @@ final class RefactorModelsQueryExecuteTest extends AbstractDatabaseTestCase
 // namespace Phalcon\Tests\Integration\Mvc\Model;
 //
 // use IntegrationTester;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 //
 // class ModelsQueryExecuteCest
 // {

--- a/tests/database/Mvc/Model/RefactorModelsRelationsMagicTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsRelationsMagicTest.php
@@ -35,7 +35,7 @@ final class RefactorModelsRelationsMagicTest extends AbstractDatabaseTestCase
 //
 // use IntegrationTester;
 // use Phalcon\Mvc\Model;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\AlbumORama\Albums;
 // use Phalcon\Tests\Support\Models\AlbumORama\Artists;
 // use Phalcon\Tests\Support\Models\AlbumORama\Songs;

--- a/tests/database/Mvc/Model/RefactorModelsRelationsTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsRelationsTest.php
@@ -71,7 +71,7 @@ final class RefactorModelsRelationsTest extends AbstractDatabaseTestCase
 //
 // use Codeception\Example;
 // use IntegrationTester;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Relations\Deles;
 // use Phalcon\Tests\Support\Models\Relations\M2MParts;
 // use Phalcon\Tests\Support\Models\Relations\M2MRobots;

--- a/tests/database/Mvc/Model/RefactorModelsResultsetCacheStaticTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsResultsetCacheStaticTest.php
@@ -34,7 +34,7 @@ final class RefactorModelsResultsetCacheStaticTest extends AbstractDatabaseTestC
 // namespace Phalcon\Tests\Integration\Mvc\Model;
 //
 // use IntegrationTester;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Cacheable\Parts;
 // use Phalcon\Tests\Support\Models\Cacheable\Robots;
 //

--- a/tests/database/Mvc/Model/RefactorModelsResultsetCacheTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsResultsetCacheTest.php
@@ -55,7 +55,7 @@ final class RefactorModelsResultsetCacheTest extends AbstractDatabaseTestCase
 // use IntegrationTester;
 // use Phalcon\Cache\Backend\File;
 // use Phalcon\Cache\Frontend\Data;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Robots;
 //
 // use function cacheDir;

--- a/tests/database/Mvc/Model/RefactorModelsResultsetTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsResultsetTest.php
@@ -188,7 +188,7 @@ final class RefactorModelsResultsetTest extends AbstractDatabaseTestCase
 //
 // use AppendIterator;
 // use IntegrationTester;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Personas;
 // use Phalcon\Tests\Support\Models\Robots;
 //

--- a/tests/database/Mvc/Model/RefactorModelsTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsTest.php
@@ -37,7 +37,7 @@ final class RefactorModelsTest extends AbstractDatabaseTestCase
 // use Phalcon\Db\RawValue;
 // use Phalcon\Messages\Message as ModelMessage;
 // use Phalcon\Mvc\Model;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Childs;
 // use Phalcon\Tests\Support\Models\I1534;
 // use Phalcon\Tests\Support\Models\Parts2;

--- a/tests/database/Mvc/Model/RefactorModelsValidatorsTest.php
+++ b/tests/database/Mvc/Model/RefactorModelsValidatorsTest.php
@@ -52,7 +52,7 @@ final class RefactorModelsValidatorsTest extends AbstractDatabaseTestCase
 // namespace Phalcon\Tests\Integration\Mvc\Model;
 //
 // use IntegrationTester;
-// use Phalcon\Tests\Fixtures\Traits\DiTrait;
+// use Phalcon\Tests\Support\Traits\DiTrait;
 // use Phalcon\Tests\Support\Models\Abonnes;
 // use Phalcon\Validation\Validator\Email;
 // use Phalcon\Validation\Validator\ExclusionIn;


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Fixes: #16886 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

`Phalcon\Translate\Adapter\Gettext::setLocale()` throws a `TypeError` on PHP 8.5 when the requested locale is not available on the system.

PHP 8.5 tightened the type signature of `setlocale()` — its `$locales` parameter now enforces `array|string|null` and no longer silently accepts `false`. When the first `setlocale()` call fails (locale not installed), it returns `false`, which was then passed directly into a second `setlocale()` call.

The fix guards the `putenv`/`setlocale` block so it only executes when the locale was resolved successfully.

