### PR TITLE
T17012 router enhancements

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- `Phalcon\Mvc\Router\Route::getCompiledHostName()` now uses cache for hostname/converters. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - Changed return types to `-> <static>` or `-> <self>` in various components. The change is a covariant narrowing on implementation methods and does not touch any interface contracts, so userland classes that implement Phalcon interfaces and return the interface type continue to work unchanged. [#17035](https://github.com/phalcon/cphalcon/issues/17035)
 
 ### Added

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; PCRE patterns chunked [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; PCRE patterns chunked; per-route metadata cache deduplicated by route id. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - `Phalcon\Mvc\Router\Route::getCompiledHostName()` now uses cache for hostname/converters. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - Changed return types to `-> <static>` or `-> <self>` in various components. The change is a covariant narrowing on implementation methods and does not touch any interface contracts, so userland classes that implement Phalcon interfaces and return the interface type continue to work unchanged. [#17035](https://github.com/phalcon/cphalcon/issues/17035)
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; PCRE patterns chunked [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - `Phalcon\Mvc\Router\Route::getCompiledHostName()` now uses cache for hostname/converters. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - Changed return types to `-> <static>` or `-> <self>` in various components. The change is a covariant narrowing on implementation methods and does not touch any interface contracts, so userland classes that implement Phalcon interfaces and return the interface type continue to work unchanged. [#17035](https://github.com/phalcon/cphalcon/issues/17035)
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -501,6 +501,10 @@
         - `MissingGettextExtension`
         - `MissingRequiredParameter`
         - `TranslatorNotRegistered` [#17019](https://github.com/phalcon/cphalcon/issues/17019)
+- `Phalcon\Mvc\Router\Route::setRouteId(string $routeId)` - setter intended for restoring cached routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- `Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- `Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- `Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 
 ### Fixed
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -88,6 +88,19 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected action = "";
 
     /**
+     * Pre-merged per-method candidate buckets in attach order. For each HTTP
+     * method seen on any registered route, the bucket contains the
+     * method-specific routes followed by the "*" (no-constraint) routes.
+     * The "*" key itself holds only the no-constraint routes — used when the
+     * request method has no specific bucket.
+     *
+     * Built in rebuildMethodIndex(); consumed by handle() in reverse.
+     *
+     * @var array
+     */
+    protected candidatesByMethod = [];
+
+    /**
      * @var string
      */
     protected controller = "";
@@ -548,9 +561,10 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      */
     public function clear() -> void
     {
-        let this->routes            = [],
-            this->methodRoutes      = [],
-            this->methodRoutesDirty = true;
+        let this->routes             = [],
+            this->methodRoutes       = [],
+            this->candidatesByMethod = [],
+            this->methodRoutesDirty  = true;
     }
 
     /**
@@ -705,9 +719,10 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     protected function rebuildMethodIndex() -> void
     {
-        var route, methods, method;
+        var route, methods, method, methodSpecific, starRoutes;
 
-        let this->methodRoutes = [];
+        let this->methodRoutes       = [],
+            this->candidatesByMethod = [];
 
         for route in this->routes {
             let methods = route->getHttpMethods();
@@ -721,6 +736,19 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                     let this->methodRoutes[method][] = route;
                 }
             }
+        }
+
+        if !fetch starRoutes, this->methodRoutes["*"] {
+            let starRoutes = [];
+        }
+
+        for method, methodSpecific in this->methodRoutes {
+            if method == "*" {
+                let this->candidatesByMethod["*"] = starRoutes;
+                continue;
+            }
+
+            let this->candidatesByMethod[method] = array_merge(methodSpecific, starRoutes);
         }
 
         let this->methodRoutesDirty = false;
@@ -809,7 +837,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     {
         var action, beforeMatch, candidateRoutes, container, controller,
             converter, converters, currentHostName, eventsManager, handledUri,
-            hostname, matched, matches, matchPosition, methodCandidates,
+            hostname, matched, matches, matchPosition,
             module, notFoundPaths, params, paramsStr, part, parts, paths,
             pattern, position, realUri, regexHostName, request, requestMethod,
             route, routeFound, strParams, vnamespace;
@@ -868,16 +896,15 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             this->rebuildMethodIndex();
         }
 
-        let requestMethod    = request->getMethod(),
-            methodCandidates = [],
-            candidateRoutes  = [];
+        let requestMethod   = request->getMethod(),
+            candidateRoutes = [];
 
-        if fetch methodCandidates, this->methodRoutes[requestMethod] {
-            let candidateRoutes = methodCandidates;
+        if !fetch candidateRoutes, this->candidatesByMethod[requestMethod] {
+            fetch candidateRoutes, this->candidatesByMethod["*"];
         }
 
-        if fetch methodCandidates, this->methodRoutes["*"] {
-            let candidateRoutes = array_merge(candidateRoutes, methodCandidates);
+        if typeof candidateRoutes !== "array" {
+            let candidateRoutes = [];
         }
 
         /**

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -117,21 +117,21 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected candidatesByMethod = [];
 
     /**
-     * Parallel to candidatesByMethod. Each entry mirrors the corresponding
-     * route as an array of cached scalars:
-     *   [
+     * Single-source per-route metadata cache. One entry per route, keyed
+     * by the route's intrinsic id. Replaces the previous per-method-bucket
+     * replication of metadata arrays. Built once in rebuildMethodIndex().
+     *
+     * Shape: routeMeta[routeId] = [
      *     "pattern":     string,        // compiled pattern
-     *     "isRegex":     bool,          // pattern contains "^"
-     *     "hostname":    string|null,   // raw hostname or null
-     *     "hostRegex":   string|null,   // compiled hostname regex (null = literal)
+     *     "isRegex":     bool,
+     *     "hostname":    string|null,
+     *     "hostRegex":   string|null,
      *     "beforeMatch": callable|null
      *   ]
      *
-     * Built in rebuildMethodIndex().
-     *
      * @var array
      */
-    protected candidatesMetaByMethod = [];
+    protected routeMeta = [];
 
     /**
      * Combined PCRE pattern per method bucket (chunked list of strings).
@@ -666,7 +666,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
         let this->routes                 = [],
             this->methodRoutes           = [],
             this->candidatesByMethod     = [],
-            this->candidatesMetaByMethod = [],
+            this->routeMeta              = [],
             this->staticByMethod         = [],
             this->staticShadowedByMethod = [],
             this->hostnameByMethod       = [],
@@ -830,13 +830,13 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected function rebuildMethodIndex() -> void
     {
         var route, methods, method, methodSpecific, starRoutes,
-            candidates, idx, candidateRoute, candidatePattern, isRegex,
+            candidates, candidateRoute, candidatePattern, isRegex,
             bucketRoute, bucketPattern, staticUri, staticBucket,
             staticRoutesList;
 
         let this->methodRoutes           = [],
             this->candidatesByMethod     = [],
-            this->candidatesMetaByMethod = [],
+            this->routeMeta              = [],
             this->staticByMethod         = [],
             this->staticShadowedByMethod = [];
 
@@ -867,25 +867,28 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             let this->candidatesByMethod[method] = array_merge(methodSpecific, starRoutes);
         }
 
-        for method, candidates in this->candidatesByMethod {
-            let this->candidatesMetaByMethod[method] = [];
+        /**
+         * Build the single-source per-route metadata cache, keyed by the
+         * route's intrinsic id. One entry per route — replaces the previous
+         * per-method-bucket replication.
+         */
+        let this->routeMeta = [];
 
-            for idx, candidateRoute in candidates {
-                let candidatePattern = candidateRoute->getCompiledPattern();
-                let isRegex          = false;
+        for candidateRoute in this->routes {
+            let candidatePattern = candidateRoute->getCompiledPattern();
+            let isRegex          = false;
 
-                if memstr(candidatePattern, "^") {
-                    let isRegex = true;
-                }
-
-                let this->candidatesMetaByMethod[method][idx] = [
-                    "pattern":     candidatePattern,
-                    "isRegex":     isRegex,
-                    "hostname":    candidateRoute->getHostName(),
-                    "hostRegex":   candidateRoute->getCompiledHostName(),
-                    "beforeMatch": candidateRoute->getBeforeMatch()
-                ];
+            if memstr(candidatePattern, "^") {
+                let isRegex = true;
             }
+
+            let this->routeMeta[candidateRoute->getRouteId()] = [
+                "pattern":     candidatePattern,
+                "isRegex":     isRegex,
+                "hostname":    candidateRoute->getHostName(),
+                "hostRegex":   candidateRoute->getCompiledHostName(),
+                "beforeMatch": candidateRoute->getBeforeMatch()
+            ];
         }
 
         /**
@@ -945,9 +948,8 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
          * are ordered in reverse-attach so PCRE's left-to-right first-match
          * yields reverse-iteration semantics.
          */
-        var combinedAlternatives, combinedMark, combinedPattern,
-            combinedBody, combinedBodyMatch, combinedShape,
-            hostnameBucketRef;
+        var combinedAlternatives, combinedMark, combinedBody,
+            combinedBodyMatch, combinedShape, hostnameBucketRef;
 
         let this->combinedRegexByMethod = [],
             this->combinedRegexMarkMap  = [],
@@ -1112,7 +1114,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      */
     public function handle(string! uri) -> void
     {
-        var action, beforeMatch, candidateRoutes, candidatesMeta, container,
+        var action, beforeMatch, candidateRoutes, container,
             controller, converter, converters, currentHostName, eventsManager,
             handledUri, hostname, matched, matches, matchPosition,
             module, notFoundPaths, params, paramsStr, part, parts, paths,
@@ -1176,8 +1178,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
         }
 
         let requestMethod   = request->getMethod(),
-            candidateRoutes = [],
-            candidatesMeta  = [];
+            candidateRoutes = [];
 
         if !fetch candidateRoutes, this->candidatesByMethod[requestMethod] {
             fetch candidateRoutes, this->candidatesByMethod["*"];
@@ -1185,14 +1186,6 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
         if typeof candidateRoutes !== "array" {
             let candidateRoutes = [];
-        }
-
-        if !fetch candidatesMeta, this->candidatesMetaByMethod[requestMethod] {
-            fetch candidatesMeta, this->candidatesMetaByMethod["*"];
-        }
-
-        if typeof candidatesMeta !== "array" {
-            let candidatesMeta = [];
         }
 
         /**
@@ -1310,7 +1303,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                 }
 
                 let combinedRoute     = candidateRoutes[combinedRouteIdx],
-                    combinedRouteMeta = candidatesMeta[combinedRouteIdx];
+                    combinedRouteMeta = this->routeMeta[combinedRoute->getRouteId()];
 
                 let combinedBeforeMatch = combinedRouteMeta["beforeMatch"];
 
@@ -1367,7 +1360,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
          */
         if !routeFound {
             for routeIdx, route in array_reverse(candidateRoutes, true) {
-            let routeMeta = candidatesMeta[routeIdx],
+            let routeMeta = this->routeMeta[route->getRouteId()],
                 params    = [],
                 matches   = null;
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -275,7 +275,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * rebuild on cache miss, then clears the property to skip subsequent
      * writes.
      *
-     * @var <CacheAdapterInterface>|null
+     * @var CacheAdapterInterface|null
      */
     protected pendingCache = null;
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -126,6 +126,34 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected candidatesMetaByMethod = [];
 
     /**
+     * Combined PCRE pattern per method bucket (chunked list of strings).
+     * Each chunk uses (?|...) branch reset and (*:N) mark labels. Built
+     * only when the bucket meets gating: no hostname routes; standard
+     * pattern shape.
+     *
+     * @var array
+     */
+    protected combinedRegexByMethod = [];
+
+    /**
+     * Boolean per method bucket: true when the combined regex cannot be
+     * built (hostname route present, exotic pattern shape, etc.).
+     *
+     * @var array
+     */
+    protected combinedRegexDisabled = [];
+
+    /**
+     * Map from MARK label back to the route index in
+     * candidatesByMethod[method]. One per chunk.
+     *
+     *   combinedRegexMarkMap[method][chunkIdx][markLabel] = routeIdx
+     *
+     * @var array
+     */
+    protected combinedRegexMarkMap = [];
+
+    /**
      * @var string
      */
     protected controller = "";
@@ -635,6 +663,9 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             this->staticShadowedByMethod = [],
             this->hostnameByMethod       = [],
             this->hostnameLessByMethod   = [],
+            this->combinedRegexByMethod  = [],
+            this->combinedRegexDisabled  = [],
+            this->combinedRegexMarkMap   = [],
             this->methodRoutesDirty      = true;
     }
 
@@ -899,6 +930,68 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             }
         }
 
+        /**
+         * Combined-regex builder: for each method bucket without hostname
+         * constraints, combine all regex routes into a single PCRE pattern
+         * with (?|...) branch reset and (*:N) mark labels. Alternatives
+         * are ordered in reverse-attach so PCRE's left-to-right first-match
+         * yields reverse-iteration semantics.
+         */
+        var combinedAlternatives, combinedMark, combinedPattern,
+            combinedBody, combinedBodyMatch, combinedShape,
+            hostnameBucketRef;
+
+        let this->combinedRegexByMethod = [],
+            this->combinedRegexMarkMap  = [],
+            this->combinedRegexDisabled = [];
+
+        for method, candidates in this->candidatesByMethod {
+            let hostnameBucketRef = this->hostnameByMethod[method];
+
+            if !empty hostnameBucketRef {
+                let this->combinedRegexDisabled[method] = true;
+                continue;
+            }
+
+            let combinedAlternatives = [],
+                combinedMark         = [];
+
+            for bucketIdx, bucketRoute in candidates {
+                let bucketPattern = bucketRoute->getCompiledPattern();
+
+                if !memstr(bucketPattern, "^") {
+                    continue;
+                }
+
+                let combinedBodyMatch = [];
+                let combinedShape = preg_match("/^#\\^(.+)\\$#u$/", bucketPattern, combinedBodyMatch);
+
+                if !combinedShape {
+                    let this->combinedRegexDisabled[method] = true;
+                    let combinedAlternatives = [];
+                    break;
+                }
+
+                let combinedBody = combinedBodyMatch[1];
+                let combinedAlternatives[] = combinedBody . "(*:" . bucketIdx . ")";
+                let combinedMark[(string) bucketIdx] = bucketIdx;
+            }
+
+            if isset this->combinedRegexDisabled[method] {
+                continue;
+            }
+
+            if empty combinedAlternatives {
+                continue;
+            }
+
+            let combinedAlternatives = array_reverse(combinedAlternatives);
+            let combinedPattern = "#^(?|" . implode("|", combinedAlternatives) . ")$#u";
+
+            let this->combinedRegexByMethod[method] = [combinedPattern];
+            let this->combinedRegexMarkMap[method]  = [combinedMark];
+        }
+
         let this->methodRoutesDirty = false;
     }
 
@@ -1146,6 +1239,89 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
                     break;
                 }
+            }
+        }
+
+        /**
+         * Combined-regex fast path: one preg_match per chunk replaces N
+         * per-route preg_matches. Disabled when events are attached or the
+         * bucket has hostname constraints.
+         */
+        var combinedChunks, combinedMarkMaps, combinedChunkIdx, combinedChunk,
+            combinedMatchesLocal, combinedMarkLabel, combinedRouteIdx,
+            combinedRoute, combinedRouteMeta, combinedBeforeMatch,
+            combinedPaths, combinedConverters, combinedPart, combinedPosition,
+            combinedMatchPosition, combinedConverter;
+
+        if !routeFound
+            && eventsManager === null
+            && !isset this->combinedRegexDisabled[requestMethod]
+            && fetch combinedChunks, this->combinedRegexByMethod[requestMethod]
+        {
+            let combinedMarkMaps = this->combinedRegexMarkMap[requestMethod];
+
+            for combinedChunkIdx, combinedChunk in combinedChunks {
+                let combinedMatchesLocal = [];
+
+                if !preg_match(combinedChunk, handledUri, combinedMatchesLocal) {
+                    continue;
+                }
+
+                let combinedMarkLabel = combinedMatchesLocal["MARK"];
+
+                if !fetch combinedRouteIdx, combinedMarkMaps[combinedChunkIdx][combinedMarkLabel] {
+                    continue;
+                }
+
+                let combinedRoute     = candidateRoutes[combinedRouteIdx],
+                    combinedRouteMeta = candidatesMeta[combinedRouteIdx];
+
+                let combinedBeforeMatch = combinedRouteMeta["beforeMatch"];
+
+                if combinedBeforeMatch !== null {
+                    if unlikely !is_callable(combinedBeforeMatch) {
+                        throw new BeforeMatchNotCallable();
+                    }
+
+                    if !{combinedBeforeMatch}(handledUri, combinedRoute, this) {
+                        continue;
+                    }
+                }
+
+                let combinedPaths      = combinedRoute->getPaths(),
+                    parts              = combinedPaths,
+                    matches            = combinedMatchesLocal,
+                    combinedConverters = combinedRoute->getConverters(),
+                    this->matches      = combinedMatchesLocal,
+                    this->matchedRoute = combinedRoute,
+                    routeFound         = true;
+
+                for combinedPart, combinedPosition in combinedPaths {
+                    if unlikely typeof combinedPart !== "string" {
+                        throw new WrongPathsKey(combinedPart);
+                    }
+
+                    if typeof combinedPosition !== "string" && typeof combinedPosition !== "integer" {
+                        continue;
+                    }
+
+                    if fetch combinedMatchPosition, combinedMatchesLocal[combinedPosition] {
+                        if typeof combinedConverters === "array" && fetch combinedConverter, combinedConverters[combinedPart] {
+                            let parts[combinedPart] = {combinedConverter}(combinedMatchPosition);
+                            continue;
+                        }
+
+                        let parts[combinedPart] = combinedMatchPosition;
+                    } else {
+                        if typeof combinedConverters === "array" && fetch combinedConverter, combinedConverters[combinedPart] {
+                            let parts[combinedPart] = {combinedConverter}(combinedPosition);
+                        } elseif typeof combinedPosition === "integer" {
+                            unset parts[combinedPart];
+                        }
+                    }
+                }
+
+                break;
             }
         }
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -221,6 +221,25 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected routes = [];
 
     /**
+     * Static-route hash, populated by rebuildMethodIndex(). For each method
+     * bucket (including "*"), maps URI => list of routes whose compiled
+     * pattern is a literal string equal to that URI.
+     *
+     * @var array
+     */
+    protected staticByMethod = [];
+
+    /**
+     * Shadow-detection map. If staticShadowedByMethod[method][uri] is set,
+     * the static URI in that bucket is shadowed by a later-attached regex
+     * route — the fast path MUST NOT be used; fall through to the dynamic
+     * loop so the regex wins (reverse-iteration semantics).
+     *
+     * @var array
+     */
+    protected staticShadowedByMethod = [];
+
+    /**
     * @var int
      */
     protected uriSource = self::URI_SOURCE_GET_URL;
@@ -590,6 +609,8 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             this->methodRoutes           = [],
             this->candidatesByMethod     = [],
             this->candidatesMetaByMethod = [],
+            this->staticByMethod         = [],
+            this->staticShadowedByMethod = [],
             this->methodRoutesDirty      = true;
     }
 
@@ -746,11 +767,15 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected function rebuildMethodIndex() -> void
     {
         var route, methods, method, methodSpecific, starRoutes,
-            candidates, idx, candidateRoute, candidatePattern, isRegex;
+            candidates, idx, candidateRoute, candidatePattern, isRegex,
+            bucketRoute, bucketPattern, staticUri, staticBucket,
+            staticRoutesList;
 
         let this->methodRoutes           = [],
             this->candidatesByMethod     = [],
-            this->candidatesMetaByMethod = [];
+            this->candidatesMetaByMethod = [],
+            this->staticByMethod         = [],
+            this->staticShadowedByMethod = [];
 
         for route in this->routes {
             let methods = route->getHttpMethods();
@@ -797,6 +822,31 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                     "hostRegex":   candidateRoute->getCompiledHostName(),
                     "beforeMatch": candidateRoute->getBeforeMatch()
                 ];
+            }
+        }
+
+        /**
+         * Build the static-route hash + shadow flags. For each method bucket
+         * (already merged with "*" routes), walk in attach order; when a
+         * regex route is encountered, mark any earlier-registered static URI
+         * it would match as shadowed. The fast path consults staticByMethod
+         * only when staticShadowedByMethod has no entry for that URI.
+         */
+        for method, candidates in this->candidatesByMethod {
+            for bucketRoute in candidates {
+                let bucketPattern = bucketRoute->getCompiledPattern();
+
+                if !memstr(bucketPattern, "^") {
+                    let this->staticByMethod[method][bucketPattern][] = bucketRoute;
+                } else {
+                    if fetch staticBucket, this->staticByMethod[method] {
+                        for staticUri, staticRoutesList in staticBucket {
+                            if preg_match(bucketPattern, staticUri) {
+                                let this->staticShadowedByMethod[method][staticUri] = true;
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -889,7 +939,9 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             handledUri, hostname, matched, matches, matchPosition,
             module, notFoundPaths, params, paramsStr, part, parts, paths,
             pattern, position, realUri, regexHostName, request, requestMethod,
-            route, routeFound, routeIdx, routeMeta, strParams, vnamespace;
+            route, routeFound, routeIdx, routeMeta, staticBeforeMatch,
+            staticBucket, staticBucketMethod, staticHostname, staticHostRegex,
+            staticMatched, staticRoute, strParams, vnamespace;
 
         if !uri {
             /**
@@ -966,9 +1018,80 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
         }
 
         /**
-         * Routes are traversed in reversed order
+         * Static-route fast path: O(1) lookup for literal URIs that are not
+         * shadowed by a later-attached regex in the same bucket. Disabled
+         * when an events manager is attached, so per-route events fire from
+         * the regular loop and preserve their existing semantics.
          */
-        for routeIdx, route in array_reverse(candidateRoutes, true) {
+        if eventsManager === null {
+            let staticBucketMethod = null;
+
+            if isset this->staticByMethod[requestMethod][handledUri]
+                && !isset this->staticShadowedByMethod[requestMethod][handledUri] {
+                let staticBucketMethod = requestMethod;
+            } elseif isset this->staticByMethod["*"][handledUri]
+                && !isset this->staticShadowedByMethod["*"][handledUri] {
+                let staticBucketMethod = "*";
+            }
+
+            if staticBucketMethod !== null {
+                let staticBucket = this->staticByMethod[staticBucketMethod][handledUri];
+
+                for staticRoute in reverse staticBucket {
+                    let staticHostname = staticRoute->getHostName();
+
+                    if staticHostname !== null {
+                        if currentHostName === null {
+                            let currentHostName = request->getHttpHost();
+                        }
+
+                        if !currentHostName {
+                            continue;
+                        }
+
+                        let staticHostRegex = staticRoute->getCompiledHostName();
+
+                        if staticHostRegex !== null {
+                            let staticMatched = preg_match(staticHostRegex, currentHostName);
+                        } else {
+                            let staticMatched = currentHostName == staticHostname;
+                        }
+
+                        if !staticMatched {
+                            continue;
+                        }
+                    }
+
+                    let staticBeforeMatch = staticRoute->getBeforeMatch();
+
+                    if staticBeforeMatch !== null {
+                        if unlikely !is_callable(staticBeforeMatch) {
+                            throw new BeforeMatchNotCallable();
+                        }
+
+                        let routeFound = {staticBeforeMatch}(handledUri, staticRoute, this);
+
+                        if !routeFound {
+                            continue;
+                        }
+                    }
+
+                    let routeFound         = true,
+                        matches            = null,
+                        parts              = staticRoute->getPaths(),
+                        this->matchedRoute = staticRoute;
+
+                    break;
+                }
+            }
+        }
+
+        /**
+         * Routes are traversed in reversed order. Skipped when the static
+         * fast path already produced a match.
+         */
+        if !routeFound {
+            for routeIdx, route in array_reverse(candidateRoutes, true) {
             let routeMeta = candidatesMeta[routeIdx],
                 params    = [],
                 matches   = null;
@@ -1119,6 +1242,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                 let this->matchedRoute = route;
 
                 break;
+            }
             }
         }
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -6,6 +6,14 @@
  *
  * For the full copyright and license information, please view the LICENSE.txt
  * file that was distributed with this source code.
+ *
+ * Additional enhancements inspired by FastRoute and Symfony
+ *
+ * @link    https://github.com/nikic/FastRoute
+ * @license https://github.com/nikic/FastRoute/blob/master/LICENSE
+ * @link    https://github.com/symfony/routing
+ * @license https://github.com/symfony/routing/blob/8.1/LICENSE
+ * @link    https://github.com/Jurigag/fast-micro-router-phalcon
  */
 
 namespace Phalcon\Mvc;
@@ -99,6 +107,23 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @var array
      */
     protected candidatesByMethod = [];
+
+    /**
+     * Parallel to candidatesByMethod. Each entry mirrors the corresponding
+     * route as an array of cached scalars:
+     *   [
+     *     "pattern":     string,        // compiled pattern
+     *     "isRegex":     bool,          // pattern contains "^"
+     *     "hostname":    string|null,   // raw hostname or null
+     *     "hostRegex":   string|null,   // compiled hostname regex (null = literal)
+     *     "beforeMatch": callable|null
+     *   ]
+     *
+     * Built in rebuildMethodIndex().
+     *
+     * @var array
+     */
+    protected candidatesMetaByMethod = [];
 
     /**
      * @var string
@@ -561,10 +586,11 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      */
     public function clear() -> void
     {
-        let this->routes             = [],
-            this->methodRoutes       = [],
-            this->candidatesByMethod = [],
-            this->methodRoutesDirty  = true;
+        let this->routes                 = [],
+            this->methodRoutes           = [],
+            this->candidatesByMethod     = [],
+            this->candidatesMetaByMethod = [],
+            this->methodRoutesDirty      = true;
     }
 
     /**
@@ -719,10 +745,12 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
     protected function rebuildMethodIndex() -> void
     {
-        var route, methods, method, methodSpecific, starRoutes;
+        var route, methods, method, methodSpecific, starRoutes,
+            candidates, idx, candidateRoute, candidatePattern, isRegex;
 
-        let this->methodRoutes       = [],
-            this->candidatesByMethod = [];
+        let this->methodRoutes           = [],
+            this->candidatesByMethod     = [],
+            this->candidatesMetaByMethod = [];
 
         for route in this->routes {
             let methods = route->getHttpMethods();
@@ -749,6 +777,27 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             }
 
             let this->candidatesByMethod[method] = array_merge(methodSpecific, starRoutes);
+        }
+
+        for method, candidates in this->candidatesByMethod {
+            let this->candidatesMetaByMethod[method] = [];
+
+            for idx, candidateRoute in candidates {
+                let candidatePattern = candidateRoute->getCompiledPattern();
+                let isRegex          = false;
+
+                if memstr(candidatePattern, "^") {
+                    let isRegex = true;
+                }
+
+                let this->candidatesMetaByMethod[method][idx] = [
+                    "pattern":     candidatePattern,
+                    "isRegex":     isRegex,
+                    "hostname":    candidateRoute->getHostName(),
+                    "hostRegex":   candidateRoute->getCompiledHostName(),
+                    "beforeMatch": candidateRoute->getBeforeMatch()
+                ];
+            }
         }
 
         let this->methodRoutesDirty = false;
@@ -835,12 +884,12 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      */
     public function handle(string! uri) -> void
     {
-        var action, beforeMatch, candidateRoutes, container, controller,
-            converter, converters, currentHostName, eventsManager, handledUri,
-            hostname, matched, matches, matchPosition,
+        var action, beforeMatch, candidateRoutes, candidatesMeta, container,
+            controller, converter, converters, currentHostName, eventsManager,
+            handledUri, hostname, matched, matches, matchPosition,
             module, notFoundPaths, params, paramsStr, part, parts, paths,
             pattern, position, realUri, regexHostName, request, requestMethod,
-            route, routeFound, strParams, vnamespace;
+            route, routeFound, routeIdx, routeMeta, strParams, vnamespace;
 
         if !uri {
             /**
@@ -897,7 +946,8 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
         }
 
         let requestMethod   = request->getMethod(),
-            candidateRoutes = [];
+            candidateRoutes = [],
+            candidatesMeta  = [];
 
         if !fetch candidateRoutes, this->candidatesByMethod[requestMethod] {
             fetch candidateRoutes, this->candidatesByMethod["*"];
@@ -907,17 +957,26 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             let candidateRoutes = [];
         }
 
+        if !fetch candidatesMeta, this->candidatesMetaByMethod[requestMethod] {
+            fetch candidatesMeta, this->candidatesMetaByMethod["*"];
+        }
+
+        if typeof candidatesMeta !== "array" {
+            let candidatesMeta = [];
+        }
+
         /**
          * Routes are traversed in reversed order
          */
-        for route in reverse candidateRoutes {
-            let params  = [],
-                matches = null;
+        for routeIdx, route in array_reverse(candidateRoutes, true) {
+            let routeMeta = candidatesMeta[routeIdx],
+                params    = [],
+                matches   = null;
 
             /**
              * Look for hostname constraints
              */
-            let hostname = route->getHostName();
+            let hostname = routeMeta["hostname"];
             if hostname !== null {
                 /**
                  * Check if the current hostname is the same as the route
@@ -937,7 +996,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                  * Check if the hostname restriction is the same as the current
                  * in the route
                  */
-                let regexHostName = route->getCompiledHostName();
+                let regexHostName = routeMeta["hostRegex"];
 
                 if regexHostName !== null {
                     let matched = preg_match(regexHostName, currentHostName);
@@ -957,9 +1016,9 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             /**
              * If the route has parentheses use preg_match
              */
-            let pattern = route->getCompiledPattern();
+            let pattern = routeMeta["pattern"];
 
-            if memstr(pattern, "^") {
+            if routeMeta["isRegex"] {
                 let routeFound = preg_match(pattern, handledUri, matches);
             } else {
                 let routeFound = pattern == handledUri;
@@ -973,7 +1032,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                     eventsManager->fire("router:matchedRoute", this, route);
                 }
 
-                let beforeMatch = route->getBeforeMatch();
+                let beforeMatch = routeMeta["beforeMatch"];
                 if beforeMatch !== null {
                     /**
                      * Check first if the callback is callable

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -82,6 +82,14 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     const POSITION_LAST = 1;
 
     /**
+     * Number of alternatives per combined-regex chunk. Empirically derived
+     * (FastRoute uses ~10) — keeps each chunk below PCRE's optimizer cliff.
+     *
+     * @var int
+     */
+    const REGEX_CHUNK_SIZE = 10;
+
+    /**
      * @var int
      */
     const URI_SOURCE_GET_URL = 0;
@@ -985,11 +993,39 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                 continue;
             }
 
-            let combinedAlternatives = array_reverse(combinedAlternatives);
-            let combinedPattern = "#^(?|" . implode("|", combinedAlternatives) . ")$#u";
+            /**
+             * Reverse alternatives so PCRE's left-to-right first-match
+             * gives reverse-attach-wins. Then chunk into groups of
+             * REGEX_CHUNK_SIZE so each chunk stays below the PCRE
+             * optimizer cliff. chunks[0] holds the LATEST-attached batch
+             * — handle() tries chunks 0..N in order.
+             */
+            var chunkedPatterns, chunkedMarkMaps, chunkOffset, chunkSlice,
+                chunkSliceMap, chunkMarkSubset, reversedMarkIds, chunkMarkId;
 
-            let this->combinedRegexByMethod[method] = [combinedPattern];
-            let this->combinedRegexMarkMap[method]  = [combinedMark];
+            let combinedAlternatives = array_reverse(combinedAlternatives);
+            let reversedMarkIds      = array_reverse(array_keys(combinedMark));
+
+            let chunkedPatterns = [],
+                chunkedMarkMaps = [],
+                chunkOffset     = 0;
+
+            while chunkOffset < count(combinedAlternatives) {
+                let chunkSlice       = array_slice(combinedAlternatives, chunkOffset, self::REGEX_CHUNK_SIZE),
+                    chunkMarkSubset  = array_slice(reversedMarkIds,      chunkOffset, self::REGEX_CHUNK_SIZE),
+                    chunkSliceMap    = [];
+
+                for chunkMarkId in chunkMarkSubset {
+                    let chunkSliceMap[chunkMarkId] = combinedMark[chunkMarkId];
+                }
+
+                let chunkedPatterns[] = "#^(?|" . implode("|", chunkSlice) . ")$#u";
+                let chunkedMarkMaps[] = chunkSliceMap;
+                let chunkOffset += self::REGEX_CHUNK_SIZE;
+            }
+
+            let this->combinedRegexByMethod[method] = chunkedPatterns;
+            let this->combinedRegexMarkMap[method]  = chunkedMarkMaps;
         }
 
         let this->methodRoutesDirty = false;

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -18,6 +18,7 @@
 
 namespace Phalcon\Mvc;
 
+use Phalcon\Cache\Adapter\AdapterInterface as CacheAdapterInterface;
 use Phalcon\Config\ConfigInterface;
 use Phalcon\Di\AbstractInjectionAware;
 use Phalcon\Di\DiInterface;
@@ -267,6 +268,21 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @var array
      */
     protected params = [];
+
+    /**
+     * Lazy-write cache target set by useCache(). When non-null, handle()
+     * writes buildDispatcherDump() to this cache after a successful
+     * rebuild on cache miss, then clears the property to skip subsequent
+     * writes.
+     *
+     * @var <CacheAdapterInterface>|null
+     */
+    protected pendingCache = null;
+
+    /**
+     * @var string
+     */
+    protected pendingCacheKey = "";
 
     /**
      * @var bool
@@ -675,6 +691,302 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             this->combinedRegexDisabled  = [],
             this->combinedRegexMarkMap   = [],
             this->methodRoutesDirty      = true;
+    }
+
+    /**
+     * Produces a pure-data array describing every piece of state needed
+     * to reconstruct this router. The returned array is var_export-able
+     * (no objects, no closures). Used by dumpDispatcher() and by
+     * Phalcon\Cache integration via useCache().
+     *
+     * Throws when a route has a Closure beforeMatch or converter — those
+     * cannot be cached.
+     *
+     * @throws \Phalcon\Mvc\Router\Exception
+     */
+    public function buildDispatcherDump() -> array
+    {
+        var route, cb, converters, convName, converter, dumpedRoutes,
+            routeToIdx, scalarIdx, scalarSubKey, scalarVal,
+            methodRoutesScalar, candidatesScalar, staticScalar,
+            innerKey, innerVal, mostInnerVal, mostInnerArr;
+
+        if this->methodRoutesDirty {
+            this->rebuildMethodIndex();
+        }
+
+        let dumpedRoutes = [];
+        let routeToIdx   = [];
+
+        for scalarIdx, route in this->routes {
+            let routeToIdx[spl_object_id(route)] = scalarIdx;
+
+            let cb = route->getBeforeMatch();
+            if cb !== null && cb instanceof \Closure {
+                throw new Exception(
+                    "Cannot cache router: route id '" . route->getRouteId() .
+                    "' has a Closure beforeMatch - only string/array callables are cacheable"
+                );
+            }
+
+            let converters = route->getConverters();
+            if typeof converters === "array" {
+                for convName, converter in converters {
+                    if converter instanceof \Closure {
+                        throw new Exception(
+                            "Cannot cache router: route id '" . route->getRouteId() .
+                            "' has a Closure converter for '" . convName .
+                            "' - only string/array callables are cacheable"
+                        );
+                    }
+                }
+            }
+
+            let dumpedRoutes[] = [
+                "class":       get_class(route),
+                "pattern":     route->getPattern(),
+                "paths":       route->getPaths(),
+                "methods":     route->getHttpMethods(),
+                "hostname":    route->getHostname(),
+                "name":        route->getName(),
+                "id":          route->getRouteId(),
+                "beforeMatch": cb,
+                "converters":  converters
+            ];
+        }
+
+        let methodRoutesScalar = [];
+        for innerKey, innerVal in this->methodRoutes {
+            let mostInnerArr = [];
+            for scalarVal in innerVal {
+                let mostInnerArr[] = routeToIdx[spl_object_id(scalarVal)];
+            }
+            let methodRoutesScalar[innerKey] = mostInnerArr;
+        }
+
+        let candidatesScalar = [];
+        for innerKey, innerVal in this->candidatesByMethod {
+            let mostInnerArr = [];
+            for scalarVal in innerVal {
+                let mostInnerArr[] = routeToIdx[spl_object_id(scalarVal)];
+            }
+            let candidatesScalar[innerKey] = mostInnerArr;
+        }
+
+        let staticScalar = [];
+        for innerKey, innerVal in this->staticByMethod {
+            let staticScalar[innerKey] = [];
+            for scalarSubKey, mostInnerVal in innerVal {
+                let mostInnerArr = [];
+                for scalarVal in mostInnerVal {
+                    let mostInnerArr[] = routeToIdx[spl_object_id(scalarVal)];
+                }
+                let staticScalar[innerKey][scalarSubKey] = mostInnerArr;
+            }
+        }
+
+        return [
+            "version":                1,
+            "routes":                 dumpedRoutes,
+            "methodRoutes":           methodRoutesScalar,
+            "candidatesByMethod":     candidatesScalar,
+            "staticByMethod":         staticScalar,
+            "staticShadowedByMethod": this->staticShadowedByMethod,
+            "hostnameByMethod":       this->hostnameByMethod,
+            "hostnameLessByMethod":   this->hostnameLessByMethod,
+            "combinedRegexByMethod":  this->combinedRegexByMethod,
+            "combinedRegexDisabled":  this->combinedRegexDisabled,
+            "combinedRegexMarkMap":   this->combinedRegexMarkMap,
+            "routeMeta":              this->routeMeta
+        ];
+    }
+
+    /**
+     * Inverse of buildDispatcherDump(). Reconstructs every Route from the
+     * scalar `routes` entries (preserving subclass and routeId), restores
+     * every index, and marks the indexes clean so handle() skips rebuild.
+     *
+     * @throws \Phalcon\Mvc\Router\Exception
+     */
+    public function loadDispatcherFromArray(array dump) -> void
+    {
+        var routeData, route, routeClass, beforeMatch, converters,
+            convName, converter, rebuiltRoutes, methodRoutesRehydrated,
+            candidatesRehydrated, staticRehydrated, innerKey, innerVal,
+            scalarIdx, scalarSubKey, mostInnerVal, mostInnerArr;
+        int dumpVersion;
+
+        if !isset dump["version"] {
+            throw new Exception("Router cache is missing 'version' field");
+        }
+
+        let dumpVersion = (int) dump["version"];
+
+        if dumpVersion !== 1 {
+            throw new Exception(
+                "Router cache version " . dumpVersion . " is not supported (this build supports version 1)"
+            );
+        }
+
+        if !isset dump["routes"] {
+            throw new Exception("Router cache is missing 'routes' field");
+        }
+
+        let rebuiltRoutes = [];
+
+        for routeData in dump["routes"] {
+            let routeClass = routeData["class"];
+            let route      = new {routeClass}(routeData["pattern"], routeData["paths"], routeData["methods"]);
+
+            if routeData["hostname"] !== null {
+                route->setHostname(routeData["hostname"]);
+            }
+
+            if routeData["name"] !== null {
+                route->setName(routeData["name"]);
+            }
+
+            route->setRouteId(routeData["id"]);
+
+            let beforeMatch = routeData["beforeMatch"];
+            if beforeMatch !== null {
+                route->beforeMatch(beforeMatch);
+            }
+
+            let converters = routeData["converters"];
+            if typeof converters === "array" {
+                for convName, converter in converters {
+                    route->convert(convName, converter);
+                }
+            }
+
+            let rebuiltRoutes[] = route;
+        }
+
+        let this->routes = rebuiltRoutes;
+
+        let methodRoutesRehydrated = [];
+        for innerKey, innerVal in dump["methodRoutes"] {
+            let mostInnerArr = [];
+            for scalarIdx in innerVal {
+                let mostInnerArr[] = this->routes[scalarIdx];
+            }
+            let methodRoutesRehydrated[innerKey] = mostInnerArr;
+        }
+
+        let candidatesRehydrated = [];
+        for innerKey, innerVal in dump["candidatesByMethod"] {
+            let mostInnerArr = [];
+            for scalarIdx in innerVal {
+                let mostInnerArr[] = this->routes[scalarIdx];
+            }
+            let candidatesRehydrated[innerKey] = mostInnerArr;
+        }
+
+        let staticRehydrated = [];
+        for innerKey, innerVal in dump["staticByMethod"] {
+            let staticRehydrated[innerKey] = [];
+            for scalarSubKey, mostInnerVal in innerVal {
+                let mostInnerArr = [];
+                for scalarIdx in mostInnerVal {
+                    let mostInnerArr[] = this->routes[scalarIdx];
+                }
+                let staticRehydrated[innerKey][scalarSubKey] = mostInnerArr;
+            }
+        }
+
+        let this->methodRoutes           = methodRoutesRehydrated,
+            this->candidatesByMethod     = candidatesRehydrated,
+            this->staticByMethod         = staticRehydrated,
+            this->staticShadowedByMethod = dump["staticShadowedByMethod"],
+            this->hostnameByMethod       = dump["hostnameByMethod"],
+            this->hostnameLessByMethod   = dump["hostnameLessByMethod"],
+            this->combinedRegexByMethod  = dump["combinedRegexByMethod"],
+            this->combinedRegexDisabled  = dump["combinedRegexDisabled"],
+            this->combinedRegexMarkMap   = dump["combinedRegexMarkMap"],
+            this->routeMeta              = dump["routeMeta"],
+            this->keyRouteIds            = [],
+            this->keyRouteNames          = [],
+            this->methodRoutesDirty      = false;
+    }
+
+    /**
+     * File-shaped helper around buildDispatcherDump(). Writes the dump as
+     * a `<?php return [...];` file, atomically (temp + rename) so concurrent
+     * dumps don't corrupt the result.
+     *
+     * @throws \Phalcon\Mvc\Router\Exception
+     */
+    public function dumpDispatcher(string! path) -> void
+    {
+        var dump, php, tmpPath;
+
+        let dump    = this->buildDispatcherDump();
+        let php     = "<?php\nreturn " . var_export(dump, true) . ";\n";
+        let tmpPath = path . ".tmp." . (string) getmypid();
+
+        if file_put_contents(tmpPath, php) === false {
+            throw new Exception("Failed to write router cache temp file: " . tmpPath);
+        }
+
+        if !rename(tmpPath, path) {
+            unlink(tmpPath);
+            throw new Exception("Failed to commit router cache: " . path);
+        }
+    }
+
+    /**
+     * File-shaped helper around loadDispatcherFromArray(). Includes the
+     * file (opcache-friendly) and forwards the return value.
+     *
+     * @throws \Phalcon\Mvc\Router\Exception
+     */
+    public function loadDispatcher(string! path) -> void
+    {
+        var dump;
+
+        if !file_exists(path) {
+            throw new Exception("Router cache not found: " . path);
+        }
+
+        let dump = require path;
+
+        if typeof dump !== "array" {
+            throw new Exception(
+                "Router cache is corrupt or invalid (expected array, got " . gettype(dump) . "): " . path
+            );
+        }
+
+        this->loadDispatcherFromArray(dump);
+    }
+
+    /**
+     * Cache-instance convenience wrapper. On cache hit, restores the
+     * dispatcher immediately. On miss, defers cache population until the
+     * next handle() completes - at which point buildDispatcherDump() is
+     * written to the cache key.
+     *
+     * @throws \Phalcon\Mvc\Router\Exception
+     */
+    public function useCache(<CacheAdapterInterface> cache, string! key = "phalcon.router.dispatcher") -> void
+    {
+        var stored;
+
+        if cache->has(key) {
+            let stored = cache->get(key);
+
+            if typeof stored !== "array" {
+                throw new Exception(
+                    "Router cache value at key '" . key . "' is not an array"
+                );
+            }
+
+            this->loadDispatcherFromArray(stored);
+            return;
+        }
+
+        let this->pendingCache    = cache,
+            this->pendingCacheKey = key;
     }
 
     /**
@@ -1605,6 +1917,12 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
         if typeof eventsManager === "object" {
             eventsManager->fire("router:afterCheckRoutes", this);
+        }
+
+        if this->pendingCache !== null {
+            this->pendingCache->set(this->pendingCacheKey, this->buildDispatcherDump());
+            let this->pendingCache    = null,
+                this->pendingCacheKey = "";
         }
     }
 

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -968,14 +968,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                     /**
                      * Check first if the callback is callable
                      */
-                    let routeFound = call_user_func_array(
-                        beforeMatch,
-                        [
-                            handledUri,
-                            route,
-                            this
-                        ]
-                    );
+                    let routeFound = {beforeMatch}(handledUri, route, this);
                 }
 
             } else {
@@ -1015,10 +1008,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                              */
                             if typeof converters === "array" {
                                 if fetch converter, converters[part] {
-                                    let parts[part] = call_user_func_array(
-                                        converter,
-                                        [matchPosition]
-                                    );
+                                    let parts[part] = {converter}(matchPosition);
 
                                     continue;
                                 }
@@ -1033,10 +1023,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                              * Apply the converters anyway
                              */
                             if typeof converters === "array" && fetch converter, converters[part] {
-                                let parts[part] = call_user_func_array(
-                                    converter,
-                                    [position]
-                                );
+                                let parts[part] = {converter}(position);
                             } elseif typeof position === "integer" {
                                 /**
                                  * Remove the path if the parameter was not

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -910,19 +910,9 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                  * Check if the hostname restriction is the same as the current
                  * in the route
                  */
-                if memstr(hostname, "(") {
-                    if !memstr(hostname, "#") {
-                        let regexHostName = "#^" . hostname;
+                let regexHostName = route->getCompiledHostName();
 
-                        if !memstr(hostname, ":") {
-                            let regexHostName .= "(:[[:digit:]]+)?";
-                        }
-
-                        let regexHostName .= "$#i";
-                    } else {
-                        let regexHostName = hostname;
-                    }
-
+                if regexHostName !== null {
                     let matched = preg_match(regexHostName, currentHostName);
                 } else {
                     let matched = currentHostName == hostname;

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -161,6 +161,28 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
     protected eventsManager;
 
     /**
+     * Per-method buckets of routes with hostname constraints, grouped by
+     * raw hostname string. Routes are referenced by their index into
+     * candidatesByMethod[method]. Built in rebuildMethodIndex().
+     *
+     * Shape: hostnameByMethod[method][hostname] = list of route indices.
+     *
+     * @var array
+     */
+    protected hostnameByMethod = [];
+
+    /**
+     * Per-method indices of routes without a hostname constraint, in
+     * attach order.
+     *
+     * Shape: hostnameLessByMethod[method] = list of route indices into
+     * candidatesByMethod[method].
+     *
+     * @var array
+     */
+    protected hostnameLessByMethod = [];
+
+    /**
      * @var array
      */
     protected keyRouteNames = [];
@@ -611,6 +633,8 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             this->candidatesMetaByMethod = [],
             this->staticByMethod         = [],
             this->staticShadowedByMethod = [],
+            this->hostnameByMethod       = [],
+            this->hostnameLessByMethod   = [],
             this->methodRoutesDirty      = true;
     }
 
@@ -850,6 +874,31 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
             }
         }
 
+        /**
+         * Hostname bucketing: split each method bucket into hostname-keyed
+         * sub-buckets and a hostname-less list. Routes are referenced by
+         * their integer index into candidatesByMethod[method].
+         */
+        var bucketIdx, bucketHostname;
+
+        let this->hostnameByMethod     = [],
+            this->hostnameLessByMethod = [];
+
+        for method, candidates in this->candidatesByMethod {
+            let this->hostnameByMethod[method]     = [],
+                this->hostnameLessByMethod[method] = [];
+
+            for bucketIdx, bucketRoute in candidates {
+                let bucketHostname = bucketRoute->getHostName();
+
+                if bucketHostname === null {
+                    let this->hostnameLessByMethod[method][] = bucketIdx;
+                } else {
+                    let this->hostnameByMethod[method][bucketHostname][] = bucketIdx;
+                }
+            }
+        }
+
         let this->methodRoutesDirty = false;
     }
 
@@ -1015,6 +1064,20 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
 
         if typeof candidatesMeta !== "array" {
             let candidatesMeta = [];
+        }
+
+        /**
+         * Resolve the current hostname once if any hostname-constrained
+         * route exists in the candidate bucket. Subsequent per-route
+         * checks below see a non-null currentHostName and skip their own
+         * lazy fetch.
+         */
+        if isset this->hostnameByMethod[requestMethod]
+            && count(this->hostnameByMethod[requestMethod]) > 0 {
+            let currentHostName = request->getHttpHost();
+        } elseif isset this->hostnameByMethod["*"]
+            && count(this->hostnameByMethod["*"]) > 0 {
+            let currentHostName = request->getHttpHost();
         }
 
         /**

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -718,6 +718,18 @@ class Route implements RouteInterface
     }
 
     /**
+     * Sets the route's id. Intended for restoring cached routes — most
+     * applications should rely on the auto-incrementing id assigned by
+     * the constructor.
+     */
+    public function setRouteId(string! routeId) -> <RouteInterface>
+    {
+        let this->id = routeId;
+
+        return this;
+    }
+
+    /**
      * Set one or more HTTP methods that constraint the matching of the route
      *
      *```php

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -25,6 +25,15 @@ class Route implements RouteInterface
     protected beforeMatch = null;
 
     /**
+     * Cached compiled hostname regex. `false` means "not yet computed";
+     * `null` means "hostname is literal — use string equality"; any string
+     * means "use this as the PCRE pattern."
+     *
+     * @var string|null|false
+     */
+    protected compiledHostName = false;
+
+    /**
      * @var string|null
      */
     protected compiledPattern = null;
@@ -345,6 +354,50 @@ class Route implements RouteInterface
     }
 
     /**
+     * Returns the compiled hostname regex, or null when the hostname is
+     * literal and a string-equality comparison should be used.
+     *
+     * The result is cached after first computation; setHostname() clears
+     * the cache.
+     */
+    public function getCompiledHostName() -> string | null
+    {
+        var hostname, regexHostName;
+
+        if this->compiledHostName !== false {
+            return this->compiledHostName;
+        }
+
+        let hostname = this->hostname;
+
+        if hostname === null {
+            let this->compiledHostName = null;
+            return null;
+        }
+
+        if !memstr(hostname, "(") {
+            let this->compiledHostName = null;
+            return null;
+        }
+
+        if !memstr(hostname, "#") {
+            let regexHostName = "#^" . hostname;
+
+            if !memstr(hostname, ":") {
+                let regexHostName .= "(:[[:digit:]]+)?";
+            }
+
+            let regexHostName .= "$#i";
+        } else {
+            let regexHostName = hostname;
+        }
+
+        let this->compiledHostName = regexHostName;
+
+        return regexHostName;
+    }
+
+    /**
      * Returns the route's compiled pattern
      */
     public function getCompiledPattern() -> string
@@ -639,7 +692,8 @@ class Route implements RouteInterface
      */
     public function setHostname(string! hostname) -> <RouteInterface>
     {
-        let this->hostname = hostname;
+        let this->hostname        = hostname,
+            this->compiledHostName = false;
 
         return this;
     }

--- a/phalcon/Mvc/Router/RouteInterface.zep
+++ b/phalcon/Mvc/Router/RouteInterface.zep
@@ -83,6 +83,11 @@ interface RouteInterface
     public function setName(string name) -> <RouteInterface>;
 
     /**
+     * Sets the route's id (intended for restoring cached routes)
+     */
+    public function setRouteId(string! routeId) -> <RouteInterface>;
+
+    /**
      * Reconfigure the route adding a new pattern and a set of paths
      */
     public function reConfigure(string! pattern, var paths = null) -> void;

--- a/tests/unit/Mvc/Router/CachedDispatcherTest.php
+++ b/tests/unit/Mvc/Router/CachedDispatcherTest.php
@@ -1,0 +1,381 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router;
+
+use Phalcon\Mvc\Router\Exception;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Fake\RouterTrait;
+
+use function cacheDir;
+use function file_put_contents;
+use function glob;
+use function uniqid;
+use function unlink;
+
+final class CachedDispatcherTest extends AbstractUnitTestCase
+{
+    use RouterTrait;
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpHasVersionAndRoutesData(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+
+        $dump = $router->buildDispatcherDump();
+
+        $this->assertSame(1, $dump['version']);
+        $this->assertCount(1, $dump['routes']);
+        $this->assertSame('/about', $dump['routes'][0]['pattern']);
+        $this->assertSame(['controller' => 'about'], $dump['routes'][0]['paths']);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpIncludesAllIndexKeys(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+
+        $dump = $router->buildDispatcherDump();
+
+        foreach ([
+            'version', 'routes',
+            'methodRoutes', 'candidatesByMethod',
+            'staticByMethod', 'staticShadowedByMethod',
+            'hostnameByMethod', 'hostnameLessByMethod',
+            'combinedRegexByMethod', 'combinedRegexDisabled', 'combinedRegexMarkMap',
+            'routeMeta',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $dump, "dump missing key: $key");
+        }
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpStoresRouteIndicesNotObjects(): void
+    {
+        $router = $this->getRouter(false);
+        $router->addGet('/users', ['controller' => 'users', 'action' => 'index']);
+        $router->addPost('/users', ['controller' => 'users', 'action' => 'create']);
+
+        $dump = $router->buildDispatcherDump();
+
+        $this->assertIsInt($dump['methodRoutes']['GET'][0]);
+        $this->assertIsInt($dump['methodRoutes']['POST'][0]);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpStoresRouteClassName(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+
+        $dump = $router->buildDispatcherDump();
+
+        $this->assertSame('Phalcon\\Mvc\\Router\\Route', $dump['routes'][0]['class']);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpRejectsClosureBeforeMatch(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/admin', ['controller' => 'admin'])
+            ->beforeMatch(static fn(): bool => false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/Closure beforeMatch/i');
+
+        $router->buildDispatcherDump();
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpRejectsClosureConverter(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/users/{id}', ['controller' => 'users'])
+            ->convert('id', static fn(string $v): int => (int) $v);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/Closure converter/i');
+
+        $router->buildDispatcherDump();
+    }
+
+    /**
+     * Static-string callable (e.g., 'App\\Auth::check') and array-callable
+     * ([class, 'method']) are both var_export-able and must NOT trigger
+     * the closure veto.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBuildDumpAllowsStringAndArrayCallables(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/x', ['controller' => 'x'])
+            ->beforeMatch('intval');
+        $router->add('/y', ['controller' => 'y'])
+            ->beforeMatch(['Phalcon\\Tests\\Unit\\Mvc\\Router\\CachedDispatcherTest', 'fakeCallable']);
+
+        $dump = $router->buildDispatcherDump();
+
+        $this->assertSame('intval', $dump['routes'][0]['beforeMatch']);
+        $this->assertSame(
+            ['Phalcon\\Tests\\Unit\\Mvc\\Router\\CachedDispatcherTest', 'fakeCallable'],
+            $dump['routes'][1]['beforeMatch']
+        );
+    }
+
+    /**
+     * Full round-trip: dump - fresh router - load - assert same match
+     * behavior as the original.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoundTripPreservesMatchBehavior(): void
+    {
+        $original = $this->getRouter(false);
+        $original->addGet('/users/{id:[0-9]+}', ['controller' => 'users', 'action' => 'show']);
+        $original->add('/about', ['controller' => 'about', 'action' => 'index']);
+
+        $dump = $original->buildDispatcherDump();
+
+        $restored = $this->getRouter(false);
+        $restored->loadDispatcherFromArray($dump);
+
+        $restored->handle('/users/42');
+        $this->assertSame('users', $restored->getControllerName());
+        $this->assertSame('show', $restored->getActionName());
+
+        $restored->handle('/about');
+        $this->assertSame('about', $restored->getControllerName());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoundTripPreservesRouteIds(): void
+    {
+        $original   = $this->getRouter(false);
+        $route      = $original->add('/about', ['controller' => 'about']);
+        $originalId = $route->getRouteId();
+
+        $dump     = $original->buildDispatcherDump();
+        $restored = $this->getRouter(false);
+        $restored->loadDispatcherFromArray($dump);
+
+        $routes = $restored->getRoutes();
+        $this->assertSame($originalId, $routes[0]->getRouteId());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoundTripPreservesRouteNames(): void
+    {
+        $original = $this->getRouter(false);
+        $original->add('/about', ['controller' => 'about'])->setName('homepage');
+
+        $restored = $this->getRouter(false);
+        $restored->loadDispatcherFromArray($original->buildDispatcherDump());
+
+        $byName = $restored->getRouteByName('homepage');
+        $this->assertNotFalse($byName);
+        $this->assertSame('/about', $byName->getPattern());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoundTripPreservesCombinedRegexFastPath(): void
+    {
+        $original = $this->getRouter(false);
+        $original->add('/users/{id:[0-9]+}', ['controller' => 'users']);
+        $original->add('/products/{slug:[a-z-]+}', ['controller' => 'products']);
+
+        $restored = $this->getRouter(false);
+        $restored->loadDispatcherFromArray($original->buildDispatcherDump());
+
+        $restored->handle('/users/42');
+        $this->assertSame('users', $restored->getControllerName());
+
+        $restored->handle('/products/widget');
+        $this->assertSame('products', $restored->getControllerName());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLoadRejectsMissingVersion(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/version/i');
+
+        $router->loadDispatcherFromArray(['routes' => []]);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLoadRejectsUnsupportedVersion(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/version/i');
+
+        $router->loadDispatcherFromArray(['version' => 99, 'routes' => []]);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoundTripWithStringBeforeMatchExecutes(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/x', ['controller' => 'x'])
+            ->beforeMatch([self::class, 'returnTrue']);
+
+        $dump     = $router->buildDispatcherDump();
+        $restored = $this->getRouter(false);
+        $restored->loadDispatcherFromArray($dump);
+
+        $restored->handle('/x');
+        $this->assertTrue($restored->wasMatched());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testFileRoundTripPreservesMatchBehavior(): void
+    {
+        $path = $this->makeCachePath();
+
+        try {
+            $original = $this->getRouter(false);
+            $original->addGet('/users/{id:[0-9]+}', ['controller' => 'users', 'action' => 'show']);
+            $original->dumpDispatcher($path);
+
+            $this->assertFileExists($path);
+
+            $restored = $this->getRouter(false);
+            $restored->loadDispatcher($path);
+
+            $restored->handle('/users/42');
+            $this->assertSame('users', $restored->getControllerName());
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLoadDispatcherThrowsOnMissingFile(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessageMatches('/not found/i');
+
+        $router->loadDispatcher(cacheDir('_router_nonexistent_' . uniqid('', true) . '.php'));
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLoadDispatcherThrowsOnCorruptFile(): void
+    {
+        $path = $this->makeCachePath();
+        file_put_contents($path, "<?php return 'not-an-array';");
+
+        try {
+            $router = $this->getRouter(false);
+
+            $this->expectException(Exception::class);
+            $this->expectExceptionMessageMatches('/corrupt|invalid|array/i');
+
+            $router->loadDispatcher($path);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    /**
+     * The dump file must not be left in a partial state — atomic write
+     * via temp + rename. After a successful dump no temp file should remain.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testDumpDispatcherWritesAtomically(): void
+    {
+        $path = $this->makeCachePath();
+
+        try {
+            $router = $this->getRouter(false);
+            $router->add('/about', ['controller' => 'about']);
+            $router->dumpDispatcher($path);
+
+            $tmps = glob($path . '.tmp.*');
+            $this->assertSame([], $tmps);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public static function fakeCallable(): bool
+    {
+        return true;
+    }
+
+    public static function returnTrue(): bool
+    {
+        return true;
+    }
+
+    private function makeCachePath(): string
+    {
+        return cacheDir('_router_cache_' . uniqid('', true) . '.php');
+    }
+}

--- a/tests/unit/Mvc/Router/CachedDispatcherTest.php
+++ b/tests/unit/Mvc/Router/CachedDispatcherTest.php
@@ -172,6 +172,7 @@ final class CachedDispatcherTest extends AbstractUnitTestCase
         $restored = $this->getRouter(false);
         $restored->loadDispatcherFromArray($dump);
 
+        $_SERVER['REQUEST_METHOD'] = 'GET';
         $restored->handle('/users/42');
         $this->assertSame('users', $restored->getControllerName());
         $this->assertSame('show', $restored->getActionName());
@@ -299,6 +300,7 @@ final class CachedDispatcherTest extends AbstractUnitTestCase
             $restored = $this->getRouter(false);
             $restored->loadDispatcher($path);
 
+            $_SERVER['REQUEST_METHOD'] = 'GET';
             $restored->handle('/users/42');
             $this->assertSame('users', $restored->getControllerName());
         } finally {

--- a/tests/unit/Mvc/Router/CachedDispatcherTest.php
+++ b/tests/unit/Mvc/Router/CachedDispatcherTest.php
@@ -55,14 +55,16 @@ final class CachedDispatcherTest extends AbstractUnitTestCase
 
         $dump = $router->buildDispatcherDump();
 
-        foreach ([
+        foreach (
+            [
             'version', 'routes',
             'methodRoutes', 'candidatesByMethod',
             'staticByMethod', 'staticShadowedByMethod',
             'hostnameByMethod', 'hostnameLessByMethod',
             'combinedRegexByMethod', 'combinedRegexDisabled', 'combinedRegexMarkMap',
             'routeMeta',
-        ] as $key) {
+            ] as $key
+        ) {
             $this->assertArrayHasKey($key, $dump, "dump missing key: $key");
         }
     }

--- a/tests/unit/Mvc/Router/CombinedRegexTest.php
+++ b/tests/unit/Mvc/Router/CombinedRegexTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router;
+
+use Phalcon\Events\Manager as EventsManager;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Fake\RouterTrait;
+
+final class CombinedRegexTest extends AbstractUnitTestCase
+{
+    use RouterTrait;
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMatchesFirstRoute(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/products/{slug:[a-z-]+}', ['controller' => 'products']);
+        $router->add('/users/{id:[0-9]+}',       ['controller' => 'users']);
+
+        $router->handle('/users/42');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('users', $router->getControllerName());
+    }
+
+    /**
+     * Two regex routes that both match the same URI; the later-attached
+     * one must win (reverse-iteration semantics preserved by the combined
+     * regex via alternative-order reversal).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLaterAttachedDynamicRouteWins(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/{anything:[a-z]+}',     ['controller' => 'first']);
+        $router->add('/{anythingElse:[a-z]+}', ['controller' => 'second']);
+
+        $router->handle('/about');
+
+        $this->assertSame('second', $router->getControllerName());
+    }
+
+    /**
+     * Named-group captures must reach the matched route's paths map even
+     * after group renumbering through (?|...) branch reset.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testNamedCapturesReachPaths(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/products/{slug:[a-z-]+}', ['controller' => 'products', 'slug' => 1]);
+
+        $router->handle('/products/widget');
+
+        $params = $router->getParams();
+        $this->assertSame('widget', $params['slug']);
+    }
+
+    /**
+     * Converters must run on a combined-regex hit.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testConverterRunsAfterCombinedRegexMatch(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/users/{id:[0-9]+}', ['controller' => 'users', 'id' => 1])
+            ->convert('id', static fn(string $v): int => (int) $v);
+
+        $router->handle('/users/42');
+
+        $params = $router->getParams();
+        $this->assertSame(42, $params['id']);
+    }
+
+    /**
+     * beforeMatch returning false on a combined-regex hit vetoes the
+     * match.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testBeforeMatchVetoOnCombinedRegexHit(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/users/{id:[0-9]+}', ['controller' => 'users'])
+            ->beforeMatch(static fn(): bool => false);
+
+        $router->handle('/users/42');
+
+        $this->assertFalse($router->wasMatched());
+    }
+
+    /**
+     * The presence of a hostname-constrained route in the bucket disables
+     * combined regex for that bucket — reverse-attach order with the
+     * hostname route is preserved by falling back to the per-route loop.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testHostnameRouteDisablesCombinedRegex(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/{anything:[a-z]+}', ['controller' => 'catchAll']);
+        $router->add('/about', ['controller' => 'about'])
+            ->setHostname('admin.example.com');
+
+        $_SERVER['HTTP_HOST'] = 'www.example.com';
+        $router->handle('/about');
+
+        // about route's hostname does not match; catchAll wins.
+        $this->assertSame('catchAll', $router->getControllerName());
+    }
+
+    /**
+     * When an events manager is attached, the combined regex must be
+     * bypassed so per-route events continue to fire.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testEventsManagerDisablesCombinedRegex(): void
+    {
+        $router  = $this->getRouter(false);
+        $fired   = [];
+        $manager = new EventsManager();
+        $manager->attach('router', static function ($event) use (&$fired) {
+            $fired[] = $event->getType();
+        });
+        $router->setEventsManager($manager);
+
+        $router->add('/users/{id:[0-9]+}',       ['controller' => 'users']);
+        $router->add('/products/{slug:[a-z-]+}', ['controller' => 'products']);
+
+        $router->handle('/users/42');
+
+        $this->assertContains('beforeCheckRoute', $fired);
+        $this->assertContains('matchedRoute',     $fired);
+    }
+}

--- a/tests/unit/Mvc/Router/CombinedRegexTest.php
+++ b/tests/unit/Mvc/Router/CombinedRegexTest.php
@@ -157,4 +157,53 @@ final class CombinedRegexTest extends AbstractUnitTestCase
         $this->assertContains('beforeCheckRoute', $fired);
         $this->assertContains('matchedRoute',     $fired);
     }
+
+    /**
+     * 25 dynamic routes (above the 10-per-chunk threshold). A route in the
+     * second chunk must still match, and a route in the third chunk must
+     * still match.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testChunkingBoundary(): void
+    {
+        $router = $this->getRouter(false);
+        for ($i = 0; $i < 25; $i++) {
+            $router->add(
+                "/r{$i}/{slug:[a-z]+}",
+                ['controller' => 'route_' . $i]
+            );
+        }
+
+        // /r22 was attached as index 22. After reversing the alternatives,
+        // the latest 10 attached (24..15) form chunk 0; r22 is in chunk 0.
+        $router->handle('/r22/widget');
+        $this->assertSame('route_22', $router->getControllerName());
+
+        // /r2 was attached as index 2. After reversing, it lands in chunk
+        // 2 (positions 20..24 of the reversed list).
+        $router->handle('/r2/widget');
+        $this->assertSame('route_2', $router->getControllerName());
+    }
+
+    /**
+     * With 25 catch-all routes attached, the latest-attached one wins
+     * regardless of which chunk it lives in (chunk 0 is tried first by
+     * design).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testChunkingPreservesReverseAttachOrder(): void
+    {
+        $router = $this->getRouter(false);
+        for ($i = 0; $i < 25; $i++) {
+            $router->add('/{anything' . $i . ':[a-z]+}', ['controller' => 'route_' . $i]);
+        }
+
+        $router->handle('/about');
+
+        $this->assertSame('route_24', $router->getControllerName());
+    }
 }

--- a/tests/unit/Mvc/Router/CombinedRegexTest.php
+++ b/tests/unit/Mvc/Router/CombinedRegexTest.php
@@ -29,7 +29,7 @@ final class CombinedRegexTest extends AbstractUnitTestCase
     {
         $router = $this->getRouter(false);
         $router->add('/products/{slug:[a-z-]+}', ['controller' => 'products']);
-        $router->add('/users/{id:[0-9]+}',       ['controller' => 'users']);
+        $router->add('/users/{id:[0-9]+}', ['controller' => 'users']);
 
         $router->handle('/users/42');
 
@@ -48,7 +48,7 @@ final class CombinedRegexTest extends AbstractUnitTestCase
     public function testLaterAttachedDynamicRouteWins(): void
     {
         $router = $this->getRouter(false);
-        $router->add('/{anything:[a-z]+}',     ['controller' => 'first']);
+        $router->add('/{anything:[a-z]+}', ['controller' => 'first']);
         $router->add('/{anythingElse:[a-z]+}', ['controller' => 'second']);
 
         $router->handle('/about');
@@ -149,13 +149,13 @@ final class CombinedRegexTest extends AbstractUnitTestCase
         });
         $router->setEventsManager($manager);
 
-        $router->add('/users/{id:[0-9]+}',       ['controller' => 'users']);
+        $router->add('/users/{id:[0-9]+}', ['controller' => 'users']);
         $router->add('/products/{slug:[a-z-]+}', ['controller' => 'products']);
 
         $router->handle('/users/42');
 
         $this->assertContains('beforeCheckRoute', $fired);
-        $this->assertContains('matchedRoute',     $fired);
+        $this->assertContains('matchedRoute', $fired);
     }
 
     /**

--- a/tests/unit/Mvc/Router/CoverageGapsTest.php
+++ b/tests/unit/Mvc/Router/CoverageGapsTest.php
@@ -215,7 +215,7 @@ final class CoverageGapsTest extends AbstractUnitTestCase
 
         // wasMatched is false (per current contract), but the not-found
         // paths populate the controller/action.
-        $this->assertSame('errors',   $router->getControllerName());
+        $this->assertSame('errors', $router->getControllerName());
         $this->assertSame('notFound', $router->getActionName());
     }
 
@@ -245,8 +245,8 @@ final class CoverageGapsTest extends AbstractUnitTestCase
         $paths = Route::getRoutePaths('Backend::Users::index');
 
         $this->assertSame('Backend', $paths['module']);
-        $this->assertSame('Users',   $paths['controller']);
-        $this->assertSame('index',   $paths['action']);
+        $this->assertSame('Users', $paths['controller']);
+        $this->assertSame('index', $paths['action']);
     }
 
     /**
@@ -276,8 +276,8 @@ final class CoverageGapsTest extends AbstractUnitTestCase
         $paths = Route::getRoutePaths('App\\Controllers\\Users::index');
 
         $this->assertSame('App\\Controllers', $paths['namespace']);
-        $this->assertSame('Users',            $paths['controller']);
-        $this->assertSame('index',            $paths['action']);
+        $this->assertSame('Users', $paths['controller']);
+        $this->assertSame('index', $paths['action']);
     }
 
     /**

--- a/tests/unit/Mvc/Router/CoverageGapsTest.php
+++ b/tests/unit/Mvc/Router/CoverageGapsTest.php
@@ -1,0 +1,612 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router;
+
+use Phalcon\Mvc\Router;
+use Phalcon\Mvc\Router\Exception;
+use Phalcon\Mvc\Router\Route;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Fake\RouterTrait;
+
+final class CoverageGapsTest extends AbstractUnitTestCase
+{
+    use RouterTrait;
+
+    /**
+     * Hostname route in the main loop: HTTP_HOST set, literal hostname match.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testHostnameLiteralMatchInMainLoop(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/admin', ['controller' => 'admin'])
+            ->setHostname('admin.example.com');
+
+        $_SERVER['HTTP_HOST'] = 'admin.example.com';
+        $router->handle('/admin');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('admin', $router->getControllerName());
+    }
+
+    /**
+     * Hostname route in the main loop with HTTP_HOST mismatching the
+     * constraint — route is skipped.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testHostnameLiteralMismatchInMainLoop(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/admin', ['controller' => 'admin'])
+            ->setHostname('admin.example.com');
+
+        $_SERVER['HTTP_HOST'] = 'www.example.com';
+        $router->handle('/admin');
+
+        $this->assertFalse($router->wasMatched());
+    }
+
+    /**
+     * Hostname regex route matches via preg_match in the main loop.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testHostnameRegexMatchInMainLoop(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/api/{action}', ['controller' => 'api'])
+            ->setHostname('([a-z]+)\\.example\\.com');
+
+        $_SERVER['HTTP_HOST'] = 'tenant.example.com';
+        $router->handle('/api/list');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('list', $router->getActionName());
+    }
+
+    /**
+     * Hostname route with empty HTTP_HOST (CLI-like environment) — continue.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testHostnameRouteSkippedWhenHttpHostEmpty(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/admin', ['controller' => 'admin'])
+            ->setHostname('admin.example.com');
+
+        $_SERVER['HTTP_HOST'] = '';
+        $router->handle('/admin');
+
+        $this->assertFalse($router->wasMatched());
+    }
+
+    /**
+     * Converter is applied to a positional default when the regex did not
+     * capture the value (the position is in `paths` but absent from
+     * `$matches`). Exercises the converter branch under the `else` arm.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testConverterAppliedToPositionalDefault(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/items/{slug:[a-z-]+}', ['controller' => 'items', 'tag' => 99])
+            ->convert('tag', static fn(int $v): string => 'tag-' . $v);
+
+        $router->handle('/items/widget');
+
+        $params = $router->getParams();
+        $this->assertSame('tag-99', $params['tag']);
+    }
+
+    /**
+     * Converter applied to a captured value during handle(). Exercises the
+     * `if (is_array($converters) && isset($converters[$part]))` branch
+     * inside the matched-position arm of the main loop.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testConverterAppliedToMatchedValue(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/users/{id:[0-9]+}', ['controller' => 'users', 'id' => 1])
+            ->convert('id', static fn(string $v): int => (int) $v * 2);
+
+        $router->handle('/users/21');
+
+        $params = $router->getParams();
+        $this->assertSame(42, $params['id']);
+    }
+
+    /**
+     * paths entry with a non-string non-int position is silently skipped
+     * (the `continue` at the `position` typecheck branch in handle()).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testPathsEntryWithNonScalarPositionIsSkipped(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add(
+            '/widgets/{id:[0-9]+}',
+            ['controller' => 'widgets', 'extra' => ['nested' => 'value']]
+        );
+
+        $router->handle('/widgets/7');
+
+        $params = $router->getParams();
+        // The non-scalar 'extra' position is skipped — but stays in $parts
+        // (the foreach `continue` doesn't unset it).
+        $this->assertSame(['nested' => 'value'], $params['extra']);
+    }
+
+    /**
+     * handle() with a query-string-only URI falls back to "/" after
+     * extractRealUri returns an empty string. Exercises line 852.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testHandleQueryStringOnlyUriFallsBackToRoot(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/', ['controller' => 'home']);
+
+        $router->handle('?foo=bar');
+
+        $this->assertSame('home', $router->getControllerName());
+    }
+
+    /**
+     * Path entry with a non-string key triggers Exception. Routes with a
+     * paths array that has an integer key reach the throw in handle().
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testWrongPathsKeyThrows(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/x/(\d+)', [0 => 'broken']);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Wrong key in paths: 0');
+
+        $router->handle('/x/42');
+    }
+
+    /**
+     * notFoundPaths fallback is used when no route matches.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testNotFoundPathsFallback(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+        $router->notFound([
+            'controller' => 'errors',
+            'action'     => 'notFound',
+        ]);
+
+        $router->handle('/nonexistent');
+
+        // wasMatched is false (per current contract), but the not-found
+        // paths populate the controller/action.
+        $this->assertSame('errors',   $router->getControllerName());
+        $this->assertSame('notFound', $router->getActionName());
+    }
+
+    /**
+     * getCompiledHostName accepts a pre-delimited regex (`#hostname#`) and
+     * returns it verbatim.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testGetCompiledHostNamePreDelimited(): void
+    {
+        $route = new Route('/api');
+        $route->setHostname('#^([a-z]+)\\.example\\.com$#i');
+
+        $this->assertSame('#^([a-z]+)\\.example\\.com$#i', $route->getCompiledHostName());
+    }
+
+    /**
+     * Route::getRoutePaths() with Module::Controller::Action string syntax.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoutePathsModuleControllerActionString(): void
+    {
+        $paths = Route::getRoutePaths('Backend::Users::index');
+
+        $this->assertSame('Backend', $paths['module']);
+        $this->assertSame('Users',   $paths['controller']);
+        $this->assertSame('index',   $paths['action']);
+    }
+
+    /**
+     * Route::getRoutePaths() with single-token string syntax (controller only).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoutePathsControllerOnlyString(): void
+    {
+        $paths = Route::getRoutePaths('Users');
+
+        $this->assertSame('Users', $paths['controller']);
+        $this->assertArrayNotHasKey('action', $paths);
+        $this->assertArrayNotHasKey('module', $paths);
+    }
+
+    /**
+     * Route::getRoutePaths() with a namespaced controller name extracts the
+     * namespace and the bare class.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testRoutePathsNamespacedController(): void
+    {
+        $paths = Route::getRoutePaths('App\\Controllers\\Users::index');
+
+        $this->assertSame('App\\Controllers', $paths['namespace']);
+        $this->assertSame('Users',            $paths['controller']);
+        $this->assertSame('index',            $paths['action']);
+    }
+
+    /**
+     * getRewriteUri reads $_GET["_url"] when uriSource is URI_SOURCE_GET_URL
+     * (the default).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testGetRewriteUriReadsGetUrl(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+
+        $_GET['_url'] = '/about';
+        $router->handle('');
+
+        $this->assertSame('about', $router->getControllerName());
+        unset($_GET['_url']);
+    }
+
+    /**
+     * getRewriteUri reads $_SERVER["REQUEST_URI"] when uriSource is
+     * URI_SOURCE_SERVER_REQUEST_URI.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testGetRewriteUriReadsServerRequestUri(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+        $router->setUriSource(Router::URI_SOURCE_SERVER_REQUEST_URI);
+
+        $_SERVER['REQUEST_URI'] = '/about';
+        $router->handle('');
+
+        $this->assertSame('about', $router->getControllerName());
+    }
+
+    /**
+     * getRewriteUri returns "/" when neither source has a usable URI.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testGetRewriteUriDefaultsToRoot(): void
+    {
+        $router = $this->getRouter(true);
+
+        unset($_GET['_url']);
+        $router->handle('');
+
+        // Default route does not match "/" alone, so no match — but the
+        // codepath through getRewriteUri returning "/" is exercised.
+        $this->assertFalse($router->wasMatched());
+    }
+
+    /**
+     * setUriSource is a setter — exercise it for coverage.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testSetUriSourceReturnsRouter(): void
+    {
+        $router = $this->getRouter(false);
+        $result = $router->setUriSource(Router::URI_SOURCE_SERVER_REQUEST_URI);
+
+        $this->assertSame($router, $result);
+    }
+
+    /**
+     * loadFromConfig throws when 'routes' is not an array.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLoadFromConfigRoutesNotArrayThrows(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("'routes' must be an array");
+
+        $router->loadFromConfig(['routes' => 'not-an-array']);
+    }
+
+    /**
+     * mount() throws when the group has no routes.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountEmptyGroupThrows(): void
+    {
+        $router = $this->getRouter(false);
+        $group  = new \Phalcon\Mvc\Router\Group();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('The group of routes does not contain any routes');
+
+        $router->mount($group);
+    }
+
+    /**
+     * mount() propagates the group's beforeMatch onto each child route.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountAppliesGroupBeforeMatch(): void
+    {
+        $router = $this->getRouter(false);
+        $group  = new \Phalcon\Mvc\Router\Group();
+        $callback = static fn(): bool => false;
+        $group->beforeMatch($callback);
+        $group->add('/admin', ['controller' => 'admin']);
+
+        $router->mount($group);
+
+        $routes = $router->getRoutes();
+        $this->assertSame($callback, end($routes)->getBeforeMatch());
+    }
+
+    /**
+     * mountGroupFromConfig: a group entry without 'routes' as an array throws.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountGroupFromConfigRoutesNotArrayThrows(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Group 'routes' must be an array");
+
+        $router->loadFromConfig([
+            'groups' => [
+                [
+                    'prefix' => '/api',
+                    'routes' => 'not-an-array',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * mountGroupFromConfig: missing 'pattern' throws.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountGroupFromConfigMissingPatternThrows(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Group route entry is missing 'pattern'");
+
+        $router->loadFromConfig([
+            'groups' => [
+                [
+                    'prefix' => '/api',
+                    'routes' => [
+                        ['paths' => ['controller' => 'users']],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * mountGroupFromConfig: missing 'paths' throws.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountGroupFromConfigMissingPathsThrows(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Group route entry is missing 'paths'");
+
+        $router->loadFromConfig([
+            'groups' => [
+                [
+                    'prefix' => '/api',
+                    'routes' => [
+                        ['pattern' => '/users'],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * mountGroupFromConfig dispatches per the 'method' key (put, trace,
+     * purge). Exercises the switch cases for the less-common verbs and
+     * verifies the route is registered with the group prefix.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountGroupFromConfigPutPurgeTraceMethods(): void
+    {
+        $router = $this->getRouter(false);
+
+        $router->loadFromConfig([
+            'groups' => [
+                [
+                    'prefix' => '/api',
+                    'routes' => [
+                        ['method' => 'put',   'pattern' => '/p', 'paths' => ['controller' => 'p'], 'name' => 'r_put'],
+                        ['method' => 'purge', 'pattern' => '/q', 'paths' => ['controller' => 'q']],
+                        ['method' => 'trace', 'pattern' => '/r', 'paths' => ['controller' => 'r']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertNotFalse($router->getRouteByName('r_put'));
+    }
+
+    /**
+     * mountGroupFromConfig throws on an unknown HTTP method.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMountGroupFromConfigUnknownMethodThrows(): void
+    {
+        $router = $this->getRouter(false);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Unknown HTTP method 'bogus'");
+
+        $router->loadFromConfig([
+            'groups' => [
+                [
+                    'prefix' => '/api',
+                    'routes' => [
+                        ['method' => 'bogus', 'pattern' => '/x', 'paths' => ['controller' => 'x']],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Route::extractNamedParams returns false for an empty pattern.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testExtractNamedParamsEmptyPattern(): void
+    {
+        $route = new Route('/x');
+        $this->assertFalse($route->extractNamedParams(''));
+    }
+
+    /**
+     * extractNamedParams: a placeholder whose first character is non-alpha
+     * is rejected — the `{1bad}` literal is kept verbatim in the route.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testExtractNamedParamsInvalidFirstChar(): void
+    {
+        $route   = new Route('/x');
+        $result  = $route->extractNamedParams('/items/{1bad}');
+
+        $this->assertIsArray($result);
+        [$compiled] = $result;
+        $this->assertStringContainsString('{1bad}', $compiled);
+    }
+
+    /**
+     * extractNamedParams: placeholder containing an illegal character
+     * (space) is rejected.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testExtractNamedParamsIllegalChar(): void
+    {
+        $route  = new Route('/x');
+        $result = $route->extractNamedParams('/items/{bad name}');
+
+        $this->assertIsArray($result);
+        [$compiled] = $result;
+        $this->assertStringContainsString('{bad name}', $compiled);
+    }
+
+    /**
+     * extractNamedParams: a placeholder whose regex part is already wrapped
+     * in parentheses must not be wrapped again.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testExtractNamedParamsRegexAlreadyParenthesized(): void
+    {
+        $route  = new Route('/x');
+        $result = $route->extractNamedParams('/items/{id:(\\d+)}');
+
+        $this->assertIsArray($result);
+        [$compiled, $matches] = $result;
+        $this->assertSame(['id' => 1], $matches);
+        $this->assertStringContainsString('(\\d+)', $compiled);
+    }
+
+    /**
+     * extractNamedParams: regex metacharacters outside placeholders are
+     * escaped to literals (`.`, `+`, `|`, `#`).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testExtractNamedParamsEscapesMetaCharacters(): void
+    {
+        $route  = new Route('/x');
+        $result = $route->extractNamedParams('/foo.bar');
+
+        $this->assertIsArray($result);
+        [$compiled] = $result;
+        $this->assertStringContainsString('foo\\.bar', $compiled);
+    }
+}

--- a/tests/unit/Mvc/Router/Route/SetRouteIdTest.php
+++ b/tests/unit/Mvc/Router/Route/SetRouteIdTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router\Route;
+
+use Phalcon\Mvc\Router\Route;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+final class SetRouteIdTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testSetRouteIdOverridesConstructorId(): void
+    {
+        $route = new Route('/x');
+        $route->setRouteId('cached-42');
+
+        $this->assertSame('cached-42', $route->getRouteId());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testSetRouteIdReturnsSelfForChaining(): void
+    {
+        $route  = new Route('/x');
+        $result = $route->setRouteId('foo');
+
+        $this->assertSame($route, $result);
+    }
+}

--- a/tests/unit/Mvc/Router/StaticRouteFastPathTest.php
+++ b/tests/unit/Mvc/Router/StaticRouteFastPathTest.php
@@ -45,7 +45,7 @@ final class StaticRouteFastPathTest extends AbstractUnitTestCase
     public function testLaterAttachedRegexShadowsEarlierStatic(): void
     {
         $router = $this->getRouter(false);
-        $router->add('/about',         ['controller' => 'about']);
+        $router->add('/about', ['controller' => 'about']);
         $router->add('/{slug:[a-z]+}', ['controller' => 'catch_all']);
 
         $router->handle('/about');
@@ -64,7 +64,7 @@ final class StaticRouteFastPathTest extends AbstractUnitTestCase
     {
         $router = $this->getRouter(false);
         $router->add('/{slug:[a-z]+}', ['controller' => 'catch_all']);
-        $router->add('/about',         ['controller' => 'about']);
+        $router->add('/about', ['controller' => 'about']);
 
         $router->handle('/about');
 
@@ -81,13 +81,13 @@ final class StaticRouteFastPathTest extends AbstractUnitTestCase
     public function testStaticFastPathHonorsMethodConstraint(): void
     {
         $router = $this->getRouter(false);
-        $router->addGet('/users',  ['controller' => 'users', 'action' => 'index']);
+        $router->addGet('/users', ['controller' => 'users', 'action' => 'index']);
         $router->addPost('/users', ['controller' => 'users', 'action' => 'create']);
 
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $router->handle('/users');
 
-        $this->assertSame('users',  $router->getControllerName());
+        $this->assertSame('users', $router->getControllerName());
         $this->assertSame('create', $router->getActionName());
     }
 
@@ -139,7 +139,7 @@ final class StaticRouteFastPathTest extends AbstractUnitTestCase
     public function testCrossBucketShadowingByStarRegex(): void
     {
         $router = $this->getRouter(false);
-        $router->addGet('/about',      ['controller' => 'about']);
+        $router->addGet('/about', ['controller' => 'about']);
         $router->add('/{slug:[a-z]+}', ['controller' => 'catch_all']);
 
         $_SERVER['REQUEST_METHOD'] = 'GET';

--- a/tests/unit/Mvc/Router/StaticRouteFastPathTest.php
+++ b/tests/unit/Mvc/Router/StaticRouteFastPathTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router;
+
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Fake\RouterTrait;
+
+final class StaticRouteFastPathTest extends AbstractUnitTestCase
+{
+    use RouterTrait;
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLiteralUriMatchesStaticRouteDirectly(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about', ['controller' => 'about']);
+
+        $router->handle('/about');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('about', $router->getControllerName());
+    }
+
+    /**
+     * Static attached first then a regex that would shadow it. Reverse
+     * iteration semantics require the regex (last attached) to win.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testLaterAttachedRegexShadowsEarlierStatic(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/about',         ['controller' => 'about']);
+        $router->add('/{slug:[a-z]+}', ['controller' => 'catch_all']);
+
+        $router->handle('/about');
+
+        $this->assertSame('catch_all', $router->getControllerName());
+    }
+
+    /**
+     * Regex attached first, static attached second. Reverse iteration puts
+     * the static first; it should win.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testStaticAttachedAfterRegexMatchesDirectly(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/{slug:[a-z]+}', ['controller' => 'catch_all']);
+        $router->add('/about',         ['controller' => 'about']);
+
+        $router->handle('/about');
+
+        $this->assertSame('about', $router->getControllerName());
+    }
+
+    /**
+     * Static routes registered under different HTTP method buckets must
+     * still respect the method constraint.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testStaticFastPathHonorsMethodConstraint(): void
+    {
+        $router = $this->getRouter(false);
+        $router->addGet('/users',  ['controller' => 'users', 'action' => 'index']);
+        $router->addPost('/users', ['controller' => 'users', 'action' => 'create']);
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $router->handle('/users');
+
+        $this->assertSame('users',  $router->getControllerName());
+        $this->assertSame('create', $router->getActionName());
+    }
+
+    /**
+     * A beforeMatch callback that returns false must veto the static fast
+     * path the same way it vetoes the regular loop.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testStaticFastPathRespectsBeforeMatchVeto(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/admin', ['controller' => 'admin'])
+            ->beforeMatch(static fn(): bool => false);
+
+        $router->handle('/admin');
+
+        $this->assertFalse($router->wasMatched());
+    }
+
+    /**
+     * Hostname constraints must be honored even when the static fast path
+     * fires.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testStaticFastPathRespectsHostName(): void
+    {
+        $router = $this->getRouter(false);
+        $router->add('/api', ['controller' => 'api'])
+            ->setHostname('api.example.com');
+
+        $_SERVER['HTTP_HOST'] = 'www.example.com';
+        $router->handle('/api');
+
+        $this->assertFalse($router->wasMatched());
+    }
+
+    /**
+     * A no-method ("*") regex attached after a method-specific static must
+     * be detected as a shadow during rebuild — otherwise the static fast
+     * path would incorrectly win for the GET request.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testCrossBucketShadowingByStarRegex(): void
+    {
+        $router = $this->getRouter(false);
+        $router->addGet('/about',      ['controller' => 'about']);
+        $router->add('/{slug:[a-z]+}', ['controller' => 'catch_all']);
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $router->handle('/about');
+
+        $this->assertSame('catch_all', $router->getControllerName());
+    }
+}

--- a/tests/unit/Mvc/Router/UseCacheTest.php
+++ b/tests/unit/Mvc/Router/UseCacheTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router;
+
+use Phalcon\Cache\Adapter\Memory;
+use Phalcon\Storage\SerializerFactory;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Fake\RouterTrait;
+
+final class UseCacheTest extends AbstractUnitTestCase
+{
+    use RouterTrait;
+
+    /**
+     * Cache miss: after handle(), the dispatcher is written to the cache.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testCacheMissPopulatesCacheAfterHandle(): void
+    {
+        $cache = $this->newMemoryCache();
+        $key   = 'phalcon.router.dispatcher';
+
+        $router = $this->getRouter(false);
+        $router->useCache($cache, $key);
+        $router->add('/about', ['controller' => 'about']);
+
+        $this->assertFalse($cache->has($key));
+
+        $router->handle('/about');
+
+        $this->assertTrue($cache->has($key));
+        $stored = $cache->get($key);
+        $this->assertIsArray($stored);
+        $this->assertSame(1, $stored['version']);
+    }
+
+    /**
+     * Cache hit: useCache restores from cache without needing routes added.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testCacheHitRestoresWithoutAddingRoutes(): void
+    {
+        $cache = $this->newMemoryCache();
+        $key   = 'phalcon.router.dispatcher';
+
+        $primer = $this->getRouter(false);
+        $primer->add('/about', ['controller' => 'about']);
+        $cache->set($key, $primer->buildDispatcherDump());
+
+        $router = $this->getRouter(false);
+        $router->useCache($cache, $key);
+
+        $router->handle('/about');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('about', $router->getControllerName());
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testUseCacheUsesDefaultKeyWhenNoneProvided(): void
+    {
+        $cache = $this->newMemoryCache();
+
+        $router = $this->getRouter(false);
+        $router->useCache($cache);
+        $router->add('/about', ['controller' => 'about']);
+        $router->handle('/about');
+
+        $this->assertTrue($cache->has('phalcon.router.dispatcher'));
+    }
+
+    private function newMemoryCache(): Memory
+    {
+        return new Memory(new SerializerFactory(), ['defaultSerializer' => 'Php']);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17012 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [x] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

`Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; PCRE patterns chunked; per-route metadata cache deduplicated by route id.

`Phalcon\Mvc\Router\Route::getCompiledHostName()` now uses cache for hostname/converters.

`Phalcon\Mvc\Router\Route::setRouteId(string $routeId)` - setter intended for restoring cached routes 

`Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes

`Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes

`Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes 


Thanks

