### PR TITLE
[#16956] - fixing regression bug introduced in 5.12.0

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,6 +1,20 @@
 # Changelog
 
-## [5.12.1](https://github.com/phalcon/cphalcon/releases/tag/v5.12.1) (xxxx-xx-xx)
+## [5.12.2](https://github.com/phalcon/cphalcon/releases/tag/v5.12.1) (2026-xx-xx)
+
+### Changed
+
+### Added
+
+### Fixed
+
+- Fixed `Phalcon\Mvc\Model::cloneResultMap()` and `Phalcon\Mvc\Model::possibleSetter()` throwing `TypeError` during hydration when a model setter has a strict type hint (e.g. `?array`) and the raw database value is incompatible; the ORM now catches `TypeError` and falls back to direct property assignment [#16956](https://github.com/phalcon/cphalcon/issues/16956)
+
+### Removed
+
+## [5.12.1](https://github.com/phalcon/cphalcon/releases/tag/v5.12.1) (2026-04-30)
+
+### Changed
 
 ### Added
 
@@ -20,6 +34,8 @@
 - Fixed `Phalcon\Paginator\Adapter\QueryBuilder::paginate()` returning wrong total item count when the query uses `DISTINCT` columns; the count now uses `COUNT(DISTINCT ...)` for a single column and a subquery for multiple columns [#16581](https://github.com/phalcon/cphalcon/issues/16581)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::autoescape()` incorrectly wrapping function expressions (e.g. `DATE_PART(...)`) in brackets when used in `groupBy()`, causing a `"Column does not belong to any of the selected models"` exception [#16599](https://github.com/phalcon/cphalcon/issues/16599)
 - Fixed `Phalcon\Mvc\Model` - saving a model with multiple fields relations threw `"Not implemented"` [#16029](https://github.com/phalcon/cphalcon/issues/16029)
+
+### Removed
 
 ## 5.12.0 (2026-04-29)
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [5.12.2](https://github.com/phalcon/cphalcon/releases/tag/v5.12.1) (2026-xx-xx)
+## [5.12.2](https://github.com/phalcon/cphalcon/releases/tag/v5.12.2) (2026-xx-xx)
 
 ### Changed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1032,7 +1032,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if !disableSetters {
                     let setter = "set" . camelize(key);
                     if method_exists(instance, setter) && !isset localMethods[setter] {
-                        instance->{setter}(value);
+                        try {
+                            instance->{setter}(value);
+                        } catch \TypeError {
+                            let instance->{key} = value;
+                        }
                         continue;
                     }
                 }
@@ -1074,7 +1078,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 if !disableSetters {
                     let setter = "set" . camelize(attribute);
                     if method_exists(instance, setter) && !isset localMethods[setter] {
-                        instance->{setter}(value);
+                        try {
+                            instance->{setter}(value);
+                        } catch \TypeError {
+                            let instance->{attribute} = value;
+                        }
                         continue;
                     }
                 }
@@ -1133,7 +1141,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if !disableSetters {
                 let setter = "set" . camelize(attributeName);
                 if method_exists(instance, setter) && !isset localMethods[setter] {
-                    instance->{setter}(castValue);
+                    try {
+                        instance->{setter}(castValue);
+                    } catch \TypeError {
+                        let instance->{attributeName} = castValue;
+                    }
                     continue;
                 }
             }
@@ -4993,7 +5005,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         }
 
         if !isset localMethods[possibleSetter] {
-            this->{possibleSetter}(value);
+            try {
+                this->{possibleSetter}(value);
+            } catch \TypeError {
+                let this->{property} = value;
+            }
         }
 
         return true;

--- a/tests/database/Mvc/Model/CloneResultMapTest.php
+++ b/tests/database/Mvc/Model/CloneResultMapTest.php
@@ -19,6 +19,7 @@ use Phalcon\Tests\AbstractDatabaseTestCase;
 use Phalcon\Tests\Support\Migrations\InvoicesMigration;
 use Phalcon\Tests\Support\Models\InvoicesMap;
 use Phalcon\Tests\Support\Models\InvoicesWithSetters;
+use Phalcon\Tests\Support\Models\InvoicesWithTypedSetters;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
 final class CloneResultMapTest extends AbstractDatabaseTestCase
@@ -149,6 +150,40 @@ final class CloneResultMapTest extends AbstractDatabaseTestCase
 
         // setInvTotal() doubles the value → setter must have been called
         $this->assertSame(20.0, (float) $invoice->inv_total);
+    }
+
+    /**
+     * Tests that cloneResultMap() does not throw when a setter has a strict
+     * type hint that is incompatible with the raw DB value. The ORM must catch
+     * the TypeError and fall back to direct property assignment.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/16956
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-30
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelCloneResultMapSetterTypeErrorFallback(): void
+    {
+        /** @var InvoicesWithTypedSetters $invoice */
+        $invoice = Model::cloneResultMap(
+            new InvoicesWithTypedSetters(),
+            [
+                'inv_id'          => 1,
+                'inv_cst_id'      => 2,
+                'inv_status_flag' => 0,
+                'inv_title'       => 'raw-string-from-db',
+                'inv_total'       => 10.0,
+                'inv_created_at'  => '2026-01-01 00:00:00',
+            ],
+            null
+        );
+
+        // setInvTitle() expects ?array — the raw string causes a TypeError.
+        // The ORM must NOT throw; it must fall back to direct property assignment.
+        $this->assertSame('raw-string-from-db', $invoice->inv_title);
     }
 
     /**

--- a/tests/support/Models/InvoicesWithTypedSetters.php
+++ b/tests/support/Models/InvoicesWithTypedSetters.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+/**
+ * Model used to verify that a TypeError from a strictly-typed setter during
+ * ORM hydration does not propagate — the ORM must fall back to direct property
+ * assignment instead.
+ *
+ * @see https://github.com/phalcon/cphalcon/issues/16956
+ */
+class InvoicesWithTypedSetters extends Invoices
+{
+    /**
+     * Setter intentionally typed as ?array so that a raw string value coming
+     * from the database triggers a TypeError, which the ORM must catch and
+     * handle gracefully by falling back to direct property assignment.
+     */
+    public function setInvTitle(?array $data): void
+    {
+        $this->inv_title = implode(',', $data ?? []);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16956 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::cloneResultMap()` and `Phalcon\Mvc\Model::possibleSetter()` throwing `TypeError` during hydration when a model setter has a strict type hint (e.g. `?array`) and the raw database value is incompatible; the ORM now catches `TypeError` and falls back to direct property assignment

Thanks

