### PR TITLE
T16453 softdelete

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -52,6 +52,7 @@
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql()` to use a named bind parameter (`:APK0:`) instead of embedding the raw primary-key value in the PHQL string when `findFirst()` is called with a numeric or numeric-string argument; this prevents unbounded growth of the internal PHQL AST cache (`Query::$internalPhqlCache`) in long-running CLI processes [#14656](https://github.com/phalcon/cphalcon/issues/14656)
 - Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to use the write connection when the query contains a `FOR UPDATE` clause, instead of always using the read connection [#16032](https://github.com/phalcon/cphalcon/issues/16032)
 - Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to embed `Phalcon\Db\RawValue` bind parameters directly in the SQL string instead of passing them to PDO [#16350](https://github.com/phalcon/cphalcon/issues/16350)
+- Fixed `Phalcon\Mvc\Model::doLowInsert()` to also reset `uniqueKey` (in addition to `uniqueParams`) after an auto-increment INSERT so that a subsequent `has()` call on the same record rebuilds the primary-key condition from current attribute values; previously, `uniqueParams` was cleared but `uniqueKey` was kept, causing `has()` to query with a `null` parameter and return `false`, which made `SoftDelete` attempt to INSERT an already-existing `belongsTo` related record instead of updating it [#16453](https://github.com/phalcon/cphalcon/issues/16453)
 
 ### Removed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4079,10 +4079,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 snapshot[attributeField] = lastInsertedId;
 
             /**
-             * Since the primary key was modified, we delete the uniqueParams
-             * to force any future update to re-build the primary key
+             * Since the primary key was modified, we delete the uniqueKey
+             * and uniqueParams to force any future has() call to re-build
+             * the primary key condition from current attribute values
              */
-            let this->uniqueParams = null;
+            let this->uniqueKey    = null,
+                this->uniqueParams = null;
         }
 
         if success {

--- a/tests/database/Mvc/Model/Behavior/SoftDeleteTest.php
+++ b/tests/database/Mvc/Model/Behavior/SoftDeleteTest.php
@@ -16,9 +16,12 @@ namespace Phalcon\Tests\Database\Mvc\Model\Behavior;
 use Phalcon\Events\Event;
 use Phalcon\Events\Manager as EventManager;
 use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Migrations\CustomersMigration;
 use Phalcon\Tests\Support\Migrations\InvoicesMigration;
+use Phalcon\Tests\Support\Models\Customers;
 use Phalcon\Tests\Support\Models\Invoices;
 use Phalcon\Tests\Support\Models\InvoicesBehavior;
+use Phalcon\Tests\Support\Models\InvoicesBehaviorBelongsToCustomers;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
 use function uniqid;
@@ -100,6 +103,42 @@ final class SoftDeleteTest extends AbstractDatabaseTestCase
 
         /** Check that SoftDelete wasn't working because beforeDelete event return false */
         $this->assertEquals(Invoices::STATUS_PAID, $invoice->inv_status_flag);
+    }
+
+    /**
+     * Tests that SoftDelete does not attempt to create a new record for a
+     * belongsTo related model when the parent model is soft-deleted.
+     *
+     * @see    https://github.com/phalcon/cphalcon/issues/16453
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-04-23
+     *
+     * @group mysql
+     */
+    public function testMvcModelBehaviorSoftDeleteDoesNotCreateRelatedBelongsToRecord(): void
+    {
+        $connection = self::getConnection();
+        (new CustomersMigration($connection));
+
+        $customer                  = new Customers();
+        $customer->cst_status_flag = 1;
+        $customer->cst_name_last   = 'SoftDeleteBelongsTo';
+        $customer->cst_name_first  = 'Test';
+        $this->assertTrue($customer->save());
+
+        $invoice                  = new InvoicesBehaviorBelongsToCustomers();
+        $invoice->inv_status_flag = Invoices::STATUS_PAID;
+        $invoice->inv_title       = uniqid('inv-');
+        $invoice->inv_total       = 100.00;
+        $invoice->customer        = $customer;
+        $this->assertTrue($invoice->save());
+
+        $customerCountBefore = Customers::count();
+
+        $this->assertTrue($invoice->delete());
+        $this->assertEquals(Invoices::STATUS_INACTIVE, $invoice->inv_status_flag);
+        $this->assertEquals($customerCountBefore, Customers::count());
     }
 
     /**

--- a/tests/support/Models/InvoicesBehaviorBelongsToCustomers.php
+++ b/tests/support/Models/InvoicesBehaviorBelongsToCustomers.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+use Phalcon\Mvc\Model\Behavior\SoftDelete;
+use Phalcon\Mvc\Model\Behavior\Timestampable;
+
+/**
+ * @property int    $inv_id
+ * @property int    $inv_cst_id
+ * @property int    $inv_status_flag
+ * @property string $inv_title
+ * @property float  $inv_total
+ * @property string $inv_created_at
+ */
+class InvoicesBehaviorBelongsToCustomers extends Invoices
+{
+    public function initialize()
+    {
+        $this->setSource('co_invoices');
+
+        $this->belongsTo(
+            'inv_cst_id',
+            Customers::class,
+            'cst_id',
+            [
+                'alias' => 'customer',
+            ]
+        );
+
+        $this->addBehavior(
+            new SoftDelete(
+                [
+                    'field' => 'inv_status_flag',
+                    'value' => Invoices::STATUS_INACTIVE,
+                ]
+            )
+        );
+
+        $this->addBehavior(
+            new Timestampable(
+                [
+                    'beforeCreate' => [
+                        'field'  => 'inv_created_at',
+                        'format' => 'Y-m-d H:i:s',
+                    ],
+                ]
+            )
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16453 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::doLowInsert()` to also reset `uniqueKey` (in addition to `uniqueParams`) after an auto-increment INSERT so that a subsequent `has()` call on the same record rebuilds the primary-key condition from current attribute values; previously, `uniqueParams` was cleared but `uniqueKey` was kept, causing `has()` to query with a `null` parameter and return `false`, which made `SoftDelete` attempt to INSERT an already-existing `belongsTo` related record instead of updating it

Thanks

