### PR TITLE
CP-17071 many to many sync

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -199,6 +199,14 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     protected snapshot = [];
 
     /**
+     * Per-save many-to-many sync overrides, keyed by lowercased relation
+     * alias (or "*" wildcard) => bool. Cleared after each save().
+     *
+     * @var array
+     */
+    protected syncRelated = [];
+
+    /**
      * @var TransactionInterface|null
      */
     protected transaction = null;
@@ -554,7 +562,13 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
                         unset this->related[lowerProperty];
 
-                        if count(related) > 0 {
+                        /**
+                         * For many-to-many keep an (even empty) entry so that
+                         * save() can synchronize the relationship - assigning an
+                         * empty array must be able to clear all intermediate rows
+                         * when syncing is enabled.
+                         */
+                        if count(related) > 0 || relation->getType() === Relation::HAS_MANY_THROUGH {
                             let this->dirtyRelated[lowerProperty] = related,
                                 this->dirtyState = self::DIRTY_STATE_TRANSIENT;
                         } else {
@@ -2802,6 +2816,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
         if hasRelatedToSave {
             if this->preSaveRelatedRecords(writeConnection, relatedToSave, visited) === false {
+                let this->syncRelated = [];
+
                 return false;
             }
         }
@@ -2851,6 +2867,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             if hasRelatedToSave {
                 writeConnection->rollback(false);
             }
+
+            let this->syncRelated = [];
 
             /**
              * Throw exceptions on failed saves?
@@ -2949,6 +2967,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             (<ManagerInterface> this->modelsManager)->clearReusableObjects();
             this->fireEvent("afterSave");
         }
+
+        let this->syncRelated = [];
 
         return success;
     }
@@ -3239,6 +3259,53 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
 
 
         let this->snapshot = snapshot;
+    }
+
+    /**
+     * Marks one or more many-to-many relationships to be synchronized (or not)
+     * on the next save() call, overriding the relation's `sync` option for that
+     * save only. The flag is cleared after save().
+     *
+     * When syncing is enabled, intermediate rows for related records no longer
+     * present in the assigned array are deleted.
+     *
+     *```php
+     * // Sync only the "tags" relationship on this save
+     * $post->setSync("tags")->save();
+     *
+     * // Sync every many-to-many relationship on this save
+     * $post->setSync()->save();
+     *
+     * // Disable syncing for every relationship on this save
+     * $post->setSync("*", false)->save();
+     *
+     * // Disable syncing for specific relationships on this save
+     * $post->setSync(["tags", "categories"], false)->save();
+     *```
+     *
+     * @param string|array|null elements
+     */
+    public function setSync(var elements = null, bool enabled = true) -> <ModelInterface>
+    {
+        var alias;
+
+        if elements === null || elements === "*" {
+            let this->syncRelated["*"] = enabled;
+
+            return this;
+        }
+
+        if typeof elements === "array" {
+            for alias in elements {
+                let this->syncRelated[strtolower(alias)] = enabled;
+            }
+
+            return this;
+        }
+
+        let this->syncRelated[strtolower(elements)] = enabled;
+
+        return this;
     }
 
     /**
@@ -5370,10 +5437,11 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             columns, referencedModel, referencedFields, relatedRecords,
             recordAfter, intermediateModel, intermediateFields,
             intermediateModelName,
-            intermediateReferencedFields, existingIntermediateModel, columnA, columnB;
-        bool isThrough;
+            intermediateReferencedFields, existingIntermediateModel, columnA, columnB,
+            existingRecords, existingRecord, keepKey, override;
+        bool isThrough, doSync;
         int columnCount, referencedFieldsCount, i, j, t, h;
-        array conditions, placeholders, loopConditions, loopPlaceholders;
+        array conditions, placeholders, loopConditions, loopPlaceholders, keptKeys;
 
         let nesting = false,
             className = get_class(this),
@@ -5426,6 +5494,18 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                         intermediateReferencedFields = relation->getIntermediateReferencedFields();
                     let placeholders = [];
                     let conditions = [];
+                    let keptKeys = [];
+
+                    /**
+                     * Resolve sync behavior: per-save override (specific alias,
+                     * then "*" wildcard) wins over the relation's `sync` option.
+                     */
+                    let doSync = (bool) relation->getOption("sync");
+                    if fetch override, this->syncRelated[name] {
+                        let doSync = (bool) override;
+                    } elseif fetch override, this->syncRelated["*"] {
+                        let doSync = (bool) override;
+                    }
 
                     /**
                      * Always check for existing intermediate models
@@ -5546,6 +5626,61 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                             connection->rollback(nesting);
 
                             return false;
+                        }
+
+                        /**
+                         * Track the referenced key of each kept record so that
+                         * sync can delete the intermediate rows left behind.
+                         */
+                        if doSync {
+                            if unlikely typeof referencedFields === "array" {
+                                let keepKey = "";
+                                for columnA in referencedFields {
+                                    let keepKey .= recordAfter->{columnA} . "|";
+                                }
+                            } else {
+                                let keepKey = (string) recordAfter->{referencedFields};
+                            }
+                            let keptKeys[keepKey] = true;
+                        }
+                    }
+
+                    /**
+                     * Sync: remove intermediate rows for records that are no
+                     * longer present in the assigned array. Only applies to
+                     * many-to-many (HAS_MANY_THROUGH).
+                     */
+                    if doSync && relation->getType() === Relation::HAS_MANY_THROUGH {
+                        let intermediateModel = <ModelInterface> manager->load(
+                            intermediateModelName
+                        );
+
+                        let existingRecords = intermediateModel->find(
+                            [
+                                join(" AND ", conditions),
+                                "bind": placeholders
+                            ]
+                        );
+
+                        for existingRecord in existingRecords {
+                            if unlikely typeof intermediateReferencedFields === "array" {
+                                let keepKey = "";
+                                for columnB in intermediateReferencedFields {
+                                    let keepKey .= existingRecord->{columnB} . "|";
+                                }
+                            } else {
+                                let keepKey = (string) existingRecord->{intermediateReferencedFields};
+                            }
+
+                            if !isset keptKeys[keepKey] {
+                                if !existingRecord->delete() {
+                                    this->appendMessagesFrom(existingRecord);
+
+                                    connection->rollback(nesting);
+
+                                    return false;
+                                }
+                            }
                         }
                     }
                 } else {

--- a/phalcon/Mvc/ModelInterface.zep
+++ b/phalcon/Mvc/ModelInterface.zep
@@ -261,6 +261,14 @@ interface ModelInterface
     public function setSnapshotData(array! data, columnMap = null) -> void;
 
     /**
+     * Marks one or more many-to-many relationships to be synchronized (or not)
+     * on the next save() call.
+     *
+     * @param string|array|null elements
+     */
+    public function setSync(var elements = null, bool enabled = true) -> <ModelInterface>;
+
+    /**
      * Sets a transaction related to the Model instance
      */
     public function setTransaction(<TransactionInterface> transaction) -> <ModelInterface>;

--- a/tests/database/Mvc/Model/RelationsTest.php
+++ b/tests/database/Mvc/Model/RelationsTest.php
@@ -749,6 +749,168 @@ final class RelationsTest extends AbstractDatabaseTestCase
     }
 
     /**
+     * Tests Phalcon\Mvc\Model :: hasManyToMany() - set with sync option
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17071
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function testMvcModelSetHasManyToManySyncOption(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+
+        $orderId     = 10;
+        $orderName   = uniqid('ord', true);
+        $orderStatus = 5;
+
+        $ordersMigration            = new OrdersMigration($connection);
+        $ordersProductsOneMigration = new OrdersProductsFieldsOneMigration($connection);
+        $productsMigrations         = new ProductsMigration($connection);
+
+        $ordersMigration->insert($orderId, $orderName, $orderStatus);
+
+        $orders                    = OrdersMultiple::findFirst(10);
+        $product1                  = new Products();
+        $product1->prd_name        = uniqid('prd1', true);
+        $product1->prd_status_flag = 5;
+
+        $product2                  = new Products();
+        $product2->prd_name        = uniqid('prd2', true);
+        $product2->prd_status_flag = 10;
+
+        // Assign two products -> two intermediate rows
+        $orders->productsFieldsOneSync = [$product1, $product2];
+        $this->assertTrue($orders->save());
+        $this->assertEquals(2, count(OrdersProductsFieldsOne::find()));
+
+        // Sync down to one product -> the other intermediate row is deleted
+        $orders->productsFieldsOneSync = [$product1];
+        $this->assertTrue($orders->save());
+        $this->assertEquals(1, count(OrdersProductsFieldsOne::find()));
+
+        // Both products still exist as records (only the link was removed)
+        $this->assertEquals(2, Products::find()->count());
+
+        // Assigning an empty array clears all links
+        $orders->productsFieldsOneSync = [];
+        $this->assertTrue($orders->save());
+        $this->assertEquals(0, count(OrdersProductsFieldsOne::find()));
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: setSync() chained override on a non-sync
+     * relation, plus the wildcard enable.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17071
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function testMvcModelSetHasManyToManySetSyncMethod(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+
+        $orderId     = 10;
+        $orderName   = uniqid('ord', true);
+        $orderStatus = 5;
+
+        $ordersMigration            = new OrdersMigration($connection);
+        $ordersProductsOneMigration = new OrdersProductsFieldsOneMigration($connection);
+        $productsMigrations         = new ProductsMigration($connection);
+
+        $ordersMigration->insert($orderId, $orderName, $orderStatus);
+
+        $orders                    = OrdersMultiple::findFirst(10);
+        $product1                  = new Products();
+        $product1->prd_name        = uniqid('prd1', true);
+        $product1->prd_status_flag = 5;
+
+        $product2                  = new Products();
+        $product2->prd_name        = uniqid('prd2', true);
+        $product2->prd_status_flag = 10;
+
+        // Default (no sync) on productsFieldsOne: assignment is additive
+        $orders->productsFieldsOne = [$product1, $product2];
+        $this->assertTrue($orders->save());
+        $this->assertEquals(2, count(OrdersProductsFieldsOne::find()));
+
+        $orders->productsFieldsOne = [$product1];
+        $this->assertTrue($orders->save());
+        // Additive: product2 link survives
+        $this->assertEquals(2, count(OrdersProductsFieldsOne::find()));
+
+        // Now enable sync just for this save via setSync()
+        $orders->productsFieldsOne = [$product1];
+        $this->assertTrue($orders->setSync('productsFieldsOne')->save());
+        // Synced: product2 link removed
+        $this->assertEquals(1, count(OrdersProductsFieldsOne::find()));
+
+        // Wildcard enable: assign only product2 then sync everything down to it
+        $orders->productsFieldsOne = [$product2];
+        $this->assertTrue($orders->setSync()->save());
+        $this->assertEquals(1, count(OrdersProductsFieldsOne::find()));
+    }
+
+    /**
+     * Tests Phalcon\Mvc\Model :: setSync("*", false) disables sync for a
+     * relation configured with the `sync` option.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17071
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     *
+     * @group  mysql
+     * @group  pgsql
+     * @group  sqlite
+     */
+    public function testMvcModelSetHasManyToManySetSyncDisable(): void
+    {
+        /** @var PDO $connection */
+        $connection = self::getConnection();
+
+        $orderId     = 10;
+        $orderName   = uniqid('ord', true);
+        $orderStatus = 5;
+
+        $ordersMigration            = new OrdersMigration($connection);
+        $ordersProductsOneMigration = new OrdersProductsFieldsOneMigration($connection);
+        $productsMigrations         = new ProductsMigration($connection);
+
+        $ordersMigration->insert($orderId, $orderName, $orderStatus);
+
+        $orders                    = OrdersMultiple::findFirst(10);
+        $product1                  = new Products();
+        $product1->prd_name        = uniqid('prd1', true);
+        $product1->prd_status_flag = 5;
+
+        $product2                  = new Products();
+        $product2->prd_name        = uniqid('prd2', true);
+        $product2->prd_status_flag = 10;
+
+        // productsFieldsOneSync has 'sync' => true; disable it for this save
+        $orders->productsFieldsOneSync = [$product1, $product2];
+        $this->assertTrue($orders->save());
+        $this->assertEquals(2, count(OrdersProductsFieldsOne::find()));
+
+        $orders->productsFieldsOneSync = [$product1];
+        $this->assertTrue($orders->setSync('*', false)->save());
+        // Sync disabled for this save -> additive, product2 link survives
+        $this->assertEquals(2, count(OrdersProductsFieldsOne::find()));
+    }
+
+    /**
      * Tests Phalcon\Mvc\Model :: hasManyToMany() - set
      * Compound Primary Key Intermediate Relations
      *

--- a/tests/support/Models/OrdersMultiple.php
+++ b/tests/support/Models/OrdersMultiple.php
@@ -118,6 +118,19 @@ class OrdersMultiple extends Model
             ]
         );
 
+        $this->hasManyToMany(
+            'ord_id',
+            OrdersProductsFieldsOne::class,
+            'oxp_ord_id',
+            'oxp_prd_id',
+            Products::class,
+            'prd_id',
+            [
+                'alias' => 'productsFieldsOneSync',
+                'sync'  => true,
+            ]
+        );
+
         $this->hasOneThrough(
             'ord_id',
             OrdersProductsFieldsOne::class,


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17071 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added a `sync` option to many-to-many (`hasManyToMany`) relations and a chainable `Phalcon\Mvc\Model::setSync()` method to synchronize related records on save. When enabled, saving deletes the intermediate rows for records no longer present in the assigned array (add/update/delete), instead of only appending.

Thanks

