### PR TITLE
CP-17047 logger trace

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -12,6 +12,7 @@
 ### Added
 
 - Added a `sync` option to many-to-many (`hasManyToMany`) relations and a chainable `Phalcon\Mvc\Model::setSync()` method to synchronize related records on save. When enabled, saving deletes the intermediate rows for records no longer present in the assigned array (add/update/delete), instead of only appending. [#17071](https://github.com/phalcon/cphalcon/issues/17071) [[doc]](https://docs.phalcon.io/5.14/db-models-relationships/)
+- Added a `trace()` method to `Phalcon\Logger\Logger` together with a new `TRACE` log level (value `9`, label `trace`). [#17047](https://github.com/phalcon/cphalcon/issues/17047) [[doc]](https://docs.phalcon.io/5.14/logger/)
 
 ### Fixed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [5.14.1](https://github.com/phalcon/cphalcon/releases/tag/v5.14.1) (2026-xx-xx)
+
+### Tools
+
+- Zephir Parser v2.0.2
+- Zephir 0.22.0 (development - 9d2def774)
+
+### Changed
+
+### Added
+
+- Added a `sync` option to many-to-many (`hasManyToMany`) relations and a chainable `Phalcon\Mvc\Model::setSync()` method to synchronize related records on save. When enabled, saving deletes the intermediate rows for records no longer present in the assigned array (add/update/delete), instead of only appending. [#17071](https://github.com/phalcon/cphalcon/issues/17071) [[doc]](https://docs.phalcon.io/5.14/db-models-relationships/)
+
+### Fixed
+
+### Removed
+
+
 ## [5.14.0](https://github.com/phalcon/cphalcon/releases/tag/v5.14.0) (2026-06-04)
 
 ### Tools

--- a/phalcon/DataMapper/Pdo/Profiler/MemoryLogger.zep
+++ b/phalcon/DataMapper/Pdo/Profiler/MemoryLogger.zep
@@ -141,6 +141,14 @@ class MemoryLogger implements LoggerInterface
         this->log(Enum::NOTICE, message, context);
     }
 
+    /**
+     * @param string message
+     * @param mixed[] context
+     */
+    public function trace(string message, array context = []) -> void
+    {
+        this->log(Enum::TRACE, message, context);
+    }
 
     /**
      * @param string message

--- a/phalcon/Logger/AbstractLogger.zep
+++ b/phalcon/Logger/AbstractLogger.zep
@@ -69,6 +69,10 @@ abstract class AbstractLogger
     /**
      * @var int
      */
+    const TRACE     = 9;
+    /**
+     * @var int
+     */
     const WARNING   = 4;
 
     /**
@@ -378,7 +382,8 @@ abstract class AbstractLogger
             self::INFO      : "info",
             self::NOTICE    : "notice",
             self::WARNING   : "warning",
-            self::CUSTOM    : "custom"
+            self::CUSTOM    : "custom",
+            self::TRACE     : "trace"
         ];
     }
 }

--- a/phalcon/Logger/Adapter/Syslog.zep
+++ b/phalcon/Logger/Adapter/Syslog.zep
@@ -143,6 +143,7 @@ class Syslog extends AbstractAdapter
             Enum::ERROR     : LOG_ERR,
             Enum::INFO      : LOG_INFO,
             Enum::NOTICE    : LOG_NOTICE,
+            Enum::TRACE     : LOG_DEBUG,
             Enum::WARNING   : LOG_WARNING
         ];
 

--- a/phalcon/Logger/Enum.zep
+++ b/phalcon/Logger/Enum.zep
@@ -50,5 +50,9 @@ class Enum
     /**
      * @var int
      */
+    const TRACE     = 9;
+    /**
+     * @var int
+     */
     const WARNING   = 4;
 }

--- a/phalcon/Logger/Logger.zep
+++ b/phalcon/Logger/Logger.zep
@@ -158,6 +158,25 @@ class Logger extends AbstractLogger implements LoggerInterface
     }
 
     /**
+     * Extra-verbose diagnostic output.
+     *
+     * Use for high-frequency, fine-grained events such as raw socket frames,
+     * HTTP response bodies, or internal state transitions that are too noisy
+     * for DEBUG.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     * @throws Exception
+     * @throws LoggerException
+     */
+    public function trace(string message, array context = []) -> void
+    {
+        this->addMessage(self::TRACE, message, context);
+    }
+
+    /**
      * Exceptional occurrences that are not errors.
      *
      * Example: Use of deprecated APIs, poor use of an API, undesirable things

--- a/phalcon/Logger/LoggerInterface.zep
+++ b/phalcon/Logger/LoggerInterface.zep
@@ -136,6 +136,16 @@ interface LoggerInterface
     public function notice(string message, array context = []) -> void;
 
     /**
+     * Extra-verbose diagnostic output.
+     *
+     * @param string $message
+     * @param array  $context
+     *
+     * @return void
+     */
+    public function trace(string message, array context = []) -> void;
+
+    /**
      * Exceptional occurrences that are not errors.
      *
      * Example: Use of deprecated APIs, poor use of an API, undesirable things

--- a/tests/unit/Logger/Logger/ConstructTest.php
+++ b/tests/unit/Logger/Logger/ConstructTest.php
@@ -62,6 +62,7 @@ final class ConstructTest extends AbstractUnitTestCase
         $this->assertSame(5, Enum::NOTICE);
         $this->assertSame(4, Enum::WARNING);
         $this->assertSame(8, Enum::CUSTOM);
+        $this->assertSame(9, Enum::TRACE);
     }
 
     /**

--- a/tests/unit/Logger/Logger/TraceTest.php
+++ b/tests/unit/Logger/Logger/TraceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Logger\Logger;
+
+use Phalcon\Logger\Adapter\Stream;
+use Phalcon\Logger\Enum;
+use Phalcon\Logger\Logger;
+use Phalcon\Tests\AbstractUnitTestCase;
+
+use function file_get_contents;
+use function logsDir;
+
+final class TraceTest extends AbstractUnitTestCase
+{
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     */
+    public function testLoggerTraceLogsWhenLevelEnabled(): void
+    {
+        $fileName   = $this->getNewFileName('log', 'log');
+        $outputPath = logsDir($fileName);
+        $adapter    = new Stream($outputPath);
+
+        $logger = new Logger(
+            'my-logger',
+            [
+                'one' => $adapter,
+            ]
+        );
+
+        $logger->setLogLevel(Enum::TRACE);
+        $logger->trace('trace message');
+
+        $contents = file_get_contents($outputPath);
+        $this->assertStringContainsString('[trace] trace message', $contents);
+
+        $adapter->close();
+        $this->safeDeleteFile($outputPath);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     */
+    public function testLoggerTraceSuppressedAtDefaultLevel(): void
+    {
+        $fileName   = $this->getNewFileName('log', 'log');
+        $outputPath = logsDir($fileName);
+        $adapter    = new Stream($outputPath);
+
+        $logger = new Logger(
+            'my-logger',
+            [
+                'one' => $adapter,
+            ]
+        );
+
+        // Default logLevel is CUSTOM (8); TRACE (9) is more verbose and opt-in.
+        // The info() call (level 6) is a control that must appear; trace must not.
+        $logger->info('control message');
+        $logger->trace('trace message');
+
+        $contents = file_get_contents($outputPath);
+        $this->assertStringContainsString('control message', $contents);
+        $this->assertStringNotContainsString('trace message', $contents);
+
+        $adapter->close();
+        $this->safeDeleteFile($outputPath);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17047 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added a `trace()` method to `Phalcon\Logger\Logger` together with a new `TRACE` log level (value `9`, label `trace`) on `Phalcon\Logger\Enum` and `Phalcon\Logger\AbstractLogger`. `trace()` is opt-in: the default threshold stays `CUSTOM` (`8`), so trace messages are emitted only after `setLogLevel(Enum::TRACE)`. The existing `CUSTOM` level and its `custom` label (the unknown-level bucket) are unchanged.

Thanks

