### PR TITLE
T16613 statementlist return types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -959,7 +959,7 @@ jobs:
         with:
           token: ${{ secrets.STUBS_REPO_TOKEN }}
           owner: phalcon
-          repo: phalcon-ide-stubs
+          repo: ide-stubs
           tag: v${{ env.PHALCON_VERSION }}
           name: v${{ env.PHALCON_VERSION }} Stubs
           body: "v${{ env.PHALCON_VERSION }} Stubs"

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -9,6 +9,8 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model\MetaDataInterface::readMetaDataIndex()` and `Phalcon\Mvc\Model\MetaData::readMetaDataIndex()` declaring return type as `array|null` when the method can also return a `string` (e.g. for `MODELS_IDENTITY_COLUMN`), causing a PHP fatal error on PHP 8+ [#16613](https://github.com/phalcon/cphalcon/issues/16613)
+- Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::statementList()` returning `null` instead of `string` when processing templates that consist entirely of block-mode statements, causing a PHP fatal error on PHP 8+ [#16613](https://github.com/phalcon/cphalcon/issues/16613)
 - Fixed `Phalcon\Forms\Element\Select::render()` multiselect regression introduced in v5.12.0 (#16894) by reverting to `Phalcon\Tag\Select::selectField()`; the new `Html\Helper\Input\Select` only supports a single selected value and does not handle array values required for multiselect [#16946](https://github.com/phalcon/cphalcon/issues/16946)
 - Fixed `Phalcon\Html\Helper\Input\AbstractInput::setValue()` ignoring empty string `""` as a valid value, causing `Checkbox` and `Radio` inputs with `value=""` to never render `checked="checked"` even when the `checked` attribute matched [#16648](https://github.com/phalcon/cphalcon/issues/16648)
 - Fixed `Phalcon\Http\Response\Cookies::get()` throwing an opaque fatal error when no DI container has been set; it now throws `Phalcon\Http\Cookie\Exception` with a descriptive message before accessing the container [#16650](https://github.com/phalcon/cphalcon/issues/16650)

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -655,7 +655,7 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      * );
      *```
      */
-    final public function readMetaDataIndex(<ModelInterface> model, int index) -> array | null
+    final public function readMetaDataIndex(<ModelInterface> model, int index) -> array | string | null
     {
         var key;
         let key = this->getMetaDataUniqueKey(model);

--- a/phalcon/Mvc/Model/MetaDataInterface.zep
+++ b/phalcon/Mvc/Model/MetaDataInterface.zep
@@ -128,7 +128,7 @@ interface MetaDataInterface
     /**
      * Reads meta-data for certain model using a MODEL_* constant
      */
-    public function readMetaDataIndex(<ModelInterface> model, int index) -> array | null;
+    public function readMetaDataIndex(<ModelInterface> model, int index) -> array | string | null;
 
     /**
      * Resets internal meta-data in order to regenerate it

--- a/phalcon/Mvc/View/Engine/Volt/Compiler.zep
+++ b/phalcon/Mvc/View/Engine/Volt/Compiler.zep
@@ -2887,7 +2887,7 @@ class Compiler implements InjectionAwareInterface
 
         let this->level--;
 
-        return compilation;
+        return (string) compilation;
     }
 
     /**


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #16613 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\MetaDataInterface::readMetaDataIndex()` and `Phalcon\Mvc\Model\MetaData::readMetaDataIndex()` declaring return type as `array|null` when the method can also return a `string` (e.g. for `MODELS_IDENTITY_COLUMN`), causing a PHP fatal error on PHP 8+ 

Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler::statementList()` returning `null` instead of `string` when processing templates that consist entirely of block-mode statements, causing a PHP fatal error on PHP 8+

Thanks

