### PR TITLE
T16316 image resize transparency

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -28,6 +28,7 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Image\Adapter\Gd::processResize()` to preserve PNG alpha channel transparency by replacing `imagescale()` with `imagecreatetruecolor()` + `imagealphablending(false)` + `imagesavealpha(true)` + `imagecopyresampled()` [#16316](https://github.com/phalcon/cphalcon/issues/16316)
 - Fixed `Phalcon\Mvc\Model::collectRelatedToSave()` to skip unmodified `hasOne`/`hasMany` related records that have snapshot data, preventing spurious `INSERT`/`UPDATE` statements when a relation is read but not changed [#16000](https://github.com/phalcon/cphalcon/issues/16000)
 - Fixed `Phalcon\Mvc\Model::getRelated()` to return already-fetched relations from the internal cache (`dirtyRelated` first, then `related`) instead of always querying the database; cache is cleared after `save()` and `delete()` to prevent stale results [#16409](https://github.com/phalcon/cphalcon/issues/16409)
 - Fixed `Phalcon\Db\Result\PdoResult::$rowCount` to use `null` as the uninitialised sentinel instead of `false`, preventing a count of `0` rows being confused with "not yet counted" [#16409](https://github.com/phalcon/cphalcon/issues/16409)

--- a/phalcon/Image/Adapter/Gd.zep
+++ b/phalcon/Image/Adapter/Gd.zep
@@ -565,7 +565,11 @@ class Gd extends AbstractAdapter
     {
         var image;
 
-        let image = imagescale(this->image, width, height);
+        let image = imagecreatetruecolor(width, height);
+
+        imagealphablending(image, false);
+        imagesavealpha(image, true);
+        imagecopyresampled(image, this->image, 0, 0, 0, 0, width, height, this->width, this->height);
 
         imagedestroy(this->image);
 

--- a/tests/unit/Image/Adapter/Gd/ResizeTest.php
+++ b/tests/unit/Image/Adapter/Gd/ResizeTest.php
@@ -19,6 +19,7 @@ use Phalcon\Image\Exception;
 use Phalcon\Tests\AbstractUnitTestCase;
 use Phalcon\Tests\Unit\Image\Fake\GdTrait;
 
+use function outputDir;
 use function supportDir;
 
 final class ResizeTest extends AbstractUnitTestCase
@@ -43,7 +44,7 @@ final class ResizeTest extends AbstractUnitTestCase
                 'resize.jpg',
                 50,
                 50,
-                'bf9f8fc5bf9bc0d0',
+                '30787c3c3f1e3c38',
             ],
         ];
     }
@@ -153,6 +154,32 @@ final class ResizeTest extends AbstractUnitTestCase
         $this->assertTrue($actual);
 
         $this->safeDeleteFile($file);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-28
+     *
+     * @issue  16316
+     */
+    public function testImageAdapterGdResizePreservesTransparency(): void
+    {
+        $source = supportDir('assets/images/example-png.png');
+        $output = outputDir('tests/image/gd/resize-transparency.png');
+
+        $image = new Gd($source);
+        $image->resize(50, 50)->save($output);
+
+        $this->assertFileExists($output);
+
+        $resized = imagecreatefrompng($output);
+        imagesavealpha($resized, true);
+        $color = imagecolorsforindex($resized, imagecolorat($resized, 0, 0));
+        imagedestroy($resized);
+
+        $this->assertSame(127, $color['alpha'], 'Transparent pixel must remain transparent after resize');
+
+        $this->safeDeleteFile($output);
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16316 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Image\Adapter\Gd::processResize()` to preserve PNG alpha channel transparency by replacing `imagescale()` with `imagecreatetruecolor()` + `imagealphablending(false)` + `imagesavealpha(true)` + `imagecopyresampled()`

Thanks

