### PR TITLE
T17052 di magic get

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ on:
 env:
   # All versions should be declared here
   PHALCON_VERSION: 5.14.0
-  ZEPHIR_PARSER_VERSION: 2.0.3
+  ZEPHIR_PARSER_VERSION: 2.0.4
   # For tests
   LANG: en_US.UTF-8
   LANGUAGE: en_US.UTF-8

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixed `Phalcon\Di\Injectable::__get()` to no longer cache resolved services as dynamic object properties. Services accessed via magic properties (e.g. `$this->request`) are now re-resolved through the container on each access, so replacing or updating a service in the container is reflected in controllers, views, and other injectable classes. Properties already declared on the class continue to be populated. [#17052](https://github.com/phalcon/cphalcon/issues/17052)
+
 ### Removed
 
 

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -59,7 +59,7 @@ abstract class Injectable extends stdClass implements InjectionAwareInterface
      */
     public function __get(string! propertyName) -> var | null
     {
-        var container;
+        var container, service;
 
         let container = <DiInterface> this->getDI();
 
@@ -85,12 +85,20 @@ abstract class Injectable extends stdClass implements InjectionAwareInterface
         }
 
         /**
-         * Resolve the service through the container on every access so that
-         * updates to the service definition are reflected. The instance is no
-         * longer stored as a property to avoid returning a stale reference.
+         * Resolve the service through the container. Only cache it on the
+         * object when the property is already declared on the class. This way
+         * dynamic services (e.g. request, response) are re-resolved on each
+         * access and reflect updates to the service definition, while declared
+         * component properties keep being populated as before.
          */
         if container->has(propertyName) {
-            return container->getShared(propertyName);
+            let service = container->getShared(propertyName);
+
+            if property_exists(this, propertyName) {
+                let this->{propertyName} = service;
+            }
+
+            return service;
         }
 
         /**

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -59,7 +59,7 @@ abstract class Injectable extends stdClass implements InjectionAwareInterface
      */
     public function __get(string! propertyName) -> var | null
     {
-        var container, service;
+        var container;
 
         let container = <DiInterface> this->getDI();
 
@@ -85,13 +85,12 @@ abstract class Injectable extends stdClass implements InjectionAwareInterface
         }
 
         /**
-         * Fallback to the PHP userland if the cache is not available
+         * Resolve the service through the container on every access so that
+         * updates to the service definition are reflected. The instance is no
+         * longer stored as a property to avoid returning a stale reference.
          */
         if container->has(propertyName) {
-            let service = container->getShared(propertyName);
-            let this->{propertyName} = service;
-
-            return service;
+            return container->getShared(propertyName);
         }
 
         /**

--- a/tests/support/Di/InjectableComponentProtected.php
+++ b/tests/support/Di/InjectableComponentProtected.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Tests\Support\Di;
+
+use Phalcon\Di\Injectable as AbstractInjectable;
+
+class InjectableComponentProtected extends AbstractInjectable
+{
+    protected $widget = null;
+
+    /**
+     * Returns the protected property directly, bypassing the magic getter, so
+     * tests can observe whether `__get()` populated the declared property.
+     */
+    public function getWidgetRaw()
+    {
+        return $this->widget;
+    }
+}

--- a/tests/unit/Di/Injectable/UnderscoreGetTest.php
+++ b/tests/unit/Di/Injectable/UnderscoreGetTest.php
@@ -16,6 +16,7 @@ namespace Phalcon\Tests\Unit\Di\Injectable;
 use Phalcon\Di\Di;
 use Phalcon\Tests\AbstractUnitTestCase;
 use Phalcon\Tests\Support\Di\InjectableComponent;
+use Phalcon\Tests\Support\Di\InjectableComponentProtected;
 use stdClass;
 
 use function spl_object_hash;
@@ -82,6 +83,40 @@ final class UnderscoreGetTest extends AbstractUnitTestCase
 
         $class = stdClass::class;
         $this->assertInstanceOf($class, $persistent);
+    }
+
+    /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/17052
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     */
+    public function testDiInjectableUnderscoreGetPopulatesDeclaredProperty(): void
+    {
+        Di::reset();
+        $container = new Di();
+
+        $container->setShared(
+            'widget',
+            function (): stdClass {
+                return new stdClass();
+            }
+        );
+
+        $container->set('component', InjectableComponentProtected::class);
+
+        /** @var InjectableComponentProtected $component */
+        $component = $container->get('component');
+
+        // The declared protected property starts unpopulated
+        $this->assertNull($component->getWidgetRaw());
+
+        // Magic access resolves the service and, because the property is
+        // declared on the class, caches it on the object
+        $widget = $component->widget;
+        $this->assertInstanceOf(stdClass::class, $widget);
+
+        // The declared property now holds the resolved instance
+        $this->assertSame($widget, $component->getWidgetRaw());
     }
 
     /**

--- a/tests/unit/Di/Injectable/UnderscoreGetTest.php
+++ b/tests/unit/Di/Injectable/UnderscoreGetTest.php
@@ -85,6 +85,47 @@ final class UnderscoreGetTest extends AbstractUnitTestCase
     }
 
     /**
+     * @issue  https://github.com/phalcon/cphalcon/issues/17052
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-04
+     */
+    public function testDiInjectableUnderscoreGetReflectsReplacedService(): void
+    {
+        Di::reset();
+        $container = new Di();
+
+        $container->setShared(
+            'someService',
+            function (): stdClass {
+                return new stdClass();
+            }
+        );
+
+        $container->set('component', InjectableComponent::class);
+
+        /** @var InjectableComponent $component */
+        $component = $container->get('component');
+
+        // First magic access resolves through the container
+        $first = $component->someService;
+        $this->assertSame($container->getShared('someService'), $first);
+
+        // Replace the service in the container after the first access
+        $container->remove('someService');
+        $container->setShared(
+            'someService',
+            function (): stdClass {
+                return new stdClass();
+            }
+        );
+
+        // The magic property must reflect the replacement, not a stale instance
+        $second = $component->someService;
+        $this->assertNotSame($first, $second);
+        $this->assertSame($container->getShared('someService'), $second);
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2019-09-09
      */


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #17052 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Di\Injectable::__get()` to no longer cache resolved services as dynamic object properties. Services accessed via magic properties (e.g. `$this->request`) are now re-resolved through the container on each access, so replacing or updating a service in the container is reflected in controllers, views, and other injectable classes. Properties already declared on the class continue to be populated.

Thanks

