### PR TITLE
T16812 manager not

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -28,6 +28,7 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Router\Annotations::handle()` to strip the `controllerSuffix` from the class name when a fully-qualified class name already includes it (e.g. `App\Controllers\InvoicesController`), preventing the doubled suffix `InvoicesControllerController` [#16238](https://github.com/phalcon/cphalcon/issues/16238)
 - Fixed `Phalcon\Db\Dialect\Postgresql::modifyColumn()` to generate correct SQL when changing a boolean column's default value: replaced `empty` check with `hasDefault()` to avoid treating `false` as "no default", removed the boolean-only branch that omitted the `ALTER TABLE` prefix, and fixed `castDefault()` to return PostgreSQL literals `true`/`false` instead of raw PHP booleans [#15829](https://github.com/phalcon/cphalcon/issues/15829)
 - Fixed `Phalcon\Image\Adapter\AbstractAdapter::crop()` to correctly handle `offsetX = 0` and `offsetY = 0` by changing the parameter types from `int` to `var`; the previous `int` typing caused Zephir to compile the `null` check as `0 == offset` in C, making explicit zero offsets indistinguishable from omitted (center) offsets [#16156](https://github.com/phalcon/cphalcon/issues/16156)
 - Fixed `Phalcon\Image\Adapter\Gd::processResize()` to preserve PNG alpha channel transparency by replacing `imagescale()` with `imagecreatetruecolor()` + `imagealphablending(false)` + `imagesavealpha(true)` + `imagecopyresampled()` [#16316](https://github.com/phalcon/cphalcon/issues/16316)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -28,6 +28,7 @@
   
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model\Query::getExpression()` to emit `NOT BETWEEN` instead of `BETWEEN NOT` for the `PHQL_T_BETWEEN_NOT` token, producing valid SQL [#16812](https://github.com/phalcon/cphalcon/issues/16812)
 - Fixed `Phalcon\Mvc\Router\Annotations::handle()` to strip the `controllerSuffix` from the class name when a fully-qualified class name already includes it (e.g. `App\Controllers\InvoicesController`), preventing the doubled suffix `InvoicesControllerController` [#16238](https://github.com/phalcon/cphalcon/issues/16238)
 - Fixed `Phalcon\Db\Dialect\Postgresql::modifyColumn()` to generate correct SQL when changing a boolean column's default value: replaced `empty` check with `hasDefault()` to avoid treating `false` as "no default", removed the boolean-only branch that omitted the `ALTER TABLE` prefix, and fixed `castDefault()` to return PostgreSQL literals `true`/`false` instead of raw PHP booleans [#15829](https://github.com/phalcon/cphalcon/issues/15829)
 - Fixed `Phalcon\Image\Adapter\AbstractAdapter::crop()` to correctly handle `offsetX = 0` and `offsetY = 0` by changing the parameter types from `int` to `var`; the previous `int` typing caused Zephir to compile the `null` check as `0 == offset` in C, making explicit zero offsets indistinguishable from omitted (center) offsets [#16156](https://github.com/phalcon/cphalcon/issues/16156)

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -2129,7 +2129,7 @@ class Query implements QueryInterface, InjectionAwareInterface
                 case PHQL_T_BETWEEN_NOT:
                     let exprReturn = [
                         "type": "binary-op",
-                        "op":   "BETWEEN NOT",
+                        "op":   "NOT BETWEEN",
                         "left": left,
                         "right": right
                     ];

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -168,6 +168,18 @@ class Annotations extends Router
                  */
                 let controllerName = get_class_ns(handler),
                     namespaceName = get_ns_class(handler);
+
+                /**
+                 * Strip the suffix if the FQCN already includes it,
+                 * so we do not end up with e.g. "InvoicesControllerController"
+                 */
+                if ends_with(controllerName, controllerSuffix) {
+                    let controllerName = substr(
+                        controllerName,
+                        0,
+                        strlen(controllerName) - strlen(controllerSuffix)
+                    );
+                }
             } else {
                 let controllerName = handler;
 

--- a/tests/unit/Mvc/Model/Query/GetExpressionTest.php
+++ b/tests/unit/Mvc/Model/Query/GetExpressionTest.php
@@ -19,8 +19,34 @@ use ReflectionClass;
 
 final class GetExpressionTest extends AbstractUnitTestCase
 {
-    private int $PHQL_T_AND = 266;
-    private int $PHQL_T_OR  = 267;
+    private int $PHQL_T_AND         = 266;
+    private int $PHQL_T_OR          = 267;
+    private int $PHQL_T_BETWEEN     = 331;
+    private int $PHQL_T_BETWEEN_NOT = 332;
+
+    /**
+     * @issue  16812
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-28
+     */
+    public function testMvcModelQueryGetExpressionNotBetween(): void
+    {
+        $expected = [
+            'type'  => 'binary-op',
+            'op'    => 'NOT BETWEEN',
+            'left'  => null,
+            'right' => null,
+        ];
+
+        $expr = ['type' => $this->PHQL_T_BETWEEN_NOT];
+
+        $query         = new Query();
+        $reflection    = new ReflectionClass(Query::class);
+        $getExpression = $reflection->getMethod('getExpression');
+        $getExpression->setAccessible(true);
+
+        $this->assertSame($expected, $getExpression->invokeArgs($query, [$expr, false]));
+    }
 
     /**
      * @issue  15553

--- a/tests/unit/Mvc/Router/Refactor/AnnotationsTest.php
+++ b/tests/unit/Mvc/Router/Refactor/AnnotationsTest.php
@@ -100,6 +100,35 @@ final class AnnotationsTest extends AbstractUnitTestCase
     }
 
     /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-28
+     *
+     * @issue  16238
+     */
+    public function testMvcRouterAnnotationsAddResourceWithFullyQualifiedClassNameIncludingSuffix(): void
+    {
+        $container = $this->getDi();
+
+        $router = new Annotations(false);
+        $router->setDI($container);
+
+        $router->addResource(
+            'Phalcon\Tests\Support\Controllers\RobotsController',
+            '/'
+        );
+
+        $router->handle('/robots');
+
+        $routes = $router->getRoutes();
+        $this->assertNotEmpty($routes, 'Routes must be registered when FQCN includes the Controller suffix');
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $router->handle('/robots');
+
+        $this->assertSame('robots', $router->getControllerName());
+    }
+
+    /**
      * @dataProvider getRoutesProvider
      *
      * @author Phalcon Team <team@phalcon.io>


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16812 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Query::getExpression()` to emit `NOT BETWEEN` instead of `BETWEEN NOT` for the `PHQL_T_BETWEEN_NOT` token, producing valid SQL

Thanks

