### PR TITLE
T15934 reusable cache

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -27,6 +27,7 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords()` to apply reusable caching for `hasManyToMany` and `hasOneThrough` relations; `reusable: true` was previously ignored for through-relations [#15934](https://github.com/phalcon/cphalcon/issues/15934)
 - Fixed `Phalcon\Filter\Validation\AbstractValidator::messageFactory()` to pass the joined field string to `Phalcon\Messages\Message` instead of the raw array when multiple fields are provided [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Filter\Validation::bind()` to skip the dependency injection container lookup when `data` is empty, preventing unnecessary `Di\Exception` errors [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Forms\Form::isValid()` to apply field filters even when no validators are specified (again) [#16830](https://github.com/phalcon/cphalcon/issues/16830)

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1436,16 +1436,35 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
              */
             let query = <QueryInterface> builder->getQuery();
 
+            let reusable = (bool) relation->isReusable();
+
+            if reusable {
+                let uniqueKey = unique_key(referencedModel, [intermediateModel, parameters, record->readAttribute(fields)]),
+                    records = this->getReusableRecords(referencedModel, uniqueKey);
+
+                if typeof records == "array" || typeof records == "object" {
+                    return records;
+                }
+            }
+
             switch relation->getType() {
                 case Relation::HAS_MANY_THROUGH:
-                    return query->execute();
+                    let records = query->execute();
+                    break;
 
                 case Relation::HAS_ONE_THROUGH:
-                    return query->setUniqueRow(true)->execute();
+                    let records = query->setUniqueRow(true)->execute();
+                    break;
 
                 default:
                     throw new Exception("Unknown relation type");
             }
+
+            if reusable {
+                this->setReusableRecords(referencedModel, uniqueKey, records);
+            }
+
+            return records;
         }
 
         let conditions = [];

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -128,6 +128,11 @@ interface ManagerInterface
     public function createQuery(string! phql) -> <QueryInterface>;
 
     /**
+     * Clears the internal reusable list
+     */
+    public function clearReusableObjects() -> void;
+
+    /**
      * Creates a Phalcon\Mvc\Model\Query and execute it
      *
      * @param array|null $placeholders
@@ -285,6 +290,16 @@ interface ManagerInterface
     public function getRelationsBetween(string! first, string! second) -> <RelationInterface[]> | bool;
 
     /**
+     * Returns a reusable object from the internal list
+     *
+     * @param string $modelName
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function getReusableRecords(string! modelName, string! key);
+
+    /**
      * Returns the connection to write data related to a model
      */
     public function getWriteConnection(<ModelInterface> model) -> <AdapterInterface>;
@@ -386,6 +401,17 @@ interface ManagerInterface
      * Sets read connection service for a model
      */
     public function setReadConnectionService(<ModelInterface> model, string! connectionService) -> void;
+
+    /**
+     * Stores a reusable record in the internal list
+     *
+     * @param string $modelName
+     * @param string $key
+     * @param mixed  $records
+     *
+     * @return void
+     */
+    public function setReusableRecords(string! modelName, string! key, var records) -> void;
 
     /**
      * Sets the mapped schema for a model

--- a/tests/database/Mvc/Model/Manager/ClearReusableObjectsTest.php
+++ b/tests/database/Mvc/Model/Manager/ClearReusableObjectsTest.php
@@ -13,16 +13,45 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Database\Mvc\Model\Manager;
 
+use Phalcon\Mvc\Model\Manager;
 use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Traits\DiTrait;
 
 final class ClearReusableObjectsTest extends AbstractDatabaseTestCase
 {
+    use DiTrait;
+
+    public function setUp(): void
+    {
+        $this->setNewFactoryDefault();
+    }
+
     /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
+     *
+     * @group  sqlite
+     * @group  mysql
+     * @group  pgsql
      */
     public function testMvcModelManagerClearReusableObjects(): void
     {
-        $this->markTestSkipped('Need implementation');
+        /** @var Manager $manager */
+        $manager = $this->container->get('modelsManager');
+
+        $records = ['record1', 'record2'];
+        $manager->setReusableRecords('SomeModel', 'key-abc', $records);
+        $manager->setReusableRecords('OtherModel', 'key-def', $records);
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-abc');
+        $this->assertSame($records, $actual);
+
+        $manager->clearReusableObjects();
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-abc');
+        $this->assertNull($actual);
+
+        $actual = $manager->getReusableRecords('OtherModel', 'key-def');
+        $this->assertNull($actual);
     }
 }

--- a/tests/database/Mvc/Model/Manager/GetReusableRecordsTest.php
+++ b/tests/database/Mvc/Model/Manager/GetReusableRecordsTest.php
@@ -13,16 +13,39 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Database\Mvc\Model\Manager;
 
+use Phalcon\Mvc\Model\Manager;
 use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Traits\DiTrait;
 
 final class GetReusableRecordsTest extends AbstractDatabaseTestCase
 {
+    use DiTrait;
+
+    public function setUp(): void
+    {
+        $this->setNewFactoryDefault();
+    }
+
     /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
+     *
+     * @group  sqlite
+     * @group  mysql
+     * @group  pgsql
      */
     public function testMvcModelManagerGetReusableRecords(): void
     {
-        $this->markTestSkipped('Need implementation');
+        /** @var Manager $manager */
+        $manager = $this->container->get('modelsManager');
+
+        $records = ['record1', 'record2'];
+        $manager->setReusableRecords('SomeModel', 'key-xyz', $records);
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-xyz');
+        $this->assertSame($records, $actual);
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-missing');
+        $this->assertNull($actual);
     }
 }

--- a/tests/database/Mvc/Model/Manager/SetReusableRecordsTest.php
+++ b/tests/database/Mvc/Model/Manager/SetReusableRecordsTest.php
@@ -13,16 +13,37 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Database\Mvc\Model\Manager;
 
+use Phalcon\Mvc\Model\Manager;
 use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Traits\DiTrait;
 
 final class SetReusableRecordsTest extends AbstractDatabaseTestCase
 {
+    use DiTrait;
+
+    public function setUp(): void
+    {
+        $this->setNewFactoryDefault();
+    }
+
     /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13
+     *
+     * @group  sqlite
+     * @group  mysql
+     * @group  pgsql
      */
     public function testMvcModelManagerSetReusableRecords(): void
     {
-        $this->markTestSkipped('Need implementation');
+        /** @var Manager $manager */
+        $manager = $this->container->get('modelsManager');
+
+        $records = ['record1', 'record2'];
+
+        $manager->setReusableRecords('SomeModel', 'key-abc', $records);
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-abc');
+        $this->assertSame($records, $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15934 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords()` to apply reusable caching for `hasManyToMany` and `hasOneThrough` relations; `reusable: true` was previously ignored for through-relations

Thanks

