### PR TITLE
[#15711] Fix toArray() and unserialize() for typed PHP properties that are uninitialized

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -40,6 +40,8 @@
 - Fixed `Phalcon\Mvc\Model\Transaction\Manager::collectTransaction()` to keep the correct transactions when rebuilding the list after removal [#16522](https://github.com/phalcon/cphalcon/issues/16522)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` to use the `columns` option as the `COUNT(DISTINCT ...)` argument when a `GROUP BY` is present, allowing NULL-safe expressions to be supplied [#15266](https://github.com/phalcon/cphalcon/issues/15266)
 - Fixed `Phalcon\Mvc\Model::__get()` to return the already-loaded related record instead of re-fetching from the database, preventing modifications to relation properties from being discarded [#15554](https://github.com/phalcon/cphalcon/issues/15554)
+- Fixed `Phalcon\Mvc\Model::toArray()` to catch `Error` thrown by a getter that accesses an uninitialized typed PHP property (can occur when `cloneResultMap()` skips a null value for a `NOT NULL` column, e.g. via a `LEFT JOIN`), returning `null` instead of propagating the error [#15711](https://github.com/phalcon/cphalcon/issues/15711)
+- Fixed `Phalcon\Mvc\Model::unserialize()` to catch `TypeError` when assigning a serialised `null` back to a typed non-nullable PHP property, preventing a crash on the second request when the model is loaded from a cache like APCu [#15711](https://github.com/phalcon/cphalcon/issues/15711)
 
 ### Removed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -2894,10 +2894,18 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              */
             if fetch properties, attributes["attributes"] {
                 /**
-                 * Update the objects properties
+                 * Update the objects properties. A TypeError can be thrown
+                 * when assigning null to a typed non-nullable PHP property
+                 * (e.g. int $id) because the serialised value was null due
+                 * to the property being uninitialized at serialize() time.
+                 * Skip such assignments gracefully.
                  */
                 for key, value in properties {
-                    let this->{key} = value;
+                    try {
+                        let this->{key} = value;
+                    } catch \TypeError {
+                        // Incompatible value for typed property – leave as-is
+                    }
                 }
             } else {
                 let properties = [];
@@ -3361,7 +3369,17 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              * Do not use the getter if the field name is `source` (getSource)
              */
             if true === useGetter && "getSource" !== method && method_exists(this, method) {
-                let data[attributeField] = this->{method}();
+                /**
+                 * A getter may access a typed property that was never
+                 * initialized (e.g. because cloneResultMap() skipped a null
+                 * value for a NOT NULL column). Catch the resulting Error and
+                 * return null rather than letting it propagate.
+                 */
+                try {
+                    let data[attributeField] = this->{method}();
+                } catch \Error {
+                    let data[attributeField] = null;
+                }
             } elseif isset(this->{attributeField}) {
                 let data[attributeField] = this->{attributeField};
             } else {

--- a/tests/database/Mvc/Model/SerializeTest.php
+++ b/tests/database/Mvc/Model/SerializeTest.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Database\Mvc\Model;
 
 use PDO;
+use Phalcon\Mvc\Model;
 use Phalcon\Tests\AbstractDatabaseTestCase;
 use Phalcon\Tests\Support\Migrations\InvoicesMigration;
 use Phalcon\Tests\Support\Models\Invoices;
+use Phalcon\Tests\Support\Models\InvoicesTypedProperties;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
 use function date;
@@ -70,6 +72,112 @@ final class SerializeTest extends AbstractDatabaseTestCase
         $this->assertEquals($title, $newObject->inv_title);
         $this->assertEquals(100.12, $newObject->inv_total);
         $this->assertEquals($date, $newObject->inv_created_at);
+    }
+
+    /**
+     * Tests that toArray() with a getter does not throw when a typed
+     * non-nullable property is uninitialized (e.g. because cloneResultMap
+     * skipped its assignment when the DB returned NULL for a NOT NULL column).
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/15711
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-22
+     *
+     * @group mysql
+     */
+    public function testMvcModelToArrayWithUninitializedTypedPropertyAndGetter(): void
+    {
+        $base     = new InvoicesTypedProperties();
+        $metadata = $base->getModelsMetaData();
+        $colMap   = $metadata->getColumnMap($base);
+
+        /**
+         * Simulate a LEFT JOIN result where the primary key (NOT NULL in DB)
+         * comes back as NULL. cloneResultMap() will skip the assignment for
+         * inv_id, leaving the typed public int $inv_id uninitialized.
+         */
+        /** @var InvoicesTypedProperties $instance */
+        $instance = Model::cloneResultMap(
+            $base,
+            [
+                'inv_id'          => null,
+                'inv_cst_id'      => 1,
+                'inv_status_flag' => 0,
+                'inv_title'       => 'test-title',
+                'inv_total'       => 9.99,
+                'inv_created_at'  => '2026-01-01 00:00:00',
+            ],
+            $colMap
+        );
+
+        /**
+         * toArray() with useGetter=true (the default) will call getInvId().
+         * getInvId() accesses the uninitialized typed $inv_id property.
+         * After the fix this must return null instead of throwing.
+         */
+        $arr = $instance->toArray();
+
+        $this->assertNull($arr['inv_id']);
+        $this->assertSame('test-title', $arr['inv_title']);
+    }
+
+    /**
+     * Tests that serialize()/unserialize() round-trips a model with typed
+     * properties correctly when a NOT NULL DB column returned NULL (leaving
+     * the typed property uninitialized). The unserialized instance must not
+     * throw TypeError when the serialised value is null.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/15711
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-22
+     *
+     * @group mysql
+     */
+    public function testMvcModelSerializeUnserializeWithTypedNullProperty(): void
+    {
+        $title  = uniqid('inv-');
+        $date   = date('Y-m-d H:i:s');
+        $base   = new InvoicesTypedProperties();
+
+        $invoice             = new InvoicesTypedProperties();
+        $invoice->inv_id     = 99;
+        $invoice->inv_title  = $title;
+        $invoice->inv_total  = 50.0;
+        $invoice->inv_created_at = $date;
+
+        $serialized = serialize($invoice);
+        /** @var InvoicesTypedProperties $restored */
+        $restored = unserialize($serialized);
+
+        $this->assertSame($title, $restored->inv_title);
+        $this->assertSame(50.0, $restored->inv_total);
+        $this->assertSame($date, $restored->inv_created_at);
+
+        /**
+         * Now simulate the unserialize path where null is stored for the
+         * typed non-nullable property (because cloneResultMap skipped it).
+         * The direct PHP serialize/unserialize cycle should not throw.
+         */
+        $raw        = unserialize(serialize($invoice));
+        $serialized = $raw->serialize();
+
+        /**
+         * Tamper: inject null for inv_id to mimic what happens when toArray()
+         * returns null for an uninitialized typed property.
+         */
+        $data               = unserialize($serialized);
+        $data['attributes']['inv_id'] = null;
+        $tamperedSerialized = serialize($data);
+
+        $fresh = new InvoicesTypedProperties();
+        $fresh->unserialize($tamperedSerialized);
+
+        /**
+         * After the fix, unserialize() must not throw TypeError. The value
+         * of inv_id will be uninitialized or null but the object is usable.
+         */
+        $arr = $fresh->toArray();
+        $this->assertNull($arr['inv_id']);
     }
 
     /**

--- a/tests/support/Models/InvoicesTypedProperties.php
+++ b/tests/support/Models/InvoicesTypedProperties.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * Model used to test serialization and toArray() with PHP typed properties.
+ *
+ * The inv_id column is NOT NULL in the database schema. When a query (e.g. a
+ * LEFT JOIN with no matching row) returns NULL for it, cloneResultMap() skips
+ * the assignment, leaving the typed property uninitialized. This model
+ * exposes that edge-case via the getInvId() getter.
+ *
+ * @see https://github.com/phalcon/cphalcon/issues/15711
+ */
+class InvoicesTypedProperties extends Model
+{
+    public const STATUS_INACTIVE = 2;
+    public const STATUS_PAID     = 1;
+    public const STATUS_UNPAID   = 0;
+
+    public int $inv_id;
+
+    public ?int $inv_cst_id = null;
+
+    public ?int $inv_status_flag = null;
+
+    public ?string $inv_title = null;
+
+    public ?float $inv_total = null;
+
+    public ?string $inv_created_at = null;
+
+    public function initialize(): void
+    {
+        $this->setSource('co_invoices');
+    }
+
+    public function getInvId(): int
+    {
+        return $this->inv_id;
+    }
+
+    public function getInvTitle(): ?string
+    {
+        return $this->inv_title;
+    }
+
+    public function setInvTitle(?string $title): void
+    {
+        $this->inv_title = $title;
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/issues/15711

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

### Root Cause

When a query result (e.g. from a LEFT JOIN with no matching row) returns `NULL` for a column that is `NOT NULL` in the database schema, `cloneResultMap()` deliberately skips the property assignment to avoid a `TypeError`. This leaves any typed non-nullable PHP property (e.g. `public int $inv_id`) **uninitialized**.

Two downstream failures then occur:

**Bug 1 — `toArray()` with a getter**

If the model defines a getter for the property (e.g. `getInvId()`), calling `toArray()` with the default `useGetter = true` invokes that getter, which reads the uninitialized typed property and throws:
> `Error: Typed property ... must not be accessed before initialization`

This is the error reported in the issue stack trace (occurring during `Apcu->set()` on the first request).

**Bug 2 — `unserialize()`**

Because `toArray()` returns `null` for an uninitialized property (via the `isset()` fallback path), the serialised data stores `inv_id => null`. On the next request, `unserialize()` tries to assign that null back to `public int $inv_id`, throwing:
> `TypeError: Cannot assign null to property of type int`

### Fixes

- **`Model::toArray()`**: wrap the getter call in `try/catch \Error` so that accessing an uninitialized typed property through a getter returns `null` instead of propagating.
- **`Model::unserialize()`**: wrap each property assignment in `try/catch \TypeError` so that restoring a `null` value into a typed non-nullable property is silently skipped rather than crashing.

Thanks