### PR TITLE
CP-17060 ev manager controller

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -542,6 +542,7 @@
 - Fixed `Phalcon\Mvc\Model::getUpdatedFields()` flagging unchanged null-valued columns as updated [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/db-models/)
 - Fixed `Phalcon\Forms\Form::clear()` leaving a previously-bound `null` field value in the data array instead of unsetting it before reassigning the element default [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/forms/)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler` emitting invalid PHP when a double-quoted Volt string contained literal single quotes (e.g. `"send_ga('Link', ...)"`). Only un-escaped single quotes are now escaped, so the `'Let\'s Encrypt'` case from [#17002](https://github.com/phalcon/cphalcon/issues/17002) is preserved [#17046](https://github.com/phalcon/cphalcon/issues/17046) [[doc]](https://docs.phalcon.io/5.14/volt/)
+- Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods [#17060](https://github.com/phalcon/cphalcon/issues/17060) [[doc]](https://docs.phalcon.io/5.14/controllers/)
 
 ### Removed
 

--- a/phalcon/Mvc/Controller.zep
+++ b/phalcon/Mvc/Controller.zep
@@ -57,11 +57,6 @@ use Phalcon\Events\ManagerInterface;
 abstract class Controller extends Injectable implements ControllerInterface, EventsAwareInterface
 {
     /**
-     * @var ManagerInterface|null
-     */
-    protected eventsManager = null;
-
-    /**
      * Phalcon\Mvc\Controller constructor
      */
     final public function __construct()
@@ -78,7 +73,7 @@ abstract class Controller extends Injectable implements ControllerInterface, Eve
      */
     public function getEventsManager() -> <ManagerInterface> | null
     {
-        return this->eventsManager;
+        return this->{"eventsManager"};
     }
 
     /**
@@ -88,7 +83,7 @@ abstract class Controller extends Injectable implements ControllerInterface, Eve
      */
     public function setEventsManager(<ManagerInterface> eventsManager) -> void
     {
-        let this->eventsManager = eventsManager;
+        let this->{"eventsManager"} = eventsManager;
     }
 
     /**
@@ -105,11 +100,12 @@ abstract class Controller extends Injectable implements ControllerInterface, Eve
         data = null,
         bool cancellable = true
     ) -> var | bool {
-        if (null !== this->eventsManager) {
-            return this
-                ->eventsManager
-                ->fire(eventName, this, data, cancellable)
-            ;
+        var eventsManager;
+
+        let eventsManager = this->{"eventsManager"};
+
+        if (null !== eventsManager) {
+            return eventsManager->fire(eventName, this, data, cancellable);
         }
 
         return true;


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #17060

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods (e.g. `beforeExecuteRoute`). The `eventsManager` property added to `Controller` in 5.12.0 shadowed `Phalcon\Di\Injectable::__get()`, preventing the shared service from being resolved from the DI container. The property declaration was removed so the magic getter resolves the service again; `getEventsManager()`/`setEventsManager()` are unaffected

Thanks

