### PR TITLE
CP-17112 extra phql comments

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -13,6 +13,7 @@
 
 - Added dialect-specific operators to PHQL: `@@`, `@>`, `<@`, `&&`, `||`, `->`, `->>`, `#>`, `#>>`. Each is parsed into a binary expression and emitted only by the dialects that support it (PostgreSQL: all nine; MySQL: `->`, `->>`; SQLite: `||`, `->`, `->>`); using an operator on a dialect that does not support it throws `Phalcon\Db\Exceptions\UnsupportedOperator`. The jsonb existence operators (`?`, `?|`, `?&`, `@?`) and the `~` regex family are intentionally unsupported - use their function equivalents (e.g. `jsonb_exists()`, `regexp_like()`). [#14954](https://github.com/phalcon/cphalcon/issues/14954) [#14579](https://github.com/phalcon/cphalcon/issues/14579)
 - Added geometry value objects under `Phalcon\Db\Geometry` (`Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`, `GeometryCollection`) and read-side hydration of spatial columns. When `orm.cast_on_hydrate` is enabled, spatial column values (MySQL WKB / PostGIS EWKB) are decoded into these objects on model read; otherwise the raw value is returned unchanged. [#17110](https://github.com/phalcon/cphalcon/issues/17110) [#14769](https://github.com/phalcon/cphalcon/issues/14769) [#13670](https://github.com/phalcon/cphalcon/issues/13670)
+- Added table comment support to the MySQL and PostgreSQL dialects. Comment values are single-quote escaped (the existing PostgreSQL column-comment emission is now escaped as well). SQLite has no native table comment and ignores the option. [#15258](https://github.com/phalcon/cphalcon/issues/15258)
 
 ### Fixed
 

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -979,7 +979,7 @@ class Mysql extends Dialect
     {
         string sql;
 
-        let sql = "SELECT TABLES.TABLE_TYPE AS table_type,TABLES.AUTO_INCREMENT AS auto_increment,TABLES.ENGINE AS engine,TABLES.TABLE_COLLATION AS table_collation FROM INFORMATION_SCHEMA.TABLES WHERE ";
+        let sql = "SELECT TABLES.TABLE_TYPE AS table_type,TABLES.AUTO_INCREMENT AS auto_increment,TABLES.ENGINE AS engine,TABLES.TABLE_COLLATION AS table_collation,TABLES.TABLE_COMMENT AS table_comment FROM INFORMATION_SCHEMA.TABLES WHERE ";
 
         if schema {
             return sql . "TABLES.TABLE_SCHEMA = '" . schema . "' AND TABLES.TABLE_NAME = '" . table . "'";
@@ -1021,7 +1021,7 @@ class Mysql extends Dialect
      */
     protected function getTableOptions(array! definition) -> string
     {
-        var options, engine, autoIncrement, tableCollation, collationParts;
+        var options, engine, autoIncrement, tableCollation, collationParts, tableComment;
         array tableOptions;
 
         if !fetch options, definition["options"] {
@@ -1056,6 +1056,15 @@ class Mysql extends Dialect
                 let collationParts = explode("_", tableCollation),
                     tableOptions[] = "DEFAULT CHARSET=" . collationParts[0],
                     tableOptions[] = "COLLATE=" . tableCollation;
+            }
+        }
+
+        /**
+         * Check if there is a TABLE_COMMENT option
+         */
+        if fetch tableComment, options["TABLE_COMMENT"] {
+            if tableComment {
+                let tableOptions[] = "COMMENT='" . str_replace("'", "''", tableComment) . "'";
             }
         }
 

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -966,10 +966,12 @@ class Mysql extends Dialect
     public function tableExists(string! tableName, string schemaName = null) -> string
     {
         if schemaName {
-            return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_NAME`= '" . tableName . "' AND `TABLE_SCHEMA` = '" . schemaName . "'";
+            return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_NAME`= '"
+                . tableName . "' AND `TABLE_SCHEMA` = '" . schemaName . "'";
         }
 
-        return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_NAME` = '" . tableName . "' AND `TABLE_SCHEMA` = DATABASE()";
+        return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_NAME` = '"
+            . tableName . "' AND `TABLE_SCHEMA` = DATABASE()";
     }
 
     /**
@@ -979,7 +981,9 @@ class Mysql extends Dialect
     {
         string sql;
 
-        let sql = "SELECT TABLES.TABLE_TYPE AS table_type,TABLES.AUTO_INCREMENT AS auto_increment,TABLES.ENGINE AS engine,TABLES.TABLE_COLLATION AS table_collation,TABLES.TABLE_COMMENT AS table_comment FROM INFORMATION_SCHEMA.TABLES WHERE ";
+        let sql = "SELECT TABLES.TABLE_TYPE AS table_type,TABLES.AUTO_INCREMENT AS auto_increment,"
+            . "TABLES.ENGINE AS engine,TABLES.TABLE_COLLATION AS table_collation,"
+            . "TABLES.TABLE_COMMENT AS table_comment FROM INFORMATION_SCHEMA.TABLES WHERE ";
 
         if schema {
             return sql . "TABLES.TABLE_SCHEMA = '" . schema . "' AND TABLES.TABLE_NAME = '" . table . "'";
@@ -1010,10 +1014,12 @@ class Mysql extends Dialect
     public function viewExists(string! viewName, string schemaName = null) -> string
     {
         if schemaName {
-            return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`VIEWS` WHERE `TABLE_NAME`= '" . viewName . "' AND `TABLE_SCHEMA`='" . schemaName . "'";
+            return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`VIEWS` WHERE `TABLE_NAME`= '"
+                . viewName . "' AND `TABLE_SCHEMA`='" . schemaName . "'";
         }
 
-        return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`VIEWS` WHERE `TABLE_NAME`='" . viewName . "' AND `TABLE_SCHEMA` = DATABASE()";
+        return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`VIEWS` WHERE `TABLE_NAME`='"
+            . viewName . "' AND `TABLE_SCHEMA` = DATABASE()";
     }
 
     /**

--- a/phalcon/Db/Dialect/Postgresql.zep
+++ b/phalcon/Db/Dialect/Postgresql.zep
@@ -154,7 +154,7 @@ class Postgresql extends Dialect
     {
         var temporary, options, table, columns, column, indexes, index,
             reference, references, indexName, indexType, onDelete, onUpdate,
-            columnDefinition, checks, check;
+            columnDefinition, checks, check, tableComment;
         array createLines, primaryColumns;
         string indexSql, indexSqlAfterCreate, columnLine, referenceSql, sql;
 
@@ -167,6 +167,7 @@ class Postgresql extends Dialect
         let temporary = false;
         if fetch options, definition["options"] {
             fetch temporary, options["temporary"];
+            fetch tableComment, options["TABLE_COMMENT"];
         }
 
         /**
@@ -220,7 +221,7 @@ class Postgresql extends Dialect
             * Add a COMMENT clause
             */
             if column->getComment() {
-                let indexSqlAfterCreate .= " COMMENT ON COLUMN " . table . ".\"" . column->getName()."\" IS '".column->getComment()."';";
+                let indexSqlAfterCreate .= " COMMENT ON COLUMN " . table . ".\"" . column->getName()."\" IS '" . str_replace("'", "''", column->getComment()) . "';";
             }
         }
 
@@ -298,6 +299,10 @@ class Postgresql extends Dialect
         if isset definition["options"] {
             let sql .= " " . this->getTableOptions(definition);
         }
+        if tableComment {
+            let indexSqlAfterCreate .= " COMMENT ON TABLE " . table . " IS '" . str_replace("'", "''", tableComment) . "';";
+        }
+
         let sql .= ";" . indexSqlAfterCreate;
 
         return sql;
@@ -875,7 +880,7 @@ class Postgresql extends Dialect
          * Add a COMMENT clause
          */
          if column->getComment() {
-            let sql .= "COMMENT ON COLUMN " . this->prepareTable(tableName, schemaName) . ".\"" .column->getName()."\" IS '" . column->getComment() . "';";
+            let sql .= "COMMENT ON COLUMN " . this->prepareTable(tableName, schemaName) . ".\"" .column->getName()."\" IS '" . str_replace("'", "''", column->getComment()) . "';";
         }
 
         // DEFAULT
@@ -965,7 +970,15 @@ class Postgresql extends Dialect
      */
     public function tableOptions(string! table, string schema = null) -> string
     {
-        return "";
+        string sql;
+
+        let sql = "SELECT obj_description(c.oid, 'pg_class') AS table_comment FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relname = '" . table . "' AND ";
+
+        if schema {
+            return sql . "n.nspname = '" . schema . "'";
+        }
+
+        return sql . "n.nspname = current_schema()";
     }
 
     /**

--- a/tests/database/Db/Adapter/Pdo/TableOptionsTest.php
+++ b/tests/database/Db/Adapter/Pdo/TableOptionsTest.php
@@ -52,6 +52,8 @@ final class TableOptionsTest extends AbstractDatabaseTestCase
         if (env('driver') === 'mysql') {
             $this->assertNotEmpty($options);
             $this->assertArrayHasKey('engine', $options);
+        } elseif (env('driver') === 'pgsql') {
+            $this->assertSame(['table_comment' => null], $options);
         } else {
             $this->assertSame([], $options);
         }

--- a/tests/database/Db/Dialect/TableCommentTest.php
+++ b/tests/database/Db/Dialect/TableCommentTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Database\Db\Dialect;
+
+use Phalcon\Db\Column;
+use Phalcon\Db\Dialect\Mysql;
+use Phalcon\Db\Dialect\Postgresql;
+use Phalcon\Db\Dialect\Sqlite;
+use Phalcon\Tests\AbstractDatabaseTestCase;
+
+final class TableCommentTest extends AbstractDatabaseTestCase
+{
+    private function definition(array $options = []): array
+    {
+        return [
+            'columns' => [
+                new Column('id', ['type' => Column::TYPE_INTEGER, 'notNull' => true]),
+            ],
+            'options' => $options,
+        ];
+    }
+
+    /**
+     * @group mysql
+     */
+    public function testMysqlCreateTableComment(): void
+    {
+        $sql = (new Mysql())->createTable(
+            'robots',
+            '',
+            $this->definition(['TABLE_COMMENT' => "it's a robot"])
+        );
+
+        $this->assertStringContainsString("COMMENT='it''s a robot'", $sql);
+    }
+
+    /**
+     * @group mysql
+     */
+    public function testMysqlTableOptionsSelectsComment(): void
+    {
+        $sql = (new Mysql())->tableOptions('robots', 'phalcon');
+
+        $this->assertStringContainsString('TABLES.TABLE_COMMENT AS table_comment', $sql);
+    }
+
+    /**
+     * @group pgsql
+     */
+    public function testPostgresqlCreateTableComment(): void
+    {
+        $sql = (new Postgresql())->createTable(
+            'robots',
+            '',
+            $this->definition(['TABLE_COMMENT' => "it's a robot"])
+        );
+
+        $this->assertStringContainsString(
+            'COMMENT ON TABLE "robots" IS \'it\'\'s a robot\';',
+            $sql
+        );
+    }
+
+    /**
+     * @group pgsql
+     */
+    public function testPostgresqlTableOptionsObjDescription(): void
+    {
+        $sql = (new Postgresql())->tableOptions('robots', 'reporting');
+
+        $this->assertStringContainsString("obj_description(c.oid, 'pg_class')", $sql);
+        $this->assertStringContainsString("n.nspname = 'reporting'", $sql);
+    }
+
+    /**
+     * @group pgsql
+     */
+    public function testPostgresqlColumnCommentEscaped(): void
+    {
+        $definition = [
+            'columns' => [
+                new Column(
+                    'name',
+                    ['type' => Column::TYPE_VARCHAR, 'size' => 70, 'comment' => "it's"]
+                ),
+            ],
+        ];
+
+        $sql = (new Postgresql())->createTable('robots', '', $definition);
+
+        $this->assertStringContainsString("IS 'it''s';", $sql);
+    }
+
+    /**
+     * @group sqlite
+     */
+    public function testSqliteIgnoresComment(): void
+    {
+        $sql = (new Sqlite())->createTable(
+            'robots',
+            '',
+            $this->definition(['TABLE_COMMENT' => 'ignored'])
+        );
+
+        $this->assertStringNotContainsString('COMMENT', $sql);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17112 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added table comment support to the MySQL and PostgreSQL dialects. Comment values are single-quote escaped (the existing PostgreSQL column-comment emission is now escaped as well). SQLite has no native table comment and ignores the option.

Thanks

