### PR TITLE
[#15912] - fixing issue with groupby multiple columns and postgresq

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -29,6 +29,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Mvc\Model::collectRelatedToSave()` to skip unmodified `hasOne`/`hasMany` related records that have snapshot data, preventing spurious `INSERT`/`UPDATE` statements when a relation is read but not changed [#16000](https://github.com/phalcon/cphalcon/issues/16000)
+- Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` to correctly count groups when `groupBy()` receives a multi-column array, using a `SELECT DISTINCT` subquery instead of the PostgreSQL-incompatible `COUNT(DISTINCT col1, col2)` form [#15912](https://github.com/phalcon/cphalcon/issues/15912)
 - Fixed `Phalcon\Mvc\Model::getRelated()` to return already-fetched relations from the internal cache (`dirtyRelated` first, then `related`) instead of always querying the database; cache is cleared after `save()` and `delete()` to prevent stale results [#16409](https://github.com/phalcon/cphalcon/issues/16409)
 - Fixed `Phalcon\Db\Result\PdoResult::$rowCount` to use `null` as the uninitialised sentinel instead of `false`, preventing a count of `0` rows being confused with "not yet counted" [#16409](https://github.com/phalcon/cphalcon/issues/16409)
 - Fixed `Phalcon\Html\Helper\AbstractHelper::renderAttributes()` to emit boolean HTML5 attributes (e.g. `async`, `defer`) as standalone attribute names instead of `async="1"` when the attribute value is `true` [#16304](https://github.com/phalcon/cphalcon/issues/16304)

--- a/phalcon/Paginator/Adapter/QueryBuilder.zep
+++ b/phalcon/Paginator/Adapter/QueryBuilder.zep
@@ -113,7 +113,7 @@ class QueryBuilder extends AbstractAdapter
             number, query, previous, items, totalQuery, result, row, rowcount,
             next, sql, columns, db, model, modelClass, dbService, groups,
             groupColumn;
-        bool hasHaving, hasGroup;
+        bool hasHaving, hasGroup, hasMultipleGroups;
         int numberPage;
 
         let originalBuilder = this->builder;
@@ -188,20 +188,36 @@ class QueryBuilder extends AbstractAdapter
         if hasGroup {
             if typeof groups == "array" {
                 let groupColumn = implode(", ", groups);
+                let hasMultipleGroups = count(groups) > 1;
             } else {
                 let groupColumn = groups;
+                let hasMultipleGroups = false;
             }
 
             if !hasHaving {
                 if !empty columns {
                     let groupColumn = columns;
+                    let hasMultipleGroups = false;
                 }
 
-                totalBuilder->groupBy(null)->columns(
-                    [
-                        "COUNT(DISTINCT " . groupColumn . ") AS [rowcount]"
-                    ]
-                );
+                if hasMultipleGroups {
+                    /**
+                     * Multiple GROUP BY columns: COUNT(DISTINCT col1, col2) is
+                     * invalid in PostgreSQL. Use DISTINCT columns and wrap in a
+                     * subquery (same strategy as hasHaving) to count groups.
+                     */
+                    totalBuilder->groupBy(null)->columns(
+                        [
+                            "DISTINCT " . groupColumn
+                        ]
+                    );
+                } else {
+                    totalBuilder->groupBy(null)->columns(
+                        [
+                            "COUNT(DISTINCT " . groupColumn . ") AS [rowcount]"
+                        ]
+                    );
+                }
             } else {
                 totalBuilder->columns(
                     [
@@ -225,7 +241,7 @@ class QueryBuilder extends AbstractAdapter
          * Obtain the result of the total query
          * If we have having perform native count on temp table
          */
-        if hasHaving {
+        if hasHaving || hasMultipleGroups {
             let sql = totalQuery->getSql(),
                 modelClass = builder->getModels();
 

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateTest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateTest.php
@@ -232,6 +232,59 @@ final class PaginateTest extends AbstractDatabaseTestCase
     }
 
     /**
+     * Tests Phalcon\Paginator\Adapter\QueryBuilder :: paginate() - groupBy with
+     * multiple columns (array) generates valid SQL for all databases
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-28
+     *
+     * @issue  15912
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testPaginatorAdapterQuerybuilderPaginateGroupByMultipleColumns(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $invId      = ('sqlite' === self::getDriver()) ? 'null' : 'default';
+
+        // 3 distinct (inv_cst_id, inv_status_flag) groups: (1,0), (1,1), (2,0)
+        $migration->insert($invId, 1, 0, 'inv-a1');
+        $migration->insert($invId, 1, 0, 'inv-a2');
+        $migration->insert($invId, 1, 0, 'inv-a3');
+        $migration->insert($invId, 1, 1, 'inv-b1');
+        $migration->insert($invId, 1, 1, 'inv-b2');
+        $migration->insert($invId, 2, 0, 'inv-c1');
+        $migration->insert($invId, 2, 0, 'inv-c2');
+        $migration->insert($invId, 2, 0, 'inv-c3');
+        $migration->insert($invId, 2, 0, 'inv-c4');
+
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->columns(['inv_cst_id', 'inv_status_flag'])
+            ->from(Invoices::class)
+            ->groupBy(['inv_cst_id', 'inv_status_flag'])
+        ;
+
+        $paginator = new QueryBuilder(
+            [
+                'builder' => $builder,
+                'limit'   => 5,
+                'page'    => 1,
+            ]
+        );
+
+        $page = $paginator->paginate();
+
+        $this->assertInstanceOf(Repository::class, $page);
+        $this->assertSame(3, $page->getTotalItems());
+        $this->assertSame(1, $page->getLast());
+    }
+
+    /**
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: paginate()
      *
      * @issue  14639


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15912 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` to correctly count groups when `groupBy()` receives a multi-column array, using a `SELECT DISTINCT` subquery instead of the PostgreSQL-incompatible `COUNT(DISTINCT col1, col2)` form

Thanks

