### PR TITLE
T16304 assets inline

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -27,6 +27,7 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Html\Helper\AbstractHelper::renderAttributes()` to emit boolean HTML5 attributes (e.g. `async`, `defer`) as standalone attribute names instead of `async="1"` when the attribute value is `true` [#16304](https://github.com/phalcon/cphalcon/issues/16304)
 - Fixed `Phalcon\Mvc\Model::__unserialize()` and `Phalcon\Mvc\Model::unserialize()` to call `onConstruct()` after deserialization, so typed properties initialized in `onConstruct` are correctly set when a model is restored from cache [#15906](https://github.com/phalcon/cphalcon/issues/15906)
 - Fixed `Phalcon\Mvc\Model::__unserialize()` and `Phalcon\Mvc\Model::unserialize()` to restore snapshot as the current attributes (instead of null) when a model is deserialized with no pending changes, preventing `getChangedFields()` from throwing after cache retrieval [#15837](https://github.com/phalcon/cphalcon/issues/15837)
 - Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords()` to apply reusable caching for `hasManyToMany` and `hasOneThrough` relations; `reusable: true` was previously ignored for through-relations [#15934](https://github.com/phalcon/cphalcon/issues/15934)

--- a/phalcon/Html/Helper/AbstractHelper.zep
+++ b/phalcon/Html/Helper/AbstractHelper.zep
@@ -160,7 +160,11 @@ abstract class AbstractHelper
         let result = "";
         for key, value in attributes {
             if typeof key === "string" && null !== value {
-                let result .= key . "=\"" . this->escaper->attributes(value) . "\" ";
+                if (true === value) {
+                    let result .= key . " ";
+                } else {
+                    let result .= key . "=\"" . this->escaper->attributes(value) . "\" ";
+                }
             }
         }
 

--- a/tests/unit/Html/Helper/Script/UnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/Script/UnderscoreInvokeTest.php
@@ -63,6 +63,18 @@ final class UnderscoreInvokeTest extends AbstractUnitTestCase
                 . "--<script type=\"application/javascript\" "
                 . "src=\"/js/print.js\" ie=\"active\"></script>+",
             ],
+            [
+                '',
+                PHP_EOL,
+                [
+                    [
+                        "/js/sdk.js",
+                        ['async' => true, 'defer' => true, 'nonce' => '12345'],
+                    ],
+                ],
+                "<script type=\"application/javascript\" src=\"/js/sdk.js\""
+                . " async defer nonce=\"12345\"></script>" . PHP_EOL,
+            ],
         ];
     }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16304 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Html\Helper\AbstractHelper::renderAttributes()` to emit boolean HTML5 attributes (e.g. `async`, `defer`) as standalone attribute names instead of `async="1"` when the attribute value is `true` 
Thanks

