### PR TITLE
[#15064] - added ability to embed placeholders in raw values

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -160,6 +160,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     protected oldSnapshot = [];
 
     /**
+     * @var array
+     */
+    protected rawValues = [];
+
+    /**
      * @var bool
      */
     protected skipped = false;
@@ -783,8 +788,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     public function assign(array! data, var whiteList = null, var dataColumnMap = null) -> <ModelInterface>
     {
         var key, keyMapped, value, attribute, attributeField, metaData,
-            columnMap, disableAssignSetters;
+            columnMap, disableAssignSetters, rawValues;
         array dataMapped;
+
+        let rawValues       = [],
+            this->rawValues = rawValues;
 
         let disableAssignSetters = Settings::get("orm.disable_assign_setters");
 
@@ -848,11 +856,15 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 }
 
                 // Try to find a possible getter
-                if disableAssignSetters || !this->possibleSetter(attributeField, value) {
+                if typeof value == "object" && value instanceof RawValue {
+                    let rawValues[attributeField] = value;
+                } elseif disableAssignSetters || !this->possibleSetter(attributeField, value) {
                     let this->{attributeField} = value;
                 }
             }
         }
+
+        let this->rawValues = rawValues;
 
         return this;
     }
@@ -3926,7 +3938,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     {
         var attributeField, attributes, automaticAttributes, bindDataTypes,
             bindSkip, bindType, bindTypes, columnMap, defaultValue, defaultValues,
-            field, fields, lastInsertedId, manager, sequenceName, schema,
+            field, fields, lastInsertedId, manager, rawValue, rawValues, sequenceName, schema,
             snapshot, source, success, unsetDefaultValues, value, values;
         bool useExplicitIdentity;
 
@@ -3937,6 +3949,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             snapshot            = [],
             bindTypes           = [],
             unsetDefaultValues  = [],
+            rawValues           = this->rawValues,
             attributes          = metaData->getAttributes(this),
             bindDataTypes       = metaData->getBindTypes(this),
             automaticAttributes = metaData->getAutomaticCreateAttributes(this),
@@ -3974,7 +3987,18 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                      * This isset checks that the property be defined in the
                      * model
                      */
-                    if fetch value, this->{attributeField} {
+                    if fetch rawValue, rawValues[attributeField] {
+                        if unlikely !fetch bindType, bindDataTypes[field] {
+                            throw new Exception(
+                                "Column '" . field . "' in '" . get_class(this) . "' have not defined a bind data type"
+                            );
+                        }
+
+                        let fields[]                 = field,
+                            values[]                 = rawValue,
+                            bindTypes[]              = bindType,
+                            snapshot[attributeField] = rawValue;
+                    } elseif fetch value, this->{attributeField} {
                         if value === null && isset defaultValues[field] {
                             let snapshot[attributeField]           = defaultValues[field],
                                 unsetDefaultValues[attributeField] = defaultValues[field];
@@ -4182,7 +4206,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      {
         var automaticAttributes, attributeField, bindSkip, bindDataTypes,
             bindType, bindTypes, columnMap, dataType, dataTypes, field, fields,
-            manager, nonPrimary, newSnapshot, success, primaryKeys, snapshot,
+            manager, nonPrimary, newSnapshot, rawValue, rawValues, success, primaryKeys, snapshot,
             snapshotValue, uniqueKey, uniqueParams, value, values,
             updateValue;
         bool changed, useDynamicUpdate;
@@ -4192,6 +4216,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             values      = [],
             bindTypes   = [],
             newSnapshot = [],
+            rawValues   = this->rawValues,
             manager     = <ManagerInterface> this->modelsManager;
 
         /**
@@ -4238,7 +4263,12 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                      * Get the field's value
                      * If a field isn't set there was no change
                      */
-                    if fetch value, this->{attributeField} {
+                    if fetch rawValue, rawValues[attributeField] {
+                        let fields[]                    = field,
+                            values[]                    = rawValue,
+                            bindTypes[]                 = bindType,
+                            newSnapshot[attributeField] = rawValue;
+                    } elseif fetch value, this->{attributeField} {
                         /**
                         * If the field is not part of the snapshot we add them as changed
                         */
@@ -4364,19 +4394,21 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                      * Get the field's value
                      * If a field isn't set we pass a null value
                      */
-                    if fetch value, this->{attributeField} {
-                        /**
-                         * When dynamic update is not used we pass every field to the update
-                         */
-                        let fields[] = field,
-                            values[] = value;
-                        let bindTypes[] = bindType;
-                        let newSnapshot[attributeField] = value;
+                    if fetch rawValue, rawValues[attributeField] {
+                        let fields[]                    = field,
+                            values[]                    = rawValue,
+                            bindTypes[]                 = bindType,
+                            newSnapshot[attributeField] = rawValue;
+                    } elseif fetch value, this->{attributeField} {
+                        let fields[]                    = field,
+                            values[]                    = value,
+                            bindTypes[]                 = bindType,
+                            newSnapshot[attributeField] = value;
                     } else {
-                        let newSnapshot[attributeField] = null;
-                        let fields[]    = field,
-                            values[]    = null,
-                            bindTypes[] = bindSkip;
+                        let newSnapshot[attributeField] = null,
+                            fields[]                    = field,
+                            values[]                    = null,
+                            bindTypes[]                 = bindSkip;
                     }
                 }
             }

--- a/tests/database/Mvc/Model/Query/ExecuteInsertRawValueTest.php
+++ b/tests/database/Mvc/Model/Query/ExecuteInsertRawValueTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Mvc\Model\Query;
+
+use PDO;
+use Phalcon\Db\RawValue;
+use Phalcon\Mvc\Model\Query\StatusInterface;
+use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Migrations\InvoicesMigration;
+use Phalcon\Tests\Support\Models\InvoicesRawValue;
+use Phalcon\Tests\Support\Traits\DiTrait;
+
+/**
+ * Tests Phalcon\Mvc\Model\Query :: executeInsert() - RawValue bind params
+ *
+ * @issue 15064
+ */
+final class ExecuteInsertRawValueTest extends AbstractDatabaseTestCase
+{
+    use DiTrait;
+
+    public function setUp(): void
+    {
+        $this->setNewFactoryDefault();
+        $this->setDatabase();
+
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+        (new InvoicesMigration($connection));
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model\Query :: executeInsert() - RawValue bind param
+     * with typed model properties: the raw SQL expression must be embedded
+     * unquoted in the INSERT, not treated as a plain string value.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-28
+     * @issue  15064
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelQueryExecuteInsertRawValue(): void
+    {
+        $manager = $this->getService('modelsManager');
+
+        $phql = sprintf(
+            "INSERT INTO [%s] (inv_cst_id, inv_status_flag, inv_title, inv_total) "
+            . "VALUES (:cst_id:, :status:, :title:, :total:)",
+            InvoicesRawValue::class
+        );
+
+        /** @var StatusInterface $result */
+        $result = $manager->executeQuery(
+            $phql,
+            [
+                'cst_id' => 1,
+                'status' => 1,
+                'title'  => new RawValue("UPPER('hello')"),
+                'total'  => 100.0,
+            ]
+        );
+
+        $this->assertInstanceOf(StatusInterface::class, $result);
+        $this->assertTrue($result->success());
+
+        $invoice = InvoicesRawValue::findFirst(
+            [
+                'conditions' => 'inv_cst_id = :cst_id:',
+                'bind'       => ['cst_id' => 1],
+                'order'      => 'inv_id DESC',
+            ]
+        );
+
+        $this->assertNotNull($invoice);
+        $this->assertSame('HELLO', $invoice->inv_title);
+    }
+}

--- a/tests/support/Models/InvoicesRawValue.php
+++ b/tests/support/Models/InvoicesRawValue.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * Model for testing RawValue bind params in PHQL INSERT/UPDATE.
+ *
+ * Uses typed properties so that PHP 8 coercion behaviour is exercised,
+ * and a nullable PK so that a fresh instance has no uninitialized typed int.
+ *
+ * @see https://github.com/phalcon/cphalcon/issues/15064
+ */
+class InvoicesRawValue extends Model
+{
+    public ?int $inv_id = null;
+
+    public ?int $inv_cst_id = null;
+
+    public ?int $inv_status_flag = null;
+
+    public ?string $inv_title = null;
+
+    public ?float $inv_total = null;
+
+    public ?string $inv_created_at = null;
+
+    public function initialize(): void
+    {
+        $this->setSource('co_invoices');
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #15064 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::assign()` to prevent PHP 8 typed-property coercion of `Phalcon\Db\RawValue` bind parameters; `RawValue` instances are now stored in an internal `rawValues` map and injected directly in `doLowInsert()` and `doLowUpdate()`, so raw SQL expressions are correctly embedded in INSERT/UPDATE statements instead of being treated as literal strings [#15064](https://github.com/phalcon/cphalcon/issues/15064)

Thanks

