### PR TITLE
T16648 checkbox value

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Http\Response\Cookies::get()` throwing an opaque fatal error when no DI container has been set; it now throws `Phalcon\Http\Cookie\Exception` with a descriptive message before accessing the container [#16650](https://github.com/phalcon/cphalcon/issues/16650)
 - Fixed `Phalcon\Mvc\Model\MetaData::writeMetaDataIndex()` prematurely initializing a child model's metadata with the parent's source table when `skipAttributes()` (or `skipAttributesOnCreate()`/`skipAttributesOnUpdate()`) is called inside a parent model's `initialize()` and the child calls `parent::initialize()` before setting its own source, corrupting the child's attribute list and breaking relationship resolution [#16544](https://github.com/phalcon/cphalcon/issues/16544)
 - Fixed `Phalcon\Storage\Serializer\Json::serialize()` rejecting plain objects (e.g. `stdClass`) that do not implement `JsonSerializable`; `json_encode()` handles such objects natively and the guard was unnecessary [#16630](https://github.com/phalcon/cphalcon/issues/16630)
 - Fixed `Phalcon\Mvc\Model\Manager` retaining a model instance in `lastInitialized` after initialization and `Phalcon\Mvc\Model` not clearing the reusable-records cache after `save()`, causing memory to grow unboundedly in long-running processes [#16566](https://github.com/phalcon/cphalcon/issues/16566)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Html\Helper\Input\AbstractInput::setValue()` ignoring empty string `""` as a valid value, causing `Checkbox` and `Radio` inputs with `value=""` to never render `checked="checked"` even when the `checked` attribute matched [#16648](https://github.com/phalcon/cphalcon/issues/16648)
 - Fixed `Phalcon\Http\Response\Cookies::get()` throwing an opaque fatal error when no DI container has been set; it now throws `Phalcon\Http\Cookie\Exception` with a descriptive message before accessing the container [#16650](https://github.com/phalcon/cphalcon/issues/16650)
 - Fixed `Phalcon\Mvc\Model\MetaData::writeMetaDataIndex()` prematurely initializing a child model's metadata with the parent's source table when `skipAttributes()` (or `skipAttributesOnCreate()`/`skipAttributesOnUpdate()`) is called inside a parent model's `initialize()` and the child calls `parent::initialize()` before setting its own source, corrupting the child's attribute list and breaking relationship resolution [#16544](https://github.com/phalcon/cphalcon/issues/16544)
 - Fixed `Phalcon\Storage\Serializer\Json::serialize()` rejecting plain objects (e.g. `stdClass`) that do not implement `JsonSerializable`; `json_encode()` handles such objects natively and the guard was unnecessary [#16630](https://github.com/phalcon/cphalcon/issues/16630)

--- a/phalcon/Cache/AbstractCache.zep
+++ b/phalcon/Cache/AbstractCache.zep
@@ -12,6 +12,7 @@ namespace Phalcon\Cache;
 
 use DateInterval;
 use Phalcon\Cache\Adapter\AdapterInterface;
+use Phalcon\Cache\Adapter\Redis;
 use Phalcon\Cache\Exception\InvalidArgumentException;
 use Phalcon\Events\EventsAwareInterface;
 use Phalcon\Events\ManagerInterface;
@@ -209,7 +210,8 @@ abstract class AbstractCache implements CacheInterface, EventsAwareInterface
         this->fire("cache:beforeGetMultiple", keys);
 
         let results = [];
-        if (adapterClass === "Phalcon\Cache\Adapter\Redis") {
+        let adapterClass = get_class(this->adapter);
+        if (adapterClass instanceof Redis) {
              let results    = this->adapter->getAdapter()->mget(keys);
              let serializer = this->adapter->getSerializer();
              let results    = array_map(

--- a/phalcon/Html/Helper/Input/AbstractInput.zep
+++ b/phalcon/Html/Helper/Input/AbstractInput.zep
@@ -94,7 +94,7 @@ abstract class AbstractInput extends AbstractHelper
      */
     public function setValue(string value = null) -> <AbstractInput>
     {
-        if is_numeric(value) || !empty(value)  {
+        if value !== null {
             let this->attributes["value"] = value;
         }
 

--- a/phalcon/Http/Response/Cookies.zep
+++ b/phalcon/Http/Response/Cookies.zep
@@ -140,24 +140,22 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
          * It's value come from $_COOKIE with request, so it shouldn't be saved
          * to _cookies property, otherwise it will always be resent after get.
          */
-        let cookie = <CookieInterface> this->container->get("Phalcon\\Http\\Cookie", [name]),
-            container = this->container;
+        let container = this->checkContainer();
+        let cookie    = <CookieInterface> container->get("Phalcon\\Http\\Cookie", [name]);
 
-        if typeof container == "object" {
-            /**
-             * Pass the DI to created cookies
-             */
-            cookie->setDi(container);
+        /**
+         * Pass the DI to created cookies
+         */
+        cookie->setDi(container);
 
-            let encryption = this->useEncryption;
+        let encryption = this->useEncryption;
 
-            /**
-             * Enable encryption in the cookie
-             */
-            if encryption {
-                cookie->useEncryption(encryption);
-                cookie->setSignKey(this->signKey);
-            }
+        /**
+         * Enable encryption in the cookie
+         */
+        if encryption {
+            cookie->useEncryption(encryption);
+            cookie->setSignKey(this->signKey);
         }
 
         return cookie;
@@ -303,15 +301,8 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
          * Register the cookies bag in the response
          */
         if this->registered === false {
-            let container = this->container;
-
-            if container === null {
-                throw new Exception(
-                    "A dependency injection container is required to access the 'response' service"
-                );
-            }
-
-            let response = container->getShared("response");
+            let container = this->checkContainer();
+            let response  = container->getShared("response");
 
             /**
              * Pass the cookies bag to the response so it can send the headers
@@ -350,5 +341,20 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
         let this->useEncryption = useEncryption;
 
         return this;
+    }
+
+    private function checkContainer() -> <DiInterface>
+    {
+        var container;
+
+        let container = this->container;
+
+        if container === null {
+            throw new Exception(
+                "A dependency injection container is required to access the 'response' service"
+            );
+        }
+
+        return container;
     }
 }

--- a/tests/unit/Html/Helper/Input/CheckboxUnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/Input/CheckboxUnderscoreInvokeTest.php
@@ -140,6 +140,21 @@ final class CheckboxUnderscoreInvokeTest extends AbstractUnitTestCase
                 . $type
                 . '" id="x_id" name="x_name" value="yes" />some text</label>',
             ],
+            [
+                'x_name',
+                '',
+                [
+                    'id'      => 'x_id',
+                    'checked' => '',
+                ],
+                null,
+                '<input type="'
+                . $type
+                . '" id="x_id" name="x_name" value="" checked="checked">',
+                '<input type="'
+                . $type
+                . '" id="x_id" name="x_name" value="" checked="checked" />',
+            ],
         ];
     }
 

--- a/tests/unit/Http/Response/Cookies/ExceptionsTest.php
+++ b/tests/unit/Http/Response/Cookies/ExceptionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Http\Response\Cookies;
+
+use Phalcon\Http\Cookie\Exception;
+use Phalcon\Http\Response\Cookies;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class ExceptionsTest extends AbstractUnitTestCase
+{
+    /**
+     * Tests that Cookies::get() throws a descriptive exception when no DI
+     * container has been set, rather than a fatal error.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/16650
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-30
+     */
+    public function testHttpResponseCookiesGetThrowsExceptionWhenContainerIsNull(): void
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(
+            "A dependency injection container is required to access the 'response' service"
+        );
+
+        $cookies = new Cookies(false);
+        $cookies->get('test-cookie');
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16648 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Html\Helper\Input\AbstractInput::setValue()` ignoring empty string `""` as a valid value, causing `Checkbox` and `Radio` inputs with `value=""` to never render `checked="checked"` even when the `checked` attribute matched

Thanks

