### PR TITLE
T17049 speed memory optimizations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -598,7 +598,7 @@ jobs:
           fi
 
           cp tests/support/_config/.env.default .env
-          php tests/support/_config/generate-db-schemas.php
+          php bin/generate-db-schemas.php
 
       - name: Run Unit Tests
         if: always()
@@ -713,7 +713,7 @@ jobs:
       - name: Setup Tests
         run: |
           cp tests/support/_config/.env.default .env
-          php tests/support/_config/generate-db-schemas.php
+          php bin/generate-db-schemas.php
 
       - name: Run Database Tests (MySQL)
         env:
@@ -811,7 +811,7 @@ jobs:
       - name: Setup Tests
         run: |
           cp tests/support/_config/.env.default .env
-          php tests/support/_config/generate-db-schemas.php
+          php bin/generate-db-schemas.php
 
       - name: Run Database Tests (SQLite)
         env:
@@ -921,7 +921,7 @@ jobs:
       - name: Setup Tests
         run: |
           cp tests/support/_config/.env.default .env
-          php tests/support/_config/generate-db-schemas.php
+          php bin/generate-db-schemas.php
 
       - name: Run Database Tests (Postgres)
         env:

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -6,7 +6,9 @@
 
 - `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; PCRE patterns chunked; per-route metadata cache deduplicated by route id. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - `Phalcon\Mvc\Router\Route::getCompiledHostName()` now uses cache for hostname/converters. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
-- Changed return types to `-> <static>` or `-> <self>` in various components. The change is a covariant narrowing on implementation methods and does not touch any interface contracts, so userland classes that implement Phalcon interfaces and return the interface type continue to work unchanged. [#17035](https://github.com/phalcon/cphalcon/issues/17035) [[doc]](https://docs.phalcon.io/5.13/)
+- Changed return types to `-> <static>` or `-> <self>` in various components. The change is a covariant narrowing on implementation methods and does not touch any interface contracts, so userland classes that implement Phalcon interfaces and return the interface type continue to work unchanged. [#17035](https://github.com/phalcon/cphalcon/issues/17035)
+- Internal performance work across `Autoload`, `Dispatcher`, `Annotations`, `Db`, `Mvc\Model`, `Mvc\Model\Query`, `Tag`, `Assets`, `Acl\Adapter\Memory`, `Http\Request`, `Encryption\Crypt`. Behavior preserved. [#17049](https://github.com/phalcon/cphalcon/issues/17049)
+- `Phalcon\Autoload\Loader` getters (`getDirectories`, `getExtensions`, `getFiles`) return arrays keyed by the value string instead of by a SHA256 hash of it; iteration order and contents are unchanged. [#17049](https://github.com/phalcon/cphalcon/issues/17049) [[doc]](https://docs.phalcon.io/5.13/autoload/)
 
 ### Added
 
@@ -505,6 +507,12 @@
 - `Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - `Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
 - `Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.13/routing/)
+- Opt-in memory caps for long-running workers (Swoole / RoadRunner / queue consumers). Default `0` preserves the original unbounded behavior: [#17049](https://github.com/phalcon/cphalcon/issues/17049)
+    - `Phalcon\Db\Profiler::setMaxProfiles(int)` / `getMaxProfiles()` [[doc]](https://docs.phalcon.io/5.13/db-layer/)
+    - `Phalcon\Logger\Adapter\AbstractAdapter::setQueueLimit(int)` / `getQueueLimit()` [[doc]](https://docs.phalcon.io/5.13/logger/)
+    - `Phalcon\Events\Manager::setMethodExistsCacheLimit(int)` / `getMethodExistsCacheLimit()` [[doc]](https://docs.phalcon.io/5.13/events/)
+    - `Phalcon\Annotations\Adapter\AbstractAdapter::setAnnotationsLimit(int)` / `getAnnotationsLimit()` [[doc]](https://docs.phalcon.io/5.13/annotations/)
+    - `Phalcon\Storage\Adapter\Memory::setMaxItems(int)` / `getMaxItems()` [[doc]](https://docs.phalcon.io/5.13/storage/)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ For detailed installation instructions you can check our [installation](https://
 
 ## Generating API Documentation
 
-Generating new documentation files for docs repository can be done using the script in tests/__config/generate-api-docs.php.
+Generating new documentation files for docs repository can be done using the script in bin/generate-api-docs.php.
 Steps:
 - Clone the phalcon repo
 - Checkout the tag you would like to generate docs for.
-- Run `php tests/__config/generate-api-docs.php`
+- Run `php bin/generate-api-docs.php`
 - The files *.md files in nikos/api/ will contain the documentation
 - For publishing to the Phalcon website this [repo](https://github.com/phalcon/docs/tree/5.0/api) is used.
 

--- a/bin/bump-version.php
+++ b/bin/bump-version.php
@@ -1,0 +1,237 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bumps the project version across every file that hard-codes it.
+ *
+ * Usage:
+ *   php bin/bump-version.php <version> [--date=YYYY-MM-DD]
+ *
+ * Examples:
+ *   php bin/bump-version.php 5.14.0
+ *   php bin/bump-version.php 5.14.0-RC1
+ *   php bin/bump-version.php 5.14.0-alpha2
+ *   php bin/bump-version.php 5.14.0-beta1 --date=2026-06-15
+ */
+
+$scriptName = $argv[0] ?? 'bin/bump-version.php';
+array_shift($argv);
+
+$version = null;
+$date    = date('Y-m-d');
+
+foreach ($argv as $arg) {
+    if (str_starts_with($arg, '--date=')) {
+        $date = substr($arg, 7);
+        continue;
+    }
+
+    if ($version === null) {
+        $version = $arg;
+        continue;
+    }
+
+    fwrite(STDERR, "Unknown argument: {$arg}\n");
+    exit(1);
+}
+
+if ($version === null) {
+    fwrite(STDERR, "Usage: {$scriptName} <version> [--date=YYYY-MM-DD]\n");
+    exit(1);
+}
+
+if (!preg_match('/^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta|RC)(\d+))?$/', $version, $matches)) {
+    fwrite(STDERR, "Invalid version '{$version}'. Expected MAJOR.MEDIUM.MINOR[-(alpha|beta|RC)N].\n");
+    exit(1);
+}
+
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+    fwrite(STDERR, "Invalid date '{$date}'. Expected YYYY-MM-DD.\n");
+    exit(1);
+}
+
+$major         = (int) $matches[1];
+$medium        = (int) $matches[2];
+$minor         = (int) $matches[3];
+$suffixWord    = $matches[4] ?? '';
+$specialNumber = (int) ($matches[5] ?? 0);
+
+$specialMap   = ['alpha' => 1, 'beta' => 2, 'RC' => 3];
+$special      = $suffixWord === '' ? 4 : $specialMap[$suffixWord];
+
+$stabilityMap = [1 => 'alpha', 2 => 'beta', 3 => 'beta', 4 => 'stable'];
+$stability    = $stabilityMap[$special];
+
+$displayVersion = $major . '.' . $medium . '.' . $minor;
+if ($suffixWord !== '') {
+    $displayVersion .= $suffixWord;
+    if ($specialNumber > 0) {
+        $displayVersion .= $specialNumber;
+    }
+}
+
+$root = dirname(__DIR__);
+
+$configPath  = $root . '/config.json';
+$oldVersion  = null;
+if (is_file($configPath)) {
+    $config = json_decode((string) file_get_contents($configPath), true);
+    if (is_array($config) && isset($config['version']) && is_string($config['version'])) {
+        $oldVersion = $config['version'];
+    }
+}
+
+$tasks = [
+    [
+        'file'    => $root . '/package.xml',
+        'patches' => [
+            [
+                '/<date>\d{4}-\d{2}-\d{2}<\/date>/',
+                '<date>' . $date . '</date>',
+            ],
+            [
+                '/<version>\s*<release>[^<]*<\/release>\s*<api>[^<]*<\/api>\s*<\/version>/',
+                "<version>\n    <release>{$displayVersion}</release>\n    <api>{$displayVersion}</api>\n  </version>",
+            ],
+            [
+                '/<stability>\s*<release>[^<]*<\/release>\s*<api>[^<]*<\/api>\s*<\/stability>/',
+                "<stability>\n    <release>{$stability}</release>\n    <api>{$stability}</api>\n  </stability>",
+            ],
+        ],
+    ],
+    [
+        'file'    => $configPath,
+        'patches' => [
+            [
+                '/"version":\s*"[^"]*"/',
+                '"version": "' . $displayVersion . '"',
+            ],
+        ],
+    ],
+    [
+        'file'    => $root . '/.github/workflows/main.yml',
+        'patches' => [
+            [
+                '/^(\s*PHALCON_VERSION:\s*).*$/m',
+                '${1}' . $displayVersion,
+            ],
+        ],
+    ],
+    [
+        'file'    => $root . '/docker/Dockerfile',
+        'patches' => [
+            [
+                '/ARG PHALCON_VERSION="v[^"]*"/',
+                'ARG PHALCON_VERSION="v' . $displayVersion . '"',
+            ],
+        ],
+    ],
+    [
+        'file'    => $root . '/phalcon/Support/Version.zep',
+        'patches' => [
+            [
+                '/return\s*\[\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*\d+\s*,\s*\d+\s*\]\s*;/',
+                "return [{$major}, {$medium}, {$minor}, {$special}, {$specialNumber}];",
+            ],
+        ],
+    ],
+];
+
+$errors        = [];
+$touchedFiles  = [];
+
+foreach ($tasks as $task) {
+    $file = $task['file'];
+
+    if (!is_file($file)) {
+        $errors[] = "missing file: {$file}";
+        continue;
+    }
+
+    $original = (string) file_get_contents($file);
+    $updated  = $original;
+
+    foreach ($task['patches'] as [$pattern, $replacement]) {
+        $count = 0;
+        $next  = preg_replace($pattern, $replacement, $updated, -1, $count);
+
+        if ($next === null) {
+            $errors[] = "{$file}: regex error for {$pattern}";
+            continue 2;
+        }
+
+        if ($count === 0) {
+            $errors[] = "{$file}: pattern not matched: {$pattern}";
+            continue 2;
+        }
+
+        $updated = $next;
+    }
+
+    if ($updated === $original) {
+        echo "  unchanged: " . substr($file, strlen($root) + 1) . "\n";
+        continue;
+    }
+
+    file_put_contents($file, $updated);
+    $touchedFiles[] = $file;
+    echo "  updated:   " . substr($file, strlen($root) + 1) . "\n";
+}
+
+if ($errors !== []) {
+    fwrite(STDERR, "\nErrors:\n");
+    foreach ($errors as $error) {
+        fwrite(STDERR, "  - {$error}\n");
+    }
+    exit(1);
+}
+
+if ($oldVersion !== null && $oldVersion !== $displayVersion) {
+    $stragglers = [];
+    foreach ($touchedFiles as $file) {
+        $contents = (string) file_get_contents($file);
+        if (strpos($contents, $oldVersion) !== false) {
+            $stragglers[] = substr($file, strlen($root) + 1);
+        }
+    }
+
+    if ($stragglers !== []) {
+        echo "\nWarning: old version '{$oldVersion}' still appears in:\n";
+        foreach ($stragglers as $straggler) {
+            echo "  - {$straggler}\n";
+        }
+    }
+}
+
+echo "\nVersion: {$displayVersion} (stability: {$stability}, date: {$date})\n";
+echo "Array:   [{$major}, {$medium}, {$minor}, {$special}, {$specialNumber}]\n";
+
+/**
+ * Recompile the extension. Mirrors the docker `cpl` alias so the steps live in
+ * source control. Intended to be run inside the cphalcon-dev-* container.
+ */
+$runStep = function (string $label, string $cwd, array $command) {
+    echo "\n>>> {$label}\n";
+
+    if (!chdir($cwd)) {
+        fwrite(STDERR, "  failed to chdir to {$cwd}\n");
+        exit(1);
+    }
+
+    $line = implode(' ', array_map('escapeshellarg', $command));
+    passthru($line, $exitCode);
+
+    if ($exitCode !== 0) {
+        fwrite(STDERR, "  step '{$label}' failed (exit {$exitCode})\n");
+        exit($exitCode);
+    }
+};
+
+$runStep('zephir fullclean', $root,            ['zephir', 'fullclean']);
+$runStep('zephir generate',  $root,            ['zephir', 'generate']);
+$runStep('ext/install',      $root . '/ext',   ['./install']);
+$runStep('build/gen-build',  $root . '/build', ['php', 'gen-build.php']);
+
+echo "\nDone.\n";

--- a/bin/generate-api-docs.php
+++ b/bin/generate-api-docs.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-$baseDir   = dirname(__FILE__, 4);
+$baseDir   = dirname(__DIR__);
 $sourceDir = implode(DIRECTORY_SEPARATOR, [$baseDir, 'phalcon', '']);
 $outputDir = implode(DIRECTORY_SEPARATOR, [$baseDir, 'nikos', 'api', '']);
 

--- a/bin/generate-db-schemas.php
+++ b/bin/generate-db-schemas.php
@@ -18,7 +18,7 @@ use Phalcon\Tests\Support\Migrations\FooterMigration;
 error_reporting(E_ALL);
 ini_set('display_errors', 'On');
 
-$root = dirname(__FILE__, 4);
+$root = dirname(__DIR__);
 
 require_once $root . '/vendor/autoload.php';
 

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -891,11 +891,18 @@ class Memory extends AbstractAdapter
     {
         var accessList, checkRoleToInherit, usedRoleToInherit;
         array usedRoleToInherits, checkRoleToInherits;
-        string accessKey;
+        string accessKey, roleComponentPrefix, inheritPrefix;
 
         let accessList = this->access;
 
-        let accessKey = roleName . "!" . componentName . "!" . access;
+        /**
+         * Build the shared `<role>!<component>!` prefix once and reuse
+         * it for the two component-scoped lookups below; only the
+         * role-only `<role>!*!*` key sits outside the prefix.
+         */
+        let roleComponentPrefix = roleName . "!" . componentName . "!";
+
+        let accessKey = roleComponentPrefix . access;
 
         /**
          * Check if there is a direct combination for role-component-access
@@ -907,7 +914,7 @@ class Memory extends AbstractAdapter
         /**
          * Check if there is a direct combination for role-*-*
          */
-        let accessKey = roleName . "!" . componentName . "!*";
+        let accessKey = roleComponentPrefix . "*";
 
         if isset accessList[accessKey] {
             return accessKey;
@@ -943,7 +950,8 @@ class Memory extends AbstractAdapter
 
                 let usedRoleToInherits[checkRoleToInherit] = true;
 
-                let accessKey = checkRoleToInherit . "!" . componentName . "!" . access;
+                let inheritPrefix = checkRoleToInherit . "!" . componentName . "!";
+                let accessKey = inheritPrefix . access;
 
                 /**
                  * Check if there is a direct combination in one of the
@@ -956,7 +964,7 @@ class Memory extends AbstractAdapter
                 /**
                  * Check if there is a direct combination for role-*-*
                  */
-                let accessKey = checkRoleToInherit . "!" . componentName . "!*";
+                let accessKey = inheritPrefix . "*";
 
                 if isset accessList[accessKey] {
                     return accessKey;

--- a/phalcon/Acl/Adapter/Memory.zep
+++ b/phalcon/Acl/Adapter/Memory.zep
@@ -285,6 +285,7 @@ class Memory extends AbstractAdapter
         var roleInheritName, roleToInherit, checkRoleToInherit,
             roleToInheritList, usedRoleToInherit;
         array checkRoleToInherits, usedRoleToInherits;
+        int pendingIndex;
 
         this->checkExists(this->roles, roleName, "Role", "role list");
 
@@ -341,8 +342,17 @@ class Memory extends AbstractAdapter
 
                 let usedRoleToInherits = [];
 
-                while !empty checkRoleToInherits {
-                    let checkRoleToInherit = array_shift(checkRoleToInherits);
+                /**
+                 * Walk the inheritance queue with an integer cursor instead
+                 * of `array_shift`. New roles enqueued by the body land at
+                 * the end of `checkRoleToInherits`, so advancing `pendingIndex`
+                 * preserves FIFO order without paying `array_shift`'s O(n)
+                 * reindex per pop.
+                 */
+                let pendingIndex = 0;
+                while pendingIndex < count(checkRoleToInherits) {
+                    let checkRoleToInherit = checkRoleToInherits[pendingIndex];
+                    let pendingIndex++;
 
                     if isset usedRoleToInherits[checkRoleToInherit] {
                         continue;
@@ -892,6 +902,7 @@ class Memory extends AbstractAdapter
         var accessList, checkRoleToInherit, usedRoleToInherit;
         array usedRoleToInherits, checkRoleToInherits;
         string accessKey, roleComponentPrefix, inheritPrefix;
+        int pendingIndex;
 
         let accessList = this->access;
 
@@ -941,8 +952,16 @@ class Memory extends AbstractAdapter
 
             let usedRoleToInherits = [];
 
-            while !empty checkRoleToInherits {
-                let checkRoleToInherit = array_shift(checkRoleToInherits);
+            /**
+             * Walk the inheritance queue with an integer cursor instead of
+             * `array_shift`. New roles enqueued by the body land at the end
+             * of `checkRoleToInherits`, so advancing `pendingIndex` preserves
+             * FIFO order without paying `array_shift`'s O(n) reindex per pop.
+             */
+            let pendingIndex = 0;
+            while pendingIndex < count(checkRoleToInherits) {
+                let checkRoleToInherit = checkRoleToInherits[pendingIndex];
+                let pendingIndex++;
 
                 if isset usedRoleToInherits[checkRoleToInherit] {
                     continue;

--- a/phalcon/Annotations/Adapter/AbstractAdapter.zep
+++ b/phalcon/Annotations/Adapter/AbstractAdapter.zep
@@ -27,6 +27,16 @@ abstract class AbstractAdapter implements AdapterInterface
     protected annotations = [];
 
     /**
+     * Maximum number of class annotation entries retained in the
+     * in-memory cache. 0 (default) keeps the original unbounded
+     * behavior; a positive value clears the cache when adding a new
+     * class would exceed it.
+     *
+     * @var int
+     */
+    protected annotationsLimit = 0;
+
+    /**
      * @var Reader
      */
     protected reader;
@@ -63,12 +73,25 @@ abstract class AbstractAdapter implements AdapterInterface
             let reader = this->getReader(),
                 parsedAnnotations = reader->parse(realClassName);
 
+            if this->annotationsLimit > 0 && count(this->annotations) >= this->annotationsLimit {
+                let this->annotations = [];
+            }
+
             let classAnnotations = new Reflection(parsedAnnotations),
                 this->annotations[realClassName] = classAnnotations;
                 this->{"write"}(realClassName, classAnnotations);
         }
 
         return classAnnotations;
+    }
+
+    /**
+     * Returns the configured annotations-cache cap (0 = unlimited).
+     * See setAnnotationsLimit().
+     */
+    public function getAnnotationsLimit() -> int
+    {
+        return this->annotationsLimit;
     }
 
     /**
@@ -159,6 +182,10 @@ abstract class AbstractAdapter implements AdapterInterface
         let methods = classAnnotations->getMethodsAnnotations();
 
         if typeof methods === "array" {
+            if fetch method, methods[methodName] {
+                return method;
+            }
+
             for methodKey, method in methods {
                 if !strcasecmp(methodKey, methodName) {
                     return method;
@@ -197,6 +224,17 @@ abstract class AbstractAdapter implements AdapterInterface
         }
 
         return this->reader;
+    }
+
+    /**
+     * Caps the number of class entries retained in the annotations
+     * cache. 0 disables the cap (the default; preserves the original
+     * unbounded behavior). When the cap is exceeded, the cache is
+     * cleared and repopulated on subsequent reads.
+     */
+    public function setAnnotationsLimit(int annotationsLimit)
+    {
+        let this->annotationsLimit = annotationsLimit;
     }
 
     /**

--- a/phalcon/Assets/Manager.zep
+++ b/phalcon/Assets/Manager.zep
@@ -367,6 +367,7 @@ class Manager extends AbstractInjectionAware
     {
         string output;
         bool filterNeeded;
+        array outputParts;
         var asset, assets, callback, callbackMethod, collectionSourcePath,
             collectionTargetPath, completeSourcePath, completeTargetPath,
             content, filter, filters, filteredContent, filteredJoinedContent,
@@ -379,6 +380,7 @@ class Manager extends AbstractInjectionAware
             filteredJoinedContent = "",
             join                  = false,
             output                = "",
+            outputParts           = [],
             options               = this->options;
 
         let callbackMethod = ("css" === type) ? "cssLink" : "jsLink",
@@ -550,7 +552,7 @@ class Manager extends AbstractInjectionAware
                 if (true === this->implicitOutput) {
                     echo html;
                 } else {
-                    let output .= html;
+                    let outputParts[] = html;
                 }
 
                 continue;
@@ -641,7 +643,7 @@ class Manager extends AbstractInjectionAware
                 if (true === this->implicitOutput) {
                     echo html;
                 } else {
-                    let output .= html;
+                    let outputParts[] = html;
                 }
             }
         }
@@ -675,9 +677,11 @@ class Manager extends AbstractInjectionAware
             if (true === this->implicitOutput) {
                 echo html;
             } else {
-                let output .= html;
+                let outputParts[] = html;
             }
         }
+
+        let output = implode("", outputParts);
 
         return output;
     }

--- a/phalcon/Autoload/Loader.zep
+++ b/phalcon/Autoload/Loader.zep
@@ -81,7 +81,7 @@ class Loader extends AbstractEventsAware
      */
     public function __construct(bool isDebug = false)
     {
-        let this->extensions[hash("sha256", "php")] = "php",
+        let this->extensions["php"] = "php",
             this->isDebug    = isDebug;
     }
 
@@ -109,7 +109,7 @@ class Loader extends AbstractEventsAware
      */
     public function addDirectory(string directory) -> <static>
     {
-        let this->directories[hash("sha256", directory)] = directory;
+        let this->directories[directory] = directory;
 
         return this;
     }
@@ -123,7 +123,7 @@ class Loader extends AbstractEventsAware
      */
     public function addExtension(string extension) -> <static>
     {
-        let this->extensions[hash("sha256", extension)] = extension;
+        let this->extensions[extension] = extension;
 
         return this;
     }
@@ -137,7 +137,7 @@ class Loader extends AbstractEventsAware
      */
     public function addFile(string file) -> <static>
     {
-        let this->files[hash("sha256", file)] = file;
+        let this->files[file] = file;
 
         return this;
     }
@@ -399,7 +399,7 @@ class Loader extends AbstractEventsAware
 
         if (!merge) {
             let this->extensions = [],
-                this->extensions[hash("sha256", "php")] = "php";
+                this->extensions["php"] = "php";
         }
 
         for extension in extensions {
@@ -733,7 +733,7 @@ class Loader extends AbstractEventsAware
         for directory in directories {
             let directory = rtrim(directory, dirSeparator) . dirSeparator;
 
-            let results[hash("sha256", directory)] = directory;
+            let results[directory] = directory;
         }
 
         return results;

--- a/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
+++ b/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
@@ -42,6 +42,8 @@ use Phalcon\Support\Settings;
  */
 abstract class AbstractPdo extends AbstractAdapter
 {
+    const BIND_PATTERN = "/\\?([0-9]+)|:([a-zA-Z0-9_]+):/";
+
     /**
      * Last affected rows
      *
@@ -335,7 +337,7 @@ abstract class AbstractPdo extends AbstractAdapter
             value;
 
         let placeHolders = [],
-            bindPattern = "/\\?([0-9]+)|:([a-zA-Z0-9_]+):/",
+            bindPattern = self::BIND_PATTERN,
             matches = null,
             setOrder = 2;
 

--- a/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
+++ b/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
@@ -477,7 +477,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * );
      *```
      */
-    public function executePrepared(<\PDOStatement> statement, array! placeholders, dataTypes) -> <\PDOStatement>
+    public function executePrepared(<\PDOStatement> statement, array! placeholders, array dataTypes = []) -> <\PDOStatement>
     {
         var wildcard, value, type, castValue, parameter, position, itemValue;
 
@@ -490,7 +490,7 @@ abstract class AbstractPdo extends AbstractAdapter
                 throw new InvalidBindParameter();
             }
 
-            if typeof dataTypes == "array" && fetch type, dataTypes[wildcard] {
+            if fetch type, dataTypes[wildcard] {
                 /**
                  * The bind type needs to be string because the precision
                  * is lost if it is casted as a double

--- a/phalcon/Db/Dialect.zep
+++ b/phalcon/Db/Dialect.zep
@@ -582,6 +582,7 @@ abstract class Dialect implements DialectInterface
     {
         var tables, columns, sql, distinct, joins, where, escapeChar, groupBy,
             having, orderBy, limit, forUpdate, bindCounts;
+        array parts;
 
         if unlikely !fetch tables, definition["tables"] {
             throw new MissingDefinitionKey("tables");
@@ -609,49 +610,38 @@ abstract class Dialect implements DialectInterface
         let escapeChar = this->escapeChar;
 
         /**
-         * Resolve COLUMNS
+         * Accumulate the top-level clauses in an array and join once.
+         * Each segment is appended without a leading space; implode adds
+         * the separator. The conditional LIMIT / FOR UPDATE tails are
+         * handled after the join because LIMIT wraps the assembled SQL.
          */
-        let sql .= " " . this->getColumnList(columns, escapeChar, bindCounts);
+        let parts = [
+            sql,
+            this->getColumnList(columns, escapeChar, bindCounts),
+            this->getSqlExpressionFrom(tables, escapeChar)
+        ];
 
-        /**
-         * Resolve FROM
-         */
-        let sql .= " " . this->getSqlExpressionFrom(tables, escapeChar);
-
-        /**
-         * Resolve JOINs
-         */
         if fetch joins, definition["joins"] && joins {
-            let sql .= " " . this->getSqlExpressionJoins(definition["joins"], escapeChar, bindCounts);
+            let parts[] = this->getSqlExpressionJoins(definition["joins"], escapeChar, bindCounts);
         }
 
-        /**
-         * Resolve WHERE
-         */
         if fetch where, definition["where"] && where {
-            let sql .= " " . this->getSqlExpressionWhere(where, escapeChar, bindCounts);
+            let parts[] = this->getSqlExpressionWhere(where, escapeChar, bindCounts);
         }
 
-        /**
-         * Resolve GROUP BY
-         */
         if fetch groupBy, definition["group"] && groupBy {
-            let sql .= " " . this->getSqlExpressionGroupBy(groupBy, escapeChar);
+            let parts[] = this->getSqlExpressionGroupBy(groupBy, escapeChar);
         }
 
-        /**
-         * Resolve HAVING
-         */
         if fetch having, definition["having"] && having {
-            let sql .= " " . this->getSqlExpressionHaving(having, escapeChar, bindCounts);
+            let parts[] = this->getSqlExpressionHaving(having, escapeChar, bindCounts);
         }
 
-        /**
-         * Resolve ORDER BY
-         */
         if fetch orderBy, definition["order"] && orderBy {
-            let sql .= " " . this->getSqlExpressionOrderBy(orderBy, escapeChar, bindCounts);
+            let parts[] = this->getSqlExpressionOrderBy(orderBy, escapeChar, bindCounts);
         }
+
+        let sql = implode(" ", parts);
 
         /**
          * Resolve LIMIT

--- a/phalcon/Db/Profiler.zep
+++ b/phalcon/Db/Profiler.zep
@@ -80,6 +80,15 @@ class Profiler
     protected allProfiles;
 
     /**
+     * Maximum number of profiles to retain. 0 (default) keeps the
+     * original unbounded behavior; a positive value drops the oldest
+     * profile FIFO before a new one is appended.
+     *
+     * @var int
+     */
+    protected maxProfiles = 0;
+
+    /**
      * Total time spent by all profiles to complete in nanoseconds
      *
      * @var float
@@ -92,6 +101,15 @@ class Profiler
     public function getLastProfile() -> <Item>
     {
         return this->activeProfile;
+    }
+
+    /**
+     * Returns the configured maximum number of retained profiles
+     * (0 = unlimited)
+     */
+    public function getMaxProfiles() -> int
+    {
+        return this->maxProfiles;
     }
 
     /**
@@ -145,6 +163,17 @@ class Profiler
     }
 
     /**
+     * Sets the maximum number of retained profiles. 0 disables the cap
+     * (the default; preserves the original unbounded behavior).
+     */
+    public function setMaxProfiles(int maxProfiles) -> <static>
+    {
+        let this->maxProfiles = maxProfiles;
+
+        return this;
+    }
+
+    /**
      * Starts the profile of a SQL sentence
      */
     public function startProfile(
@@ -175,11 +204,18 @@ class Profiler
      */
     public function stopProfile() -> <static>
     {
-        var activeProfile;
+        var activeProfile, firstKey;
 
         let activeProfile = <Item> this->activeProfile;
 
         activeProfile->setFinalTime(hrtime(true));
+
+        if this->maxProfiles > 0 && count(this->allProfiles) >= this->maxProfiles {
+            let firstKey = array_key_first(this->allProfiles);
+            if firstKey !== null {
+                unset(this->allProfiles[firstKey]);
+            }
+        }
 
         let this->totalNanoseconds = this->totalNanoseconds + activeProfile->getTotalElapsedNanoseconds(),
             this->allProfiles[]    = activeProfile;

--- a/phalcon/Dispatcher/AbstractDispatcher.zep
+++ b/phalcon/Dispatcher/AbstractDispatcher.zep
@@ -75,6 +75,11 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
     protected handlerHashes = [];
 
     /**
+     * @var array
+     */
+    protected handlerHookCache = [];
+
+    /**
      * @var string
      */
     protected handlerName = "";
@@ -220,7 +225,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
         int numberDispatches;
         var value, handler, container, namespaceName, handlerName, actionName,
             eventsManager, handlerClass, status, actionMethod,
-            modelBinder, bindCacheKey, isNewHandler, handlerHash, e;
+            modelBinder, bindCacheKey, isNewHandler, handlerHash, hookCache, e;
 
         let container = <DiInterface> this->container;
 
@@ -370,6 +375,17 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
 
             let this->activeHandler = handler;
 
+            if !isset this->handlerHookCache[handlerClass] {
+                let this->handlerHookCache[handlerClass] = [
+                    method_exists(handler, "beforeExecuteRoute"),
+                    method_exists(handler, "initialize"),
+                    method_exists(handler, "afterBinding"),
+                    method_exists(handler, "afterExecuteRoute")
+                ];
+            }
+
+            let hookCache = this->handlerHookCache[handlerClass];
+
             let namespaceName = this->namespaceName;
             let handlerName = this->handlerName;
             let actionName = this->actionName;
@@ -453,7 +469,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
                 }
             }
 
-            if method_exists(handler, "beforeExecuteRoute") {
+            if hookCache[0] {
                 try {
                     // Calling "beforeExecuteRoute" as direct method
                     if handler->beforeExecuteRoute(this) === false || this->finished === false {
@@ -490,7 +506,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
              * @see https://github.com/phalcon/cphalcon/pull/13112
              */
             if isNewHandler {
-                if method_exists(handler, "initialize") {
+                if hookCache[1] {
                     try {
                         let this->isControllerInitialize = true;
 
@@ -574,7 +590,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
             /**
              * Calling afterBinding as callback and event
              */
-            if method_exists(handler, "afterBinding") {
+            if hookCache[2] {
                 if handler->afterBinding(this) === false {
                     continue;
                 }
@@ -633,7 +649,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
             /**
              * Calling "afterExecuteRoute" as direct method
              */
-            if method_exists(handler, "afterExecuteRoute") {
+            if hookCache[3] {
                 try {
                     if handler->afterExecuteRoute(this, value) === false || this->finished === false {
                         continue;

--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -121,6 +121,16 @@ class Crypt implements CryptInterface
     protected hashAlgorithm = self::DEFAULT_ALGORITHM;
 
     /**
+     * Memoized `strlen(hash($algo, "", true))` results, keyed by
+     * algorithm name. The hash output length is deterministic for a
+     * given algorithm, so this collapses the per-decrypt strlen+hash
+     * call to a single hash lookup after warm-up.
+     *
+     * @var array
+     */
+    protected hashLengthCache = [];
+
+    /**
      * The cipher iv length.
      *
      * @var int
@@ -223,8 +233,11 @@ class Crypt implements CryptInterface
         let digest        = "",
             hashAlgorithm = this->getHashAlgorithm();
         if true === this->useSigning {
-            let hashLength = strlen(hash(hashAlgorithm, "", true)),
-                digest     = mb_substr(input, ivLength, hashLength, "8bit"),
+            if !fetch hashLength, this->hashLengthCache[hashAlgorithm] {
+                let hashLength = strlen(hash(hashAlgorithm, "", true));
+                let this->hashLengthCache[hashAlgorithm] = hashLength;
+            }
+            let digest     = mb_substr(input, ivLength, hashLength, "8bit"),
                 cipherText = mb_substr(input, ivLength + hashLength, null, "8bit");
         } else {
             let cipherText = mb_substr(input, ivLength, null, "8bit");

--- a/phalcon/Events/Manager.zep
+++ b/phalcon/Events/Manager.zep
@@ -100,6 +100,18 @@ class Manager implements ManagerInterface
     protected methodExistsCache = [];
 
     /**
+     * Maximum number of distinct handler classes retained in
+     * methodExistsCache. 0 (default) keeps the original unbounded
+     * behavior; a positive value clears the cache when adding a new
+     * class would exceed it. Re-warming is cheap (method_exists is
+     * O(1)) and the cap is meant for very long-lived workers that see
+     * many distinct listener classes over time.
+     *
+     * @var int
+     */
+    protected methodExistsCacheLimit = 0;
+
+    /**
      * Memoized getSubscribedEvents() maps keyed by Subscriber class name.
      * The static method's return is stable for the lifetime of a class
      * definition, so the cache never needs invalidation.
@@ -648,6 +660,15 @@ class Manager implements ManagerInterface
     }
 
     /**
+     * Returns the configured method_exists-cache cap (0 = unlimited).
+     * See setMethodExistsCacheLimit().
+     */
+    public function getMethodExistsCacheLimit() -> int
+    {
+        return this->methodExistsCacheLimit;
+    }
+
+    /**
      * Returns all the responses returned by every handler executed by the last
      * 'fire' executed
      */
@@ -762,6 +783,18 @@ class Manager implements ManagerInterface
     }
 
     /**
+     * Caps the number of distinct handler classes retained in the
+     * method_exists memoization cache. 0 disables the cap (the
+     * default; preserves the original unbounded behavior). When the
+     * cap is exceeded, the cache is cleared and re-warms on subsequent
+     * fires.
+     */
+    public function setMethodExistsCacheLimit(int methodExistsCacheLimit) -> void
+    {
+        let this->methodExistsCacheLimit = methodExistsCacheLimit;
+    }
+
+    /**
      * Enables/disables the stop-on-false short-circuit. When true, a
      * listener returning literal `false` (with cancelable=true) stops
      * the current event's queue and pins the fire() return as `false`.
@@ -841,6 +874,11 @@ class Manager implements ManagerInterface
                 let handlerClass = tuple[3];
 
                 if !isset this->methodExistsCache[handlerClass][eventName] {
+                    if !isset this->methodExistsCache[handlerClass]
+                        && this->methodExistsCacheLimit > 0
+                        && count(this->methodExistsCache) >= this->methodExistsCacheLimit {
+                        let this->methodExistsCache = [];
+                    }
                     let this->methodExistsCache[handlerClass][eventName] = method_exists(handler, eventName);
                 }
 
@@ -890,6 +928,11 @@ class Manager implements ManagerInterface
                 let handlerClass = tuple[3];
 
                 if !isset this->methodExistsCache[handlerClass][eventName] {
+                    if !isset this->methodExistsCache[handlerClass]
+                        && this->methodExistsCacheLimit > 0
+                        && count(this->methodExistsCache) >= this->methodExistsCacheLimit {
+                        let this->methodExistsCache = [];
+                    }
                     let this->methodExistsCache[handlerClass][eventName] = method_exists(handler, eventName);
                 }
 

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -507,7 +507,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
         let authHeaders = this->resolveAuthorizationHeaders();
 
         // Protect for future (child classes) changes
-        let headers = array_merge(headers, authHeaders);
+        let headers = authHeaders + headers;
 
         return headers;
     }
@@ -1692,7 +1692,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
             );
 
             if typeof resolved === "array" {
-                let headers = array_merge(headers, resolved);
+                let headers = resolved + headers;
             }
         }
 
@@ -1747,7 +1747,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
             );
 
             if typeof resolved === "array" {
-                let headers = array_merge(headers, resolved);
+                let headers = resolved + headers;
             }
 
         }

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -139,13 +139,21 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      */
     public function getBasicAuth() -> array | null
     {
-        if !this->hasServer("PHP_AUTH_USER") {
+        var password, server, username;
+
+        let server = this->getServerArray();
+
+        if !fetch username, server["PHP_AUTH_USER"] {
             return null;
         }
 
+        if !fetch password, server["PHP_AUTH_PW"] {
+            let password = null;
+        }
+
         return [
-            "username": this->getServer("PHP_AUTH_USER"),
-            "password": this->getServer("PHP_AUTH_PW")
+            "username": username,
+            "password": password
         ];
     }
 

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -507,7 +507,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
         let authHeaders = this->resolveAuthorizationHeaders();
 
         // Protect for future (child classes) changes
-        let headers = authHeaders + headers;
+        let headers = array_merge(headers, authHeaders);
 
         return headers;
     }
@@ -1692,7 +1692,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
             );
 
             if typeof resolved === "array" {
-                let headers = resolved + headers;
+                let headers = array_merge(headers, resolved);
             }
         }
 
@@ -1747,7 +1747,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
             );
 
             if typeof resolved === "array" {
-                let headers = resolved + headers;
+                let headers = array_merge(headers, resolved);
             }
 
         }

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -81,6 +81,16 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     protected rawBody = "";
 
     /**
+     * Cached snapshot of $_SERVER taken on first access. Reset
+     * implicitly by Request instance lifetime — one Request per
+     * request is the common model; long-running workers create a
+     * new Request each cycle.
+     *
+     * @var array|null
+     */
+    protected serverCache = null;
+
+    /**
      * @var bool
      */
     protected strictHostCheck = false;
@@ -1822,11 +1832,17 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
 
     private function getServerArray() -> array
     {
-        if _SERVER {
-            return _SERVER;
+        if this->serverCache !== null {
+            return this->serverCache;
         }
 
-        return [];
+        if _SERVER {
+            let this->serverCache = _SERVER;
+        } else {
+            let this->serverCache = [];
+        }
+
+        return this->serverCache;
     }
 
     /**

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -81,16 +81,6 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     protected rawBody = "";
 
     /**
-     * Cached snapshot of $_SERVER taken on first access. Reset
-     * implicitly by Request instance lifetime — one Request per
-     * request is the common model; long-running workers create a
-     * new Request each cycle.
-     *
-     * @var array|null
-     */
-    protected serverCache = null;
-
-    /**
      * @var bool
      */
     protected strictHostCheck = false;
@@ -1832,17 +1822,11 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
 
     private function getServerArray() -> array
     {
-        if this->serverCache !== null {
-            return this->serverCache;
-        }
-
         if _SERVER {
-            let this->serverCache = _SERVER;
-        } else {
-            let this->serverCache = [];
+            return _SERVER;
         }
 
-        return this->serverCache;
+        return [];
     }
 
     /**

--- a/phalcon/Logger/Adapter/AbstractAdapter.zep
+++ b/phalcon/Logger/Adapter/AbstractAdapter.zep
@@ -57,6 +57,16 @@ abstract class AbstractAdapter implements AdapterInterface
     protected queue = [];
 
     /**
+     * Maximum number of items retained in the transaction queue.
+     * 0 (default) keeps the original unbounded behavior; a positive
+     * value drops the oldest queued item FIFO before a new one is
+     * appended in add().
+     *
+     * @var int
+     */
+    protected queueLimit = 0;
+
+    /**
      * Destructor cleanup
      *
      * @throws TransactionAlreadyActive
@@ -95,6 +105,15 @@ abstract class AbstractAdapter implements AdapterInterface
      */
     public function add(<Item> item) -> <AdapterInterface>
     {
+        var firstKey;
+
+        if this->queueLimit > 0 && count(this->queue) >= this->queueLimit {
+            let firstKey = array_key_first(this->queue);
+            if firstKey !== null {
+                unset(this->queue[firstKey]);
+            }
+        }
+
         let this->queue[] = item;
 
         return this;
@@ -150,6 +169,14 @@ abstract class AbstractAdapter implements AdapterInterface
     }
 
     /**
+     * Returns the configured transaction-queue cap (0 = unlimited)
+     */
+    public function getQueueLimit() -> int
+    {
+        return this->queueLimit;
+    }
+
+    /**
      * Returns the whether the logger is currently in an active transaction or
      * not
      */
@@ -189,6 +216,18 @@ abstract class AbstractAdapter implements AdapterInterface
     public function setFormatter(<FormatterInterface> formatter) -> <AdapterInterface>
     {
         let this->formatter = formatter;
+
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of items retained in the transaction
+     * queue. 0 disables the cap (the default; preserves the original
+     * unbounded behavior).
+     */
+    public function setQueueLimit(int queueLimit) -> <AdapterInterface>
+    {
+        let this->queueLimit = queueLimit;
 
         return this;
     }

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1184,11 +1184,16 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
         }
 
         /**
-         * Models that keep snapshots store the original data in t
+         * Models that keep snapshots store the original data in t.
+         * At hydration both snapshot and oldSnapshot are the same
+         * "as fetched" baseline — reuse the column-mapped result of
+         * setSnapshotData() instead of running the column-map walk
+         * a second time. PHP's COW lets the two refs share memory
+         * until one is mutated by save().
          */
         if keepSnapshots {
             instance->setSnapshotData(data, columnMap);
-            instance->setOldSnapshotData(data, columnMap);
+            instance->setOldSnapshotData(instance->getSnapshotData());
         }
 
         /**

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -4003,12 +4003,12 @@ class Query implements QueryInterface, InjectionAwareInterface
                 tempSqlModelsAliases = this->sqlModelsAliases,
                 tempSqlAliasesModelsInstances = this->sqlAliasesModelsInstances;
 
-            let this->models = models + this->models,
-                this->modelsInstances = modelsInstances + this->modelsInstances,
-                this->sqlAliases = sqlAliases + this->sqlAliases,
-                this->sqlAliasesModels = sqlAliasesModels + this->sqlAliasesModels,
-                this->sqlModelsAliases = sqlModelsAliases + this->sqlModelsAliases,
-                this->sqlAliasesModelsInstances = sqlAliasesModelsInstances + this->sqlAliasesModelsInstances;
+            let this->models = array_merge(this->models, models),
+                this->modelsInstances = array_merge(this->modelsInstances, modelsInstances),
+                this->sqlAliases = array_merge(this->sqlAliases, sqlAliases),
+                this->sqlAliasesModels = array_merge(this->sqlAliasesModels, sqlAliasesModels),
+                this->sqlModelsAliases = array_merge(this->sqlModelsAliases, sqlModelsAliases),
+                this->sqlAliasesModelsInstances = array_merge(this->sqlAliasesModelsInstances, sqlAliasesModelsInstances);
         }
 
         fetch joins, select["joins"];

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -3775,7 +3775,7 @@ class Query implements QueryInterface, InjectionAwareInterface
             tempSqlAliases, tempSqlModelsAliases,
             tempSqlAliasesModelsInstances, tempSqlAliasesModels, with, withs,
             withItem, automaticJoins, number, relation, joinAlias,
-            relationModel, bestAlias, eagerType;
+            relationModel, bestAlias, eagerType, mergeKey, mergeValue;
         array sqlModels, sqlTables, sqlAliases, sqlColumns, sqlAliasesModels,
             sqlModelsAliases, sqlAliasesModelsInstances, models,
             modelsInstances;
@@ -4003,12 +4003,34 @@ class Query implements QueryInterface, InjectionAwareInterface
                 tempSqlModelsAliases = this->sqlModelsAliases,
                 tempSqlAliasesModelsInstances = this->sqlAliasesModelsInstances;
 
-            let this->models = array_merge(this->models, models),
-                this->modelsInstances = array_merge(this->modelsInstances, modelsInstances),
-                this->sqlAliases = array_merge(this->sqlAliases, sqlAliases),
-                this->sqlAliasesModels = array_merge(this->sqlAliasesModels, sqlAliasesModels),
-                this->sqlModelsAliases = array_merge(this->sqlModelsAliases, sqlModelsAliases),
-                this->sqlAliasesModelsInstances = array_merge(this->sqlAliasesModelsInstances, sqlAliasesModelsInstances);
+            /**
+             * In-place updates instead of array_merge: preserves the
+             * "right-side wins, original order kept" semantics that
+             * union (+) cannot give, with no fresh array allocation.
+             */
+            for mergeKey, mergeValue in models {
+                let this->models[mergeKey] = mergeValue;
+            }
+
+            for mergeKey, mergeValue in modelsInstances {
+                let this->modelsInstances[mergeKey] = mergeValue;
+            }
+
+            for mergeKey, mergeValue in sqlAliases {
+                let this->sqlAliases[mergeKey] = mergeValue;
+            }
+
+            for mergeKey, mergeValue in sqlAliasesModels {
+                let this->sqlAliasesModels[mergeKey] = mergeValue;
+            }
+
+            for mergeKey, mergeValue in sqlModelsAliases {
+                let this->sqlModelsAliases[mergeKey] = mergeValue;
+            }
+
+            for mergeKey, mergeValue in sqlAliasesModelsInstances {
+                let this->sqlAliasesModelsInstances[mergeKey] = mergeValue;
+            }
         }
 
         fetch joins, select["joins"];

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -4003,12 +4003,12 @@ class Query implements QueryInterface, InjectionAwareInterface
                 tempSqlModelsAliases = this->sqlModelsAliases,
                 tempSqlAliasesModelsInstances = this->sqlAliasesModelsInstances;
 
-            let this->models = array_merge(this->models, models),
-                this->modelsInstances = array_merge(this->modelsInstances, modelsInstances),
-                this->sqlAliases = array_merge(this->sqlAliases, sqlAliases),
-                this->sqlAliasesModels = array_merge(this->sqlAliasesModels, sqlAliasesModels),
-                this->sqlModelsAliases = array_merge(this->sqlModelsAliases, sqlModelsAliases),
-                this->sqlAliasesModelsInstances = array_merge(this->sqlAliasesModelsInstances, sqlAliasesModelsInstances);
+            let this->models = models + this->models,
+                this->modelsInstances = modelsInstances + this->modelsInstances,
+                this->sqlAliases = sqlAliases + this->sqlAliases,
+                this->sqlAliasesModels = sqlAliasesModels + this->sqlAliasesModels,
+                this->sqlModelsAliases = sqlModelsAliases + this->sqlModelsAliases,
+                this->sqlAliasesModelsInstances = sqlAliasesModelsInstances + this->sqlAliasesModelsInstances;
         }
 
         fetch joins, select["joins"];

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -655,7 +655,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
              * Merge the new params as parameters
              */
             let viewParams = this->viewParams;
-            let this->viewParams = params + viewParams;
+            let this->viewParams = array_merge(viewParams, params);
 
             /**
              * Create a virtual symbol table

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -655,7 +655,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
              * Merge the new params as parameters
              */
             let viewParams = this->viewParams;
-            let this->viewParams = array_merge(viewParams, params);
+            let this->viewParams = params + viewParams;
 
             /**
              * Create a virtual symbol table

--- a/phalcon/Storage/Adapter/Memory.zep
+++ b/phalcon/Storage/Adapter/Memory.zep
@@ -28,6 +28,15 @@ class Memory extends AbstractAdapter
     protected data = [];
 
     /**
+     * Maximum number of items retained in the in-memory store.
+     * 0 (default) keeps the original unbounded behavior; a positive
+     * value drops the oldest entry FIFO before a new key is stored.
+     *
+     * @var int
+     */
+    protected maxItems = 0;
+
+    /**
      * Memory constructor.
      *
      * @param SerializerFactory $factory
@@ -62,6 +71,27 @@ class Memory extends AbstractAdapter
     public function getKeys(string prefix = "") -> array
     {
         return this->getFilteredKeys(array_keys(this->data), prefix);
+    }
+
+    /**
+     * Returns the configured store cap (0 = unlimited). See setMaxItems().
+     */
+    public function getMaxItems() -> int
+    {
+        return this->maxItems;
+    }
+
+    /**
+     * Caps the number of items retained in the in-memory store.
+     * 0 disables the cap (the default; preserves the original
+     * unbounded behavior). When the cap is exceeded, the oldest
+     * entry is evicted FIFO before a new key is stored.
+     */
+    public function setMaxItems(int maxItems) -> <static>
+    {
+        let this->maxItems = maxItems;
+
+        return this;
     }
 
     /**
@@ -187,7 +217,7 @@ class Memory extends AbstractAdapter
      */
     protected function doSet(string! key, var value, var ttl = null) -> bool
     {
-        var content, prefixedKey;
+        var content, firstKey, prefixedKey;
 
         if (typeof ttl === "integer" && ttl < 1) {
             return this->delete(key);
@@ -195,6 +225,15 @@ class Memory extends AbstractAdapter
 
         let content     = this->getSerializedData(value),
             prefixedKey = this->getPrefixedKey(key);
+
+        if this->maxItems > 0
+            && !array_key_exists(prefixedKey, this->data)
+            && count(this->data) >= this->maxItems {
+            let firstKey = array_key_first(this->data);
+            if firstKey !== null {
+                unset(this->data[firstKey]);
+            }
+        }
 
         let this->data[prefixedKey] = content;
 

--- a/phalcon/Tag.zep
+++ b/phalcon/Tag.zep
@@ -909,7 +909,8 @@ class Tag
      */
     public static function renderAttributes(string! code, array! attributes) -> string
     {
-        var order, escaper, attrs, attribute, value, escaped, key, newCode;
+        var order, escaper, attrs, attribute, value, escaped, key;
+        array attrParts;
 
         let order = [
             "rel"    : null,
@@ -942,7 +943,7 @@ class Tag
 
         unset attrs["escape"];
 
-        let newCode = code;
+        let attrParts = [];
 
         for key, value in attrs {
             if typeof key == "string" && value !== null {
@@ -958,11 +959,15 @@ class Tag
                     let escaped = value;
                 }
 
-                let newCode .= " " . key . "=\"" . escaped . "\"";
+                let attrParts[] = key . "=\"" . escaped . "\"";
             }
         }
 
-        return newCode;
+        if empty attrParts {
+            return code;
+        }
+
+        return code . " " . implode(" ", attrParts);
     }
 
     /**

--- a/tests/README.md
+++ b/tests/README.md
@@ -85,7 +85,7 @@ The PHP extensions enabled are:
 To generate the necessary database schemas, you need to run the relevant script:
 
 ```shell script
-$ php tests/_config/generate-db-schemas.php
+$ php bin/generate-db-schemas.php
 ```
 
 ### Run tests
@@ -231,7 +231,7 @@ First, we need to have a `.env` file in the project root.
 To generate the necessary database schemas, you need to run the relevant script:
 
 ```shell script
-/app $ php tests/support/_config/generate-db-schemas.php
+/app $ php bin/generate-db-schemas.php
 ```
 
 The script looks for classes located under `tests/support/Migrations`.

--- a/tests/support/assets/schema/mysql.sql
+++ b/tests/support/assets/schema/mysql.sql
@@ -197,6 +197,34 @@ create table co_dialect
             
 
 
+DROP TABLE IF EXISTS `foreign_key_child`;
+            
+
+
+DROP TABLE IF EXISTS `foreign_key_parent`;
+            
+
+
+CREATE TABLE `foreign_key_parent` (
+    `id`        int(10) NOT NULL AUTO_INCREMENT,
+    `name`      varchar(70) NOT NULL,
+    `refer_int` int NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `foreign_key_parent_refer_int` (`refer_int`)
+) ENGINE=InnoDB;
+            
+
+
+CREATE TABLE `foreign_key_child` (
+    `id`        int(10) NOT NULL AUTO_INCREMENT,
+    `name`      varchar(70) NOT NULL,
+    `child_int` int NOT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `foreign_key_child_child_int` (`child_int`)
+) ENGINE=InnoDB;
+            
+
+
 drop table if exists `fractal_dates`;
             
 
@@ -208,6 +236,32 @@ create table fractal_dates
     `fdatetime`    datetime(2)  null,
     `ftimestamp`   timestamp(2) null
 );
+            
+
+DROP TABLE IF EXISTS `co_invoices_fk`;
+
+DROP TABLE IF EXISTS `co_customers_fk`;
+
+
+CREATE TABLE `co_customers_fk` (
+    `cst_id`   int(10) NOT NULL AUTO_INCREMENT,
+    `cst_name` varchar(100) NULL,
+    PRIMARY KEY (`cst_id`)
+) ENGINE=InnoDB;
+            
+
+
+CREATE TABLE `co_invoices_fk` (
+    `inv_id`     int(10) NOT NULL AUTO_INCREMENT,
+    `inv_cst_id` int(10) NOT NULL,
+    `inv_title`  varchar(100) NULL,
+    PRIMARY KEY (`inv_id`),
+    KEY `co_invoices_fk_inv_cst_id_index` (`inv_cst_id`),
+    CONSTRAINT `co_invoices_fk_cst_fk`
+        FOREIGN KEY (`inv_cst_id`)
+        REFERENCES `co_customers_fk` (`cst_id`)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+) ENGINE=InnoDB;
             
 
 
@@ -542,25 +596,6 @@ create table stuff
     `stf_name` varchar(100) not null,
     `stf_type` tinyint(3) unsigned not null
 );
-
-
-DROP TABLE IF EXISTS `foreign_key_child`;
-DROP TABLE IF EXISTS `foreign_key_parent`;
-
-CREATE TABLE `foreign_key_parent` (
-    `id`        int(10) NOT NULL AUTO_INCREMENT,
-    `name`      varchar(70) NOT NULL,
-    `refer_int` int NOT NULL,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `foreign_key_parent_refer_int` (`refer_int`)
-) ENGINE=InnoDB;
-
-CREATE TABLE `foreign_key_child` (
-    `id`        int(10) NOT NULL AUTO_INCREMENT,
-    `name`      varchar(70) NOT NULL,
-    `child_int` int NOT NULL,
-    PRIMARY KEY (`id`),
-    UNIQUE KEY `foreign_key_child_child_int` (`child_int`)
-) ENGINE=InnoDB;
+            
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/tests/support/assets/schema/pgsql.sql
+++ b/tests/support/assets/schema/pgsql.sql
@@ -432,6 +432,29 @@ CREATE TABLE fractal_dates (
 );
             
 
+DROP TABLE IF EXISTS co_invoices_fk;
+
+DROP TABLE IF EXISTS co_customers_fk;
+
+
+CREATE TABLE co_customers_fk (
+    cst_id   serial PRIMARY KEY,
+    cst_name varchar(100)
+);
+            
+
+
+CREATE TABLE co_invoices_fk (
+    inv_id     serial PRIMARY KEY,
+    inv_cst_id integer NOT NULL,
+    inv_title  varchar(100),
+    CONSTRAINT co_invoices_fk_cst_fk
+        FOREIGN KEY (inv_cst_id)
+        REFERENCES co_customers_fk (cst_id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+            
+
 
 drop table if exists co_invoices;
             

--- a/tests/support/assets/schema/sqlite.sql
+++ b/tests/support/assets/schema/sqlite.sql
@@ -179,6 +179,55 @@ create table co_dialect
             
 
 
+DROP TABLE IF EXISTS foreign_key_child;
+            
+
+
+DROP TABLE IF EXISTS foreign_key_parent;
+            
+
+
+CREATE TABLE foreign_key_parent (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name      varchar(70) NOT NULL,
+    refer_int INTEGER     NOT NULL,
+    UNIQUE (refer_int)
+);
+            
+
+
+CREATE TABLE foreign_key_child (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    name      varchar(70) NOT NULL,
+    child_int INTEGER     NOT NULL,
+    UNIQUE (child_int)
+);
+            
+
+DROP TABLE IF EXISTS co_invoices_fk;
+
+DROP TABLE IF EXISTS co_customers_fk;
+
+
+CREATE TABLE co_customers_fk (
+    cst_id   integer CONSTRAINT co_customers_fk_pk PRIMARY KEY AUTOINCREMENT,
+    cst_name text
+);
+            
+
+
+CREATE TABLE co_invoices_fk (
+    inv_id     integer CONSTRAINT co_invoices_fk_pk PRIMARY KEY AUTOINCREMENT,
+    inv_cst_id integer NOT NULL,
+    inv_title  text,
+    CONSTRAINT co_invoices_fk_cst_fk
+        FOREIGN KEY (inv_cst_id)
+        REFERENCES co_customers_fk (cst_id)
+        ON UPDATE CASCADE ON DELETE RESTRICT
+);
+            
+
+
 drop table if exists co_invoices;
             
 

--- a/tests/unit/Autoload/Loader/GetAddSetDirectoriesTest.php
+++ b/tests/unit/Autoload/Loader/GetAddSetDirectoriesTest.php
@@ -42,7 +42,7 @@ final class GetAddSetDirectoriesTest extends AbstractUnitTestCase
                 '/phalcon/public/css',
             ]
         );
-        $expected = [hash("sha256", '/phalcon/public/css') => '/phalcon/public/css'];
+        $expected = ['/phalcon/public/css' => '/phalcon/public/css'];
         $actual   = $loader->getDirectories();
         $this->assertSame($expected, $actual);
 
@@ -62,8 +62,8 @@ final class GetAddSetDirectoriesTest extends AbstractUnitTestCase
         ;
 
         $expected = [
-            hash("sha256", '/phalcon/public/css') => '/phalcon/public/css',
-            hash("sha256", '/phalcon/public/js')  => '/phalcon/public/js',
+            '/phalcon/public/css' => '/phalcon/public/css',
+            '/phalcon/public/js'  => '/phalcon/public/js',
         ];
         $actual   = $loader->getDirectories();
         $this->assertSame($expected, $actual);

--- a/tests/unit/Autoload/Loader/GetAddSetExtensionsTest.php
+++ b/tests/unit/Autoload/Loader/GetAddSetExtensionsTest.php
@@ -31,7 +31,7 @@ final class GetAddSetExtensionsTest extends AbstractUnitTestCase
     {
         $loader = new Loader();
 
-        $expected = [hash("sha256", 'php') => 'php'];
+        $expected = ['php' => 'php'];
         $actual   = $loader->getExtensions();
         $this->assertSame($expected, $actual);
 
@@ -44,8 +44,8 @@ final class GetAddSetExtensionsTest extends AbstractUnitTestCase
         );
 
         $expected = [
-            hash("sha256", 'php') => 'php',
-            hash("sha256", 'inc') => 'inc',
+            'php' => 'php',
+            'inc' => 'inc',
         ];
         $actual   = $loader->getExtensions();
         $this->assertSame($expected, $actual);
@@ -54,7 +54,7 @@ final class GetAddSetExtensionsTest extends AbstractUnitTestCase
          * Clear
          */
         $loader->setExtensions([]);
-        $expected = [hash("sha256", 'php') => 'php'];
+        $expected = ['php' => 'php'];
         $actual   = $loader->getExtensions();
         $this->assertSame($expected, $actual);
 
@@ -64,9 +64,9 @@ final class GetAddSetExtensionsTest extends AbstractUnitTestCase
             ->addExtension('inc')
         ;
         $expected = [
-            hash("sha256", 'php')  => 'php',
-            hash("sha256", 'inc')  => 'inc',
-            hash("sha256", 'phpt') => 'phpt',
+            'php'  => 'php',
+            'inc'  => 'inc',
+            'phpt' => 'phpt',
         ];
         $actual   = $loader->getExtensions();
         $this->assertSame($expected, $actual);

--- a/tests/unit/Autoload/Loader/GetAddSetFilesTest.php
+++ b/tests/unit/Autoload/Loader/GetAddSetFilesTest.php
@@ -42,7 +42,7 @@ final class GetAddSetFilesTest extends AbstractUnitTestCase
                 'classOne.php',
             ]
         );
-        $expected = [hash("sha256", 'classOne.php') => 'classOne.php'];
+        $expected = ['classOne.php' => 'classOne.php'];
         $actual   = $loader->getFiles();
         $this->assertSame($expected, $actual);
 
@@ -62,8 +62,8 @@ final class GetAddSetFilesTest extends AbstractUnitTestCase
         ;
 
         $expected = [
-            hash("sha256", 'classOne.php') => 'classOne.php',
-            hash("sha256", 'classTwo.php') => 'classTwo.php',
+            'classOne.php' => 'classOne.php',
+            'classTwo.php' => 'classTwo.php',
         ];
         $actual   = $loader->getFiles();
         $this->assertSame($expected, $actual);

--- a/tests/unit/Autoload/Loader/GetAddSetNamespacesTest.php
+++ b/tests/unit/Autoload/Loader/GetAddSetNamespacesTest.php
@@ -52,11 +52,11 @@ final class GetAddSetNamespacesTest extends AbstractUnitTestCase
 
         $expected = [
             'Phalcon\Loader\\'   => [
-                hash("sha256", '/path/to/loader/') => '/path/to/loader/',
+                '/path/to/loader/' => '/path/to/loader/',
             ],
             'Phalcon\Provider\\' => [
-                hash("sha256", '/path/to/provider/source/') => '/path/to/provider/source/',
-                hash("sha256", '/path/to/provider/target/') => '/path/to/provider/target/',
+                '/path/to/provider/source/' => '/path/to/provider/source/',
+                '/path/to/provider/target/' => '/path/to/provider/target/',
             ],
         ];
         $actual   = $loader->getNamespaces();
@@ -91,11 +91,11 @@ final class GetAddSetNamespacesTest extends AbstractUnitTestCase
 
         $expected = [
             'Phalcon\Loader\\'   => [
-                hash("sha256", '/path/to/loader/') => '/path/to/loader/',
+                '/path/to/loader/' => '/path/to/loader/',
             ],
             'Phalcon\Provider\\' => [
-                hash("sha256", '/path/to/provider/source/') => '/path/to/provider/source/',
-                hash("sha256", '/path/to/provider/target/') => '/path/to/provider/target/',
+                '/path/to/provider/source/' => '/path/to/provider/source/',
+                '/path/to/provider/target/' => '/path/to/provider/target/',
             ],
         ];
         $actual   = $loader->getNamespaces();
@@ -132,9 +132,9 @@ final class GetAddSetNamespacesTest extends AbstractUnitTestCase
 
         $expected = [
             'Phalcon\Loader\\' => [
-                hash("sha256", '/path/to/provider/target/') => '/path/to/provider/target/',
-                hash("sha256", '/path/to/loader/')          => '/path/to/loader/',
-                hash("sha256", '/path/to/provider/source/') => '/path/to/provider/source/',
+                '/path/to/provider/target/' => '/path/to/provider/target/',
+                '/path/to/loader/'          => '/path/to/loader/',
+                '/path/to/provider/source/' => '/path/to/provider/source/',
             ],
         ];
         $actual   = $loader->getNamespaces();


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17049 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Enhancements:

- Internal performance work across `Autoload`, `Dispatcher`, `Annotations`, `Db`, `Mvc\Model`, `Mvc\Model\Query`, `Tag`, `Assets`, `Acl\Adapter\Memory`, `Http\Request`, `Encryption\Crypt`. Behavior preserved. 
- `Phalcon\Autoload\Loader` getters (`getDirectories`, `getExtensions`, `getFiles`) return arrays keyed by the value string instead of by a SHA256 hash of it; iteration order and contents are unchanged.
- Opt-in memory caps for long-running workers (Swoole / RoadRunner / queue consumers). Default `0` preserves the original unbounded behavior: 
    - `Phalcon\Db\Profiler::setMaxProfiles(int)` / `getMaxProfiles()` 
    - `Phalcon\Logger\Adapter\AbstractAdapter::setQueueLimit(int)` / `getQueueLimit()`
    - `Phalcon\Events\Manager::setMethodExistsCacheLimit(int)` / `getMethodExistsCacheLimit()`
    - `Phalcon\Annotations\Adapter\AbstractAdapter::setAnnotationsLimit(int)` / `getAnnotationsLimit()`
    - `Phalcon\Storage\Adapter\Memory::setMaxItems(int)` / `getMaxItems()`

Thanks

