### PR TITLE
T16946 select multi

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Forms\Element\Select::render()` multiselect regression introduced in v5.12.0 (#16894) by reverting to `Phalcon\Tag\Select::selectField()`; the new `Html\Helper\Input\Select` only supports a single selected value and does not handle array values required for multiselect [#16946](https://github.com/phalcon/cphalcon/issues/16946)
 - Fixed `Phalcon\Html\Helper\Input\AbstractInput::setValue()` ignoring empty string `""` as a valid value, causing `Checkbox` and `Radio` inputs with `value=""` to never render `checked="checked"` even when the `checked` attribute matched [#16648](https://github.com/phalcon/cphalcon/issues/16648)
 - Fixed `Phalcon\Http\Response\Cookies::get()` throwing an opaque fatal error when no DI container has been set; it now throws `Phalcon\Http\Cookie\Exception` with a descriptive message before accessing the container [#16650](https://github.com/phalcon/cphalcon/issues/16650)
 - Fixed `Phalcon\Mvc\Model\MetaData::writeMetaDataIndex()` prematurely initializing a child model's metadata with the parent's source table when `skipAttributes()` (or `skipAttributesOnCreate()`/`skipAttributesOnUpdate()`) is called inside a parent model's `initialize()` and the child calls `parent::initialize()` before setting its own source, corrupting the child's attribute list and breaking relationship resolution [#16544](https://github.com/phalcon/cphalcon/issues/16544)

--- a/phalcon/Forms/Element/Select.zep
+++ b/phalcon/Forms/Element/Select.zep
@@ -10,11 +10,7 @@
 
 namespace Phalcon\Forms\Element;
 
-use Phalcon\Forms\Exception;
-use Phalcon\Html\Helper\Input\Select\ArrayData;
-use Phalcon\Html\Helper\Input\Select\ResultsetData;
-use Phalcon\Html\TagFactory;
-use Phalcon\Mvc\Model\ResultsetInterface;
+use Phalcon\Tag\Select as SelectTag;
 
 /**
  * Component SELECT (choice) for forms
@@ -75,90 +71,13 @@ class Select extends AbstractElement
      */
     public function render(array attributes = []) -> string
     {
-        var attrs, emptyText, emptyValue, html, name, options,
-            select, tagFactory, using, useEmpty, value;
-
-        let attrs = this->prepareAttributes(attributes);
-
-        let name = attrs[0];
-        unset attrs[0];
-
-        if isset attrs["value"] {
-            let value = attrs["value"];
-            unset attrs["value"];
-        } else {
-            let value = null;
-        }
-
-        if isset attrs["useEmpty"] {
-            let useEmpty = attrs["useEmpty"];
-        } else {
-            let useEmpty = false;
-        }
-
-        if isset attrs["emptyValue"] {
-            let emptyValue = attrs["emptyValue"];
-        } else {
-            let emptyValue = "";
-        }
-
-        if isset attrs["emptyText"] {
-            let emptyText = attrs["emptyText"];
-        } else {
-            let emptyText = "Choose...";
-        }
-
-        if isset attrs["using"] {
-            let using = attrs["using"];
-        } else {
-            let using = null;
-        }
-
-        unset attrs["useEmpty"];
-        unset attrs["emptyValue"];
-        unset attrs["emptyText"];
-        unset attrs["using"];
-
-        if !isset attrs["name"] {
-            let attrs["name"] = name;
-        }
-
-        if !strpos(name, "[") && !isset attrs["id"] {
-            let attrs["id"] = name;
-        }
-
-        let tagFactory = this->getLocalTagFactory(),
-            select     = tagFactory->newInstance("inputSelect");
-
-        select->__invoke("", "", attrs);
-
-        if value !== null {
-            select->selected((string) value);
-        }
-
-        if useEmpty {
-            select->addPlaceholder(emptyText, emptyValue, [], true);
-        }
-
-        let options = this->optionsValues;
-
-        if typeof options == "array" {
-            select->fromData(new ArrayData(options));
-        } elseif typeof options == "object" && options instanceof ResultsetInterface {
-            if unlikely using === null || typeof using != "array" {
-                throw Exception::usingParameterRequired();
-            }
-
-            select->fromData(new ResultsetData(options, using));
-        }
-
-        let html = (string) select;
-
-        if html === "" {
-            return tagFactory->newInstance("element")->__invoke("select", PHP_EOL, attrs, true);
-        }
-
-        return html;
+        /**
+         * Merged passed attributes with previously defined ones
+         */
+        return SelectTag::selectField(
+            this->prepareAttributes(attributes),
+            this->optionsValues
+        );
     }
 
     /**

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -230,7 +230,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      * @return string|false
      * @throws \Exception
      */
-    public function getClientAddress(bool trustForwardedHeader = false) -> string | false
+    public function getClientAddress(bool trustForwardedHeader = false) -> string | bool
     {
         var server, address, trustedProxyHeaderIp,
             forwarded, forwardedIps, reverseForwardedIps, forwardedIp,
@@ -1884,7 +1884,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      * @return string|false
      * @throws \Phalcon\Filter\Exception
      */
-    private function isValidPublicIp(string forwardedIp) -> string | false
+    private function isValidPublicIp(string forwardedIp) -> string | bool
     {
         var filterService, filtered;
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16946 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Forms\Element\Select::render()` multiselect regression introduced in v5.12.0 (#16894) by reverting to `Phalcon\Tag\Select::selectField()`; the new `Html\Helper\Input\Select` only supports a single selected value and does not handle array values required for multiselect

Thanks

