### PR TITLE
T16630 serialize stdclass

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Storage\Serializer\Json::serialize()` rejecting plain objects (e.g. `stdClass`) that do not implement `JsonSerializable`; `json_encode()` handles such objects natively and the guard was unnecessary [#16630](https://github.com/phalcon/cphalcon/issues/16630)
 - Fixed `Phalcon\Mvc\Model\Manager` retaining a model instance in `lastInitialized` after initialization and `Phalcon\Mvc\Model` not clearing the reusable-records cache after `save()`, causing memory to grow unboundedly in long-running processes [#16566](https://github.com/phalcon/cphalcon/issues/16566)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` returning wrong total item count when the query uses `DISTINCT` columns; the count now uses `COUNT(DISTINCT ...)` for a single column and a subquery for multiple columns [#16581](https://github.com/phalcon/cphalcon/issues/16581)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::autoescape()` incorrectly wrapping function expressions (e.g. `DATE_PART(...)`) in brackets when used in `groupBy()`, causing a `"Column does not belong to any of the selected models"` exception [#16599](https://github.com/phalcon/cphalcon/issues/16599)

--- a/phalcon/Storage/Serializer/Json.zep
+++ b/phalcon/Storage/Serializer/Json.zep
@@ -11,7 +11,6 @@
 namespace Phalcon\Storage\Serializer;
 
 use InvalidArgumentException;
-use JsonSerializable;
 use Phalcon\Support\Helper\Json\Decode;
 use Phalcon\Support\Helper\Json\Encode;
 
@@ -43,17 +42,10 @@ class Json extends AbstractSerializer
     /**
      * Serializes data
      *
-     * @return JsonSerializable|mixed|string
+     * @return mixed|string
      */
     public function serialize() -> mixed
     {
-        if (typeof this->data === "object" && !(this->data instanceof JsonSerializable)) {
-            throw new InvalidArgumentException(
-                "Data for the JSON serializer cannot be of type 'object' " .
-                "without implementing 'JsonSerializable'"
-            );
-        }
-
         if (true !== this->isSerializable(this->data)) {
             return this->data;
         }

--- a/tests/unit/Storage/Serializer/ExceptionsTest.php
+++ b/tests/unit/Storage/Serializer/ExceptionsTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Storage\Serializer;
 
-use Exception;
 use InvalidArgumentException;
 use Phalcon\Storage\Serializer\Base64;
 use Phalcon\Storage\Serializer\Json;
@@ -29,8 +28,6 @@ use Phalcon\Tests\Unit\Storage\Fake\FakeIgbinaryUnserializeWarning;
 use stdClass;
 
 use function json_encode;
-use function serialize;
-use function unserialize;
 
 final class ExceptionsTest extends AbstractUnitTestCase
 {
@@ -168,25 +165,6 @@ final class ExceptionsTest extends AbstractUnitTestCase
 
         $actual = $serializer->isSuccess();
         $this->assertFalse($actual);
-    }
-
-    /**
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2020-09-09
-     */
-    public function testStorageSerializerJsonSerializeError(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            "Data for the JSON serializer cannot be of type 'object' " .
-            "without implementing 'JsonSerializable'"
-        );
-
-        $example      = new stdClass();
-        $example->one = 'two';
-
-        $serializer = new Json($example);
-        $serializer->serialize();
     }
 
     /**

--- a/tests/unit/Storage/Serializer/SerializeUnserializeTest.php
+++ b/tests/unit/Storage/Serializer/SerializeUnserializeTest.php
@@ -127,6 +127,11 @@ final class SerializeUnserializeTest extends AbstractUnitTestCase
                 json_encode([self::TEXT]),
             ],
             [
+                Json::class,
+                $stdClass,
+                json_encode($stdClass),
+            ],
+            [
                 MemcachedIgbinary::class,
                 null,
                 null,


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16630 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Storage\Serializer\Json::serialize()` rejecting plain objects (e.g. `stdClass`) that do not implement `JsonSerializable`; `json_encode()` handles such objects natively and the guard was unnecessary

Thanks

