### PR TITLE
CP-17062 router match

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -536,13 +536,14 @@
 
 ### Fixed
 
-- Fixed `Phalcon\Mvc\Model\Row::offsetGet()` / `offsetExists()` throwing `The index does not exist in the row` when accessing a column whose value is `null` [#17041](https://github.com/phalcon/cphalcon/issues/17041) [[doc]](https://docs.phalcon.io/5.14/db-models/)
-- Fixed `Phalcon\Mvc\View::getContent()` throwing `TypeError` after `View::start()`. `start()` was assigning `$this->content = null` [#17041](https://github.com/phalcon/cphalcon/issues/17041) [[doc]](https://docs.phalcon.io/5.14/views/)
+- Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods [#17060](https://github.com/phalcon/cphalcon/issues/17060) [[doc]](https://docs.phalcon.io/5.14/controllers/)
+- Fixed `Phalcon\Forms\Form::clear()` leaving a previously-bound `null` field value in the data array instead of unsetting it before reassigning the element default [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/forms/)
 - Fixed `Phalcon\Mvc\Model::getChangedFields()` / `hasChanged()` flagging every null-valued column of a freshly-loaded row as changed [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/db-models/)
 - Fixed `Phalcon\Mvc\Model::getUpdatedFields()` flagging unchanged null-valued columns as updated [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/db-models/)
-- Fixed `Phalcon\Forms\Form::clear()` leaving a previously-bound `null` field value in the data array instead of unsetting it before reassigning the element default [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/forms/)
+- Fixed `Phalcon\Mvc\Model\Row::offsetGet()` / `offsetExists()` throwing `The index does not exist in the row` when accessing a column whose value is `null` [#17041](https://github.com/phalcon/cphalcon/issues/17041) [[doc]](https://docs.phalcon.io/5.14/db-models/)
+- Fixed `Phalcon\Mvc\Router::handle()` falling back to a default catch-all route instead of matching an HTTP-method-constrained route attached afterward. [#17062](https://github.com/phalcon/cphalcon/issues/17062) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- Fixed `Phalcon\Mvc\View::getContent()` throwing `TypeError` after `View::start()`. `start()` was assigning `$this->content = null` [#17041](https://github.com/phalcon/cphalcon/issues/17041) [[doc]](https://docs.phalcon.io/5.14/views/)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler` emitting invalid PHP when a double-quoted Volt string contained literal single quotes (e.g. `"send_ga('Link', ...)"`). Only un-escaped single quotes are now escaped, so the `'Let\'s Encrypt'` case from [#17002](https://github.com/phalcon/cphalcon/issues/17002) is preserved [#17046](https://github.com/phalcon/cphalcon/issues/17046) [[doc]](https://docs.phalcon.io/5.14/volt/)
-- Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods [#17060](https://github.com/phalcon/cphalcon/issues/17060) [[doc]](https://docs.phalcon.io/5.14/controllers/)
 
 ### Removed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -542,6 +542,7 @@
 - Fixed `Phalcon\Mvc\Model::getUpdatedFields()` flagging unchanged null-valued columns as updated [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/db-models/)
 - Fixed `Phalcon\Forms\Form::clear()` leaving a previously-bound `null` field value in the data array instead of unsetting it before reassigning the element default [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/forms/)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler` emitting invalid PHP when a double-quoted Volt string contained literal single quotes (e.g. `"send_ga('Link', ...)"`). Only un-escaped single quotes are now escaped, so the `'Let\'s Encrypt'` case from [#17002](https://github.com/phalcon/cphalcon/issues/17002) is preserved [#17046](https://github.com/phalcon/cphalcon/issues/17046) [[doc]](https://docs.phalcon.io/5.14/volt/)
+- Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods [#17060](https://github.com/phalcon/cphalcon/issues/17060) [[doc]](https://docs.phalcon.io/5.14/controllers/)
 
 ### Removed
 

--- a/phalcon/Mvc/Controller.zep
+++ b/phalcon/Mvc/Controller.zep
@@ -57,11 +57,6 @@ use Phalcon\Events\ManagerInterface;
 abstract class Controller extends Injectable implements ControllerInterface, EventsAwareInterface
 {
     /**
-     * @var ManagerInterface|null
-     */
-    protected eventsManager = null;
-
-    /**
      * Phalcon\Mvc\Controller constructor
      */
     final public function __construct()
@@ -78,7 +73,7 @@ abstract class Controller extends Injectable implements ControllerInterface, Eve
      */
     public function getEventsManager() -> <ManagerInterface> | null
     {
-        return this->eventsManager;
+        return this->{"eventsManager"};
     }
 
     /**
@@ -88,7 +83,7 @@ abstract class Controller extends Injectable implements ControllerInterface, Eve
      */
     public function setEventsManager(<ManagerInterface> eventsManager) -> void
     {
-        let this->eventsManager = eventsManager;
+        let this->{"eventsManager"} = eventsManager;
     }
 
     /**
@@ -105,11 +100,12 @@ abstract class Controller extends Injectable implements ControllerInterface, Eve
         data = null,
         bool cancellable = true
     ) -> var | bool {
-        if (null !== this->eventsManager) {
-            return this
-                ->eventsManager
-                ->fire(eventName, this, data, cancellable)
-            ;
+        var eventsManager;
+
+        let eventsManager = this->{"eventsManager"};
+
+        if (null !== eventsManager) {
+            return eventsManager->fire(eventName, this, data, cancellable);
         }
 
         return true;

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -2215,7 +2215,29 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                 continue;
             }
 
-            let this->candidatesByMethod[method] = array_merge(methodSpecific, starRoutes);
+            /**
+             * Build the bucket by walking the routes in their original
+             * attach order, keeping both method-specific routes and the
+             * unconstrained "*" routes. array_merge() would place every
+             * method-specific route ahead of the "*" routes regardless of
+             * when each was attached, inverting the reverse-iteration
+             * priority that route matching relies on (see #17062).
+             */
+            let this->candidatesByMethod[method] = [];
+
+            for route in this->routes {
+                let methods = route->getHttpMethods();
+
+                if methods === null {
+                    let this->candidatesByMethod[method][] = route;
+                } elseif typeof methods == "string" {
+                    if methods === method {
+                        let this->candidatesByMethod[method][] = route;
+                    }
+                } elseif in_array(method, methods) {
+                    let this->candidatesByMethod[method][] = route;
+                }
+            }
         }
 
         /**

--- a/tests/unit/Mvc/Router/MethodBucketOrderTest.php
+++ b/tests/unit/Mvc/Router/MethodBucketOrderTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Mvc\Router;
+
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Mvc\Fake\RouterTrait;
+
+final class MethodBucketOrderTest extends AbstractUnitTestCase
+{
+    use RouterTrait;
+
+    /**
+     * Regression for [#17062]: the `addGet()` helper produces a route in the
+     * "GET" method bucket. Attached after the default catch-all routes, it
+     * must still win for a GET request - rebuildMethodIndex() must preserve
+     * the global attach order inside the merged bucket.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-03
+     */
+    public function testAddGetHelperWinsOverDefaultCatchAll(): void
+    {
+        $router = $this->getRouter();
+        $router->addGet(
+            '/home',
+            [
+                'controller' => 'index',
+                'action'     => 'home',
+            ]
+        );
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $router->handle('/home');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('index', $router->getControllerName());
+        $this->assertSame('home', $router->getActionName());
+    }
+
+    /**
+     * Regression for [#17062]: a method-constrained route attached after the
+     * default catch-all routes was deprioritized because rebuildMethodIndex()
+     * merged the method bucket as [method routes, "*" routes], placing the
+     * later-attached GET route ahead of the earlier defaults and inverting
+     * the reverse-iteration priority. The GET route must win for a GET
+     * request rather than falling back to the default `/:controller` route.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-03
+     */
+    public function testMethodConstrainedRouteWinsOverDefaultCatchAll(): void
+    {
+        $router = $this->getRouter();
+        $router->add(
+            '/home',
+            [
+                'controller' => 'index',
+                'action'     => 'home',
+            ],
+            'GET'
+        );
+
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $router->handle('/home');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('index', $router->getControllerName());
+        $this->assertSame('home', $router->getActionName());
+    }
+
+    /**
+     * Guard for [#17062]: the fix must not swallow the method constraint.
+     * A GET-only route must not match a POST request; with no POST-specific
+     * route the default catch-all takes over, so `/home` resolves to the
+     * default `/:controller` route (controller "home", empty action).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-03
+     */
+    public function testMethodConstraintStillHonoredForOtherMethods(): void
+    {
+        $router = $this->getRouter();
+        $router->add(
+            '/home',
+            [
+                'controller' => 'index',
+                'action'     => 'home',
+            ],
+            'GET'
+        );
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $router->handle('/home');
+
+        $this->assertSame('home', $router->getControllerName());
+        $this->assertSame('', $router->getActionName());
+    }
+
+    /**
+     * Regression for [#17062]: a route constrained to several methods lands
+     * in each of those buckets via the array branch of rebuildMethodIndex().
+     * Attached after the defaults, it must still win for any of its methods -
+     * here a POST request.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-03
+     */
+    public function testMultiMethodRouteWinsOverDefaultCatchAll(): void
+    {
+        $router = $this->getRouter();
+        $router->add(
+            '/home',
+            [
+                'controller' => 'index',
+                'action'     => 'home',
+            ],
+            ['GET', 'POST']
+        );
+
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+        $router->handle('/home');
+
+        $this->assertTrue($router->wasMatched());
+        $this->assertSame('index', $router->getControllerName());
+        $this->assertSame('home', $router->getActionName());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17062 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Router::handle()` falling back to a default catch-all route instead of matching an HTTP-method-constrained route attached afterward. `rebuildMethodIndex()` built each method bucket as `array_merge(methodSpecific, starRoutes)`, which placed method-specific routes ahead of the unconstrained `*` routes regardless of attach order and inverted the reverse-iteration priority

Thanks

