### PR TITLE
Fix query builder order by complex expressions

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Di\Injectable::__get()` to no longer cache resolved services as dynamic object properties. Services accessed via magic properties (e.g. `$this->request`) are now re-resolved through the container on each access, so replacing or updating a service in the container is reflected in controllers, views, and other injectable classes. Properties already declared on the class continue to be populated. [#17052](https://github.com/phalcon/cphalcon/issues/17052)
+- Fixed `Phalcon\Mvc\Model\Query\Builder::orderBy()` when the array syntax is used with complex PHQL expressions. Previously any array item containing a space was split as a simple `column direction` pair, corrupting expressions such as `CASE WHEN inv_status_flag = 1 THEN 0 ELSE 1 END ASC`. The builder now only treats a trailing `ASC`/`DESC` as the direction (autoescaping a simple column) and preserves complex expressions verbatim. [#17077](https://github.com/phalcon/cphalcon/issues/17077)
 
 ### Removed
 

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -964,16 +964,37 @@ class Builder implements BuilderInterface, InjectionAwareInterface
                         continue;
                     }
 
-                    if memstr(orderItem, " ") !== 0 {
-                        var itemExplode;
+                    /**
+                     * For cases 'ORDER BY column ASC' and complex expressions
+                     */
+                    var itemTrimmed, lastSpacePosition;
 
-                        let itemExplode = explode(" ", orderItem);
-                        let orderItems[] = this->autoescape(itemExplode[0]) . " " . itemExplode[1];
+                    let itemTrimmed = trim(orderItem),
+                        lastSpacePosition = strrpos(itemTrimmed, " ");
+
+                    if false !== lastSpacePosition {
+                        var perhapsExpression, perhapsDirection;
+
+                        let perhapsExpression = trim(substr(itemTrimmed, 0, lastSpacePosition)),
+                            perhapsDirection = rtrim(substr(itemTrimmed, lastSpacePosition + 1));
+
+                        if (
+                            strcasecmp(perhapsDirection, "desc") == 0 ||
+                            strcasecmp(perhapsDirection, "asc") == 0
+                        ) {
+                            if !memstr(perhapsExpression, " ") {
+                                let perhapsExpression = this->autoescape(perhapsExpression);
+                            }
+
+                            let orderItems[] = perhapsExpression . " " . perhapsDirection;
+                        } else {
+                            let orderItems[] = itemTrimmed;
+                        }
 
                         continue;
                     }
 
-                    let orderItems[] = this->autoescape(orderItem);
+                    let orderItems[] = this->autoescape(itemTrimmed);
                 }
 
                 let phql .= " ORDER BY " . join(", ", orderItems);

--- a/tests/database/Mvc/Model/Query/Builder/OrderByTest.php
+++ b/tests/database/Mvc/Model/Query/Builder/OrderByTest.php
@@ -79,6 +79,83 @@ final class OrderByTest extends AbstractDatabaseTestCase
     }
 
     /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/17077
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-05
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelQueryBuilderOrderByArrayComplexWithoutDirection(): void
+    {
+        $builder = new Builder();
+        $phql    = $builder
+            ->columns('inv_id, inv_title')
+            ->addFrom(Invoices::class)
+            ->orderBy(['COALESCE(inv_a, inv_b)'])
+            ->getPhql()
+        ;
+
+        $expected = 'SELECT inv_id, inv_title '
+            . 'FROM [Phalcon\Tests\Support\Models\Invoices] '
+            . 'ORDER BY COALESCE(inv_a, inv_b)';
+        $this->assertEquals($expected, $phql);
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/17077
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-05
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelQueryBuilderOrderByArraySimpleColumns(): void
+    {
+        $builder = new Builder();
+        $builder
+            ->columns('inv_id, inv_title')
+            ->addFrom(Invoices::class)
+        ;
+
+        $prefix = 'SELECT inv_id, inv_title '
+            . 'FROM [Phalcon\Tests\Support\Models\Invoices] '
+            . 'ORDER BY ';
+
+        // Bare column - autoescaped
+        $this->assertEquals(
+            $prefix . '[inv_title]',
+            $builder->orderBy(['inv_title'])->getPhql()
+        );
+
+        // Column with direction - autoescaped, direction preserved
+        $this->assertEquals(
+            $prefix . '[inv_title] DESC',
+            $builder->orderBy(['inv_title DESC'])->getPhql()
+        );
+
+        // Extra whitespace between column and direction is normalized
+        $this->assertEquals(
+            $prefix . '[inv_title] DESC',
+            $builder->orderBy(['inv_title    DESC'])->getPhql()
+        );
+
+        // Lowercase direction is preserved as written
+        $this->assertEquals(
+            $prefix . '[inv_title] desc',
+            $builder->orderBy(['inv_title desc'])->getPhql()
+        );
+
+        // Dotted identifier is left untouched by autoescape
+        $this->assertEquals(
+            $prefix . 'i.inv_title ASC',
+            $builder->orderBy(['i.inv_title ASC'])->getPhql()
+        );
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2026-05-05
      *

--- a/tests/database/Mvc/Model/Query/Builder/OrderByTest.php
+++ b/tests/database/Mvc/Model/Query/Builder/OrderByTest.php
@@ -77,4 +77,36 @@ final class OrderByTest extends AbstractDatabaseTestCase
         $actual   = $phql;
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-05
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelQueryBuilderOrderByWithComplexExpression(): void
+    {
+        $builder = new Builder();
+        $phql    = $builder
+            ->columns('inv_id, inv_title')
+            ->addFrom(Invoices::class)
+            ->orderBy(
+                [
+                    'CASE WHEN inv_status_flag = 1 THEN 0 ELSE 1 END ASC',
+                    'NOT inv_status_flag',
+                    'inv_title DESC',
+                ]
+            )
+            ->getPhql()
+        ;
+
+        $expected = 'SELECT inv_id, inv_title '
+            . 'FROM [Phalcon\Tests\Support\Models\Invoices] '
+            . 'ORDER BY CASE WHEN inv_status_flag = 1 THEN 0 ELSE 1 END ASC, '
+            . 'NOT inv_status_flag, [inv_title] DESC';
+        $actual   = $phql;
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #17077 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

This PR fixes `Phalcon\Mvc\Model\Query\Builder::orderBy()` when the array syntax is used with complex PHQL expressions.

Previously, any array item containing a space was treated as a simple `column direction` pair. This worked for values like `inv_title DESC`, but corrupted complex expressions such as `CASE WHEN inv_status_flag = 1 THEN 0 ELSE 1 END ASC`.

The builder now checks whether the last part of the order item is `ASC` or `DESC`. Simple column ordering keeps the existing `autoescape()` behavior, while complex expressions are preserved as-is.

A regression test was added for complex `ORDER BY` expressions.