### PR TITLE
CP-17065 ev manager

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -12,6 +12,10 @@
 - Alignment with v6; docblocks; sorting; return types; minor fixes (image watermark opacity calc, serializer/helpers, readonly-becoming-mutable, ACL local access). [#17055](https://github.com/phalcon/cphalcon/issues/17055)
 - Changed return types to `-> <static>` or `-> <self>` in various components. The change is a covariant narrowing on implementation methods and does not touch any interface contracts, so userland classes that implement Phalcon interfaces and return the interface type continue to work unchanged. [#17035](https://github.com/phalcon/cphalcon/issues/17035)
 - Internal performance work across `Autoload`, `Dispatcher`, `Annotations`, `Db`, `Mvc\Model`, `Mvc\Model\Query`, `Tag`, `Assets`, `Acl\Adapter\Memory`, `Http\Request`, `Encryption\Crypt`. Behavior preserved. [#17049](https://github.com/phalcon/cphalcon/issues/17049)
+- Moved CI tools/scripts in `resources/` removed unused ones [#17066](https://github.com/phalcon/cphalcon/pull/17066)
+- Moved docker in `resources/` [#17066](https://github.com/phalcon/cphalcon/pull/17066)
+- Refactored docker images (more flexible less cruft) [#17066](https://github.com/phalcon/cphalcon/pull/17066)
+- Reorganization of quality tool config files (in `resources/`) [#17066](https://github.com/phalcon/cphalcon/pull/17066)
 - `Phalcon\Autoload\Loader` getters (`getDirectories`, `getExtensions`, `getFiles`) return arrays keyed by the value string instead of by a SHA256 hash of it; iteration order and contents are unchanged. [#17049](https://github.com/phalcon/cphalcon/issues/17049) [[doc]](https://docs.phalcon.io/5.14/autoload/)
 - `Phalcon\Mvc\Router::handle()` internal optimizations: O(1) hash lookup for literal-URI routes; per-HTTP-method buckets; hot-loop reads; PCRE patterns chunked; per-route metadata cache deduplicated by route id. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
 - `Phalcon\Mvc\Router\Route::getCompiledHostName()` now uses cache for hostname/converters. [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
@@ -523,16 +527,16 @@
         - `MissingGettextExtension`
         - `MissingRequiredParameter`
         - `TranslatorNotRegistered` [#17019](https://github.com/phalcon/cphalcon/issues/17019)
-- `Phalcon\Mvc\Router\Route::setRouteId(string $routeId)` - setter intended for restoring cached routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
-- `Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
-- `Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
-- `Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
 - Opt-in memory caps for long-running workers (Swoole / RoadRunner / queue consumers). Default `0` preserves the original unbounded behavior: [#17049](https://github.com/phalcon/cphalcon/issues/17049)
     - `Phalcon\Db\Profiler::setMaxProfiles(int)` / `getMaxProfiles()` [[doc]](https://docs.phalcon.io/5.14/db-layer/)
     - `Phalcon\Logger\Adapter\AbstractAdapter::setQueueLimit(int)` / `getQueueLimit()` [[doc]](https://docs.phalcon.io/5.14/logger/)
     - `Phalcon\Events\Manager::setMethodExistsCacheLimit(int)` / `getMethodExistsCacheLimit()` [[doc]](https://docs.phalcon.io/5.14/events/)
     - `Phalcon\Annotations\Adapter\AbstractAdapter::setAnnotationsLimit(int)` / `getAnnotationsLimit()` [[doc]](https://docs.phalcon.io/5.14/annotations/)
     - `Phalcon\Storage\Adapter\Memory::setMaxItems(int)` / `getMaxItems()` [[doc]](https://docs.phalcon.io/5.14/storage/)
+- `Phalcon\Mvc\Router\Route::setRouteId(string $routeId)` - setter intended for restoring cached routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- `Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- `Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- `Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
 
 ### Fixed
 
@@ -544,10 +548,11 @@
 - Fixed `Phalcon\Mvc\Router::handle()` falling back to a default catch-all route instead of matching an HTTP-method-constrained route attached afterward. [#17062](https://github.com/phalcon/cphalcon/issues/17062) [[doc]](https://docs.phalcon.io/5.14/routing/)
 - Fixed `Phalcon\Mvc\View::getContent()` throwing `TypeError` after `View::start()`. `start()` was assigning `$this->content = null` [#17041](https://github.com/phalcon/cphalcon/issues/17041) [[doc]](https://docs.phalcon.io/5.14/views/)
 - Fixed `Phalcon\Mvc\View\Engine\Volt\Compiler` emitting invalid PHP when a double-quoted Volt string contained literal single quotes (e.g. `"send_ga('Link', ...)"`). Only un-escaped single quotes are now escaped, so the `'Let\'s Encrypt'` case from [#17002](https://github.com/phalcon/cphalcon/issues/17002) is preserved [#17046](https://github.com/phalcon/cphalcon/issues/17046) [[doc]](https://docs.phalcon.io/5.14/volt/)
-- Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods [#17060](https://github.com/phalcon/cphalcon/issues/17060) [[doc]](https://docs.phalcon.io/5.14/controllers/)
+- Fixed warning in `Phalcon\Auth\ManagerFactory` emitted in tests (random commit but had to be fixed) [#17066](https://github.com/phalcon/cphalcon/pull/17066)
 
 ### Removed
 
+- Removed unused `Phalcon\Contracts\Container\Service\Lifetime` [#17066](https://github.com/phalcon/cphalcon/pull/17066)
 - Reverted the `Phalcon\Mvc\Model\Query::executeUpdate()` named-placeholder substitution introduced for [#16976](https://github.com/phalcon/cphalcon/issues/16976). The substitution path was triggering a use-after-free in the model update flow under PostgreSQL ([#17042](https://github.com/phalcon/cphalcon/issues/17042)). Issue [#16976](https://github.com/phalcon/cphalcon/issues/16976) is reopened and will be addressed with a different approach. [[doc]](https://docs.phalcon.io/5.14/db-phql/)
 
 ## [5.13.0](https://github.com/phalcon/cphalcon/releases/tag/v5.13.0) (2026-05-18)

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -527,20 +527,22 @@
         - `MissingGettextExtension`
         - `MissingRequiredParameter`
         - `TranslatorNotRegistered` [#17019](https://github.com/phalcon/cphalcon/issues/17019)
-- Opt-in memory caps for long-running workers (Swoole / RoadRunner / queue consumers). Default `0` preserves the original unbounded behavior: [#17049](https://github.com/phalcon/cphalcon/issues/17049)
+- Added `Phalcon\Events\Manager::fire()` `beforeFire()` / `afterFire()` extension seams to `Manager::fire()`. [#17065](https://github.com/phalcon/cphalcon/issues/17065) [[doc]](https://docs.phalcon.io/5.14/events/)
+- Added opt-in memory caps for long-running workers (Swoole / RoadRunner / queue consumers). Default `0` preserves the original unbounded behavior: [#17049](https://github.com/phalcon/cphalcon/issues/17049)
     - `Phalcon\Db\Profiler::setMaxProfiles(int)` / `getMaxProfiles()` [[doc]](https://docs.phalcon.io/5.14/db-layer/)
     - `Phalcon\Logger\Adapter\AbstractAdapter::setQueueLimit(int)` / `getQueueLimit()` [[doc]](https://docs.phalcon.io/5.14/logger/)
     - `Phalcon\Events\Manager::setMethodExistsCacheLimit(int)` / `getMethodExistsCacheLimit()` [[doc]](https://docs.phalcon.io/5.14/events/)
     - `Phalcon\Annotations\Adapter\AbstractAdapter::setAnnotationsLimit(int)` / `getAnnotationsLimit()` [[doc]](https://docs.phalcon.io/5.14/annotations/)
     - `Phalcon\Storage\Adapter\Memory::setMaxItems(int)` / `getMaxItems()` [[doc]](https://docs.phalcon.io/5.14/storage/)
-- `Phalcon\Mvc\Router\Route::setRouteId(string $routeId)` - setter intended for restoring cached routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
-- `Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
-- `Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
-- `Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- Added `Phalcon\Mvc\Router\Route::setRouteId(string $routeId)` - setter intended for restoring cached routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- Added `Phalcon\Mvc\Router::buildDispatcherDump()` / `Phalcon\Mvc\Router::loadDispatcherFromArray(array $dump)` - used to build/load the routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- Added `Phalcon\Mvc\Router::dumpDispatcher(string $path)` / `Phalcon\Mvc\Router::loadDispatcher(string $path)` - file-shaped helpers that write/read routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
+- Added `Phalcon\Mvc\Router::useCache()` - to use a `Phalcon\Cache` adapter to store routes [#17012](https://github.com/phalcon/cphalcon/issues/17012) [[doc]](https://docs.phalcon.io/5.14/routing/)
 
 ### Fixed
 
 - Fixed `$this->eventsManager` resolving to `null` inside `Phalcon\Mvc\Controller` methods [#17060](https://github.com/phalcon/cphalcon/issues/17060) [[doc]](https://docs.phalcon.io/5.14/controllers/)
+- Fixed `Phalcon\Events\Event` and `Phalcon\Events\Manager::fire()` being declared `final` in 5.13.0 ([#17006](https://github.com/phalcon/cphalcon/issues/17006)), which prevented subclassing the events manager. [#17065](https://github.com/phalcon/cphalcon/issues/17065) [[doc]](https://docs.phalcon.io/5.14/events/)
 - Fixed `Phalcon\Forms\Form::clear()` leaving a previously-bound `null` field value in the data array instead of unsetting it before reassigning the element default [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/forms/)
 - Fixed `Phalcon\Mvc\Model::getChangedFields()` / `hasChanged()` flagging every null-valued column of a freshly-loaded row as changed [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/db-models/)
 - Fixed `Phalcon\Mvc\Model::getUpdatedFields()` flagging unchanged null-valued columns as updated [#17042](https://github.com/phalcon/cphalcon/issues/17042) [[doc]](https://docs.phalcon.io/5.14/db-models/)

--- a/phalcon/Events/Event.zep
+++ b/phalcon/Events/Event.zep
@@ -27,7 +27,7 @@ use Phalcon\Events\Exceptions\InvalidEventSource;
  * }
  * ```
  */
-final class Event implements EventInterface, Stoppable
+class Event implements EventInterface, Stoppable
 {
     /**
      * Is event cancelable?

--- a/phalcon/Events/Manager.zep
+++ b/phalcon/Events/Manager.zep
@@ -353,7 +353,7 @@ class Manager implements ManagerInterface
      * @param mixed  data
      * @return mixed
      */
-    final public function fire(
+    public function fire(
         string eventType,
         object source,
         var data = null,
@@ -366,6 +366,10 @@ class Manager implements ManagerInterface
         // Manager-level kill switch — halt() trips this and every fire
         // returns null without dispatching until resume() clears it.
         if this->halted {
+            return null;
+        }
+
+        if this->beforeFire(eventType, source, data, cancelable) === false {
             return null;
         }
 
@@ -483,7 +487,7 @@ class Manager implements ManagerInterface
 
         let this->fireDepth = wasDepth;
 
-        return status;
+        return this->afterFire(status, eventType, source, data, cancelable);
     }
 
     /**
@@ -815,6 +819,44 @@ class Manager implements ManagerInterface
     public function setStrict(bool strict) -> void
     {
         let this->strict = strict;
+    }
+
+    /**
+     * Extension seam invoked after an event has been dispatched to its
+     * listener queues. Receives the computed dispatch result as `status`
+     * and returns the value fire() hands back to its caller; the base
+     * implementation returns `status` unchanged. A subclass can override
+     * it to run bookkeeping or to post-process / rewrite the result.
+     *
+     * Only called when the event was actually dispatched; the halted and
+     * no-listener short-circuits in fire() return before reaching it.
+     */
+    protected function afterFire(
+        var status,
+        string eventType,
+        object source,
+        var data = null,
+        bool cancelable = true
+    ) -> var {
+        return status;
+    }
+
+    /**
+     * Extension seam invoked before an event is dispatched. The base
+     * implementation returns true, so dispatch proceeds unchanged. A
+     * subclass can override it to inspect the source and data and, by
+     * returning false, abort the dispatch entirely - for example to
+     * redirect a deferred event onto an external queue. Invoked before the
+     * no-listener short-circuits, so it sees every fire(), including those
+     * with no locally attached listeners.
+     */
+    protected function beforeFire(
+        string eventType,
+        object source,
+        var data = null,
+        bool cancelable = true
+    ) -> bool {
+        return true;
     }
 
     /**

--- a/tests/unit/Events/Event/NotFinalTest.php
+++ b/tests/unit/Events/Event/NotFinalTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Events\Event;
+
+use Phalcon\Events\Event;
+use Phalcon\Tests\AbstractUnitTestCase;
+use ReflectionClass;
+
+final class NotFinalTest extends AbstractUnitTestCase
+{
+    public function testEventIsNotFinal(): void
+    {
+        $class = new ReflectionClass(Event::class);
+
+        $this->assertFalse($class->isFinal());
+    }
+}

--- a/tests/unit/Events/Fake/DeferredManager.php
+++ b/tests/unit/Events/Fake/DeferredManager.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Events\Fake;
+
+use Phalcon\Events\Manager;
+
+/**
+ * Manager subclass used to exercise the beforeFire()/afterFire() seams.
+ */
+class DeferredManager extends Manager
+{
+    public array $afterCalls    = [];
+    public array $beforeCalls   = [];
+    public bool  $defer         = false;
+    public bool  $rewriteResult = false;
+
+    protected function afterFire(
+        mixed $status,
+        string $eventType,
+        mixed $source,
+        mixed $data = null,
+        bool $cancelable = true
+    ): mixed {
+        $this->afterCalls[] = [$status, $eventType, $source, $data, $cancelable];
+
+        if ($this->rewriteResult) {
+            return 'rewritten';
+        }
+
+        return $status;
+    }
+
+    protected function beforeFire(
+        string $eventType,
+        mixed $source,
+        mixed $data = null,
+        bool $cancelable = true
+    ): bool {
+        $this->beforeCalls[] = [$eventType, $source, $data, $cancelable];
+
+        return !$this->defer;
+    }
+}

--- a/tests/unit/Events/Fake/DeferredManager.php
+++ b/tests/unit/Events/Fake/DeferredManager.php
@@ -22,8 +22,8 @@ class DeferredManager extends Manager
 {
     public array $afterCalls    = [];
     public array $beforeCalls   = [];
-    public bool  $defer         = false;
-    public bool  $rewriteResult = false;
+    public bool $defer         = false;
+    public bool $rewriteResult = false;
 
     protected function afterFire(
         mixed $status,

--- a/tests/unit/Events/Manager/AfterFireTest.php
+++ b/tests/unit/Events/Manager/AfterFireTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Events\Manager;
+
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Events\Fake\DeferredManager;
+use stdClass;
+
+final class AfterFireTest extends AbstractUnitTestCase
+{
+    public function testAfterFireCalledAfterDispatch(): void
+    {
+        $manager = new DeferredManager();
+        $source  = new stdClass();
+        $data    = ['key' => 'value'];
+
+        $manager->attach(
+            'test:event',
+            function () {
+                return 'handled';
+            }
+        );
+
+        $result = $manager->fire('test:event', $source, $data);
+
+        $expected = [['handled', 'test:event', $source, $data, true]];
+        $this->assertSame($expected, $manager->afterCalls);
+        $this->assertSame('handled', $result);
+    }
+
+    public function testAfterFireCanTransformResult(): void
+    {
+        $manager                = new DeferredManager();
+        $manager->rewriteResult = true;
+
+        $manager->attach(
+            'test:event',
+            function () {
+                return 'handled';
+            }
+        );
+
+        $result = $manager->fire('test:event', new stdClass());
+
+        $this->assertSame('rewritten', $result);
+    }
+
+    public function testAfterFireNotCalledWhenHalted(): void
+    {
+        $manager = new DeferredManager();
+
+        $manager->attach(
+            'test:event',
+            function () {
+                return 'handled';
+            }
+        );
+
+        $manager->halt();
+        $manager->fire('test:event', new stdClass());
+
+        $this->assertCount(0, $manager->afterCalls);
+    }
+
+    public function testAfterFireNotCalledWithoutListeners(): void
+    {
+        $manager = new DeferredManager();
+
+        $manager->fire('test:event', new stdClass());
+
+        $this->assertCount(0, $manager->afterCalls);
+    }
+}

--- a/tests/unit/Events/Manager/BeforeFireTest.php
+++ b/tests/unit/Events/Manager/BeforeFireTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Events\Manager;
+
+use Phalcon\Events\Manager;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Events\Fake\DeferredManager;
+use ReflectionMethod;
+use stdClass;
+
+final class BeforeFireTest extends AbstractUnitTestCase
+{
+    public function testBeforeFireReceivesArguments(): void
+    {
+        $manager = new DeferredManager();
+        $source  = new stdClass();
+        $data    = ['key' => 'value'];
+
+        $manager->attach(
+            'test:event',
+            function () {
+                return 'handled';
+            }
+        );
+
+        $manager->fire('test:event', $source, $data);
+
+        $expected = [['test:event', $source, $data, true]];
+        $this->assertSame($expected, $manager->beforeCalls);
+    }
+
+    public function testBeforeFireFalseAbortsDispatch(): void
+    {
+        $manager        = new DeferredManager();
+        $manager->defer = true;
+        $invoked        = false;
+
+        $manager->attach(
+            'test:event',
+            function () use (&$invoked) {
+                $invoked = true;
+
+                return 'handled';
+            }
+        );
+
+        $result = $manager->fire('test:event', new stdClass());
+
+        $this->assertFalse($invoked);
+        $this->assertNull($result);
+        $this->assertCount(1, $manager->beforeCalls);
+    }
+
+    public function testBeforeFireRunsWithoutListeners(): void
+    {
+        $manager = new DeferredManager();
+
+        $manager->fire('test:event', new stdClass());
+
+        $this->assertCount(1, $manager->beforeCalls);
+    }
+
+    public function testFireIsNotFinal(): void
+    {
+        $method = new ReflectionMethod(Manager::class, 'fire');
+
+        $this->assertFalse($method->isFinal());
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix | new feature
* Link to issue: #17065 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

 Added `Phalcon\Events\Manager::fire()` `beforeFire()` / `afterFire()` extension seams to `Manager::fire()`

Fixed `Phalcon\Events\Event` and `Phalcon\Events\Manager::fire()` being declared `final` in 5.13.0
Thanks

