### PR TITLE
T15266 paginator group null

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -37,6 +37,7 @@
 - Fixed `Phalcon\Storage\Adapter\Libmemcached`, `Phalcon\Storage\Adapter\Redis` and `Phalcon\Storage\Adapter\Weak` to call `initSerializer()` during construction [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Storage\Adapter\Redis` to initialize `lifetime` from options during construction [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Mvc\Model\Transaction\Manager::commit` to correctly recycle transactions after a commit [#16522](https://github.com/phalcon/cphalcon/issues/16522)
+- Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate` to correctly count when having a `GROUP BY` for `null` columns [#15266](https://github.com/phalcon/cphalcon/issues/15266)
 
 ### Removed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -36,8 +36,9 @@
 - Fixed `Phalcon\Support\Helper\Json\Encode` to prefix the `InvalidArgumentException` message with `"json_encode error: "` for consistency [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Storage\Adapter\Libmemcached`, `Phalcon\Storage\Adapter\Redis` and `Phalcon\Storage\Adapter\Weak` to call `initSerializer()` during construction [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Storage\Adapter\Redis` to initialize `lifetime` from options during construction [#16889](https://github.com/phalcon/cphalcon/issues/16889)
-- Fixed `Phalcon\Mvc\Model\Transaction\Manager::commit` to correctly recycle transactions after a commit [#16522](https://github.com/phalcon/cphalcon/issues/16522)
-- Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate` to correctly count when having a `GROUP BY` for `null` columns [#15266](https://github.com/phalcon/cphalcon/issues/15266)
+- Fixed `Phalcon\Mvc\Model\Transaction\Manager::commit()` to remove each transaction from the pool after committing so that subsequent `get()` calls return a fresh transaction [#16522](https://github.com/phalcon/cphalcon/issues/16522)
+- Fixed `Phalcon\Mvc\Model\Transaction\Manager::collectTransaction()` to keep the correct transactions when rebuilding the list after removal [#16522](https://github.com/phalcon/cphalcon/issues/16522)
+- Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` to use the `columns` option as the `COUNT(DISTINCT ...)` argument when a `GROUP BY` is present, allowing NULL-safe expressions to be supplied [#15266](https://github.com/phalcon/cphalcon/issues/15266)
 
 ### Removed
 

--- a/phalcon/Paginator/Adapter/QueryBuilder.zep
+++ b/phalcon/Paginator/Adapter/QueryBuilder.zep
@@ -47,7 +47,7 @@ class QueryBuilder extends AbstractAdapter
     protected builder;
 
     /**
-     * Columns for count query if builder has having
+     * Columns for count query if builder has having or group by
      *
      * @var array|string
      */
@@ -193,6 +193,10 @@ class QueryBuilder extends AbstractAdapter
             }
 
             if !hasHaving {
+                if !empty columns {
+                    let groupColumn = columns;
+                }
+
                 totalBuilder->groupBy(null)->columns(
                     [
                         "COUNT(DISTINCT " . groupColumn . ") AS [rowcount]"

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateTest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateTest.php
@@ -24,6 +24,7 @@ use Phalcon\Tests\Support\Migrations\InvoicesMigration;
 use Phalcon\Tests\Support\Models\Invoices;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
+use function date;
 use function is_int;
 
 /**
@@ -162,6 +163,62 @@ final class PaginateTest extends AbstractDatabaseTestCase
         $this->assertEquals(5, $page->limit);
         $this->assertEquals(17, $page->getTotalItems());
         $this->assertTrue(is_int($page->getTotalItems()));
+    }
+
+    /**
+     * Tests Phalcon\Paginator\Adapter\QueryBuilder :: paginate() - groupBy with
+     * NULL column values and the columns option to handle them
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-21
+     *
+     * @issue  15266
+     * @group mysql
+     */
+    public function testPaginatorAdapterQuerybuilderPaginateGroupByNullColumnsOption(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+        $migration  = new InvoicesMigration($connection);
+
+        $this->insertDataInvoices($migration, 2, 'default', 1, 'grp1');
+        $this->insertDataInvoices($migration, 2, 'default', 2, 'grp2');
+
+        $now = date('Y-m-d H:i:s');
+        $connection->exec(
+            "INSERT INTO co_invoices "
+            . "(inv_cst_id, inv_status_flag, inv_title, inv_total, inv_created_at) "
+            . "VALUES (NULL, 1, 'grp-null-1', 0, '{$now}')"
+        );
+        $connection->exec(
+            "INSERT INTO co_invoices "
+            . "(inv_cst_id, inv_status_flag, inv_title, inv_total, inv_created_at) "
+            . "VALUES (NULL, 1, 'grp-null-2', 0, '{$now}')"
+        );
+
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->columns(['inv_cst_id'])
+            ->from(Invoices::class)
+            ->groupBy('inv_cst_id')
+        ;
+
+        $paginator = new QueryBuilder(
+            [
+                'builder' => $builder,
+                'limit'   => 5,
+                'page'    => 1,
+                'columns' => 'IFNULL(inv_cst_id, 0)',
+            ]
+        );
+
+        $page = $paginator->paginate();
+
+        $this->assertInstanceOf(Repository::class, $page);
+        $this->assertCount(3, $page->getItems());
+        $this->assertSame(3, $page->getTotalItems());
+        $this->assertSame(1, $page->getLast());
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15266 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate` to correctly count when having a `GROUP BY` for `null` columns

Thanks

