### PR TITLE
T16000 save hasone

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -28,6 +28,7 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model::collectRelatedToSave()` to skip unmodified `hasOne`/`hasMany` related records that have snapshot data, preventing spurious `INSERT`/`UPDATE` statements when a relation is read but not changed [#16000](https://github.com/phalcon/cphalcon/issues/16000)
 - Fixed `Phalcon\Mvc\Model::getRelated()` to return already-fetched relations from the internal cache (`dirtyRelated` first, then `related`) instead of always querying the database; cache is cleared after `save()` and `delete()` to prevent stale results [#16409](https://github.com/phalcon/cphalcon/issues/16409)
 - Fixed `Phalcon\Db\Result\PdoResult::$rowCount` to use `null` as the uninitialised sentinel instead of `false`, preventing a count of `0` rows being confused with "not yet counted" [#16409](https://github.com/phalcon/cphalcon/issues/16409)
 - Fixed `Phalcon\Html\Helper\AbstractHelper::renderAttributes()` to emit boolean HTML5 attributes (e.g. `async`, `defer`) as standalone attribute names instead of `async="1"` when the attribute value is `true` [#16304](https://github.com/phalcon/cphalcon/issues/16304)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1256,6 +1256,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 continue;
             }
 
+            if record->hasSnapshotData() && !record->hasChanged() {
+                continue;
+            }
+
             record->setDirtyState(self::DIRTY_STATE_TRANSIENT);
             let dirtyRelated[name] = record;
         }

--- a/tests/database/Mvc/Model/SaveTest.php
+++ b/tests/database/Mvc/Model/SaveTest.php
@@ -25,10 +25,12 @@ use Phalcon\Tests\Support\Models\Customers;
 use Phalcon\Tests\Support\Models\CustomersDefaults;
 use Phalcon\Tests\Support\Models\CustomersKeepSnapshots;
 use Phalcon\Tests\Support\Models\Invoices;
+use Phalcon\Tests\Support\Models\InvoicesHasOneKeepSnapshots;
 use Phalcon\Tests\Support\Models\InvoicesHasOneNotReusable;
 use Phalcon\Tests\Support\Models\InvoicesKeepSnapshots;
 use Phalcon\Tests\Support\Models\InvoicesSchema;
 use Phalcon\Tests\Support\Models\InvoicesValidationFails;
+use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Tests\Support\Models\Sources;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
@@ -397,6 +399,47 @@ final class SaveTest extends AbstractDatabaseTestCase
 
         $this->assertSame('newFirstName', $customer->cst_name_first);
         $this->assertSame(0, (int) $customer->cst_status_flag);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-28
+     *
+     * @issue  16000
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelSaveDoesNotSaveUnmodifiedHasOneRelation(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->insert(1, 1, 'firstName', 'lastName');
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert(77, 1, 0, uniqid('inv-', true));
+
+        $invoice  = InvoicesHasOneKeepSnapshots::findFirst(77);
+        $customer = $invoice->getRelated('customer');
+
+        $this->assertNotFalse($customer);
+
+        $eventsManager  = new EventsManager();
+        $customerSaved  = false;
+        $eventsManager->attach(
+            'model:beforeSave',
+            function () use (&$customerSaved): void {
+                $customerSaved = true;
+            }
+        );
+        $customer->setEventsManager($eventsManager);
+
+        $invoice->inv_title = uniqid('inv-updated-', true);
+
+        $this->assertTrue($invoice->save());
+        $this->assertFalse($customerSaved, 'Unmodified hasOne related record must not be saved');
     }
 
     /**

--- a/tests/support/Models/InvoicesHasOneKeepSnapshots.php
+++ b/tests/support/Models/InvoicesHasOneKeepSnapshots.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+class InvoicesHasOneKeepSnapshots extends Invoices
+{
+    public function initialize()
+    {
+        $this->setSource('co_invoices');
+        $this->keepSnapshots(true);
+
+        $this->hasOne(
+            'inv_cst_id',
+            CustomersKeepSnapshots::class,
+            'cst_id',
+            [
+                'alias'    => 'customer',
+                'reusable' => false,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16000 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::collectRelatedToSave()` to skip unmodified `hasOne`/`hasMany` related records that have snapshot data, preventing spurious `INSERT`/`UPDATE` statements when a relation is read but not changed

Thanks

