### PR TITLE
T15906 onconstruct cached model

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -27,6 +27,8 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model::__unserialize()` and `Phalcon\Mvc\Model::unserialize()` to call `onConstruct()` after deserialization, so typed properties initialized in `onConstruct` are correctly set when a model is restored from cache [#15906](https://github.com/phalcon/cphalcon/issues/15906)
+- Fixed `Phalcon\Mvc\Model::__unserialize()` and `Phalcon\Mvc\Model::unserialize()` to restore snapshot as the current attributes (instead of null) when a model is deserialized with no pending changes, preventing `getChangedFields()` from throwing after cache retrieval [#15837](https://github.com/phalcon/cphalcon/issues/15837)
 - Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords()` to apply reusable caching for `hasManyToMany` and `hasOneThrough` relations; `reusable: true` was previously ignored for through-relations [#15934](https://github.com/phalcon/cphalcon/issues/15934)
 - Fixed `Phalcon\Filter\Validation\AbstractValidator::messageFactory()` to pass the joined field string to `Phalcon\Messages\Message` instead of the raw array when multiple fields are provided [#16889](https://github.com/phalcon/cphalcon/issues/16889)
 - Fixed `Phalcon\Filter\Validation::bind()` to skip the dependency injection container lookup when `data` is empty, preventing unnecessary `Di\Exception` errors [#16889](https://github.com/phalcon/cphalcon/issues/16889)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -594,6 +594,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         manager->initialize(this);
 
         /**
+         * Allow the developer to run initialization code every time
+         * the model is instantiated, including when restored from cache
+         */
+        if method_exists(this, "onConstruct") {
+            this->{"onConstruct"}();
+        }
+
+        /**
          * Fetch serialized props
          */
         if fetch properties, data["attributes"] {
@@ -615,11 +623,13 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         }
 
         /**
-         * Fetch serialized snapshot when option is active
+         * Fetch serialized snapshot when option is active.
+         * When attributes == snapshot at serialize-time, snapshot is stored
+         * as null. Treat null as "no changes" and fall back to properties.
          */
         if manager->isKeepingSnapshots(this) {
             if fetch snapshot, data["snapshot"] {
-                let this->snapshot = snapshot;
+                let this->snapshot = (snapshot !== null) ? snapshot : properties;
             } else {
                 let this->snapshot = properties;
             }
@@ -2932,6 +2942,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             manager->initialize(this);
 
             /**
+             * Allow the developer to run initialization code every time
+             * the model is instantiated, including when restored from cache
+             */
+            if method_exists(this, "onConstruct") {
+                this->{"onConstruct"}();
+            }
+
+            /**
              * Fetch serialized props
              */
             if fetch properties, attributes["attributes"] {
@@ -2961,11 +2979,13 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
 
             /**
-             * Fetch serialized snapshot when option is active
+             * Fetch serialized snapshot when option is active.
+             * When attributes == snapshot at serialize-time, snapshot is stored
+             * as null. Treat null as "no changes" and fall back to properties.
              */
             if manager->isKeepingSnapshots(this) {
                 if fetch snapshot, attributes["snapshot"] {
-                    let this->snapshot = snapshot;
+                    let this->snapshot = (snapshot !== null) ? snapshot : properties;
                 } else {
                     let this->snapshot = properties;
                 }

--- a/tests/database/Mvc/Model/SerializeTest.php
+++ b/tests/database/Mvc/Model/SerializeTest.php
@@ -18,6 +18,8 @@ use Phalcon\Mvc\Model;
 use Phalcon\Tests\AbstractDatabaseTestCase;
 use Phalcon\Tests\Support\Migrations\InvoicesMigration;
 use Phalcon\Tests\Support\Models\Invoices;
+use Phalcon\Tests\Support\Models\InvoicesKeepSnapshots;
+use Phalcon\Tests\Support\Models\InvoicesOnConstruct;
 use Phalcon\Tests\Support\Models\InvoicesTypedProperties;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
@@ -210,5 +212,75 @@ final class SerializeTest extends AbstractDatabaseTestCase
         /** @var Invoices $newObject */
         $newObject = unserialize($serialized);
         $this->assertEquals(0, $newObject->getDirtyState());
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/15906
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-23
+     *
+     * @group  mysql
+     * @group  sqlite
+     */
+    public function testMvcModelUnserializeCallsOnConstruct(): void
+    {
+        $title = uniqid('inv-');
+        $date  = date('Y-m-d H:i:s');
+
+        $invoice                 = new InvoicesOnConstruct();
+        $invoice->inv_cst_id     = 1;
+        $invoice->inv_status_flag = 0;
+        $invoice->inv_title      = $title;
+        $invoice->inv_total      = 10.0;
+        $invoice->inv_created_at = $date;
+        $invoice->save();
+
+        // old-style serialize/unserialize
+        $serialized = $invoice->serialize();
+        $restored   = new InvoicesOnConstruct();
+        $restored->unserialize($serialized);
+
+        $this->assertSame('initialized', $restored->onConstructLabel);
+
+        // PHP 8 __serialize/__unserialize
+        $phpSerialized = serialize($invoice);
+        /** @var InvoicesOnConstruct $phpRestored */
+        $phpRestored = unserialize($phpSerialized);
+
+        $this->assertSame('initialized', $phpRestored->onConstructLabel);
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/15837
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-23
+     *
+     * @group  mysql
+     * @group  sqlite
+     */
+    public function testMvcModelUnserializeRestoresNullSnapshot(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+        (new InvoicesMigration($connection))->insert(10, 1, 0, uniqid('inv-'));
+
+        $invoice = InvoicesKeepSnapshots::findFirst(10);
+        $this->assertNotFalse($invoice);
+
+        // old-style serialize/unserialize
+        $serialized = $invoice->serialize();
+        $restored   = new InvoicesKeepSnapshots();
+        $restored->unserialize($serialized);
+
+        $this->assertIsArray($restored->getChangedFields());
+        $this->assertEmpty($restored->getChangedFields());
+
+        // PHP 8 __serialize/__unserialize
+        $phpSerialized = serialize($invoice);
+        /** @var InvoicesKeepSnapshots $phpRestored */
+        $phpRestored = unserialize($phpSerialized);
+
+        $this->assertIsArray($phpRestored->getChangedFields());
+        $this->assertEmpty($phpRestored->getChangedFields());
     }
 }

--- a/tests/support/Models/InvoicesOnConstruct.php
+++ b/tests/support/Models/InvoicesOnConstruct.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+class InvoicesOnConstruct extends Invoices
+{
+    public ?string $onConstructLabel = null;
+
+    public function onConstruct(): void
+    {
+        $this->onConstructLabel = 'initialized';
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15837 #15906 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::__unserialize()` and `Phalcon\Mvc\Model::unserialize()` to call `onConstruct()` after deserialization, so typed properties initialized in `onConstruct` are correctly set when a model is restored from cache 

Fixed `Phalcon\Mvc\Model::__unserialize()` and `Phalcon\Mvc\Model::unserialize()` to restore snapshot as the current attributes (instead of null) when a model is deserialized with no pending changes, preventing `getChangedFields()` from throwing after cache retrieval
