### PR TITLE
T16350 raw value

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -46,6 +46,7 @@
 - Fixed `Phalcon\Filter\Validation\AbstractValidator::allowEmpty()` to support a value-list array (e.g. `[null, '']`) in addition to the per-field map syntax, using strict `===` comparison so that `'0'` is never silently treated as empty [#15491](https://github.com/phalcon/cphalcon/issues/15491)
 - Fixed `Phalcon\Filter\Validation\Validator\Alpha::validate()` to return `false` when `allowEmpty` is explicitly set to `false` and the submitted value is `null` or an empty string [#16200](https://github.com/phalcon/cphalcon/issues/16200)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql()` to use a named bind parameter (`:APK0:`) instead of embedding the raw primary-key value in the PHQL string when `findFirst()` is called with a numeric or numeric-string argument; this prevents unbounded growth of the internal PHQL AST cache (`Query::$internalPhqlCache`) in long-running CLI processes [#14656](https://github.com/phalcon/cphalcon/issues/14656)
+- Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to embed `Phalcon\Db\RawValue` bind parameters directly in the SQL string instead of passing them to PDO [#16350](https://github.com/phalcon/cphalcon/issues/16350)
 
 ### Removed
 

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -1229,6 +1229,23 @@ class Query implements QueryInterface, InjectionAwareInterface
         }
 
         /**
+         * Embed RawValue bind params directly in the SQL instead of passing
+         * them to PDO, which would quote them as strings.
+         */
+        for wildcard, value in processed {
+            if typeof value == "object" && value instanceof RawValue {
+                if substr(wildcard, 0, 1) === ":" {
+                    let sqlSelect = str_replace(wildcard, (string) value, sqlSelect);
+                } else {
+                    let sqlSelect = str_replace(":" . wildcard, (string) value, sqlSelect);
+                }
+
+                unset processed[wildcard];
+                unset processedTypes[wildcard];
+            }
+        }
+
+        /**
          * Return the SQL to be executed instead of execute it
          */
         if simulate {

--- a/tests/database/Mvc/Model/FindFirstTest.php
+++ b/tests/database/Mvc/Model/FindFirstTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Database\Mvc\Model;
 
 use PDO;
+use Phalcon\Db\RawValue;
 use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Mvc\Model\Row;
@@ -406,5 +407,36 @@ final class FindFirstTest extends AbstractDatabaseTestCase
         $model = ModelWithStringPrimary::findFirst($params);
 
         $this->assertSame($found, $model instanceof Model);
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/16350
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-23
+     *
+     * @group mysql
+     */
+    public function testMvcModelFindFirstWithRawValueBind(): void
+    {
+        $connection = self::getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $migration->insert(4, null, 1, 'test-raw-value', 100, '2000-01-01 00:00:00');
+
+        $invoice = Invoices::findFirst(
+            [
+                'conditions' => 'inv_created_at <= :date: AND inv_status_flag = :status:',
+                'bind'       => [
+                    'date'   => new RawValue('NOW()'),
+                    'status' => 1,
+                ],
+            ]
+        );
+
+        $this->assertNotNull($invoice);
+        $this->assertInstanceOf(Invoices::class, $invoice);
+
+        $expected = 4;
+        $actual   = $invoice->inv_id;
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/database/Mvc/Model/FindTest.php
+++ b/tests/database/Mvc/Model/FindTest.php
@@ -16,6 +16,7 @@ namespace Phalcon\Tests\Database\Mvc\Model;
 use PDO;
 use Phalcon\Cache\AdapterFactory;
 use Phalcon\Cache\Cache;
+use Phalcon\Db\RawValue;
 use Phalcon\Mvc\Model\Exception;
 use Phalcon\Mvc\Router;
 use Phalcon\Storage\SerializerFactory;
@@ -572,5 +573,34 @@ final class FindTest extends AbstractDatabaseTestCase
 
         $data = $modelsCache->get('my-cache');
         $this->assertNull($data);
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/16350
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-23
+     *
+     * @group mysql
+     */
+    public function testMvcModelFindWithRawValueBind(): void
+    {
+        $connection = self::getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $migration->insert(1, null, 1, 'raw-value-one', 100, '2000-01-01 00:00:00');
+        $migration->insert(2, null, 1, 'raw-value-two', 200, '2000-06-01 00:00:00');
+        $migration->insert(3, null, 0, 'raw-value-three', 50, '2000-01-01 00:00:00');
+
+        $invoices = Invoices::find(
+            [
+                'conditions' => 'inv_created_at <= :date: AND inv_status_flag = :status:',
+                'bind'       => [
+                    'date'   => new RawValue('NOW()'),
+                    'status' => 1,
+                ],
+            ]
+        );
+
+        $this->assertNotNull($invoices);
+        $this->assertCount(2, $invoices);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16350 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to embed `Phalcon\Db\RawValue` bind parameters directly in the SQL string instead of passing them to PDO

Thanks

