### PR TITLE
T16976 update set phql

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -61,9 +61,7 @@
 - Fixed `Phalcon\Mvc\Model\Query\Builder::autoescape()` incorrectly wrapping function expressions (e.g. `DATE_PART(...)`) in brackets when used in `groupBy()`, causing a `"Column does not belong to any of the selected models"` exception [#16599](https://github.com/phalcon/cphalcon/issues/16599)
 - Fixed `Phalcon\Mvc\Model` - saving a model with multiple fields relations threw `"Not implemented"` [#16029](https://github.com/phalcon/cphalcon/issues/16029)
 
-### Removed
-
-## 5.12.0 (2026-04-29)
+## [5.12.0](https://github.com/phalcon/cphalcon/releases/tag/v5.12.0) (2026-04-29)
 
 ### Changed
 
@@ -123,7 +121,7 @@
 - Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to embed `Phalcon\Db\RawValue` bind parameters directly in the SQL string instead of passing them to PDO [#16350](https://github.com/phalcon/cphalcon/issues/16350)
 - Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to use the write connection when the query contains a `FOR UPDATE` clause, instead of always using the read connection [#16032](https://github.com/phalcon/cphalcon/issues/16032)
 - Fixed `Phalcon\Mvc\Model\Query::getExpression()` to emit `NOT BETWEEN` instead of `BETWEEN NOT` for the `PHQL_T_BETWEEN_NOT` token, producing valid SQL [#16812](https://github.com/phalcon/cphalcon/issues/16812)
-- Fixed `Phalcon\Mvc\Model\Query::getSelectColumn()` to use the full model class name as the `balias` key in a complex resultset when the model is namespaced (e.g. `App\Models\Users`), instead of incorrectly applying `lcfirst()` to the fully-qualified name; non-namespaced models (e.g. `Robots`) retain the existing `lcfirst()` behaviour (`robots`) [#16052](https://github.com/phalcon/cphalcon/issues/16052]
+- Fixed `Phalcon\Mvc\Model\Query::getSelectColumn()` to use the full model class name as the `balias` key in a complex resultset when the model is namespaced (e.g. `App\Models\Users`), instead of incorrectly applying `lcfirst()` to the fully-qualified name; non-namespaced models (e.g. `Robots`) retain the existing `lcfirst()` behaviour (`robots`) [#16052](https://github.com/phalcon/cphalcon/issues/16052)
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql()` to use a named bind parameter (`:APK0:`) instead of embedding the raw primary-key value in the PHQL string when `findFirst()` is called with a numeric or numeric-string argument; this prevents unbounded growth of the internal PHQL AST cache (`Query::$internalPhqlCache`) in long-running CLI processes [#14656](https://github.com/phalcon/cphalcon/issues/14656)
 - Fixed `Phalcon\Mvc\Model\Resultset\Complex::current()` to return `null` instead of an empty model instance when a `LEFT JOIN` produces no matching row (all column values are `null`) [#16239](https://github.com/phalcon/cphalcon/issues/16239)
 - Fixed `Phalcon\Mvc\Model\Transaction\Manager::collectTransaction()` to keep the correct transactions when rebuilding the list after removal [#16522](https://github.com/phalcon/cphalcon/issues/16522)
@@ -141,8 +139,7 @@
 
 ### Removed
 
-# Changelog
-## 5.11.1 (2026-04-04)
+## [5.11.1](https://github.com/phalcon/cphalcon/releases/tag/v5.11.1) (2026-04-04)
 
 ### Changed
 
@@ -158,7 +155,7 @@
 
 ### Removed
 
-## 5.11.0 (2026-04-03)
+## [5.11.0](https://github.com/phalcon/cphalcon/releases/tag/v5.11.0) (2026-04-03)
 
 ### Changed
 
@@ -188,8 +185,7 @@
 
 ### Removed
 
-# Changelog
-## 5.10.0 (2025-12-25)
+## [5.10.0](https://github.com/phalcon/cphalcon/releases/tag/v5.10.0) (2025-12-25)
 
 ### Changed
 
@@ -279,8 +275,16 @@
 - Fixed `Phalcon\Forms\Form` and `Phalcon\Filter\Validation` to correctly handle the `validate()` response when using validation class `beforeValidate()` [#16702](https://github.com/phalcon/cphalcon/issues/16702)
 - Fixed `Phalcon\Support\Debug` to use correct passed arguments in `set_error_handler` callback. PHP v7.2.0 deprecated `errcontext` and has been removed since php v8.0.0 [#16649](https://github.com/phalcon/cphalcon/issues/16686)
 - Fixed `Phalcon\Http\Response\Cookies`, `Phalcon\Http\Response\CookiesInterface` and `Phalcon\Http\Cookie` to use correct cookie default arguments, avoid deprecated null assign warning when trying to assign the same cookie twice [#16649](https://github.com/phalcon/cphalcon/issues/16649)
-- Fixed `Phalcon\Encryption\Crypt` method `checkCipherHashIsAvailable(string $cipher, string $type)` to correctly check the `cipher` or `hash` type [#16822](https://github.com/phalcon/cphalcon/issues/16822)
-- Fixed `Phalcon\Mvc\Model` docblocks [#16825](https://github.com/phalcon/cphalcon/issues/16825)
+- Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)
+- Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)
+- Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to explicitly set the `referencedModel` in the conditions along with the `referencedFields` [#16655](https://github.com/phalcon/cphalcon/pull/16655)
+- Fixed `Phalcon\Image\Adapters\AbstractAdapter::watermark` to correctly calculate the Y offset [#16658](https://github.com/phalcon/cphalcon/issues/16658)
+- Fixed `Phalcon\Dispatcher\AbstractDispatcher` when calling action methods that do not define parameters to prevent `Unknown named parameter` error.
+- Fixed `Phalcon\Di\Injectable` to reference the correct instance of `Phalcon\Di\Di` in the docblock property [#16634](https://github.com/phalcon/cphalcon/issues/16634)
+- Fixed `Phalcon\Filter\Filter` to have the correct docblock for IDE completion
+- Fixed `Phalcon\Mvc\Model\Query` to use the lifetime in the "cache" service if none has been supplied by the options [#16696](https://github.com/phalcon/cphalcon/issues/16696)
+- Fixed `Phalcon\Session\Adapter\Stream::gc()` to throw an exception if something is wrong with `glob()` [#16713](https://github.com/phalcon/cphalcon/issues/16713)
+- Fixed `Phalcon\Http\Request::getBasicAuth()` to return a `null` password if not defined on the server [#16668](https://github.com/phalcon/cphalcon/issues/16668)
 
 ### Removed
 
@@ -325,6 +329,7 @@
 - Fixed `Phalcon\Support\Helper\PascalCase` causing memory leak by anonymous function [#16593](https://github.com/phalcon/cphalcon/issues/16593)
 - Fixed `Phalcon\Mvc\Model\Query` to rollback failed transactions and re-throw exception for data consistency [#16604](https://github.com/phalcon/cphalcon/issues/16604)
 
+### Removed
 
 ## [5.7.0](https://github.com/phalcon/cphalcon/releases/tag/v5.7.0) (2024-05-17)
 
@@ -726,6 +731,7 @@
     - `Phalcon\Cache\CacheInterface`
     - `Phalcon\Cache\AbstractCache` to be used in the cache class but also the proxy-psr16 repo [#15927](https://github.com/phalcon/cphalcon/issues/15927)
 - Added
+    - `Phalcon\Html\Link\Interfaces\EvolvableLinkInterface`
     - `Phalcon\Html\Link\Interfaces\EvolvableLinkProviderInterface`
     - `Phalcon\Html\Link\Interfaces\LinkInterface`
     - `Phalcon\Html\Link\Interfaces\LinkProviderInterface`
@@ -922,8 +928,8 @@
 - Removed `Phalcon\Helper\File` - replaced by `Phalcon\Support\Helper\File\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Removed `Phalcon\Helper\Json` - replaced by `Phalcon\Support\Helper\Json\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Removed `Phalcon\Helper\Number` - replaced by `Phalcon\Support\Helper\Number\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
-- Removed `Phalcon\Helper\Str` - replaced by `Phalcon\Support\Helper\Str\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776]
-- Removed references to `Phalcon\Text`, `Phacon\Helper\*` from the code replacing it with `Phalcon\Support\Helper\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776]
+- Removed `Phalcon\Helper\Str` - replaced by `Phalcon\Support\Helper\Str\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
+- Removed references to `Phalcon\Text`, `Phacon\Helper\*` from the code replacing it with `Phalcon\Support\Helper\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Synchronized tests with `phalcon/phalcon` thus increasing coverage [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Changed `Phalcon\Assets\Manager` to require a `Phalcon\Html\TagFactory` in its constructor [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 
@@ -1163,3 +1169,26 @@
 - Corrected `Phalcon\Cache` to cast keys as strings before sending them to adapters [#15249](https://github.com/phalcon/cphalcon/issues/15249)
 - Binding form values with specified whitelist [#15070](https://github.com/phalcon/cphalcon/issues/15070)
 
+## [5.0.0-alpha.1](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0-alpha.1) (2021-03-31)
+
+### Fixed
+
+- Support for PHP 7.4 and PHP 8.0
+- Fixed `Logger\Log::log()` `log` to recognize all log levels [#15214](https://github.com/phalcon/cphalcon/issues/15214)
+- Changed `setClaims` to be protected so that the `Phalcon\Security\JWT\Builder` class can be properly extended. [#15322](https://github.com/phalcon/cphalcon/issues/15322)
+- Fixed `Phalcon\Mvc\Model::average()` to return `float` value when is `string` [#15287](https://github.com/phalcon/cphalcon/pull/15287)
+- Fixed `Phalcon\Storage\Serializer\Igbinary` to store `is_numeric` and `bool` values properly [#15240](https://github.com/phalcon/cphalcon/pull/15240)
+- Fixed `Phalcon\Validation\Validator\Confirmation` was failing to compare cases such as 000123 = 123 [#15347](https://github.com/phalcon/cphalcon/pull/15347)
+- Fixed `Phalcon\Storage\Adapter` failing to retrieve empty like stored data (such as [], 0, false) [15125](https://github.com/phalcon/cphalcon/issues/15125)
+- Fixed declarations for `function getEventsManager()` to allow null return [15010](https://github.com/phalcon/cphalcon/issues/15010)
+- Removed underscore from method names (starting) to abide with PSR-12 [15345](https://github.com/phalcon/cphalcon/issues/15345)
+- Fixed `Phalcon\Flash\Session::has()` to properly check if any messages are existing [15204](https://github.com/phalcon/cphalcon/issues/15204)
+- Fixed signature of `Phalcon\Forms\Element\Select::__construct()`
+- Fixed signature of `Phalcon\Assets\Manager::addCss()`
+- Fixed signature of `Phalcon\Assets\Manager::addJs()`
+- Fixed signature of `Phalcon\Db\Adapter\AdapterInterface::execute()`, `Phalcon\Db\Adapter\AdapterInterface::fetchOne()` and `Phalcon\Db\Adapter\AdapterInterface::query()`
+- Fixed `Phalcon\Annotations\Reader::parse()` to return constants annotations [#15919](https://github.com/phalcon/cphalcon/issues/15919)
+- Added `Phalcon\Annotations\Reflection::getConstantsAnnotations()` method that returns constants annotations [#15919](https://github.com/phalcon/cphalcon/issues/15919)
+- Changes to the `Phalcon\Annotations\Adapter\AdapterInterface`:
+    - Added `getConstant()` method that returns class constant annotations collection
+    - Added `getConstants()` method that returns class constants annotations array list

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -31,6 +31,7 @@
 - Fixed `Phalcon\Mvc\View::getActiveRenderPath()` returning only the first candidate path as a string when a single `viewsDir` was configured with multiple registered render engines and the view was not found; the method now collapses the internal `activeRenderPaths` array to a string only when it contains exactly one element, returning the full array of candidate paths in all other cases [#16614](https://github.com/phalcon/cphalcon/issues/16614)
 - Fixed `Phalcon\Tag\Select::optionsFromArray()` not escaping option label text, allowing XSS injection via malicious values; labels are now escaped with `escapeHtml()` and option values with `escapeHtmlAttr()` via the escaper service, consistent with `optionsFromResultset()` [#16660](https://github.com/phalcon/cphalcon/issues/16660)
 - Fixed `Phalcon\Mvc\Model::doLowInsert()` throwing `Unable to insert into <table> without data` when saving a model whose only column is an auto-increment primary key; on dialects where `useExplicitIdValue()` is `false` (MySQL, SQLite) the identity branch produced an empty `values` array. The identity column is now added with the connection's default identity value when the resulting `values` array would otherwise be empty [#156](https://github.com/phalcon/phalcon/issues/156)
+- Fixed `Phalcon\Mvc\Model\Query::executeUpdate()` and `Phalcon\Mvc\Model::doLowUpdate()` for PHQL `UPDATE ... SET <expr>` expressions with placeholders (e.g. `col = col + :inc:`): named placeholders embedded in expression SQL are now resolved before creating `RawValue` to avoid PDO "mixed named and positional parameters", and dynamic-update comparisons now always treat `RawValue` assignments as changed so updates are not skipped when the current numeric value is `0` [#16976](https://github.com/phalcon/cphalcon/issues/16976)
 
 ### Removed
 
@@ -122,7 +123,7 @@
 - Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to embed `Phalcon\Db\RawValue` bind parameters directly in the SQL string instead of passing them to PDO [#16350](https://github.com/phalcon/cphalcon/issues/16350)
 - Fixed `Phalcon\Mvc\Model\Query::executeSelect()` to use the write connection when the query contains a `FOR UPDATE` clause, instead of always using the read connection [#16032](https://github.com/phalcon/cphalcon/issues/16032)
 - Fixed `Phalcon\Mvc\Model\Query::getExpression()` to emit `NOT BETWEEN` instead of `BETWEEN NOT` for the `PHQL_T_BETWEEN_NOT` token, producing valid SQL [#16812](https://github.com/phalcon/cphalcon/issues/16812)
-- Fixed `Phalcon\Mvc\Model\Query::getSelectColumn()` to use the full model class name as the `balias` key in a complex resultset when the model is namespaced (e.g. `App\Models\Users`), instead of incorrectly applying `lcfirst()` to the fully-qualified name; non-namespaced models (e.g. `Robots`) retain the existing `lcfirst()` behaviour (`robots`) [#16052](https://github.com/phalcon/cphalcon/issues/16052)
+- Fixed `Phalcon\Mvc\Model\Query::getSelectColumn()` to use the full model class name as the `balias` key in a complex resultset when the model is namespaced (e.g. `App\Models\Users`), instead of incorrectly applying `lcfirst()` to the fully-qualified name; non-namespaced models (e.g. `Robots`) retain the existing `lcfirst()` behaviour (`robots`) [#16052](https://github.com/phalcon/cphalcon/issues/16052]
 - Fixed `Phalcon\Mvc\Model\Query\Builder::getPhql()` to use a named bind parameter (`:APK0:`) instead of embedding the raw primary-key value in the PHQL string when `findFirst()` is called with a numeric or numeric-string argument; this prevents unbounded growth of the internal PHQL AST cache (`Query::$internalPhqlCache`) in long-running CLI processes [#14656](https://github.com/phalcon/cphalcon/issues/14656)
 - Fixed `Phalcon\Mvc\Model\Resultset\Complex::current()` to return `null` instead of an empty model instance when a `LEFT JOIN` produces no matching row (all column values are `null`) [#16239](https://github.com/phalcon/cphalcon/issues/16239)
 - Fixed `Phalcon\Mvc\Model\Transaction\Manager::collectTransaction()` to keep the correct transactions when rebuilding the list after removal [#16522](https://github.com/phalcon/cphalcon/issues/16522)
@@ -278,16 +279,8 @@
 - Fixed `Phalcon\Forms\Form` and `Phalcon\Filter\Validation` to correctly handle the `validate()` response when using validation class `beforeValidate()` [#16702](https://github.com/phalcon/cphalcon/issues/16702)
 - Fixed `Phalcon\Support\Debug` to use correct passed arguments in `set_error_handler` callback. PHP v7.2.0 deprecated `errcontext` and has been removed since php v8.0.0 [#16649](https://github.com/phalcon/cphalcon/issues/16686)
 - Fixed `Phalcon\Http\Response\Cookies`, `Phalcon\Http\Response\CookiesInterface` and `Phalcon\Http\Cookie` to use correct cookie default arguments, avoid deprecated null assign warning when trying to assign the same cookie twice [#16649](https://github.com/phalcon/cphalcon/issues/16649)
-- Fixed `Phalcon\Encryption\Crypt` to use `strlen` instead of `mb_strlen` for padding calculations [#16642](https://github.com/phalcon/cphalcon/issues/16642)
-- Fixed `Phalcon\Filter\Validation\Validator\File\MimeType::validate` to close the handle when using `finfo` [#16647](https://github.com/phalcon/cphalcon/issues/16647)
-- Fixed `Phalcon\Mvc\Model\Manager::getRelationRecords` to explicitly set the `referencedModel` in the conditions along with the `referencedFields` [#16655](https://github.com/phalcon/cphalcon/pull/16655)
-- Fixed `Phalcon\Image\Adapters\AbstractAdapter::watermark` to correctly calculate the Y offset [#16658](https://github.com/phalcon/cphalcon/issues/16658)
-- Fixed `Phalcon\Dispatcher\AbstractDispatcher` when calling action methods that do not define parameters to prevent `Unknown named parameter` error.
-- Fixed `Phalcon\Di\Injectable` to reference the correct instance of `Phalcon\Di\Di` in the docblock property [#16634](https://github.com/phalcon/cphalcon/issues/16634)
-- Fixed `Phalcon\Filter\Filter` to have the correct docblock for IDE completion
-- Fixed `Phalcon\Mvc\Model\Query` to use the lifetime in the "cache" service if none has been supplied by the options [#16696](https://github.com/phalcon/cphalcon/issues/16696)
-- Fixed `Phalcon\Session\Adapter\Stream::gc()` to throw an exception if something is wrong with `glob()` [#16713](https://github.com/phalcon/cphalcon/issues/16713)
-- Fixed `Phalcon\Http\Request::getBasicAuth()` to return a `null` password if not defined on the server [#16668](https://github.com/phalcon/cphalcon/issues/16668)
+- Fixed `Phalcon\Encryption\Crypt` method `checkCipherHashIsAvailable(string $cipher, string $type)` to correctly check the `cipher` or `hash` type [#16822](https://github.com/phalcon/cphalcon/issues/16822)
+- Fixed `Phalcon\Mvc\Model` docblocks [#16825](https://github.com/phalcon/cphalcon/issues/16825)
 
 ### Removed
 
@@ -332,7 +325,6 @@
 - Fixed `Phalcon\Support\Helper\PascalCase` causing memory leak by anonymous function [#16593](https://github.com/phalcon/cphalcon/issues/16593)
 - Fixed `Phalcon\Mvc\Model\Query` to rollback failed transactions and re-throw exception for data consistency [#16604](https://github.com/phalcon/cphalcon/issues/16604)
 
-### Removed
 
 ## [5.7.0](https://github.com/phalcon/cphalcon/releases/tag/v5.7.0) (2024-05-17)
 
@@ -734,7 +726,6 @@
     - `Phalcon\Cache\CacheInterface`
     - `Phalcon\Cache\AbstractCache` to be used in the cache class but also the proxy-psr16 repo [#15927](https://github.com/phalcon/cphalcon/issues/15927)
 - Added
-    - EvolvableLinkInterface.zep
     - `Phalcon\Html\Link\Interfaces\EvolvableLinkProviderInterface`
     - `Phalcon\Html\Link\Interfaces\LinkInterface`
     - `Phalcon\Html\Link\Interfaces\LinkProviderInterface`
@@ -931,8 +922,8 @@
 - Removed `Phalcon\Helper\File` - replaced by `Phalcon\Support\Helper\File\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Removed `Phalcon\Helper\Json` - replaced by `Phalcon\Support\Helper\Json\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Removed `Phalcon\Helper\Number` - replaced by `Phalcon\Support\Helper\Number\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
-- Removed `Phalcon\Helper\Str` - replaced by `Phalcon\Support\Helper\Str\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
-- Removed references to `Phalcon\Text`, `Phacon\Helper\*` from the code replacing it with `Phalcon\Support\Helper\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776)
+- Removed `Phalcon\Helper\Str` - replaced by `Phalcon\Support\Helper\Str\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776]
+- Removed references to `Phalcon\Text`, `Phacon\Helper\*` from the code replacing it with `Phalcon\Support\Helper\*` [#15776](https://github.com/phalcon/cphalcon/issues/15776]
 - Synchronized tests with `phalcon/phalcon` thus increasing coverage [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 - Changed `Phalcon\Assets\Manager` to require a `Phalcon\Html\TagFactory` in its constructor [#15776](https://github.com/phalcon/cphalcon/issues/15776)
 
@@ -1172,26 +1163,3 @@
 - Corrected `Phalcon\Cache` to cast keys as strings before sending them to adapters [#15249](https://github.com/phalcon/cphalcon/issues/15249)
 - Binding form values with specified whitelist [#15070](https://github.com/phalcon/cphalcon/issues/15070)
 
-## [5.0.0-alpha.1](https://github.com/phalcon/cphalcon/releases/tag/v5.0.0-alpha.1) (2021-03-31)
-
-### Fixed
-
-- Support for PHP 7.4 and PHP 8.0
-- Fixed `Logger\Log::log()` `log` to recognize all log levels [#15214](https://github.com/phalcon/cphalcon/issues/15214)
-- Changed `setClaims` to be protected so that the `Phalcon\Security\JWT\Builder` class can be properly extended. [#15322](https://github.com/phalcon/cphalcon/issues/15322)
-- Fixed `Phalcon\Mvc\Model::average()` to return `float` value when is `string` [#15287](https://github.com/phalcon/cphalcon/pull/15287)
-- Fixed `Phalcon\Storage\Serializer\Igbinary` to store `is_numeric` and `bool` values properly [#15240](https://github.com/phalcon/cphalcon/pull/15240)
-- Fixed `Phalcon\Validation\Validator\Confirmation` was failing to compare cases such as 000123 = 123 [#15347](https://github.com/phalcon/cphalcon/pull/15347)
-- Fixed `Phalcon\Storage\Adapter` failing to retrieve empty like stored data (such as [], 0, false) [15125](https://github.com/phalcon/cphalcon/issues/15125)
-- Fixed declarations for `function getEventsManager()` to allow null return [15010](https://github.com/phalcon/cphalcon/issues/15010)
-- Removed underscore from method names (starting) to abide with PSR-12 [15345](https://github.com/phalcon/cphalcon/issues/15345)
-- Fixed `Phalcon\Flash\Session::has()` to properly check if any messages are existing [15204](https://github.com/phalcon/cphalcon/issues/15204)
-- Fixed signature of `Phalcon\Forms\Element\Select::__construct()`
-- Fixed signature of `Phalcon\Assets\Manager::addCss()`
-- Fixed signature of `Phalcon\Assets\Manager::addJs()`
-- Fixed signature of `Phalcon\Db\Adapter\AdapterInterface::execute()`, `Phalcon\Db\Adapter\AdapterInterface::fetchOne()` and `Phalcon\Db\Adapter\AdapterInterface::query()`
-- Fixed `Phalcon\Annotations\Reader::parse()` to return constants annotations [#15919](https://github.com/phalcon/cphalcon/issues/15919)
-- Added `Phalcon\Annotations\Reflection::getConstantsAnnotations()` method that returns constants annotations [#15919](https://github.com/phalcon/cphalcon/issues/15919)
-- Changes to the `Phalcon\Annotations\Adapter\AdapterInterface`:
-    - Added `getConstant()` method that returns class constant annotations collection
-    - Added `getConstants()` method that returns class constants annotations array list

--- a/phalcon/Html/Helper/Breadcrumbs.zep
+++ b/phalcon/Html/Helper/Breadcrumbs.zep
@@ -23,17 +23,8 @@ use Phalcon\Support\Helper\Str\Interpolate;
  * The resulting HTML when calling `render()` will have each breadcrumb enclosed
  * in `<li>` tags, while the whole string is enclosed in `<nav>` and `<ol>` tags.
  *
- * @phpstan-type TTemplate = array{
- *      main: string,
- *      line: string,
- *      last: string,
- * }
- * @phpstan-type TElement = array{
- *      attributes: array<string, string>,
- *      icon: string,
- *      link: string,
- *      text: string,
- * }
+ * @phpstan-type TTemplate array{main: string, line: string, last: string}
+ * @phpstan-type TElement array{attributes: array<string, string>, icon: string, link: string, text: string}
  */
 class Breadcrumbs extends AbstractHelper
 {

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4361,10 +4361,21 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                         let snapshotValue = snapshotValue->getValue();
                                     }
 
-                                    let updateValue = value;
+                                    /**
+                                     * A RawValue holds a SQL expression (e.g.
+                                     * "col + 2"). It cannot be meaningfully
+                                     * compared to a stored scalar, so always
+                                     * treat the field as changed. This fixes
+                                     * the case where the current DB value is 0
+                                     * and the expression evaluates (via
+                                     * floatval) to 0.0, incorrectly suppressing
+                                     * the UPDATE.
+                                     */
                                     if is_object(value) && value instanceof RawValue {
-                                        let updateValue = value->getValue();
-                                    }
+                                        let changed = true;
+                                    } else {
+
+                                    let updateValue = value;
 
                                     switch dataType {
 
@@ -4394,6 +4405,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                         default:
                                             let changed = updateValue != snapshotValue;
                                     }
+                                    } // end else (value is not RawValue)
                                 }
                             }
                         }

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -4374,38 +4374,37 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                                     if is_object(value) && value instanceof RawValue {
                                         let changed = true;
                                     } else {
+                                        let updateValue = value;
 
-                                    let updateValue = value;
+                                        switch dataType {
 
-                                    switch dataType {
+                                            case Column::TYPE_BOOLEAN:
+                                                let changed = (bool) snapshotValue !== (bool) updateValue;
+                                                break;
 
-                                        case Column::TYPE_BOOLEAN:
-                                            let changed = (bool) snapshotValue !== (bool) updateValue;
-                                            break;
+                                            case Column::TYPE_DECIMAL:
+                                            case Column::TYPE_FLOAT:
+                                                let changed = floatval(snapshotValue) !== floatval(updateValue);
+                                                break;
 
-                                        case Column::TYPE_DECIMAL:
-                                        case Column::TYPE_FLOAT:
-                                            let changed = floatval(snapshotValue) !== floatval(updateValue);
-                                            break;
+                                            case Column::TYPE_INTEGER:
+                                            case Column::TYPE_DATE:
+                                            case Column::TYPE_VARCHAR:
+                                            case Column::TYPE_DATETIME:
+                                            case Column::TYPE_CHAR:
+                                            case Column::TYPE_TEXT:
+                                            case Column::TYPE_VARCHAR:
+                                            case Column::TYPE_BIGINTEGER:
+                                                let changed = (string) snapshotValue !== (string) updateValue;
+                                                break;
 
-                                        case Column::TYPE_INTEGER:
-                                        case Column::TYPE_DATE:
-                                        case Column::TYPE_VARCHAR:
-                                        case Column::TYPE_DATETIME:
-                                        case Column::TYPE_CHAR:
-                                        case Column::TYPE_TEXT:
-                                        case Column::TYPE_VARCHAR:
-                                        case Column::TYPE_BIGINTEGER:
-                                            let changed = (string) snapshotValue !== (string) updateValue;
-                                            break;
-
-                                        /**
-                                        * Any other type is not really supported...
-                                        */
-                                        default:
-                                            let changed = updateValue != snapshotValue;
+                                            /**
+                                            * Any other type is not really supported...
+                                            */
+                                            default:
+                                                let changed = updateValue != snapshotValue;
+                                        }
                                     }
-                                    } // end else (value is not RawValue)
                                 }
                             }
                         }

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -1417,7 +1417,7 @@ class Query implements QueryInterface, InjectionAwareInterface
         var models, modelName, model, connection, dialect, fields, values,
             updateValues, fieldName, value, selectBindParams, selectBindTypes,
             number, field, records, exprValue, updateValue, wildcard, record,
-            exception;
+            exception, sqlExpr, namedParams, paramKey, paramValue;
 
         let models = intermediate["models"];
 
@@ -1506,9 +1506,41 @@ class Query implements QueryInterface, InjectionAwareInterface
                     throw new Exception("Not supported");
 
                 default:
-                    let updateValue = new RawValue(
-                        dialect->getSqlExpression(exprValue)
-                    );
+                    let sqlExpr = dialect->getSqlExpression(exprValue);
+
+                    /**
+                     * If the expression contains named placeholders (e.g.
+                     * "col + :param"), resolve them from bindParams so the
+                     * RawValue is free of named params. This prevents a PDO
+                     * "mixed named and positional parameters" error when the
+                     * WHERE clause uses positional "?" markers.
+                     */
+                    let namedParams = [];
+
+                    if preg_match_all("/:([a-zA-Z0-9_]+)/", sqlExpr, namedParams) {
+                        for paramKey in namedParams[1] {
+                            if fetch paramValue, bindParams[paramKey] {
+                                if typeof paramValue == "integer" || typeof paramValue == "double" {
+                                    let sqlExpr = str_replace(
+                                        ":" . paramKey,
+                                        (string) paramValue,
+                                        sqlExpr
+                                    );
+                                } else {
+                                    let sqlExpr = str_replace(
+                                        ":" . paramKey,
+                                        connection->escapeString((string) paramValue),
+                                        sqlExpr
+                                    );
+                                }
+
+                                unset selectBindParams[paramKey];
+                                unset selectBindTypes[paramKey];
+                            }
+                        }
+                    }
+
+                    let updateValue = new RawValue(sqlExpr);
 
                     break;
             }

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -1417,7 +1417,7 @@ class Query implements QueryInterface, InjectionAwareInterface
         var models, modelName, model, connection, dialect, fields, values,
             updateValues, fieldName, value, selectBindParams, selectBindTypes,
             number, field, records, exprValue, updateValue, wildcard, record,
-            exception, sqlExpr, namedParams, paramKey, paramValue;
+            exception, sqlExpr, namedParams, paramKey, paramKeys, paramValue;
 
         let models = intermediate["models"];
 
@@ -1518,17 +1518,31 @@ class Query implements QueryInterface, InjectionAwareInterface
                     let namedParams = [];
 
                     if preg_match_all("/:([a-zA-Z0-9_]+)/", sqlExpr, namedParams) {
-                        for paramKey in namedParams[1] {
+                        /**
+                         * Sort by length descending so a key like "id" does
+                         * not partially match a longer placeholder like
+                         * ":idx" when running str_replace.
+                         */
+                        let paramKeys = array_unique(namedParams[1]);
+
+                        usort(
+                            paramKeys,
+                            function (a, b) {
+                                return strlen(b) - strlen(a);
+                            }
+                        );
+
+                        for paramKey in paramKeys {
                             if fetch paramValue, bindParams[paramKey] {
                                 if typeof paramValue == "integer" || typeof paramValue == "double" {
-                                    let sqlExpr = str_replace(
-                                        ":" . paramKey,
+                                    let sqlExpr = preg_replace(
+                                        "/:" . preg_quote(paramKey, "/") . "\\b/",
                                         (string) paramValue,
                                         sqlExpr
                                     );
                                 } else {
-                                    let sqlExpr = str_replace(
-                                        ":" . paramKey,
+                                    let sqlExpr = preg_replace(
+                                        "/:" . preg_quote(paramKey, "/") . "\\b/",
                                         connection->escapeString((string) paramValue),
                                         sqlExpr
                                     );

--- a/tests/database/Mvc/Model/Manager/ExecuteQueryTest.php
+++ b/tests/database/Mvc/Model/Manager/ExecuteQueryTest.php
@@ -73,4 +73,65 @@ final class ExecuteQueryTest extends AbstractDatabaseTestCase
         $sql = sprintf("DELETE FROM [%s] WHERE inv_id = :id:", Invoices::class);
         $this->assertInstanceOf(StatusInterface::class, $manager->executeQuery($sql, ["id" => 0]));
     }
+
+    /**
+     * @issue  16976
+     * @issue  2373
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-04
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelManagerExecuteQueryIssue16976(): void
+    {
+        /** @var ManagerInterface $manager */
+        $manager = $this->getService("modelsManager");
+
+        $manager->executeQuery(
+            sprintf("INSERT INTO [%s] (inv_total) VALUES (0)", Invoices::class)
+        );
+
+        $invoice = Invoices::findFirst(
+            [
+                "order" => "inv_id DESC",
+            ]
+        );
+
+        $this->assertNotFalse($invoice);
+
+        $manager->useDynamicUpdate($invoice, true);
+
+        $id = (int) $invoice->inv_id;
+
+        $manager->executeQuery(
+            sprintf("UPDATE [%s] SET inv_total = 0 WHERE inv_id = :id:", Invoices::class),
+            ["id" => $id]
+        );
+
+        $status = $manager->executeQuery(
+            sprintf(
+                "UPDATE [%s] SET inv_total = inv_total + :inc: WHERE inv_id = :id:",
+                Invoices::class
+            ),
+            [
+                "id"  => $id,
+                "inc" => 2,
+            ]
+        );
+
+        $this->assertInstanceOf(StatusInterface::class, $status);
+        $this->assertTrue($status->success());
+
+        $invoice = Invoices::findFirst(
+            [
+                "conditions" => "inv_id = :id:",
+                "bind"       => ["id" => $id],
+            ]
+        );
+
+        $this->assertNotFalse($invoice);
+        $this->assertSame(2.0, (float) $invoice->inv_total);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #16976 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Query::executeUpdate()` and `Phalcon\Mvc\Model::doLowUpdate()` for PHQL `UPDATE ... SET <expr>` expressions with placeholders (e.g. `col = col + :inc:`): named placeholders embedded in expression SQL are now resolved before creating `RawValue` to avoid PDO "mixed named and positional parameters", and dynamic-update comparisons now always treat `RawValue` assignments as changed so updates are not skipped when the current numeric value is `0`

Thanks

