### PR TITLE
T16614 view renderpath

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -11,6 +11,7 @@
 - Fixed `Phalcon\Mvc\Model::cloneResultMap()` and `Phalcon\Mvc\Model::possibleSetter()` throwing `TypeError` during hydration when a model setter has a strict type hint (e.g. `?array`) and the raw database value is incompatible; the ORM now catches `TypeError` and falls back to direct property assignment [#16956](https://github.com/phalcon/cphalcon/issues/16956)
 - Fixed `Phalcon\Tag\Select::optionsFromArray()` not escaping option label text, allowing XSS injection via malicious values; labels are now escaped with `escapeHtml()` and option values with `escapeHtmlAttr()` via the escaper service, consistent with `optionsFromResultset()` [#16660](https://github.com/phalcon/cphalcon/issues/16660)
 - Fixed `Phalcon\Mvc\Model::__set()` not clearing the cached related record when a `belongsTo` relation alias is assigned `null`; calling a getter before setting the relation to null caused `preSaveRelatedRecords()` to overwrite the FK back to its previous value on save [#16611](https://github.com/phalcon/cphalcon/issues/16611)
+- Fixed `Phalcon\Mvc\View::getActiveRenderPath()` returning only the first candidate path as a string when a single `viewsDir` was configured with multiple registered render engines and the view was not found; the method now collapses the internal `activeRenderPaths` array to a string only when it contains exactly one element, returning the full array of candidate paths in all other cases [#16614](https://github.com/phalcon/cphalcon/issues/16614)
 
 ### Removed
 

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -341,15 +341,11 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
     public function getActiveRenderPath() -> string | array
     {
         var activeRenderPath;
-        int viewsDirsCount;
 
-        let viewsDirsCount = count(this->getViewsDirs()),
-            activeRenderPath = this->activeRenderPaths;
+        let activeRenderPath = this->activeRenderPaths;
 
-        if viewsDirsCount === 1 {
-            if typeof activeRenderPath === "array" && count(activeRenderPath) {
-                let activeRenderPath = activeRenderPath[0];
-            }
+        if typeof activeRenderPath === "array" && count(activeRenderPath) === 1 {
+            let activeRenderPath = activeRenderPath[0];
         }
 
         if activeRenderPath === null {

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -344,8 +344,12 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
 
         let activeRenderPath = this->activeRenderPaths;
 
-        if typeof activeRenderPath === "array" && count(activeRenderPath) === 1 {
-            let activeRenderPath = activeRenderPath[0];
+        if typeof activeRenderPath === "array" {
+            if count(activeRenderPath) === 1 {
+                let activeRenderPath = activeRenderPath[0];
+            } elseif count(activeRenderPath) === 0 {
+                let activeRenderPath = "";
+            }
         }
 
         if activeRenderPath === null {

--- a/tests/unit/Mvc/View/GetActiveRenderPathTest.php
+++ b/tests/unit/Mvc/View/GetActiveRenderPathTest.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Mvc\View;
 
+use Phalcon\Di\Di;
 use Phalcon\Events\Manager;
 use Phalcon\Mvc\View;
+use Phalcon\Mvc\View\Engine\Php;
 use Phalcon\Tests\Support\Mvc\View\AfterRenderListener;
 use Phalcon\Tests\AbstractUnitTestCase;
 
@@ -60,8 +62,44 @@ class GetActiveRenderPathTest extends AbstractUnitTestCase
         ]);
 
         $this->assertEquals(
-            [dataDir('views' . DIRECTORY_SEPARATOR . 'activerender' . DIRECTORY_SEPARATOR . 'index.phtml')],
+            dataDir('views' . DIRECTORY_SEPARATOR . 'activerender' . DIRECTORY_SEPARATOR . 'index.phtml'),
             $view->getActiveRenderPath()
+        );
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/16614
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-02
+     */
+    public function testMvcViewGetActiveRenderPathSingleDirMultipleEnginesNotFound(): void
+    {
+        $container     = new Di();
+        $eventsManager = new Manager();
+
+        $view = new View();
+        $view->setDI($container);
+        $view->setViewsDir(dataDir('views' . DIRECTORY_SEPARATOR));
+        $view->setRenderLevel(View::LEVEL_ACTION_VIEW);
+        $view->setEventsManager($eventsManager);
+        $view->registerEngines(
+            [
+                '.volt'  => new Php($view),
+                '.phtml' => new Php($view),
+            ]
+        );
+
+        $view->start();
+        $view->render('activerender', 'missing_file');
+        $view->finish();
+
+        $base   = dataDir('views' . DIRECTORY_SEPARATOR . 'activerender' . DIRECTORY_SEPARATOR . 'missing_file');
+        $actual = $view->getActiveRenderPath();
+
+        $this->assertIsArray($actual);
+        $this->assertEquals(
+            [$base . '.volt', $base . '.phtml'],
+            $actual
         );
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16614 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\View::getActiveRenderPath()` returning only the first candidate path as a string when a single `viewsDir` was configured with multiple registered render engines and the view was not found; the method now collapses the internal `activeRenderPaths` array to a string only when it contains exactly one element, returning the full array of candidate paths in all other cases

Thanks

