### PR TITLE
T16894 html helpers

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,6 +3,8 @@
 
 ### Changed
 
+- Changed `Phalcon\Forms\Element\Select::render()` to use `TagFactory`-based `Html\Helper\Input\Select` instead of the deprecated `Phalcon\Tag\Select` [#16892](https://github.com/phalcon/cphalcon/issues/16892)
+- Changed `Phalcon\Forms\Element\AbstractElement::getLocalTagFactory()` to throw `Phalcon\Forms\Exception` instead of silently creating a new `TagFactory` when neither `setTagFactory()` nor a parent `Form` provides one [#16892](https://github.com/phalcon/cphalcon/issues/16892)
 - Changed `Phalcon\Assets\Manager` filter type check from `is_object()` to `typeof` and updated the error message to `"The filter is not valid"` [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Changed `Phalcon\Cache\AbstractCache::doDeleteMultiple()` to delegate to the storage adapter's `deleteMultiple()` instead of looping over individual `delete()` calls [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Changed calls to `globals_get` and `globals_set` in the code with `Phalcon\Support\Settings::get()/set()` [#16884](https://github.com/phalcon/cphalcon/issues/16884)
@@ -15,6 +17,9 @@
 
 ### Added
 
+- Added `Phalcon\Html\Helper\Input\Select\SelectDataInterface`, `Phalcon\Html\Helper\Input\Select\ArrayData`, and `Phalcon\Html\Helper\Input\Select\ResultsetData` as data providers for the `Select` helper [#16892](https://github.com/phalcon/cphalcon/issues/16892)
+- Added `Phalcon\Html\Helper\Input\Select::fromData()` to populate select options from a `SelectDataInterface` provider, with optgroup support [#16892](https://github.com/phalcon/cphalcon/issues/16892)
+- Added named static factory methods `Phalcon\Forms\Exception::tagFactoryNotFound()` and `Phalcon\Forms\Exception::usingParameterRequired()` [#16892](https://github.com/phalcon/cphalcon/issues/16892)
 - Added `deleteMultiple()` to `Phalcon\Storage\Adapter\*` to delete multiple keys in a single operation using native batch capabilities per adapter [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Added key validation per entry in `Phalcon\Cache\AbstractCache::doDeleteMultiple()` throwing `InvalidArgumentException` for keys containing invalid characters [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Added `Phalcon\Html\Helper\FriendlyTitle` - available via `TagFactory` as `friendlyTitle` [#16892(https://github.com/phalcon/cphalcon/issues/16892)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -3,8 +3,8 @@
 
 ### Changed
 
-- Changed `Phalcon\Forms\Element\Select::render()` to use `TagFactory`-based `Html\Helper\Input\Select` instead of the deprecated `Phalcon\Tag\Select` [#16892](https://github.com/phalcon/cphalcon/issues/16892)
-- Changed `Phalcon\Forms\Element\AbstractElement::getLocalTagFactory()` to throw `Phalcon\Forms\Exception` instead of silently creating a new `TagFactory` when neither `setTagFactory()` nor a parent `Form` provides one [#16892](https://github.com/phalcon/cphalcon/issues/16892)
+- Changed `Phalcon\Forms\Element\Select::render()` to use `TagFactory`-based `Html\Helper\Input\Select` instead of the deprecated `Phalcon\Tag\Select` [#16894](https://github.com/phalcon/cphalcon/issues/16894)
+- Changed `Phalcon\Forms\Element\AbstractElement::getLocalTagFactory()` to throw `Phalcon\Forms\Exception` instead of silently creating a new `TagFactory` when neither `setTagFactory()` nor a parent `Form` provides one [#16894](https://github.com/phalcon/cphalcon/issues/16894)
 - Changed `Phalcon\Assets\Manager` filter type check from `is_object()` to `typeof` and updated the error message to `"The filter is not valid"` [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Changed `Phalcon\Cache\AbstractCache::doDeleteMultiple()` to delegate to the storage adapter's `deleteMultiple()` instead of looping over individual `delete()` calls [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Changed calls to `globals_get` and `globals_set` in the code with `Phalcon\Support\Settings::get()/set()` [#16884](https://github.com/phalcon/cphalcon/issues/16884)
@@ -17,9 +17,9 @@
 
 ### Added
 
-- Added `Phalcon\Html\Helper\Input\Select\SelectDataInterface`, `Phalcon\Html\Helper\Input\Select\ArrayData`, and `Phalcon\Html\Helper\Input\Select\ResultsetData` as data providers for the `Select` helper [#16892](https://github.com/phalcon/cphalcon/issues/16892)
-- Added `Phalcon\Html\Helper\Input\Select::fromData()` to populate select options from a `SelectDataInterface` provider, with optgroup support [#16892](https://github.com/phalcon/cphalcon/issues/16892)
-- Added named static factory methods `Phalcon\Forms\Exception::tagFactoryNotFound()` and `Phalcon\Forms\Exception::usingParameterRequired()` [#16892](https://github.com/phalcon/cphalcon/issues/16892)
+- Added `Phalcon\Html\Helper\Input\Select\SelectDataInterface`, `Phalcon\Html\Helper\Input\Select\ArrayData`, and `Phalcon\Html\Helper\Input\Select\ResultsetData` as data providers for the `Select` helper [#16894](https://github.com/phalcon/cphalcon/issues/16894)
+- Added `Phalcon\Html\Helper\Input\Select::fromData()` to populate select options from a `SelectDataInterface` provider, with optgroup support [#16894](https://github.com/phalcon/cphalcon/issues/16894)
+- Added named static factory methods `Phalcon\Forms\Exception::tagFactoryNotFound()` and `Phalcon\Forms\Exception::usingParameterRequired()` [#16894](https://github.com/phalcon/cphalcon/issues/16894)
 - Added `deleteMultiple()` to `Phalcon\Storage\Adapter\*` to delete multiple keys in a single operation using native batch capabilities per adapter [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Added key validation per entry in `Phalcon\Cache\AbstractCache::doDeleteMultiple()` throwing `InvalidArgumentException` for keys containing invalid characters [#16859](https://github.com/phalcon/cphalcon/issues/16859)
 - Added `Phalcon\Html\Helper\FriendlyTitle` - available via `TagFactory` as `friendlyTitle` [#16892(https://github.com/phalcon/cphalcon/issues/16892)

--- a/phalcon/Forms/Element/AbstractElement.zep
+++ b/phalcon/Forms/Element/AbstractElement.zep
@@ -14,9 +14,8 @@ use InvalidArgumentException;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Di;
 use Phalcon\Filter\Validation\ValidatorInterface;
-use Phalcon\Forms\Form;
 use Phalcon\Forms\Exception;
-use Phalcon\Html\Escaper;
+use Phalcon\Forms\Form;
 use Phalcon\Html\TagFactory;
 use Phalcon\Messages\MessageInterface;
 use Phalcon\Messages\Messages;
@@ -524,7 +523,7 @@ abstract class AbstractElement implements ElementInterface
      */
     protected function getLocalTagFactory() -> <TagFactory>
     {
-        var container, escaper, tagFactory;
+        var container, tagFactory;
 
         let tagFactory = null;
 
@@ -542,24 +541,13 @@ abstract class AbstractElement implements ElementInterface
             if tagFactory === null {
                 let container = Di::getDefault();
 
-                if likely true === container->has("tag") {
+                if container !== null && true === container->has("tag") {
                     let tagFactory = container->getShared("tag");
                 }
             }
 
-            /**
-             * All failed, create a new TagFactory
-             */
-            if tagFactory === null {
-                let container = Di::getDefault();
-
-                if likely true === container->has("escaper") {
-                    let escaper = container->getShared("escaper");
-                } else {
-                    let escaper = new Escaper();
-                }
-
-                let tagFactory = new TagFactory(escaper);
+            if unlikely tagFactory === null {
+                throw Exception::tagFactoryNotFound();
             }
 
             let this->tagFactory = tagFactory;

--- a/phalcon/Forms/Element/Select.zep
+++ b/phalcon/Forms/Element/Select.zep
@@ -10,7 +10,11 @@
 
 namespace Phalcon\Forms\Element;
 
-use Phalcon\Tag\Select as SelectTag;
+use Phalcon\Forms\Exception;
+use Phalcon\Html\Helper\Input\Select\ArrayData;
+use Phalcon\Html\Helper\Input\Select\ResultsetData;
+use Phalcon\Html\TagFactory;
+use Phalcon\Mvc\Model\ResultsetInterface;
 
 /**
  * Component SELECT (choice) for forms
@@ -25,8 +29,9 @@ class Select extends AbstractElement
     /**
      * Constructor
      *
-     * @param object|array options
-     * @param array        attributes
+     * @param string            name
+     * @param object|array|null options
+     * @param array             attributes
      */
     public function __construct(string name, options = null, array attributes = [])
     {
@@ -70,13 +75,90 @@ class Select extends AbstractElement
      */
     public function render(array attributes = []) -> string
     {
-        /**
-         * Merged passed attributes with previously defined ones
-         */
-        return SelectTag::selectField(
-            this->prepareAttributes(attributes),
-            this->optionsValues
-        );
+        var attrs, emptyText, emptyValue, html, name, options,
+            select, tagFactory, using, useEmpty, value;
+
+        let attrs = this->prepareAttributes(attributes);
+
+        let name = attrs[0];
+        unset attrs[0];
+
+        if isset attrs["value"] {
+            let value = attrs["value"];
+            unset attrs["value"];
+        } else {
+            let value = null;
+        }
+
+        if isset attrs["useEmpty"] {
+            let useEmpty = attrs["useEmpty"];
+        } else {
+            let useEmpty = false;
+        }
+
+        if isset attrs["emptyValue"] {
+            let emptyValue = attrs["emptyValue"];
+        } else {
+            let emptyValue = "";
+        }
+
+        if isset attrs["emptyText"] {
+            let emptyText = attrs["emptyText"];
+        } else {
+            let emptyText = "Choose...";
+        }
+
+        if isset attrs["using"] {
+            let using = attrs["using"];
+        } else {
+            let using = null;
+        }
+
+        unset attrs["useEmpty"];
+        unset attrs["emptyValue"];
+        unset attrs["emptyText"];
+        unset attrs["using"];
+
+        if !isset attrs["name"] {
+            let attrs["name"] = name;
+        }
+
+        if !strpos(name, "[") && !isset attrs["id"] {
+            let attrs["id"] = name;
+        }
+
+        let tagFactory = this->getLocalTagFactory(),
+            select     = tagFactory->newInstance("inputSelect");
+
+        select->__invoke("", "", attrs);
+
+        if value !== null {
+            select->selected((string) value);
+        }
+
+        if useEmpty {
+            select->addPlaceholder(emptyText, emptyValue, [], true);
+        }
+
+        let options = this->optionsValues;
+
+        if typeof options == "array" {
+            select->fromData(new ArrayData(options));
+        } elseif typeof options == "object" && options instanceof ResultsetInterface {
+            if unlikely using === null || typeof using != "array" {
+                throw Exception::usingParameterRequired();
+            }
+
+            select->fromData(new ResultsetData(options, using));
+        }
+
+        let html = (string) select;
+
+        if html === "" {
+            return tagFactory->newInstance("element")->__invoke("select", PHP_EOL, attrs, true);
+        }
+
+        return html;
     }
 
     /**

--- a/phalcon/Forms/Exception.zep
+++ b/phalcon/Forms/Exception.zep
@@ -15,5 +15,17 @@ namespace Phalcon\Forms;
  */
 class Exception extends \Exception
 {
+    public static function tagFactoryNotFound() -> <Exception>
+    {
+        return new self(
+            "A TagFactory must be provided via setTagFactory() or through a parent Form"
+        );
+    }
 
+    public static function usingParameterRequired() -> <Exception>
+    {
+        return new self(
+            "The 'using' parameter is required for resultset options"
+        );
+    }
 }

--- a/phalcon/Html/Helper/Input/Select.zep
+++ b/phalcon/Html/Helper/Input/Select.zep
@@ -11,6 +11,7 @@
 namespace Phalcon\Html\Helper\Input;
 
 use Phalcon\Html\Helper\AbstractList;
+use Phalcon\Html\Helper\Input\Select\SelectDataInterface;
 
 /**
  * Class Select
@@ -94,6 +95,37 @@ class Select extends AbstractList
             ],
             this->indent()
         ];
+
+        return this;
+    }
+
+    /**
+     * Populates the select from a data provider.
+     *
+     * Flat entries: key = option value, value = label string.
+     * Optgroup entries: key = group label, value = [value => label] array.
+     *
+     * @param SelectDataInterface data
+     *
+     * @return Select
+     */
+    public function fromData(<SelectDataInterface> data) -> <Select>
+    {
+        var key, subKey, subValue, value;
+
+        for key, value in data->getOptions() {
+            if typeof value == "array" {
+                this->optGroup((string) key);
+
+                for subKey, subValue in value {
+                    this->add((string) subValue, (string) subKey);
+                }
+
+                this->optGroup((string) key);
+            } else {
+                this->add((string) value, (string) key);
+            }
+        }
 
         return this;
     }

--- a/phalcon/Html/Helper/Input/Select/ArrayData.zep
+++ b/phalcon/Html/Helper/Input/Select/ArrayData.zep
@@ -1,0 +1,41 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Html\Helper\Input\Select;
+
+/**
+ * Wraps a plain PHP array as a SELECT data provider.
+ *
+ * Keys are option values; string values are labels;
+ * array values define optgroups.
+ */
+class ArrayData implements SelectDataInterface
+{
+    /**
+     * @var array
+     */
+    protected data = [];
+
+    /**
+     * @param array data
+     */
+    public function __construct(array data = [])
+    {
+        let this->data = data;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions() -> array
+    {
+        return this->data;
+    }
+}

--- a/phalcon/Html/Helper/Input/Select/ResultsetData.zep
+++ b/phalcon/Html/Helper/Input/Select/ResultsetData.zep
@@ -1,0 +1,80 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Html\Helper\Input\Select;
+
+use InvalidArgumentException;
+use Phalcon\Mvc\Model\ResultsetInterface;
+
+class ResultsetData implements SelectDataInterface
+{
+    /**
+     * @var ResultsetInterface
+     */
+    protected resultset;
+
+    /**
+     * @var array
+     */
+    protected using = [];
+
+    /**
+     * @param ResultsetInterface resultset
+     * @param array              using
+     */
+    public function __construct(<ResultsetInterface> resultset, array using)
+    {
+        if unlikely count(using) !== 2 {
+            throw new InvalidArgumentException(
+                "The 'using' parameter requires exactly two values"
+            );
+        }
+
+        let this->resultset = resultset;
+        let this->using     = using;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions() -> array
+    {
+        var option, optionText, optionValue, options, usingZero, usingOne;
+
+        let usingZero = this->using[0],
+            usingOne  = this->using[1],
+            options   = [];
+
+        for option in this->resultset {
+            if typeof option == "object" {
+                if method_exists(option, "readAttribute") {
+                    let optionValue = option->readAttribute(usingZero),
+                        optionText  = option->readAttribute(usingOne);
+                } else {
+                    let optionValue = option->{usingZero},
+                        optionText  = option->{usingOne};
+                }
+            } else {
+                if unlikely typeof option != "array" {
+                    throw new InvalidArgumentException(
+                        "Resultset returned an invalid value"
+                    );
+                }
+
+                let optionValue = option[usingZero],
+                    optionText  = option[usingOne];
+            }
+
+            let options[optionValue] = optionText;
+        }
+
+        return options;
+    }
+}

--- a/phalcon/Html/Helper/Input/Select/SelectDataInterface.zep
+++ b/phalcon/Html/Helper/Input/Select/SelectDataInterface.zep
@@ -1,0 +1,22 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Html\Helper\Input\Select;
+
+/**
+ * Interface for SELECT option data providers.
+ *
+ * Return format: [value => label] for flat options;
+ * [groupLabel => [value => label, ...]] for optgroups.
+ */
+interface SelectDataInterface
+{
+    public function getOptions() -> array;
+}

--- a/tests/unit/Forms/Element/GetSetTagFactoryTest.php
+++ b/tests/unit/Forms/Element/GetSetTagFactoryTest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Tests\Unit\Forms\Element;
 
 use Phalcon\Di\Di;
 use Phalcon\Forms\Element\Text;
+use Phalcon\Forms\Exception;
 use Phalcon\Forms\Form;
 use Phalcon\Html\Escaper;
 use Phalcon\Html\TagFactory;
@@ -123,22 +124,15 @@ final class GetSetTagFactoryTest extends AbstractUnitTestCase
      * @author Phalcon Team <team@phalcon.io>
      * @since  2024-01-01
      */
-    public function testFormsElementGetLocalTagFactoryDiFallbackNoTagService(): void
+    public function testFormsElementGetLocalTagFactoryThrowsWhenNotResolvable(): void
     {
-        $escaper = new Escaper();
-        $di      = new Di();
-        $di->setShared('escaper', $escaper);
-        // Deliberately no 'tag' service
-        Di::setDefault($di);
+        Di::reset();
 
         $name    = uniqid();
         $element = new Text($name);
 
-        // render() calls getLocalTagFactory() which falls through to L603-609
-        $expected = sprintf('<input type="text" id="%s" name="%s">', $name, $name);
-        $actual   = $element->render();
-        $this->assertSame($expected, $actual);
+        $this->expectException(Exception::class);
 
-        Di::reset();
+        $element->render();
     }
 }

--- a/tests/unit/Forms/Element/Select/RenderTest.php
+++ b/tests/unit/Forms/Element/Select/RenderTest.php
@@ -13,19 +13,109 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Forms\Element\Select;
 
+use Phalcon\Forms\Element\Select;
+use Phalcon\Html\Escaper;
+use Phalcon\Html\TagFactory;
 use Phalcon\Tests\AbstractUnitTestCase;
 
-/**
- * Class RenderTest extends AbstractUnitTestCase
- */
+use function preg_replace;
+
 final class RenderTest extends AbstractUnitTestCase
 {
-    /**
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
-     */
-    public function testFormsElementSelectRender(): void
+    private function normalize(string $html): string
     {
-        $this->markTestSkipped('Need implementation');
+        return preg_replace('/[[:cntrl:]]/', '', $html);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderFlatOptions(): void
+    {
+        $element = new Select('status', ['1' => 'Active', '2' => 'Inactive']);
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render());
+
+        $this->assertSame(
+            '<select id="status" name="status">'
+            . '<option value="1">Active</option>'
+            . '<option value="2">Inactive</option>'
+            . '</select>',
+            $actual
+        );
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithSelectedValue(): void
+    {
+        $element = new Select('status', ['1' => 'Active', '2' => 'Inactive']);
+        $element->setTagFactory(new TagFactory(new Escaper()));
+        $element->setDefault('2');
+
+        $actual = $element->render();
+
+        $this->assertStringContainsString('selected="selected"', $actual);
+        $this->assertStringContainsString('value="2"', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithUseEmpty(): void
+    {
+        $element = new Select(
+            'status',
+            ['1' => 'Active'],
+            [
+                'useEmpty'   => true,
+                'emptyValue' => '',
+                'emptyText'  => 'Pick one',
+            ]
+        );
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render());
+
+        $this->assertStringContainsString('<option value="">Pick one</option>', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithOptgroups(): void
+    {
+        $element = new Select(
+            'cars',
+            [
+                'Italian'  => ['1' => 'Ferrari'],
+                'American' => ['2' => 'Ford'],
+            ]
+        );
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $element->render();
+
+        $this->assertStringContainsString('<optgroup', $actual);
+        $this->assertStringContainsString('label="Italian"', $actual);
+        $this->assertStringContainsString('label="American"', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderWithExtraAttributes(): void
+    {
+        $element = new Select('status', ['1' => 'Active']);
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render(['class' => 'form-select']));
+
+        $this->assertStringContainsString('class="form-select"', $actual);
+        $this->assertStringContainsString('id="status"', $actual);
+        $this->assertStringContainsString('name="status"', $actual);
+    }
+
+    /** @author Phalcon Team <team@phalcon.io> @since 2026-04-17 */
+    public function testRenderReturnsWrapperWhenNoOptions(): void
+    {
+        $element = new Select('status');
+        $element->setTagFactory(new TagFactory(new Escaper()));
+
+        $actual = $this->normalize($element->render());
+
+        $this->assertSame('<select id="status" name="status"></select>', $actual);
     }
 }

--- a/tests/unit/Html/Helper/Input/Select/ArrayDataTest.php
+++ b/tests/unit/Html/Helper/Input/Select/ArrayDataTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input\Select;
+
+use Phalcon\Html\Helper\Input\Select\ArrayData;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class ArrayDataTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsFlatArray(): void
+    {
+        $data     = new ArrayData(['1' => 'Ferrari', '2' => 'Ford']);
+        $expected = ['1' => 'Ferrari', '2' => 'Ford'];
+        $actual   = $data->getOptions();
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsNestedArrayForOptgroups(): void
+    {
+        $input = [
+            'Group A' => ['1' => 'Ferrari', '2' => 'Ford'],
+            '3'       => 'Toyota',
+        ];
+        $data   = new ArrayData($input);
+        $actual = $data->getOptions();
+        $this->assertSame($input, $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsEmptyArrayWhenNoData(): void
+    {
+        $data     = new ArrayData();
+        $expected = [];
+        $actual   = $data->getOptions();
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/unit/Html/Helper/Input/Select/Fake/FakeResultset.php
+++ b/tests/unit/Html/Helper/Input/Select/Fake/FakeResultset.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input\Select\Fake;
+
+use ArrayIterator;
+use Closure;
+use Phalcon\Mvc\Model\ResultsetInterface;
+use Phalcon\Mvc\ModelInterface;
+
+final class FakeResultset extends ArrayIterator implements ResultsetInterface
+{
+    public function delete(Closure | null $conditionCallback = null): bool
+    {
+        return false;
+    }
+
+    public function filter($filter): array
+    {
+        return [];
+    }
+
+    public function getCache(): mixed
+    {
+        return null;
+    }
+
+    public function getFirst(): mixed
+    {
+        return null;
+    }
+
+    public function getHydrateMode(): int
+    {
+        return 0;
+    }
+
+    public function getLast(): ModelInterface | null
+    {
+        return null;
+    }
+
+    public function getMessages(): array
+    {
+        return [];
+    }
+
+    public function getType(): int
+    {
+        return 0;
+    }
+
+    public function isFresh(): bool
+    {
+        return false;
+    }
+
+    public function setHydrateMode(int $hydrateMode): ResultsetInterface
+    {
+        return $this;
+    }
+
+    public function setIsFresh(bool $isFresh): ResultsetInterface
+    {
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return iterator_to_array($this);
+    }
+
+    public function update(mixed $data, Closure | null $conditionCallback = null): bool
+    {
+        return false;
+    }
+}

--- a/tests/unit/Html/Helper/Input/Select/ResultsetDataTest.php
+++ b/tests/unit/Html/Helper/Input/Select/ResultsetDataTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input\Select;
+
+use InvalidArgumentException;
+use Phalcon\Html\Helper\Input\Select\ResultsetData;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Html\Helper\Input\Select\Fake\FakeResultset;
+
+final class ResultsetDataTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testConstructorThrowsOnInvalidUsingCount(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires exactly two values');
+
+        new ResultsetData(new FakeResultset([]), ['id']);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsEmptyArrayForEmptyResultset(): void
+    {
+        $data = new ResultsetData(new FakeResultset([]), ['id', 'name']);
+
+        $this->assertSame([], $data->getOptions());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsValueLabelPairsFromArrayRows(): void
+    {
+        $rows = [
+            ['id' => '1', 'name' => 'Ferrari'],
+            ['id' => '2', 'name' => 'Ford'],
+        ];
+
+        $data     = new ResultsetData(new FakeResultset($rows), ['id', 'name']);
+        $expected = ['1' => 'Ferrari', '2' => 'Ford'];
+
+        $this->assertSame($expected, $data->getOptions());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testGetOptionsReturnsValueLabelPairsFromObjects(): void
+    {
+        $row1 = $this->getMockBuilder(\stdClass::class)
+                     ->addMethods(['readAttribute'])
+                     ->getMock();
+        $row1->method('readAttribute')
+             ->willReturnMap([['id', '1'], ['name', 'Ferrari']]);
+
+        $row2 = $this->getMockBuilder(\stdClass::class)
+                     ->addMethods(['readAttribute'])
+                     ->getMock();
+        $row2->method('readAttribute')
+             ->willReturnMap([['id', '2'], ['name', 'Ford']]);
+
+        $data   = new ResultsetData(new FakeResultset([$row1, $row2]), ['id', 'name']);
+        $actual = $data->getOptions();
+
+        $this->assertSame(['1' => 'Ferrari', '2' => 'Ford'], $actual);
+    }
+}

--- a/tests/unit/Html/Helper/Input/SelectFromDataTest.php
+++ b/tests/unit/Html/Helper/Input/SelectFromDataTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Html\Helper\Input;
+
+use Phalcon\Html\Escaper;
+use Phalcon\Html\Helper\Input\Select;
+use Phalcon\Html\Helper\Input\Select\ArrayData;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+use const PHP_EOL;
+
+final class SelectFromDataTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataRendersFlatOptions(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->fromData(new ArrayData(['1' => 'Ferrari', '2' => 'Ford']));
+
+        $expected = '<select id="cars">' . PHP_EOL
+            . '    <option value="1">Ferrari</option>' . PHP_EOL
+            . '    <option value="2">Ford</option>' . PHP_EOL
+            . '</select>';
+
+        $this->assertSame($expected, (string) $result);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataRendersOptgroups(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->fromData(new ArrayData([
+            'Italian'  => ['1' => 'Ferrari'],
+            'American' => ['2' => 'Ford'],
+        ]));
+
+        $expected = '<select id="cars">' . PHP_EOL
+            . '    <optgroup label="Italian">' . PHP_EOL
+            . '        <option value="1">Ferrari</option>' . PHP_EOL
+            . '    </optgroup>' . PHP_EOL
+            . '    <optgroup label="American">' . PHP_EOL
+            . '        <option value="2">Ford</option>' . PHP_EOL
+            . '    </optgroup>' . PHP_EOL
+            . '</select>';
+
+        $this->assertSame($expected, (string) $result);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataRespectsSelectedValue(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->selected('2');
+        $result->fromData(new ArrayData(['1' => 'Ferrari', '2' => 'Ford']));
+
+        $actual = (string) $result;
+
+        $this->assertStringContainsString('selected="selected"', $actual);
+        $this->assertStringContainsString('value="2"', $actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-17
+     */
+    public function testFromDataWithEmptyArrayRendersEmptySelect(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Select($escaper);
+        $result  = $helper('    ', PHP_EOL, ['id' => 'cars']);
+        $result->fromData(new ArrayData([]));
+
+        $this->assertSame('', (string) $result);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #16894 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Replaces the deprecated `Phalcon\Tag\Select` usage in `Forms\Element\Select::render()` with the `TagFactory`-based `Html\Helper\Input\Select` helper.

Changes:

- Introduces a `SelectDataInterface` with two concrete implementations - `ArrayData` (wraps a plain PHP array) and `ResultsetData` (wraps a `ResultsetInterface` with a two-column using  map) - keeping ORM concerns out of the HTML helper.
- Adds `Html\Helper\Input\Select::fromData()` which iterates the data provider and delegates to existing `add()` / `optGroup()` methods, with full optgroup support for nested arrays.  
- Rewrites `Forms\Element\Select::render()` to use the new helper, preserving all existing behavior: selected value, `useEmpty`/`emptyValue`/`emptyText`, using for resultsets, `id`/`name` attribute handling, and bracket-name detection.                                                                                                                                   
- Moves exception messages out of throw sites into named static factory methods on Forms\Exception (`usingParameterRequired`, `tagFactoryNotFound`).
- Removes the silent last-resort DI fallback in `AbstractElement::getLocalTagFactory()` that constructed a fresh `TagFactory` from scratch; an explicit exception is now thrown when  neither `setTagFactory()` nor the parent Form provides one, with a null guard for environments where no DI container is registered.