### PR TITLE
T16570 assets uri

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added `Phalcon\Db\Column::TYPE_UUID` constant (value `29`) and added support for PostgreSQL native `uuid` column type in `Phalcon\Db\Adapter\Pdo\Postgresql` and `Phalcon\Db\Dialect\Postgresql` [#16840](https://github.com/phalcon/cphalcon/issues/16840)
+- Added support for `Phalcon\Mvc\Url` static base URI in `Phalcon\Assets\Manager`; when a DI container is set and a `url` service is available, local asset paths are now resolved via `getStatic()` instead of a bare `/` prefix [#16570](https://github.com/phalcon/cphalcon/issues/16570)
 
 ### Fixed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` returning wrong total item count when the query uses `DISTINCT` columns; the count now uses `COUNT(DISTINCT ...)` for a single column and a subquery for multiple columns [#16581](https://github.com/phalcon/cphalcon/issues/16581)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::autoescape()` incorrectly wrapping function expressions (e.g. `DATE_PART(...)`) in brackets when used in `groupBy()`, causing a `"Column does not belong to any of the selected models"` exception [#16599](https://github.com/phalcon/cphalcon/issues/16599)
 - Fixed `Phalcon\Mvc\Model` - saving a model with multiple fields relations threw `"Not implemented"` [#16029](https://github.com/phalcon/cphalcon/issues/16029)
 

--- a/phalcon/Assets/Manager.zep
+++ b/phalcon/Assets/Manager.zep
@@ -1050,10 +1050,17 @@ class Manager extends AbstractInjectionAware
         unset(params[name]);
 
         /**
-         * URLs are generated through the "url" service
+         * URLs are generated through the "url" service when available
          */
         if local {
-            let tag = "/" . ltrim(tag, "/");
+            if (
+                this->container !== null &&
+                this->container->has("url")
+            ) {
+                let tag = this->container->get("url")->getStatic(tag);
+            } else {
+                let tag = "/" . ltrim(tag, "/");
+            }
         }
 
         let helper = this->tagFactory->newInstance(helperClass);

--- a/phalcon/Paginator/Adapter/QueryBuilder.zep
+++ b/phalcon/Paginator/Adapter/QueryBuilder.zep
@@ -112,8 +112,8 @@ class QueryBuilder extends AbstractAdapter
         var originalBuilder, builder, totalBuilder, totalPages, limit,
             number, query, previous, items, totalQuery, result, row, rowcount,
             next, sql, columns, db, model, modelClass, dbService, groups,
-            groupColumn;
-        bool hasHaving, hasGroup, hasMultipleGroups;
+            groupColumn, builderColumns, distinctColumn;
+        bool hasHaving, hasGroup, hasMultipleGroups, hasDistinct;
         int numberPage;
 
         let originalBuilder = this->builder;
@@ -179,7 +179,26 @@ class QueryBuilder extends AbstractAdapter
 
             totalBuilder->columns(columns);
         } else {
-            totalBuilder->columns("COUNT(*) [rowcount]");
+            let hasDistinct    = false,
+                builderColumns = builder->getColumns();
+
+            if typeof builderColumns == "string" && stripos(trim(builderColumns), "DISTINCT ") === 0 {
+                let distinctColumn = trim(substr(trim(builderColumns), 9));
+                let hasDistinct = true;
+
+                if strpos(distinctColumn, ",") !== false {
+                    totalBuilder->columns(["DISTINCT " . distinctColumn]);
+                    let hasMultipleGroups = true;
+                } else {
+                    totalBuilder->columns(
+                        ["COUNT(DISTINCT " . distinctColumn . ") AS [rowcount]"]
+                    );
+                }
+            }
+
+            if !hasDistinct {
+                totalBuilder->columns("COUNT(*) [rowcount]");
+            }
         }
 
         /**

--- a/tests/database/Paginator/Adapter/QueryBuilder/PaginateTest.php
+++ b/tests/database/Paginator/Adapter/QueryBuilder/PaginateTest.php
@@ -285,6 +285,51 @@ final class PaginateTest extends AbstractDatabaseTestCase
     }
 
     /**
+     * Tests Phalcon\Paginator\Adapter\QueryBuilder :: paginate() - distinct
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-04-29
+     *
+     * @issue  16581
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testPaginatorAdapterQuerybuilderPaginateDistinct(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+        $migration  = new InvoicesMigration($connection);
+        $invId      = ('sqlite' === self::getDriver()) ? 'null' : 'default';
+
+        // Insert 5 invoices for customer 1 and 5 for customer 2 (10 total rows,
+        // but only 2 distinct inv_cst_id values)
+        $this->insertDataInvoices($migration, 5, $invId, 1, 'aaa');
+        $this->insertDataInvoices($migration, 5, $invId, 2, 'bbb');
+
+        $manager = $this->getService('modelsManager');
+        $builder = $manager
+            ->createBuilder()
+            ->columns('DISTINCT inv_cst_id')
+            ->from(Invoices::class)
+        ;
+
+        $paginator = new QueryBuilder(
+            [
+                'builder' => $builder,
+                'limit'   => 5,
+                'page'    => 1,
+            ]
+        );
+
+        $page = $paginator->paginate();
+
+        $this->assertInstanceOf(Repository::class, $page);
+        $this->assertSame(2, $page->getTotalItems());
+        $this->assertSame(1, $page->getLast());
+    }
+
+    /**
      * Tests Phalcon\Paginator\Adapter\QueryBuilder :: paginate()
      *
      * @issue  14639

--- a/tests/unit/Assets/Manager/OutputCssWithUrlTest.php
+++ b/tests/unit/Assets/Manager/OutputCssWithUrlTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Assets\Manager;
+
+use Phalcon\Assets\Manager;
+use Phalcon\Di\Di;
+use Phalcon\Html\Escaper;
+use Phalcon\Html\TagFactory;
+use Phalcon\Mvc\Url;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Support\Traits\DiTrait;
+
+use const PHP_EOL;
+
+final class OutputCssWithUrlTest extends AbstractUnitTestCase
+{
+    use DiTrait;
+
+    public function tearDown(): void
+    {
+        $this->resetDi();
+    }
+
+    /**
+     * Tests Phalcon\Assets\Manager :: outputCss() - uses URL service static base URI
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-04-29
+     *
+     * @issue  16570
+     */
+    public function testAssetsManagerOutputCssUsesUrlStaticBaseUri(): void
+    {
+        $url = new Url();
+        $url->setStaticBaseUri('/my_app/');
+
+        $container = new Di();
+        $container->setShared('url', $url);
+
+        $manager = new Manager(new TagFactory(new Escaper()));
+        $manager->setDI($container);
+
+        $manager->addCss('css/style.css');
+        $manager->useImplicitOutput(false);
+
+        $expected = '<link rel="stylesheet" type="text/css" href="/my_app/css/style.css" />' . PHP_EOL;
+        $actual   = $manager->outputCss();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Tests Phalcon\Assets\Manager :: outputCss() - falls back to "/" prefix when no URL service
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2025-04-29
+     *
+     * @issue  16570
+     */
+    public function testAssetsManagerOutputCssFallsBackWithoutUrlService(): void
+    {
+        $manager = new Manager(new TagFactory(new Escaper()));
+
+        $manager->addCss('css/style.css');
+        $manager->useImplicitOutput(false);
+
+        $expected = '<link rel="stylesheet" type="text/css" href="/css/style.css" />' . PHP_EOL;
+        $actual   = $manager->outputCss();
+
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16570 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added support for `Phalcon\Mvc\Url` static base URI in `Phalcon\Assets\Manager`; when a DI container is set and a `url` service is available, local asset paths are now resolved via `getStatic()` instead of a bare `/` prefix

Thanks

