### PR TITLE
T16611 related entities null

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -10,6 +10,7 @@
 
 - Fixed `Phalcon\Mvc\Model::cloneResultMap()` and `Phalcon\Mvc\Model::possibleSetter()` throwing `TypeError` during hydration when a model setter has a strict type hint (e.g. `?array`) and the raw database value is incompatible; the ORM now catches `TypeError` and falls back to direct property assignment [#16956](https://github.com/phalcon/cphalcon/issues/16956)
 - Fixed `Phalcon\Tag\Select::optionsFromArray()` not escaping option label text, allowing XSS injection via malicious values; labels are now escaped with `escapeHtml()` and option values with `escapeHtmlAttr()` via the escaper service, consistent with `optionsFromResultset()` [#16660](https://github.com/phalcon/cphalcon/issues/16660)
+- Fixed `Phalcon\Mvc\Model::__set()` not clearing the cached related record when a `belongsTo` relation alias is assigned `null`; calling a getter before setting the relation to null caused `preSaveRelatedRecords()` to overwrite the FK back to its previous value on save [#16611](https://github.com/phalcon/cphalcon/issues/16611)
 
 ### Removed
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -550,6 +550,33 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             }
         }
 
+        /**
+         * Null assigned to a relationship alias must clear the cached related
+         * records so that preSaveRelatedRecords() does not overwrite the FK
+         * back to its old value during save().
+         *
+         * Pre-assigning this->{property} = null before calling possibleSetter
+         * prevents infinite recursion: once the property exists as a real
+         * (dynamic) property, any subsequent `$this->property = null` inside
+         * the user-defined setter will not re-enter __set.
+         */
+        elseif value === null {
+            let lowerProperty = strtolower(property),
+                modelName     = get_class(this),
+                manager       = this->getModelsManager(),
+                relation      = <RelationInterface> manager->getRelationByAlias(
+                    modelName,
+                    lowerProperty
+                );
+
+            if typeof relation === "object" {
+                unset this->related[lowerProperty];
+                unset this->dirtyRelated[lowerProperty];
+
+                let this->{property} = null;
+            }
+        }
+
         // Use possible setter.
         if this->possibleSetter(property, value) {
             return value;

--- a/tests/database/Mvc/Model/SaveTest.php
+++ b/tests/database/Mvc/Model/SaveTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Database\Mvc\Model;
 
 use PDO;
+use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Mvc\Model;
 use Phalcon\Mvc\Model\Manager;
 use Phalcon\Mvc\Model\MetaData;
@@ -26,12 +27,12 @@ use Phalcon\Tests\Support\Models\Customers;
 use Phalcon\Tests\Support\Models\CustomersDefaults;
 use Phalcon\Tests\Support\Models\CustomersKeepSnapshots;
 use Phalcon\Tests\Support\Models\Invoices;
+use Phalcon\Tests\Support\Models\InvoicesBelongsToCustomers;
 use Phalcon\Tests\Support\Models\InvoicesHasOneKeepSnapshots;
 use Phalcon\Tests\Support\Models\InvoicesHasOneNotReusable;
 use Phalcon\Tests\Support\Models\InvoicesKeepSnapshots;
 use Phalcon\Tests\Support\Models\InvoicesSchema;
 use Phalcon\Tests\Support\Models\InvoicesValidationFails;
-use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Tests\Support\Models\Sources;
 use Phalcon\Tests\Support\Traits\DiTrait;
 
@@ -400,6 +401,43 @@ final class SaveTest extends AbstractDatabaseTestCase
 
         $this->assertSame('newFirstName', $customer->cst_name_first);
         $this->assertSame(0, (int) $customer->cst_status_flag);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-04-30
+     *
+     * @issue  16611
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelSaveNullRelatedAfterCallingGetter(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+
+        $customersMigration = new CustomersMigration($connection);
+        $customersMigration->insert(1, 1, 'firstName', 'lastName');
+
+        $invoicesMigration = new InvoicesMigration($connection);
+        $invoicesMigration->insert(77, 1, 0, uniqid('inv-', true));
+
+        $invoice = InvoicesBelongsToCustomers::findFirst(77);
+
+        $this->assertNotNull($invoice->inv_cst_id);
+
+        // Calling the getter caches the related customer in $this->related.
+        // Setting the relation to null must clear that cache so that
+        // preSaveRelatedRecords() does not overwrite inv_cst_id on save.
+        $invoice->getCustomer();
+        $invoice->setCustomer(null);
+
+        $this->assertTrue($invoice->save());
+
+        $reloaded = InvoicesBelongsToCustomers::findFirst(77);
+
+        $this->assertNull($reloaded->inv_cst_id);
     }
 
     /**

--- a/tests/support/Models/InvoicesBelongsToCustomers.php
+++ b/tests/support/Models/InvoicesBelongsToCustomers.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Support\Models;
+
+use Phalcon\Mvc\Model;
+
+/**
+ * Model used to verify that setting a belongsTo relation to null after calling
+ * the getter correctly clears the cached related record, so that save() does
+ * not overwrite the FK back to its previous value.
+ *
+ * @see https://github.com/phalcon/cphalcon/issues/16611
+ *
+ * @property int|null $inv_id
+ * @property int|null $inv_cst_id
+ * @property int|null $inv_status_flag
+ * @property string   $inv_title
+ * @property float    $inv_total
+ * @property string   $inv_created_at
+ *
+ * @method static static findFirst($parameters = null)
+ */
+class InvoicesBelongsToCustomers extends Model
+{
+    public ?int $inv_id           = null;
+    public ?int $inv_cst_id       = null;
+    public ?int $inv_status_flag  = null;
+    public string $inv_title      = '';
+    public float $inv_total       = 0.0;
+    public string $inv_created_at = '';
+
+    public function initialize(): void
+    {
+        $this->setSource('co_invoices');
+
+        $this->belongsTo(
+            'inv_cst_id',
+            Customers::class,
+            'cst_id',
+            [
+                'alias' => 'customer',
+            ]
+        );
+    }
+
+    public function setCustomer(?Customers $customer): void
+    {
+        $this->customer = $customer;
+
+        if ($customer === null) {
+            $this->inv_cst_id = null;
+        }
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16611 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::__set()` not clearing the cached related record when a `belongsTo` relation alias is assigned `null`; calling a getter before setting the relation to null caused `preSaveRelatedRecords()` to overwrite the FK back to its previous value on save

Thanks

