### PR TITLE
[#17113] - fixing permissions

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Fixed the alternative installation script (`build/install`) to set the installed `phalcon.so` to mode `0644` after `make install`. The PHP build system installs shared extensions with the `install` default mode `0755`; shared objects only need read permission. [#17113](https://github.com/phalcon/cphalcon/issues/17113)
+
 ### Removed
 
 ## [5.14.1](https://github.com/phalcon/cphalcon/releases/tag/v5.14.1) (2026-06-08)

--- a/build/install
+++ b/build/install
@@ -117,4 +117,7 @@ fi
 make -s -j"$(getconf _NPROCESSORS_ONLN)"
 make -s install
 
+# `make install` copies the module with mode 0755; shared objects only need read permission
+chmod 644 "$(${PHPCONFIG_BIN} --extension-dir)/phalcon.so"
+
 echo -e "\nThanks for compiling Phalcon!\nBuild succeed: Please restart your web server to complete the installation\n"


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17113 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed the alternative installation script (`build/install`) to set the installed `phalcon.so` to mode `0644` after `make install`. The PHP build system installs shared extensions with the `install` default mode `0755`; shared objects only need read permission. [#17113](https://github.com/phalcon/cphalcon/issues/17113)

Thanks

