### PR TITLE
T16544 metadata keys collision

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model\MetaData::writeMetaDataIndex()` prematurely initializing a child model's metadata with the parent's source table when `skipAttributes()` (or `skipAttributesOnCreate()`/`skipAttributesOnUpdate()`) is called inside a parent model's `initialize()` and the child calls `parent::initialize()` before setting its own source, corrupting the child's attribute list and breaking relationship resolution [#16544](https://github.com/phalcon/cphalcon/issues/16544)
 - Fixed `Phalcon\Storage\Serializer\Json::serialize()` rejecting plain objects (e.g. `stdClass`) that do not implement `JsonSerializable`; `json_encode()` handles such objects natively and the guard was unnecessary [#16630](https://github.com/phalcon/cphalcon/issues/16630)
 - Fixed `Phalcon\Mvc\Model\Manager` retaining a model instance in `lastInitialized` after initialization and `Phalcon\Mvc\Model` not clearing the reusable-records cache after `save()`, causing memory to grow unboundedly in long-running processes [#16566](https://github.com/phalcon/cphalcon/issues/16566)
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` returning wrong total item count when the query uses `DISTINCT` columns; the count now uses `COUNT(DISTINCT ...)` for a single column and a subquery for multiple columns [#16581](https://github.com/phalcon/cphalcon/issues/16581)

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -126,6 +126,16 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
     protected metaData = [];
 
     /**
+     * Holds metadata index writes that arrived before the model's metadata was
+     * properly initialized (e.g. skipAttributes() called in a parent model's
+     * initialize() while the child's source had not yet been set).  Applied
+     * inside initializeMetaData() after the real schema is loaded.
+     *
+     * @var array
+     */
+    protected pendingMetaDataWrites = [];
+
+    /**
      * @var StrategyInterface|null
      */
     protected strategy = null;
@@ -664,8 +674,9 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      */
     public function reset() -> void
     {
-        let this->metaData = [],
-            this->columnMap = [];
+        let this->metaData             = [],
+            this->columnMap            = [],
+            this->pendingMetaDataWrites = [];
     }
 
     /**
@@ -783,10 +794,16 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      */
     final public function writeMetaDataIndex(<ModelInterface> model, int index, var data) -> void
     {
-        var key;
-        let key = this->getMetaDataUniqueKey(model);
-        if likely key !== null {
+        string key;
+        let key = get_class_lower(model);
+
+        if isset(this->metaData[key]) {
             let this->metaData[key][index] = data;
+        } else {
+            if !isset(this->pendingMetaDataWrites[key]) {
+                let this->pendingMetaDataWrites[key] = [];
+            }
+            let this->pendingMetaDataWrites[key][index] = data;
         }
     }
 
@@ -854,6 +871,20 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
                      * Store the meta-data in the adapter
                      */
                     this->{"write"}(prefixKey, modelMetadata);
+                }
+
+                /**
+                 * Apply any metadata index writes that were buffered before
+                 * this model's metadata was properly initialized (e.g. from
+                 * skipAttributes() called during a parent model's initialize()
+                 * while the child's source had not yet been set).
+                 */
+                if isset(this->pendingMetaDataWrites[key]) {
+                    var pendingIndex, pendingData;
+                    for pendingIndex, pendingData in this->pendingMetaDataWrites[key] {
+                        let this->metaData[key][pendingIndex] = pendingData;
+                    }
+                    unset(this->pendingMetaDataWrites[key]);
                 }
             }
             return true;

--- a/tests/database/Mvc/Model/MetaData/SkipAttributesInheritedModelTest.php
+++ b/tests/database/Mvc/Model/MetaData/SkipAttributesInheritedModelTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Mvc\Model\MetaData;
+
+use Phalcon\Tests\AbstractDatabaseTestCase;
+use Phalcon\Tests\Support\Models\InvoicesSkipCreate;
+use Phalcon\Tests\Support\Models\InvoicesSkipCreateExtended;
+use Phalcon\Tests\Support\Traits\DiTrait;
+
+final class SkipAttributesInheritedModelTest extends AbstractDatabaseTestCase
+{
+    use DiTrait;
+
+    public function setUp(): void
+    {
+        $this->setNewFactoryDefault();
+        $this->setDatabase();
+    }
+
+    /**
+     * Tests that skipAttributes() called in a parent model's initialize() does
+     * not prematurely initialize metadata for an inheriting child model using
+     * the parent's source table, corrupting the child's attribute list.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/16544
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-30
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelMetadataSkipAttributesDoesNotCorruptInheritedModelMetadata(): void
+    {
+        $adapter = $this->newService('metadataMemory');
+        $adapter->setDi($this->container);
+        $adapter->reset();
+
+        $this->container->setShared('modelsMetadata', $adapter);
+
+        $parent = new InvoicesSkipCreate();
+        $child  = new InvoicesSkipCreateExtended();
+
+        /**
+         * Parent attributes must come from co_invoices
+         */
+        $expected = [
+            'inv_id',
+            'inv_cst_id',
+            'inv_status_flag',
+            'inv_title',
+            'inv_total',
+            'inv_created_at',
+        ];
+        $actual   = $adapter->getAttributes($parent);
+        $this->assertSame($expected, $actual);
+
+        /**
+         * Child attributes must come from co_customers, not co_invoices.
+         * With the bug, this returns the invoice columns instead.
+         */
+        $expected = [
+            'cst_id',
+            'cst_status_flag',
+            'cst_name_last',
+            'cst_name_first',
+        ];
+        $actual   = $adapter->getAttributes($child);
+        $this->assertSame($expected, $actual);
+
+        /**
+         * skipAttributes() registered in the parent's initialize() must still
+         * be honoured on the child after the fix.
+         */
+        $expected = ['inv_created_at' => null];
+        $actual   = $adapter->getAutomaticCreateAttributes($child);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/support/Models/InvoicesSkipCreate.php
+++ b/tests/support/Models/InvoicesSkipCreate.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+use Phalcon\Mvc\Model;
+
+class InvoicesSkipCreate extends Model
+{
+    public $inv_id;
+    public $inv_cst_id;
+    public $inv_status_flag;
+    public $inv_title;
+    public $inv_total;
+    public $inv_created_at;
+
+    public function initialize()
+    {
+        $this->setSource('co_invoices');
+
+        $this->hasOne(
+            'inv_cst_id',
+            Customers::class,
+            'cst_id',
+            ['alias' => 'customer']
+        );
+
+        $this->skipAttributes(['inv_created_at']);
+    }
+}

--- a/tests/support/Models/InvoicesSkipCreateExtended.php
+++ b/tests/support/Models/InvoicesSkipCreateExtended.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+class InvoicesSkipCreateExtended extends InvoicesSkipCreate
+{
+    public $cst_id;
+    public $cst_status_flag;
+    public $cst_name_last;
+    public $cst_name_first;
+
+    public function initialize()
+    {
+        parent::initialize();
+
+        $this->setSource('co_customers');
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16544 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\MetaData::writeMetaDataIndex()` prematurely initializing a child model's metadata with the parent's source table when `skipAttributes()` (or `skipAttributesOnCreate()`/`skipAttributesOnUpdate()`) is called inside a parent model's `initialize()` and the child calls `parent::initialize()` before setting its own source, corrupting the child's attribute list and breaking relationship resolution

Thanks

