### PR TITLE
T17041 row offsetget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ zephir
 tests/_output/*
 tests/support/assets/phalcon_test*
 .claude/
+nikos/
 
 # Docker
 docker-compose.override.yml

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -508,6 +508,9 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Mvc\Model\Row::offsetGet()` / `offsetExists()` throwing `The index does not exist in the row` when accessing a column whose value is `null` [#17041](https://github.com/phalcon/cphalcon/issues/17041)
+- Fixed `Phalcon\Mvc\View::getContent()` throwing `TypeError` after `View::start()`. `start()` was assigning `$this->content = null` [#17041](https://github.com/phalcon/cphalcon/issues/17041)
+
 ### Removed
 
 ## [5.13.0](https://github.com/phalcon/cphalcon/releases/tag/v5.13.0) (2026-05-18)

--- a/phalcon/Mvc/Model/Row.zep
+++ b/phalcon/Mvc/Model/Row.zep
@@ -40,21 +40,31 @@ class Row extends \stdClass implements EntityInterface, ResultInterface, ArrayAc
      */
     public function offsetGet(mixed index) -> mixed
     {
-        if !this->offsetExists(index) {
+        var value, key;
+
+        let key = (string) index;
+
+        if !fetch value, this->{key} {
             throw new IndexNotInRow();
         }
 
-        return this->{index};
+        return value;
     }
 
     /**
-     * Checks whether offset exists in the row
+     * Checks whether offset exists in the row. Returns true when the property
+     * is present on the row, regardless of whether its value is null - column
+     * presence is the contract, not value truthiness.
      *
      * @param string|int $index
      */
     public function offsetExists(mixed index) -> bool
     {
-        return isset this->{index};
+        var value, key;
+
+        let key = (string) index;
+
+        return (bool) fetch value, this->{key};
     }
 
     /**

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -275,7 +275,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * rebuild on cache miss, then clears the property to skip subsequent
      * writes.
      *
-     * @var <CacheAdapterInterface>|null
+     * @var CacheAdapterInterface|null
      */
     protected pendingCache = null;
 

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -1025,7 +1025,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
     {
         ob_start();
 
-        let this->content = null;
+        let this->content = "";
 
         return this;
     }

--- a/tests/database/Mvc/Model/Row/OffsetExistsTest.php
+++ b/tests/database/Mvc/Model/Row/OffsetExistsTest.php
@@ -45,4 +45,27 @@ final class OffsetExistsTest extends AbstractDatabaseTestCase
             isset($row['inv_id'])
         );
     }
+
+    /**
+     * Regression coverage for [#17041]: a property that exists on the row
+     * but holds a null value must still report as set - column presence is
+     * the contract, not value truthiness. Resultset\Complex rows that come
+     * back from SELECT projections include NULL columns and userland code
+     * relies on `isset($row['col'])` to detect column presence regardless
+     * of the value.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelRowOffsetExistsForNullValuedColumn(): void
+    {
+        $row = new Row();
+        $row->writeAttribute('inv_discount', null);
+
+        $this->assertTrue(isset($row['inv_discount']));
+    }
 }

--- a/tests/database/Mvc/Model/Row/OffsetGetTest.php
+++ b/tests/database/Mvc/Model/Row/OffsetGetTest.php
@@ -37,4 +37,25 @@ final class OffsetGetTest extends AbstractDatabaseTestCase
             $row['inv_title']
         );
     }
+
+    /**
+     * Regression coverage for [#17041]: reading a property that exists on
+     * the row but holds a null value must return null - not throw - so
+     * Resultset\Complex rows with NULL columns can be accessed via the
+     * ArrayAccess contract without `property_exists` guards.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     *
+     * @group mysql
+     * @group pgsql
+     * @group sqlite
+     */
+    public function testMvcModelRowOffsetGetReturnsNullForNullValuedColumn(): void
+    {
+        $row = new Row();
+        $row->writeAttribute('inv_discount', null);
+
+        $this->assertNull($row['inv_discount']);
+    }
 }

--- a/tests/unit/Mvc/View/StartTest.php
+++ b/tests/unit/Mvc/View/StartTest.php
@@ -29,4 +29,24 @@ class StartTest extends AbstractUnitTestCase
         $this->assertInstanceOf(View::class, $result);
         $view->finish();
     }
+
+    /**
+     * Regression coverage for [#17041]: View::start() must leave $content
+     * as an empty string so that View::getContent() (declared `-> string`)
+     * does not throw a TypeError. Application::handle() calls getContent()
+     * after start() on every request, so a null assignment in start() is
+     * not survivable from userland.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-05-21
+     */
+    public function testMvcViewStartLeavesContentAsEmptyString(): void
+    {
+        $view = new View();
+        $view->start();
+
+        $this->assertSame('', $view->getContent());
+
+        $view->finish();
+    }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17041 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model\Row::offsetGet()` / `offsetExists()` throwing `The index does not exist in the row` when accessing a column whose value is `null`

Fixed `Phalcon\Mvc\View::getContent()` throwing `TypeError` after `View::start()`. `start()` was assigning `$this->content = null` 


Thanks

