### PR TITLE
T15554 reusable

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -39,6 +39,7 @@
 - Fixed `Phalcon\Mvc\Model\Transaction\Manager::commit()` to remove each transaction from the pool after committing so that subsequent `get()` calls return a fresh transaction [#16522](https://github.com/phalcon/cphalcon/issues/16522)
 - Fixed `Phalcon\Mvc\Model\Transaction\Manager::collectTransaction()` to keep the correct transactions when rebuilding the list after removal [#16522](https://github.com/phalcon/cphalcon/issues/16522)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` to use the `columns` option as the `COUNT(DISTINCT ...)` argument when a `GROUP BY` is present, allowing NULL-safe expressions to be supplied [#15266](https://github.com/phalcon/cphalcon/issues/15266)
+- Fixed `Phalcon\Mvc\Model::__get()` to return the already-loaded related record instead of re-fetching from the database, preventing modifications to relation properties from being discarded [#15554](https://github.com/phalcon/cphalcon/issues/15554)
 
 ### Removed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -327,6 +327,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
 
             /**
+             * Return already-loaded related records to avoid overwriting
+             * any modifications made to the object between accesses
+             */
+            if isset this->related[lowerProperty] {
+                return this->related[lowerProperty];
+            }
+
+            /**
              * Get the related records
              */
             return this->getRelated(lowerProperty);

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -327,11 +327,16 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
 
             /**
-             * Return already-loaded related records to avoid overwriting
-             * any modifications made to the object between accesses
+             * Return an already-loaded single model for non-reusable relations to
+             * avoid overwriting modifications made to the object between accesses.
+             * Resultsets (hasMany) are never returned from this cache because they
+             * can go stale after external deletes; reusable relations delegate
+             * caching to the models manager.
              */
-            if isset this->related[lowerProperty] {
-                return this->related[lowerProperty];
+            if isset this->related[lowerProperty] && !relation->isReusable() {
+                if typeof this->related[lowerProperty] === "object" && (this->related[lowerProperty] instanceof ModelInterface) {
+                    return this->related[lowerProperty];
+                }
             }
 
             /**

--- a/tests/database/Mvc/Model/DeleteTest.php
+++ b/tests/database/Mvc/Model/DeleteTest.php
@@ -157,9 +157,6 @@ final class DeleteTest extends AbstractDatabaseTestCase
         $customersMigration = new CustomersMigration($connection);
         $customersMigration->insert($custId, 0, $firstName, $lastName);
 
-        $paidInvoiceId   = 40;
-        $unpaidInvoiceId = 50;
-
         $title = uniqid('inv-');
 
         /**

--- a/tests/database/Mvc/Model/SaveTest.php
+++ b/tests/database/Mvc/Model/SaveTest.php
@@ -25,6 +25,7 @@ use Phalcon\Tests\Support\Models\Customers;
 use Phalcon\Tests\Support\Models\CustomersDefaults;
 use Phalcon\Tests\Support\Models\CustomersKeepSnapshots;
 use Phalcon\Tests\Support\Models\Invoices;
+use Phalcon\Tests\Support\Models\InvoicesHasOneNotReusable;
 use Phalcon\Tests\Support\Models\InvoicesKeepSnapshots;
 use Phalcon\Tests\Support\Models\InvoicesSchema;
 use Phalcon\Tests\Support\Models\InvoicesValidationFails;
@@ -350,6 +351,37 @@ final class SaveTest extends AbstractDatabaseTestCase
         $this->assertNotNull($actual);
         $actual = $customer->cst_id;
         $this->assertNotNull($actual);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-21
+     *
+     * @issue  15554
+     * @group mysql
+     */
+    public function testMvcModelSaveMultipleChangedRelationValues(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert(77, 1, 0, uniqid('inv-', true));
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->insert(1, 1, 'firstName', 'lastName');
+
+        $invoice = InvoicesHasOneNotReusable::findFirst(77);
+
+        $invoice->customer->cst_name_first  = 'newFirstName';
+        $invoice->customer->cst_status_flag = 0;
+
+        $this->assertTrue($invoice->save());
+
+        $customer = Customers::findFirst(1);
+
+        $this->assertSame('newFirstName', $customer->cst_name_first);
+        $this->assertSame(0, (int) $customer->cst_status_flag);
     }
 
     /**

--- a/tests/support/Models/InvoicesHasOneNotReusable.php
+++ b/tests/support/Models/InvoicesHasOneNotReusable.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+use Phalcon\Mvc\Model;
+
+class InvoicesHasOneNotReusable extends Model
+{
+    public $inv_id;
+    public $inv_cst_id;
+    public $inv_status_flag;
+    public $inv_title;
+    public $inv_total;
+    public $inv_created_at;
+
+    public function initialize()
+    {
+        $this->setSource('co_invoices');
+
+        $this->hasOne(
+            'inv_cst_id',
+            Customers::class,
+            'cst_id',
+            [
+                'alias'    => 'customer',
+                'reusable' => false,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #15554 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::__get()` to return the already-loaded related record instead of re-fetching from the database, preventing modifications to relation properties from being discarded
Thanks

