### PR TITLE
CP-17124 filter refactoring

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -10,12 +10,16 @@
 ### Changed
 
 - Changed `Phalcon\Cli\Console::handle()` to process module definitions the same way as `Phalcon\Mvc\Application::handle()`. The module is now resolved through the inherited `getModule()`, so an unregistered module throws `Phalcon\Application\Exceptions\ModuleNotRegistered` (as `Console::getModule()` already did) instead of `Phalcon\Cli\Console\Exceptions\ConsoleModuleNotRegistered`. `Closure` module definitions are now supported and are invoked with the container, matching MVC. A definition that is neither an array nor a `Closure` throws the new `Phalcon\Cli\Console\Exceptions\InvalidModuleDefinition` instead of `InvalidModuleDefinitionPath`. [#17107](https://github.com/phalcon/cphalcon/issues/17107)
+- Consolidated the `allowEmpty` handling of `Phalcon\Filter\Validation` into the validator (`Phalcon\Filter\Validation\AbstractValidator::isAllowEmpty()`). The per-field `allowEmpty` map is also honored. [#17124](https://github.com/phalcon/cphalcon/issues/17124)
+- Moved the resolution of an array `attribute` option from `Phalcon\Filter\Validation\AbstractValidator::getOption()` into `Phalcon\Filter\Validation\Validator\Uniqueness::getOption()`. [#17124](https://github.com/phalcon/cphalcon/issues/17124)
 
 ### Added
 
 - Added dialect-specific operators to PHQL: `@@`, `@>`, `<@`, `&&`, `||`, `->`, `->>`, `#>`, `#>>`. Each is parsed into a binary expression and emitted only by the dialects that support it (PostgreSQL: all nine; MySQL: `->`, `->>`; SQLite: `||`, `->`, `->>`); using an operator on a dialect that does not support it throws `Phalcon\Db\Exceptions\UnsupportedOperator`. The jsonb existence operators (`?`, `?|`, `?&`, `@?`) and the `~` regex family are intentionally unsupported - use their function equivalents (e.g. `jsonb_exists()`, `regexp_like()`). [#14954](https://github.com/phalcon/cphalcon/issues/14954) [#14579](https://github.com/phalcon/cphalcon/issues/14579)
 - Added geometry value objects under `Phalcon\Db\Geometry` (`Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`, `GeometryCollection`) and read-side hydration of spatial columns. When `orm.cast_on_hydrate` is enabled, spatial column values (MySQL WKB / PostGIS EWKB) are decoded into these objects on model read; otherwise the raw value is returned unchanged. [#17110](https://github.com/phalcon/cphalcon/issues/17110) [#14769](https://github.com/phalcon/cphalcon/issues/14769) [#13670](https://github.com/phalcon/cphalcon/issues/13670)
 - Added table comment support to the MySQL and PostgreSQL dialects. Comment values are single-quote escaped (the existing PostgreSQL column-comment emission is now escaped as well). SQLite has no native table comment and ignores the option. [#15258](https://github.com/phalcon/cphalcon/issues/15258)
+- Added the `Phalcon\Contracts\Filter\Sanitizer` interface and moving array recursion in `Phalcon\Filter\Filter::sanitize()`. [#17124](https://github.com/phalcon/cphalcon/issues/17124)
+- Added `Phalcon\Filter\Filter::getDefaultMapper()`, for mapper services used also by `Phalcon\Filter\FilterFactory::getServices()`. [#17124](https://github.com/phalcon/cphalcon/issues/17124)
 
 ### Fixed
 

--- a/phalcon/Contracts/Filter/Sanitizer.zep
+++ b/phalcon/Contracts/Filter/Sanitizer.zep
@@ -1,0 +1,33 @@
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+namespace Phalcon\Contracts\Filter;
+
+/**
+ * The contract for sanitizers registered in Phalcon\Filter\Filter.
+ *
+ * A sanitizer is an invokable object: it must expose a public `__invoke()`
+ * method that receives the value to sanitize as its first parameter and
+ * returns the sanitized value. Additional parameters, when a sanitizer
+ * needs them (e.g. `regex`, `replace`), must be declared after the value
+ * parameter; Phalcon\Filter\Filter::sanitize() forwards them in order.
+ *
+ * `__invoke()` is intentionally not declared here: implementations type
+ * their value parameter differently (`string` for text-only sanitizers,
+ * untyped for coercing ones), and PHP parameter variance does not allow an
+ * implementation to narrow a parameter declared by an interface.
+ *
+ * A sanitizer operates on a single value. Array handling (one level of
+ * recursion by default) is the responsibility of
+ * Phalcon\Filter\Filter::sanitize(), not of the sanitizer.
+ */
+interface Sanitizer
+{
+}

--- a/phalcon/Filter/Filter.zep
+++ b/phalcon/Filter/Filter.zep
@@ -201,6 +201,42 @@ class Filter implements FilterInterface
     }
 
     /**
+     * Returns the default sanitizer name to class map. This is the single
+     * source for the built-in sanitizer registry: when adding a sanitizer,
+     * add its `FILTER_*` constant and its entry here.
+     *
+     * @return string[]
+     */
+    public static function getDefaultMapper() -> array
+    {
+        return [
+            self::FILTER_ABSINT        : "Phalcon\\Filter\\Sanitize\\AbsInt",
+            self::FILTER_ALNUM         : "Phalcon\\Filter\\Sanitize\\Alnum",
+            self::FILTER_ALPHA         : "Phalcon\\Filter\\Sanitize\\Alpha",
+            self::FILTER_BOOL          : "Phalcon\\Filter\\Sanitize\\BoolVal",
+            self::FILTER_EMAIL         : "Phalcon\\Filter\\Sanitize\\Email",
+            self::FILTER_FLOAT         : "Phalcon\\Filter\\Sanitize\\FloatVal",
+            self::FILTER_INT           : "Phalcon\\Filter\\Sanitize\\IntVal",
+            self::FILTER_IP            : "Phalcon\\Filter\\Sanitize\\Ip",
+            self::FILTER_LOWER         : "Phalcon\\Filter\\Sanitize\\Lower",
+            self::FILTER_LOWERFIRST    : "Phalcon\\Filter\\Sanitize\\LowerFirst",
+            self::FILTER_REGEX         : "Phalcon\\Filter\\Sanitize\\Regex",
+            self::FILTER_REMOVE        : "Phalcon\\Filter\\Sanitize\\Remove",
+            self::FILTER_REPLACE       : "Phalcon\\Filter\\Sanitize\\Replace",
+            self::FILTER_SPECIAL       : "Phalcon\\Filter\\Sanitize\\Special",
+            self::FILTER_SPECIALFULL   : "Phalcon\\Filter\\Sanitize\\SpecialFull",
+            self::FILTER_STRING        : "Phalcon\\Filter\\Sanitize\\StringVal",
+            self::FILTER_STRING_LEGACY : "Phalcon\\Filter\\Sanitize\\StringValLegacy",
+            self::FILTER_STRIPTAGS     : "Phalcon\\Filter\\Sanitize\\Striptags",
+            self::FILTER_TRIM          : "Phalcon\\Filter\\Sanitize\\Trim",
+            self::FILTER_UPPER         : "Phalcon\\Filter\\Sanitize\\Upper",
+            self::FILTER_UPPERFIRST    : "Phalcon\\Filter\\Sanitize\\UpperFirst",
+            self::FILTER_UPPERWORDS    : "Phalcon\\Filter\\Sanitize\\UpperWords",
+            self::FILTER_URL           : "Phalcon\\Filter\\Sanitize\\Url"
+        ];
+    }
+
+    /**
      * Checks if a service exists in the map array
      *
      * @param string $name
@@ -214,6 +250,14 @@ class Filter implements FilterInterface
 
     /**
      * Sanitizes a value with a specified single or set of sanitizers
+     *
+     * Array policy: when `$value` is an array and `$noRecursive` is `false`
+     * (the default), each element is passed to the sanitizer individually
+     * and an array is returned - recursion is one level deep only. Elements
+     * that are themselves arrays are passed to the sanitizer as-is, which
+     * raises a `TypeError` for sanitizers that type their value parameter
+     * (e.g. `trim`). When `$noRecursive` is `true`, the whole array is
+     * passed to the sanitizer as a single value.
      *
      * @param mixed $value
      * @param mixed $sanitizers

--- a/phalcon/Filter/FilterFactory.zep
+++ b/phalcon/Filter/FilterFactory.zep
@@ -37,30 +37,6 @@ class FilterFactory
      */
     protected function getServices() -> array
     {
-        return [
-            Filter::FILTER_ABSINT        : "Phalcon\\Filter\\Sanitize\\AbsInt",
-            Filter::FILTER_ALNUM         : "Phalcon\\Filter\\Sanitize\\Alnum",
-            Filter::FILTER_ALPHA         : "Phalcon\\Filter\\Sanitize\\Alpha",
-            Filter::FILTER_BOOL          : "Phalcon\\Filter\\Sanitize\\BoolVal",
-            Filter::FILTER_EMAIL         : "Phalcon\\Filter\\Sanitize\\Email",
-            Filter::FILTER_FLOAT         : "Phalcon\\Filter\\Sanitize\\FloatVal",
-            Filter::FILTER_INT           : "Phalcon\\Filter\\Sanitize\\IntVal",
-            Filter::FILTER_IP            : "Phalcon\\Filter\\Sanitize\\Ip",
-            Filter::FILTER_LOWER         : "Phalcon\\Filter\\Sanitize\\Lower",
-            Filter::FILTER_LOWERFIRST    : "Phalcon\\Filter\\Sanitize\\LowerFirst",
-            Filter::FILTER_REGEX         : "Phalcon\\Filter\\Sanitize\\Regex",
-            Filter::FILTER_REMOVE        : "Phalcon\\Filter\\Sanitize\\Remove",
-            Filter::FILTER_REPLACE       : "Phalcon\\Filter\\Sanitize\\Replace",
-            Filter::FILTER_SPECIAL       : "Phalcon\\Filter\\Sanitize\\Special",
-            Filter::FILTER_SPECIALFULL   : "Phalcon\\Filter\\Sanitize\\SpecialFull",
-            Filter::FILTER_STRING        : "Phalcon\\Filter\\Sanitize\\StringVal",
-            Filter::FILTER_STRING_LEGACY : "Phalcon\\Filter\\Sanitize\\StringValLegacy",
-            Filter::FILTER_STRIPTAGS     : "Phalcon\\Filter\\Sanitize\\Striptags",
-            Filter::FILTER_TRIM          : "Phalcon\\Filter\\Sanitize\\Trim",
-            Filter::FILTER_UPPER         : "Phalcon\\Filter\\Sanitize\\Upper",
-            Filter::FILTER_UPPERFIRST    : "Phalcon\\Filter\\Sanitize\\UpperFirst",
-            Filter::FILTER_UPPERWORDS    : "Phalcon\\Filter\\Sanitize\\UpperWords",
-            Filter::FILTER_URL           : "Phalcon\\Filter\\Sanitize\\Url"
-        ];
+        return Filter::getDefaultMapper();
     }
 }

--- a/phalcon/Filter/FilterInterface.zep
+++ b/phalcon/Filter/FilterInterface.zep
@@ -18,6 +18,11 @@ interface FilterInterface
     /**
      * Sanitizes a value with a specified single or set of sanitizers
      *
+     * Array policy: when `$value` is an array and `$noRecursive` is `false`
+     * (the default), each element is sanitized individually and an array is
+     * returned - recursion is one level deep only. When `$noRecursive` is
+     * `true`, the whole array is passed to the sanitizer as a single value.
+     *
      * @param mixed $value
      * @param mixed $sanitizers
      * @param bool  $noRecursive

--- a/phalcon/Filter/Sanitize/AbsInt.zep
+++ b/phalcon/Filter/Sanitize/AbsInt.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\AbsInt
  *
  * Sanitizes a value to absolute integer
  */
-class AbsInt
+class AbsInt implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Alnum.zep
+++ b/phalcon/Filter/Sanitize/Alnum.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Alnum
  *
  * Sanitizes a value to an alphanumeric value
  */
-class Alnum
+class Alnum implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Alpha.zep
+++ b/phalcon/Filter/Sanitize/Alpha.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Alpha
  *
  * Sanitizes a value to an alpha value
  */
-class Alpha
+class Alpha implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/BoolVal.zep
+++ b/phalcon/Filter/Sanitize/BoolVal.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\BoolVal
  *
  * Sanitizes a value to boolean
  */
-class BoolVal
+class BoolVal implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Email.zep
+++ b/phalcon/Filter/Sanitize/Email.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Email
  *
  * Sanitizes an email string
  */
-class Email
+class Email implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/FloatVal.zep
+++ b/phalcon/Filter/Sanitize/FloatVal.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\FloatVal
  *
  * Sanitizes a value to float
  */
-class FloatVal
+class FloatVal implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/IntVal.zep
+++ b/phalcon/Filter/Sanitize/IntVal.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\IntVal
  *
  * Sanitizes a value to integer
  */
-class IntVal
+class IntVal implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Ip.zep
+++ b/phalcon/Filter/Sanitize/Ip.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\IP
  *
  * Sanitizes a value to an ip address or CIDR range
  */
-class Ip
+class Ip implements Sanitizer
 {
     /**
      * @param string $input

--- a/phalcon/Filter/Sanitize/Lower.zep
+++ b/phalcon/Filter/Sanitize/Lower.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Lower
  *
  * Sanitizes a value to lowercase
  */
-class Lower
+class Lower implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/LowerFirst.zep
+++ b/phalcon/Filter/Sanitize/LowerFirst.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\LowerFirst
  *
  * Sanitizes a value to lcfirst
  */
-class LowerFirst
+class LowerFirst implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Regex.zep
+++ b/phalcon/Filter/Sanitize/Regex.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Regex
  *
  * Sanitizes a value performing preg_replace
  */
-class Regex
+class Regex implements Sanitizer
 {
     /**
      * @param mixed $input

--- a/phalcon/Filter/Sanitize/Remove.zep
+++ b/phalcon/Filter/Sanitize/Remove.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Remove
  *
  * Sanitizes a value removing parts of a string
  */
-class Remove
+class Remove implements Sanitizer
 {
     /**
      * @param mixed $input

--- a/phalcon/Filter/Sanitize/Replace.zep
+++ b/phalcon/Filter/Sanitize/Replace.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Replace
  *
  * Sanitizes a value replacing parts of a string
  */
-class Replace
+class Replace implements Sanitizer
 {
     /**
      * @param mixed $input

--- a/phalcon/Filter/Sanitize/Special.zep
+++ b/phalcon/Filter/Sanitize/Special.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Special
  *
  * Sanitizes a value special characters
  */
-class Special
+class Special implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/SpecialFull.zep
+++ b/phalcon/Filter/Sanitize/SpecialFull.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\SpecialFull
  *
  * Sanitizes a value special characters (htmlspecialchars() and ENT_QUOTES)
  */
-class SpecialFull
+class SpecialFull implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Sanitize/StringVal.zep
+++ b/phalcon/Filter/Sanitize/StringVal.zep
@@ -10,10 +10,12 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Sanitizes a value to string
  */
-class StringVal
+class StringVal implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/StringValLegacy.zep
+++ b/phalcon/Filter/Sanitize/StringValLegacy.zep
@@ -10,13 +10,15 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Sanitizes a value to string using `filter_var()`. The filter provides
  * backwards compatibility with versions prior to v5. For PHP higher or equal to
  * 8.1, the filter will remain the string unchanged. If anything other than a
  * string is passed, the method will return false
  */
-class StringValLegacy
+class StringValLegacy implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Striptags.zep
+++ b/phalcon/Filter/Sanitize/Striptags.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Striptags
  *
  * Sanitizes a value striptags
  */
-class Striptags
+class Striptags implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Trim.zep
+++ b/phalcon/Filter/Sanitize/Trim.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Trim
  *
  * Sanitizes a value removing leading and trailing spaces
  */
-class Trim
+class Trim implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Upper.zep
+++ b/phalcon/Filter/Sanitize/Upper.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Upper
  *
  * Sanitizes a value to uppercase
  */
-class Upper
+class Upper implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/UpperFirst.zep
+++ b/phalcon/Filter/Sanitize/UpperFirst.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\UpperFirst
  *
  * Sanitizes a value to ucfirst
  */
-class UpperFirst
+class UpperFirst implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/UpperWords.zep
+++ b/phalcon/Filter/Sanitize/UpperWords.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\UpperWords
  *
  * Sanitizes a value to uppercase the first character of each word
  */
-class UpperWords
+class UpperWords implements Sanitizer
 {
     /**
      * @param string $input The text to sanitize

--- a/phalcon/Filter/Sanitize/Url.zep
+++ b/phalcon/Filter/Sanitize/Url.zep
@@ -10,12 +10,14 @@
 
 namespace Phalcon\Filter\Sanitize;
 
+use Phalcon\Contracts\Filter\Sanitizer;
+
 /**
  * Phalcon\Filter\Sanitize\Url
  *
  * Sanitizes a value url
  */
-class Url
+class Url implements Sanitizer
 {
     /**
      * @param mixed $input The text to sanitize

--- a/phalcon/Filter/Validation.zep
+++ b/phalcon/Filter/Validation.zep
@@ -687,7 +687,7 @@ class Validation extends Injectable implements ValidationInterface
      */
     protected function preChecking(var field, <ValidatorInterface> validator) -> bool
     {
-        var singleField, allowEmpty, emptyValue, value;
+        var singleField, allowEmpty, value;
         array results = [];
 
         if typeof field == "array" {
@@ -704,20 +704,22 @@ class Validation extends Injectable implements ValidationInterface
             let allowEmpty = validator->getOption("allowEmpty", false);
 
             if allowEmpty {
+                /**
+                 * The `allowEmpty` rule is owned by the validator
+                 * (AbstractValidator::isAllowEmpty() or an override)
+                 */
                 if method_exists(validator, "isAllowEmpty") {
                     return validator->isAllowEmpty(this, field);
                 }
 
+                /**
+                 * Compatibility path for validators implementing
+                 * ValidatorInterface without extending AbstractValidator
+                 */
                 let value = this->getValue(field);
 
                 if typeof allowEmpty == "array" {
-                    for emptyValue in allowEmpty {
-                        if emptyValue === value {
-                            return true;
-                        }
-                    }
-
-                    return false;
+                    return in_array(value, allowEmpty, true);
                 }
 
                 return empty value;

--- a/phalcon/Filter/Validation/AbstractValidator.zep
+++ b/phalcon/Filter/Validation/AbstractValidator.zep
@@ -79,20 +79,10 @@ abstract class AbstractValidator implements ValidatorInterface
      */
     public function getOption(string key, var defaultValue = null) -> var
     {
-        var value, fieldValue;
+        var value;
 
         if !fetch value, this->options[key] {
             return defaultValue;
-        }
-
-        /*
-         * If we have `attribute` as a key, it means it is a Uniqueness
-         * validator, we can have here multiple fields, so we need to check it
-         */
-        if key === "attribute" && typeof value === "array" {
-            if fetch fieldValue, value[key] {
-                return fieldValue;
-            }
         }
 
         return value;
@@ -141,6 +131,25 @@ abstract class AbstractValidator implements ValidatorInterface
     public function hasOption(string key) -> bool
     {
         return isset this->options[key];
+    }
+
+    /**
+     * Checks whether the field can be considered empty and therefore
+     * skipped, honoring the `allowEmpty` option (boolean flag, list of
+     * empty values, or per-field map).
+     *
+     * @param Validation $validation
+     * @param string     $field
+     *
+     * @return bool
+     */
+    public function isAllowEmpty(<Validation> validation, string field) -> bool
+    {
+        var value;
+
+        let value = validation->getValue(field);
+
+        return this->allowEmpty(field, value);
     }
 
     /**

--- a/phalcon/Filter/Validation/Validator/Uniqueness.zep
+++ b/phalcon/Filter/Validation/Validator/Uniqueness.zep
@@ -120,6 +120,37 @@ class Uniqueness extends AbstractCombinedFieldsValidator
     }
 
     /**
+     * Returns an option in the validator's options
+     * Returns null if the option hasn't set
+     *
+     * The `attribute` option can be defined as an array when validating a
+     * combination of fields; in that case resolve it to the mapped value.
+     *
+     * @param string     $key
+     * @param mixed|null $defaultValue
+     *
+     * @return mixed
+     */
+    public function getOption(string key, var defaultValue = null) -> var
+    {
+        var fieldValue, value;
+
+        if !this->hasOption(key) {
+            return defaultValue;
+        }
+
+        let value = parent::getOption(key, defaultValue);
+
+        if key === "attribute" && typeof value === "array" {
+            if fetch fieldValue, value[key] {
+                return fieldValue;
+            }
+        }
+
+        return value;
+    }
+
+    /**
      * Executes the validation
      */
     public function validate(<Validation> validation, var field) -> bool

--- a/tests/unit/Filter/Validation/Validator/GetSetOptionTest.php
+++ b/tests/unit/Filter/Validation/Validator/GetSetOptionTest.php
@@ -102,10 +102,16 @@ final class GetSetOptionTest extends AbstractUnitTestCase
      */
     public function testFilterValidationValidatorGetOptionAttributeNestedArray(): void
     {
-        $validator = new Alnum(['attribute' => ['attribute' => 'fieldName', 'other' => 'value']]);
+        $validator = new Uniqueness(['attribute' => ['attribute' => 'fieldName', 'other' => 'value']]);
 
         $actual = $validator->getOption('attribute');
 
         $this->assertSame('fieldName', $actual);
+
+        $validator = new Alnum(['attribute' => ['attribute' => 'fieldName', 'other' => 'value']]);
+
+        $actual = $validator->getOption('attribute');
+
+        $this->assertSame(['attribute' => 'fieldName', 'other' => 'value'], $actual);
     }
 }


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17124 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Consolidated the `allowEmpty` handling of `Phalcon\Filter\Validation` into the validator: the new public `Phalcon\Filter\Validation\AbstractValidator::isAllowEmpty()` is the single owner of the rule (boolean flag, list of empty values, or per-field map) and `Validation::preChecking()` delegates to it instead of reimplementing it. The per-field `allowEmpty` map (e.g. used by the `Ip` validator) is now also honored during pre-checking.

Moved the resolution of an array `attribute` option from `Phalcon\Filter\Validation\AbstractValidator::getOption()` into `Phalcon\Filter\Validation\Validator\Uniqueness::getOption()` - the only validator that uses it. `getOption()` on every other validator now returns the stored option unchanged.

Added the `Phalcon\Contracts\Filter\Sanitizer` interface, implemented by all `Phalcon\Filter\Sanitize\*` classes. It documents the sanitizer contract: an invokable object receiving the value to sanitize as its first parameter, with sanitizer-specific parameters after it; array recursion is handled by `Phalcon\Filter\Filter::sanitize()` (one level deep by default), not by the sanitizer.

Added `Phalcon\Filter\Filter::getDefaultMapper()`, the single source for the built-in sanitizer name-to-class registry, located next to the `FILTER_*` constants. `Phalcon\Filter\FilterFactory::getServices()` now delegates to it.


Thanks

