### PR TITLE
T16892 html helpers

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -11,12 +11,15 @@
 - Changed exception messages across multiple components to use `"does not"` instead of `"doesn't"` for consistency [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Changed `Phalcon\Mvc\Controller` and `Phalcon\Mvc\View\Engine\AbstractEngine` to be events aware [#16890](https://github.com/phalcon/cphalcon/pull/16890)
 - Changed `Phalcon\Mvc\View\Engine\Volt\Compiler::setOptions` to return `$this` now [#16891](https://github.com/phalcon/cphalcon/pull/16891)
+- Changed `Phalcon\Html\TagFactory` to accept an optional `ResponseInterface` in the constructor (useful for `preload`) [#16892](https://github.com/phalcon/cphalcon/issues/16892)
 
 ### Added
 
 - Added `deleteMultiple()` to `Phalcon\Storage\Adapter\*` to delete multiple keys in a single operation using native batch capabilities per adapter [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Added key validation per entry in `Phalcon\Cache\AbstractCache::doDeleteMultiple()` throwing `InvalidArgumentException` for keys containing invalid characters [#16859](https://github.com/phalcon/cphalcon/issues/16859)
-
+- Added `Phalcon\Html\Helper\FriendlyTitle` - available via `TagFactory` as `friendlyTitle` [#16892(https://github.com/phalcon/cphalcon/issues/16892)
+- Added `Phalcon\Html\Helper\Preload` - available via `TagFactory` as `preload`; `TagFactory` now accepts an optional `ResponseInterface` as its third constructor parameter [#16892(https://github.com/phalcon/cphalcon/issues/16892)
+  
 ### Fixed
 
 - Fixed `Phalcon\Filter\Validation\AbstractValidator::messageFactory()` to pass the joined field string to `Phalcon\Messages\Message` instead of the raw array when multiple fields are provided [#16889](https://github.com/phalcon/cphalcon/issues/16889)

--- a/phalcon/Html/Helper/FriendlyTitle.zep
+++ b/phalcon/Html/Helper/FriendlyTitle.zep
@@ -1,0 +1,60 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Html\Helper;
+
+use Phalcon\Html\Escaper\EscaperInterface;
+use Phalcon\Html\Exception;
+use Phalcon\Support\Helper\Str\Friendly;
+
+/**
+ * Converts text to a URL-friendly slug.
+ */
+class FriendlyTitle extends AbstractHelper
+{
+    /**
+     * @var Friendly
+     */
+    protected friendly;
+
+    /**
+     * @param EscaperInterface $escaper
+     */
+    public function __construct(<EscaperInterface> escaper)
+    {
+        parent::__construct(escaper);
+
+        let this->friendly = new Friendly();
+    }
+
+    /**
+     * @param string     $text
+     * @param string     $separator
+     * @param bool       $lowercase
+     * @param mixed|null $replace
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function __invoke(
+        string text,
+        string separator = "-",
+        bool lowercase = true,
+        var replace = null
+    ) -> string {
+        var ex;
+
+        try {
+            return this->friendly->__invoke(text, separator, lowercase, replace);
+        } catch \Exception, ex {
+            throw new Exception(ex->getMessage());
+        }
+    }
+}

--- a/phalcon/Html/Helper/Preload.zep
+++ b/phalcon/Html/Helper/Preload.zep
@@ -1,0 +1,77 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Html\Helper;
+
+use Phalcon\Html\Escaper\EscaperInterface;
+use Phalcon\Html\Link\Link;
+use Phalcon\Html\Link\Serializer\Header;
+use Phalcon\Http\ResponseInterface;
+
+/**
+ * Generates a <link rel="preload"> tag for resource hinting.
+ * If a ResponseInterface is provided, also sets the HTTP Link header.
+ */
+class Preload extends AbstractHelper
+{
+    /**
+     * @var ResponseInterface|null
+     */
+    protected response = null;
+
+    /**
+     * @param EscaperInterface      $escaper
+     * @param ResponseInterface|null $response
+     */
+    public function __construct(
+        <EscaperInterface> escaper,
+        <ResponseInterface> response = null
+    ) {
+        parent::__construct(escaper);
+
+        let this->response = response;
+    }
+
+    /**
+     * @param string $href
+     * @param string $type
+     * @param array  $attributes
+     *
+     * @return string
+     */
+    public function __invoke(
+        string href,
+        string type = "style",
+        array attributes = []
+    ) -> string {
+        var link, header, overrides;
+
+        let overrides = [
+            "rel"  : "preload",
+            "href" : href,
+            "as"   : type
+        ];
+
+        unset attributes["rel"];
+        unset attributes["href"];
+        unset attributes["as"];
+
+        let overrides = array_merge(overrides, attributes);
+
+        if this->response !== null {
+            let link   = new Link("preload", href, ["as": type]),
+                header = "Link: " . (new Header())->serialize([link]);
+
+            this->response->setRawHeader(header);
+        }
+
+        return this->selfClose("link", overrides);
+    }
+}

--- a/phalcon/Html/TagFactory.zep
+++ b/phalcon/Html/TagFactory.zep
@@ -45,6 +45,7 @@ use Phalcon\Html\Helper\Style;
 use Phalcon\Html\Helper\Title;
 use Phalcon\Html\Helper\Ul;
 use Phalcon\Html\Link\Link;
+use Phalcon\Http\ResponseInterface;
 
 /**
  * ServiceLocator implementation for Tag helpers.
@@ -67,6 +68,7 @@ use Phalcon\Html\Link\Link;
  * @method Doctype       doctype(int $flag, string $delimiter)
  * @method string        element(string $tag, string $text, array $attributes = [], bool $raw = false)
  * @method string        form(array $attributes = [])
+ * @method string        friendlyTitle(string $text, string $separator = '-', bool $lowercase = true, mixed $replace = null)
  * @method string        img(string $src, array $attributes = [])
  * @method Checkbox      inputCheckbox(string $name, string $value = null, array $attributes = [])
  * @method Color         inputColor(string $name, string $value = null, array $attributes = [])
@@ -96,6 +98,7 @@ use Phalcon\Html\Link\Link;
  * @method Link          link(string $indent = '    ', string $delimiter = PHP_EOL)
  * @method Meta          meta(string $indent = '    ', string $delimiter = PHP_EOL)
  * @method Ol            ol(string $text, array $attributes = [], bool $raw = false)
+ * @method string        preload(string $href, string $type = 'style', array $attributes = [])
  * @method Script        script(string $indent = '    ', string $delimiter = PHP_EOL)
  * @method Style         style(string $indent = '    ', string $delimiter = PHP_EOL)
  * @method Title         title(string $indent = '    ', string $delimiter = PHP_EOL)
@@ -109,6 +112,11 @@ class TagFactory extends AbstractFactory
     private escaper;
 
     /**
+     * @var ResponseInterface|null
+     */
+    private response = null;
+
+    /**
      * @var array
      */
     protected services = [];
@@ -116,12 +124,17 @@ class TagFactory extends AbstractFactory
     /**
      * TagFactory constructor.
      *
-     * @param Escaper $escaper
-     * @param array   $services
+     * @param EscaperInterface       $escaper
+     * @param array                  $services
+     * @param ResponseInterface|null $response
      */
-    public function __construct(<EscaperInterface> escaper, array! services = [])
-    {
-        let this->escaper = escaper;
+    public function __construct(
+        <EscaperInterface> escaper,
+        array! services = [],
+        <ResponseInterface> response = null
+    ) {
+        let this->escaper  = escaper,
+            this->response = response;
 
         this->init(services);
     }
@@ -176,6 +189,14 @@ class TagFactory extends AbstractFactory
                             doctype
                         ]
                     );
+            } elseif name === "preload" {
+                let this->services[name] = create_instance_params(
+                    definition,
+                    [
+                        this->escaper,
+                        this->response
+                    ]
+                );
             } else {
                 let this->services[name] = create_instance_params(
                     definition,
@@ -224,6 +245,7 @@ class TagFactory extends AbstractFactory
             "doctype"            : "Phalcon\\Html\\Helper\\Doctype",
             "element"            : "Phalcon\\Html\\Helper\\Element",
             "form"               : "Phalcon\\Html\\Helper\\Form",
+            "friendlyTitle"      : "Phalcon\\Html\\Helper\\FriendlyTitle",
             "img"                : "Phalcon\\Html\\Helper\\Img",
             "inputCheckbox"      : "Phalcon\\Html\\Helper\\Input\\Checkbox",
             "inputColor"         : "Phalcon\\Html\\Helper\\Input\\Color",
@@ -253,6 +275,7 @@ class TagFactory extends AbstractFactory
             "link"               : "Phalcon\\Html\\Helper\\Link",
             "meta"               : "Phalcon\\Html\\Helper\\Meta",
             "ol"                 : "Phalcon\\Html\\Helper\\Ol",
+            "preload"            : "Phalcon\\Html\\Helper\\Preload",
             "script"             : "Phalcon\\Html\\Helper\\Script",
             "style"              : "Phalcon\\Html\\Helper\\Style",
             "title"              : "Phalcon\\Html\\Helper\\Title",

--- a/tests/unit/Html/Helper/FriendlyTitle/UnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/FriendlyTitle/UnderscoreInvokeTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\FriendlyTitle;
+
+use Phalcon\Html\Escaper;
+use Phalcon\Html\Helper\FriendlyTitle;
+use Phalcon\Html\TagFactory;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class UnderscoreInvokeTest extends AbstractUnitTestCase
+{
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function getExamples(): array
+    {
+        return [
+            [
+                'hello-world',
+                'Hello World',
+                '-',
+                true,
+                null,
+            ],
+            [
+                'Hello-World',
+                'Hello World',
+                '-',
+                false,
+                null,
+            ],
+            [
+                'hello_world',
+                'Hello World',
+                '_',
+                true,
+                null,
+            ],
+            [
+                'hello-and-world',
+                'Hello & World',
+                '-',
+                true,
+                null,
+            ],
+            [
+                'hello-world',
+                'Héllo Wörld',
+                '-',
+                true,
+                null,
+            ],
+            [
+                'hello-world',
+                'Hello/World',
+                '-',
+                true,
+                ['/'],
+            ],
+            [
+                'hello-world',
+                'Hello.World',
+                '-',
+                true,
+                '.',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getExamples
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2026-04-17
+     */
+    public function testHtmlHelperFriendlyTitleUnderscoreInvoke(
+        string $expected,
+        string $text,
+        string $separator,
+        bool $lowercase,
+        mixed $replace
+    ): void {
+        $escaper = new Escaper();
+        $helper  = new FriendlyTitle($escaper);
+
+        $actual = $helper($text, $separator, $lowercase, $replace);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $locator = $factory->newInstance('friendlyTitle');
+        $actual  = $locator($text, $separator, $lowercase, $replace);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $actual  = $factory->friendlyTitle($text, $separator, $lowercase, $replace);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/unit/Html/Helper/Preload/UnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/Preload/UnderscoreInvokeTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * For the full copyright and license information, please view the LICENSE.md
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Preload;
+
+use Phalcon\Html\Escaper;
+use Phalcon\Html\Helper\Preload;
+use Phalcon\Html\TagFactory;
+use Phalcon\Http\ResponseInterface;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class UnderscoreInvokeTest extends AbstractUnitTestCase
+{
+    /**
+     * @return array<array<mixed>>
+     */
+    public static function getExamples(): array
+    {
+        return [
+            [
+                '<link rel="preload" href="/my-style.css" as="style" />',
+                '/my-style.css',
+                'style',
+                [],
+            ],
+            [
+                '<link rel="preload" href="/my-script.js" as="script" />',
+                '/my-script.js',
+                'script',
+                [],
+            ],
+            [
+                '<link rel="preload" href="/my-font.woff2" as="font" />',
+                '/my-font.woff2',
+                'font',
+                [],
+            ],
+            [
+                '<link rel="preload" href="/my-style.css" as="style" crossorigin="anonymous" />',
+                '/my-style.css',
+                'style',
+                ['crossorigin' => 'anonymous'],
+            ],
+            [
+                '<link rel="preload" href="/my-style.css" as="style" />',
+                '/my-style.css',
+                'style',
+                ['rel' => 'stylesheet', 'href' => '/other.css', 'as' => 'font'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider getExamples
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2026-04-17
+     */
+    public function testHtmlHelperPreloadUnderscoreInvoke(
+        string $expected,
+        string $href,
+        string $type,
+        array $attributes
+    ): void {
+        $escaper = new Escaper();
+        $helper  = new Preload($escaper);
+
+        $actual = $helper($href, $type, $attributes);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $locator = $factory->newInstance('preload');
+        $actual  = $locator($href, $type, $attributes);
+        $this->assertSame($expected, $actual);
+
+        $factory = new TagFactory($escaper);
+        $actual  = $factory->preload($href, $type, $attributes);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testHtmlHelperPreloadSetsResponseHeader(): void
+    {
+        $escaper  = new Escaper();
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('setRawHeader')
+            ->with('Link: </my-font.woff2>; rel="preload"; as="font"')
+        ;
+
+        $helper = new Preload($escaper, $response);
+        $actual = $helper('/my-font.woff2', 'font');
+
+        $this->assertSame('<link rel="preload" href="/my-font.woff2" as="font" />', $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testHtmlHelperPreloadSetsResponseHeaderViaTagFactory(): void
+    {
+        $escaper  = new Escaper();
+        $response = $this->createMock(ResponseInterface::class);
+
+        $response
+            ->expects($this->once())
+            ->method('setRawHeader')
+            ->with('Link: </my-style.css>; rel="preload"; as="style"')
+        ;
+
+        $factory = new TagFactory($escaper, [], $response);
+        $actual  = $factory->preload('/my-style.css', 'style');
+
+        $this->assertSame('<link rel="preload" href="/my-style.css" as="style" />', $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #16892 
* Fixes: #16892 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Introduces `preload` and `friendlyTitle` in the `TagHelper` (as per `Tag`'s implementation)

Thanks

