### PR TITLE
T16566 memory leak model validation

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model\Manager` retaining a model instance in `lastInitialized` after initialization and `Phalcon\Mvc\Model` not clearing the reusable-records cache after `save()`, causing memory to grow unboundedly in long-running processes [#16566](https://github.com/phalcon/cphalcon/issues/16566)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` returning wrong total item count when the query uses `DISTINCT` columns; the count now uses `COUNT(DISTINCT ...)` for a single column and a subquery for multiple columns [#16581](https://github.com/phalcon/cphalcon/issues/16581)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::autoescape()` incorrectly wrapping function expressions (e.g. `DATE_PART(...)`) in brackets when used in `groupBy()`, causing a `"Column does not belong to any of the selected models"` exception [#16599](https://github.com/phalcon/cphalcon/issues/16599)
 - Fixed `Phalcon\Mvc\Model` - saving a model with multiple fields relations threw `"Not implemented"` [#16029](https://github.com/phalcon/cphalcon/issues/16029)

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -2924,6 +2924,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 let this->dirtyRelated = [];
             }
             let this->related = [];
+            (<ManagerInterface> this->modelsManager)->clearReusableObjects();
             this->fireEvent("afterSave");
         }
 

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -1851,6 +1851,13 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
             eventsManager->fire("modelsManager:afterInitialize", this, model);
         }
 
+        /**
+         * Release the reference so the model instance is not permanently
+         * retained in memory (prevents a reference cycle in long-running
+         * processes). The event above already received the model directly.
+         */
+        let this->lastInitialized = null;
+
         return true;
     }
 

--- a/tests/database/Mvc/Model/Manager/GetLastInitializedTest.php
+++ b/tests/database/Mvc/Model/Manager/GetLastInitializedTest.php
@@ -13,16 +13,47 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Database\Mvc\Model\Manager;
 
+use Phalcon\Mvc\Model\Manager;
 use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Models\Invoices;
+use Phalcon\Tests\Support\Traits\DiTrait;
 
 final class GetLastInitializedTest extends AbstractDatabaseTestCase
 {
-    /**
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2018-11-13
-     */
-    public function testMvcModelManagerGetLastInitialized(): void
+    use DiTrait;
+
+    public function setUp(): void
     {
-        $this->markTestSkipped('Need implementation');
+        $this->setNewFactoryDefault();
+        $this->setDatabase();
+    }
+
+    public function tearDown(): void
+    {
+        $this->tearDownDatabase();
+    }
+
+    /**
+     * Tests that getLastInitialized() returns null after initialization
+     * completes so that the manager does not permanently retain the model
+     * instance (which would create a reference cycle in long-running
+     * processes).
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/16566
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-30
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function testMvcModelManagerGetLastInitializedIsNullAfterInitialization(): void
+    {
+        /** @var Manager $manager */
+        $manager = $this->container->getShared('modelsManager');
+
+        new Invoices();
+
+        $this->assertNull($manager->getLastInitialized());
     }
 }

--- a/tests/database/Mvc/Model/SaveTest.php
+++ b/tests/database/Mvc/Model/SaveTest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Tests\Database\Mvc\Model;
 
 use PDO;
 use Phalcon\Mvc\Model;
+use Phalcon\Mvc\Model\Manager;
 use Phalcon\Mvc\Model\MetaData;
 use Phalcon\Tests\AbstractDatabaseTestCase;
 use Phalcon\Tests\Support\Migrations\CustomersDefaultsMigration;
@@ -698,6 +699,47 @@ final class SaveTest extends AbstractDatabaseTestCase
         $expected = $value;
         $actual   = $storedModel->cst_status_flag;
         $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the reusable-records cache in Manager is cleared after a
+     * successful save(), preventing unbounded memory growth in long-running
+     * processes that call save() in a loop.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/16566
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-30
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function testMvcModelSaveClearsReusableObjects(): void
+    {
+        $connection        = self::getConnection();
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert('default', 1, 0, uniqid('inv-', true));
+
+        /** @var Manager $manager */
+        $manager = $this->container->getShared('modelsManager');
+
+        $manager->setReusableRecords('SomeModel', 'key-abc', ['record1', 'record2']);
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-abc');
+        $this->assertNotNull($actual);
+
+        $invoice              = new Invoices();
+        $invoice->inv_cst_id  = 1;
+        $invoice->inv_status_flag = 0;
+        $invoice->inv_title   = uniqid('inv-', true);
+        $invoice->inv_total   = 100.0;
+        $invoice->inv_created_at = date('Y-m-d H:i:s');
+
+        $actual = $invoice->save();
+        $this->assertTrue($actual);
+
+        $actual = $manager->getReusableRecords('SomeModel', 'key-abc');
+        $this->assertNull($actual);
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16566

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Manager` retaining a model instance in `lastInitialized` after initialization and `Phalcon\Mvc\Model` not clearing the reusable-records cache after `save()`, causing memory to grow unboundedly in long-running processes

Thanks

