### PR TITLE
T16840 UUID column

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,10 @@
 
 ## [5.12.1](https://github.com/phalcon/cphalcon/releases/tag/v5.12.1) (xxxx-xx-xx)
 
+### Added
+
+- Added `Phalcon\Db\Column::TYPE_UUID` constant (value `29`) and added support for PostgreSQL native `uuid` column type in `Phalcon\Db\Adapter\Pdo\Postgresql` and `Phalcon\Db\Dialect\Postgresql` [#16840](https://github.com/phalcon/cphalcon/issues/16840)
+
 ### Fixed
 
 - Fixed `Phalcon\Mvc\Model\Query\Builder::autoescape()` incorrectly wrapping function expressions (e.g. `DATE_PART(...)`) in brackets when used in `groupBy()`, causing a `"Column does not belong to any of the selected models"` exception [#16599](https://github.com/phalcon/cphalcon/issues/16599)

--- a/phalcon/Db/Adapter/Pdo/Postgresql.zep
+++ b/phalcon/Db/Adapter/Pdo/Postgresql.zep
@@ -452,8 +452,7 @@ class Postgresql extends PdoAdapter
                  * UUID
                  */
                 case memstr(columnType, "uuid"):
-                    let definition["type"] = Column::TYPE_CHAR,
-                        definition["size"] = 36;
+                    let definition["type"] = Column::TYPE_UUID;
 
                     break;
 

--- a/phalcon/Db/Column.zep
+++ b/phalcon/Db/Column.zep
@@ -274,6 +274,13 @@ class Column implements ColumnInterface
     const TYPE_TINYTEXT = 25;
 
     /**
+     * UUID abstract data type
+     *
+     * @var int
+     */
+    const TYPE_UUID = 29;
+
+    /**
      * Varbinary abstract data type
      *
      * @var int

--- a/phalcon/Db/Dialect/Postgresql.zep
+++ b/phalcon/Db/Dialect/Postgresql.zep
@@ -495,6 +495,13 @@ class Postgresql extends Dialect
 
                 break;
 
+            case Column::TYPE_UUID:
+                if empty columnSql {
+                    let columnSql .= "UUID";
+                }
+
+                break;
+
             case Column::TYPE_VARCHAR:
                 if empty columnSql {
                     let columnSql .= "CHARACTER VARYING";

--- a/tests/database/Db/Adapter/Pdo/Postgresql/DescribeColumnsTest.php
+++ b/tests/database/Db/Adapter/Pdo/Postgresql/DescribeColumnsTest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Tests\Database\Db\Adapter\Pdo\Postgresql;
 
 use Phalcon\Db\Column;
 use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Migrations\FractalDatesMigration;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
 use function env;
@@ -54,6 +55,33 @@ final class DescribeColumnsTest extends AbstractDatabaseTestCase
 
         $actual = $db->describeColumns('co_invoices', env('DATA_POSTGRES_SCHEMA'));
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Db\Adapter\Pdo\Postgresql :: describeColumns() - uuid type
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-04-29
+     * @group  pgsql
+     */
+    public function testDbAdapterPdoPostgresqlDescribeColumnsUuid(): void
+    {
+        $connection = self::getConnection();
+        (new FractalDatesMigration($connection))->clear();
+
+        $db      = $this->container->get('db');
+        $columns = $db->describeColumns('fractal_dates');
+
+        $uuidColumn = null;
+        foreach ($columns as $column) {
+            if ($column->getName() === 'cuuid') {
+                $uuidColumn = $column;
+                break;
+            }
+        }
+
+        $this->assertNotNull($uuidColumn);
+        $this->assertSame(Column::TYPE_UUID, $uuidColumn->getType());
     }
 
     /**

--- a/tests/database/Db/Column/ConstantsTest.php
+++ b/tests/database/Db/Column/ConstantsTest.php
@@ -71,6 +71,7 @@ final class ConstantsTest extends AbstractDatabaseTestCase
             [Column::TYPE_TINYBLOB, 10],
             [Column::TYPE_TINYINTEGER, 26],
             [Column::TYPE_TINYTEXT, 25],
+            [Column::TYPE_UUID, 29],
             [Column::TYPE_VARBINARY, 28],
             [Column::TYPE_VARCHAR, 2],
         ];

--- a/tests/database/Db/Dialect/Postgresql/GetColumnDefinitionTest.php
+++ b/tests/database/Db/Dialect/Postgresql/GetColumnDefinitionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Db\Dialect\Postgresql;
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Dialect\Postgresql;
+use Phalcon\Tests\AbstractDatabaseTestCase;
+
+final class GetColumnDefinitionTest extends AbstractDatabaseTestCase
+{
+    /**
+     * @return array[]
+     */
+    public static function getPostgresqlData(): array
+    {
+        return [
+            [
+                [
+                    'type'      => Column::TYPE_UUID,
+                    'isNumeric' => false,
+                    'size'      => 0,
+                    'unsigned'  => false,
+                ],
+                'UUID',
+            ],
+        ];
+    }
+
+    /**
+     * Tests Phalcon\Db\Dialect\Postgresql :: getColumnDefinition - uuid
+     *
+     * @dataProvider getPostgresqlData
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2025-04-29
+     *
+     * @group pgsql
+     */
+    public function testDbDialectPostgresqlGetColumnDefinition(
+        array $definition,
+        string $expected
+    ): void {
+        $dialect = new Postgresql();
+        $column  = new Column('column_name', $definition);
+
+        $actual = $dialect->getColumnDefinition($column);
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #16840 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Db\Column::TYPE_UUID` constant (value `29`) and added support for PostgreSQL native `uuid` column type in `Phalcon\Db\Adapter\Pdo\Postgresql` and `Phalcon\Db\Dialect\Postgresql`

Thanks

