### PR TITLE
CP-17151 time optimizations

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -22,6 +22,9 @@
 - Changed the `Phalcon\Auth\Guard\Session` remember-me cookie lifetime to a configurable `Phalcon\Auth\Guard\Config\SessionGuardConfig` value (`rememberTtl`, default `DEFAULT_REMEMBER_TTL`); the default is now 365 days (previously a hardcoded 360). [#17148](https://github.com/phalcon/cphalcon/issues/17148) [[doc]](https://docs.phalcon.io/5.15/auth/)
 - Changed `Phalcon\Auth\Manager::attempt()` and `Phalcon\Auth\Manager::logout()` to throw `Phalcon\Auth\Exceptions\DoesNotImplement` (a subclass of `Phalcon\Auth\Exception`) when the default guard does not implement `GuardStateful`. [#17148](https://github.com/phalcon/cphalcon/issues/17148) [[doc]](https://docs.phalcon.io/5.15/auth/)
 - Changed the `Phalcon\Auth\Guard\Session` `auth:*` events to fire as non-cancellable, matching that their return value was already ignored. [#17148](https://github.com/phalcon/cphalcon/issues/17148) [[doc]](https://docs.phalcon.io/5.15/auth/)
+- Changed `Phalcon\Logger\AbstractLogger` to accept an optional `Phalcon\Time\Clock\ClockInterface` constructor parameter; log item timestamps now come from the clock, defaulting to a `Phalcon\Time\Clock\SystemClock` on the logger timezone (current behavior preserved). [#17151](https://github.com/phalcon/cphalcon/issues/17151) [[doc]](https://docs.phalcon.io/5.15/logger/) [[doc]](https://docs.phalcon.io/5.15/time-clock/)
+- Changed `Phalcon\Encryption\Security\JWT\Validator` to accept an optional `Phalcon\Time\Clock\ClockInterface` constructor parameter for reading the current time; `timeShift` is retained as the legacy clock-skew mechanism. [#17151](https://github.com/phalcon/cphalcon/issues/17151) [[doc]](https://docs.phalcon.io/5.15/encryption-security/) [[doc]](https://docs.phalcon.io/5.15/time-clock/)
+- Changed `Phalcon\Auth\Guard\Session` to accept an optional `Phalcon\Time\Clock\ClockInterface`; the remember-me cookie expiry now reads "now" through the clock, defaulting to `Phalcon\Time\Clock\SystemClock::fromUTC()` (current behavior preserved). [#17151](https://github.com/phalcon/cphalcon/issues/17151) [[doc]](https://docs.phalcon.io/5.15/auth/) [[doc]](https://docs.phalcon.io/5.15/time-clock/)
 
 ### Added
 
@@ -30,6 +33,7 @@
 ### Fixed
 
 - Fixed the `Phalcon\Acl\Adapter\Memory` documentation and metadata. [#17143](https://github.com/phalcon/cphalcon/issues/17143) [[doc]](https://docs.phalcon.io/5.15/acl/)
+- Fixed `Phalcon\Time\Clock\FrozenClock::adjust()` leaving the process-global `warning.enable` flag clobbered on the pre-PHP-8.3 fallback path; the prior value is now restored on both exits. [#17151](https://github.com/phalcon/cphalcon/issues/17151) [[doc]](https://docs.phalcon.io/5.15/time-clock/)
 
 ### Removed
 

--- a/phalcon/Auth/Guard/Session.zep
+++ b/phalcon/Auth/Guard/Session.zep
@@ -13,6 +13,7 @@
 
 namespace Phalcon\Auth\Guard;
 
+use DateTimeImmutable;
 use Phalcon\Auth\Exception;
 use Phalcon\Auth\Exceptions\DoesNotImplement;
 use Phalcon\Auth\Guard\Config\SessionGuardConfig;
@@ -29,6 +30,8 @@ use Phalcon\Http\RequestInterface;
 use Phalcon\Http\Response\CookiesInterface;
 use Phalcon\Session\ManagerInterface as SessionManagerInterface;
 use Phalcon\Support\Helper\Json\Encode;
+use Phalcon\Time\Clock\ClockInterface;
+use Phalcon\Time\Clock\SystemClock;
 
 /**
  * @phpstan-import-type AuthCredentials from Adapter
@@ -37,6 +40,10 @@ use Phalcon\Support\Helper\Json\Encode;
  */
 class Session extends AbstractGuard implements GuardStateful, BasicAuth
 {
+    /**
+     * @var ClockInterface
+     */
+    protected clock;
     /**
      * @var CookiesInterface
      */
@@ -59,7 +66,8 @@ class Session extends AbstractGuard implements GuardStateful, BasicAuth
         <RequestInterface> request,
         <CookiesInterface> cookies,
         <SessionManagerInterface> session,
-        <SessionGuardConfig> config = null
+        <SessionGuardConfig> config = null,
+        <ClockInterface> clock = null
     ) {
         let this->request = request;
         let this->cookies = cookies;
@@ -68,6 +76,12 @@ class Session extends AbstractGuard implements GuardStateful, BasicAuth
         if (config === null) {
             let config = new SessionGuardConfig();
         }
+
+        if (clock === null) {
+            let clock = SystemClock::fromUTC();
+        }
+
+        let this->clock = clock;
 
         parent::__construct(adapter, config);
     }
@@ -411,7 +425,7 @@ class Session extends AbstractGuard implements GuardStateful, BasicAuth
         this->cookies->set(
             this->getRememberName(),
             payload,
-            time() + this->config->getRememberTtl()
+            this->clock->now()->getTimestamp() + this->config->getRememberTtl()
         );
     }
 

--- a/phalcon/Encryption/Security/JWT/Validator.zep
+++ b/phalcon/Encryption/Security/JWT/Validator.zep
@@ -10,11 +10,13 @@
 
 namespace Phalcon\Encryption\Security\JWT;
 
+use DateTimeImmutable;
 use Phalcon\Encryption\Security\JWT\Exceptions\InvalidAudienceType;
 use Phalcon\Encryption\Security\JWT\Exceptions\ValidatorException;
 use Phalcon\Encryption\Security\JWT\Signer\SignerInterface;
 use Phalcon\Encryption\Security\JWT\Token\Enum;
 use Phalcon\Encryption\Security\JWT\Token\Token;
+use Phalcon\Time\Clock\ClockInterface;
 
 /**
  * Class Validator
@@ -44,15 +46,28 @@ class Validator
     /**
      * Validator constructor.
      *
-     * @param Token $token
-     * @param int   $timeShift
+     * @param Token               $token
+     * @param int                 $timeShift Legacy clock-skew offset in seconds
+     *                                       added to validated timestamps.
+     *                                       Prefer injecting a ClockInterface
+     *                                       for testable time; retained for BC.
+     * @param ClockInterface|null $clock     Clock used to read "now" at
+     *                                       construction. Defaults to the
+     *                                       system wall clock (time()).
      */
-    public function __construct(<Token> token, int timeShift = 0)
-    {
+    public function __construct(
+        <Token> token,
+        int timeShift = 0,
+        <ClockInterface> clock = null
+    ) {
         var now;
 
-        let now             = time(),
-            this->token     = token,
+        let now = time();
+        if (null !== clock) {
+            let now = clock->now()->getTimestamp();
+        }
+
+        let this->token     = token,
             this->timeShift = timeShift,
             this->claims    = [
                 Enum::AUDIENCE        : null,

--- a/phalcon/Logger/AbstractLogger.zep
+++ b/phalcon/Logger/AbstractLogger.zep
@@ -16,6 +16,8 @@ use Exception;
 use Phalcon\Logger\Adapter\AdapterInterface;
 use Phalcon\Logger\Exceptions\AdapterNotFound;
 use Phalcon\Logger\Exceptions\NoAdaptersConfigured;
+use Phalcon\Time\Clock\ClockInterface;
+use Phalcon\Time\Clock\SystemClock;
 
 /**
  * Abstract Logger Class
@@ -83,6 +85,13 @@ abstract class AbstractLogger
     protected adapters = [];
 
     /**
+     * Clock used to timestamp log items
+     *
+     * @var ClockInterface
+     */
+    protected clock;
+
+    /**
      * The excluded adapters for this log process
      *
      * @var array
@@ -112,13 +121,17 @@ abstract class AbstractLogger
      * @param string            $name     The name of the logger
      * @param array             $adapters The collection of adapters to be used
      *                                    for logging (default [])
-     * @param DateTimeZone|null $timezone Timezone. If omitted,
-     *                                    date_Default_timezone_get() is used
+     * @param DateTimeZone|null   $timezone Timezone. If omitted,
+     *                                      date_Default_timezone_get() is used
+     * @param ClockInterface|null $clock    Clock used to timestamp log items.
+     *                                      Defaults to a SystemClock on the
+     *                                      resolved timezone.
      */
     public function __construct(
         string name,
         array adapters = [],
-        <DateTimeZone> timezone = null
+        <DateTimeZone> timezone = null,
+        <ClockInterface> clock = null
     ) {
         var defaultTimezone;
 
@@ -134,6 +147,12 @@ abstract class AbstractLogger
 
         let this->name     = name,
             this->timezone = timezone;
+
+        if (null === clock) {
+            let clock = new SystemClock(timezone);
+        }
+
+        let this->clock = clock;
 
         this->setAdapters(adapters);
     }
@@ -308,7 +327,7 @@ abstract class AbstractLogger
                 message,
                 levelName,
                 level,
-                new DateTimeImmutable("now", this->timezone),
+                this->clock->now(),
                 context
             );
 

--- a/phalcon/Time/Clock/Exceptions/InvalidModifier.zep
+++ b/phalcon/Time/Clock/Exceptions/InvalidModifier.zep
@@ -20,8 +20,8 @@ use Throwable;
 
 class InvalidModifier extends Exception
 {
-    public function __construct(string message, <Throwable> ex = null)
+    public function __construct(string modifier, <Throwable> ex = null)
     {
-        parent::__construct("Invalid modifier: \"" . message . "\"", 0, ex);
+        parent::__construct("Invalid modifier: \"" . modifier . "\"", 0, ex);
     }
 }

--- a/phalcon/Time/Clock/FrozenClock.zep
+++ b/phalcon/Time/Clock/FrozenClock.zep
@@ -39,7 +39,7 @@ final class FrozenClock implements ClockInterface
      */
     public function adjust(string modifier) -> <static>
     {
-        var ex, modified;
+        var ex, modified, priorWarning;
         bool failed;
 
         let failed = false;
@@ -51,6 +51,14 @@ final class FrozenClock implements ClockInterface
                 throw new InvalidModifier(modifier, ex);
             }
         } else {
+            /**
+             * Pre-8.3 fallback: DateTimeImmutable::modify() emits a warning
+             * instead of throwing on an invalid modifier, so the warning is
+             * captured through a temporary error handler. Remove this branch
+             * once the minimum supported PHP version reaches 8.3.
+             */
+            let priorWarning = globals_get("warning.enable");
+
             globals_set("warning.enable", false);
             set_error_handler(
                 function (number, message, file, line) {
@@ -64,6 +72,8 @@ final class FrozenClock implements ClockInterface
             restore_error_handler();
 
             let failed = (bool) globals_get("warning.enable");
+
+            globals_set("warning.enable", priorWarning);
         }
 
         if unlikely failed || false === modified {

--- a/tests/unit/Auth/Fake/FakeCookie.php
+++ b/tests/unit/Auth/Fake/FakeCookie.php
@@ -20,6 +20,7 @@ use Phalcon\Http\Cookie\CookieInterface;
 
 final class FakeCookie implements CookieInterface
 {
+    private int $expiration = 0;
     private string $name;
     private mixed $value;
 
@@ -40,7 +41,7 @@ final class FakeCookie implements CookieInterface
 
     public function getExpiration(): int
     {
-        return 0;
+        return $this->expiration;
     }
 
     public function getHttpOnly(): bool
@@ -90,6 +91,8 @@ final class FakeCookie implements CookieInterface
 
     public function setExpiration(int $expire): CookieInterface
     {
+        $this->expiration = $expire;
+
         return $this;
     }
 

--- a/tests/unit/Auth/Fake/FakeCookies.php
+++ b/tests/unit/Auth/Fake/FakeCookies.php
@@ -70,7 +70,10 @@ final class FakeCookies implements CookiesInterface
         bool $httpOnly = false,
         array $options = []
     ): CookiesInterface {
-        $this->store[$name] = new FakeCookie($name, $value);
+        $cookie = new FakeCookie($name, $value);
+        $cookie->setExpiration($expire);
+
+        $this->store[$name] = $cookie;
 
         return $this;
     }

--- a/tests/unit/Auth/Guard/SessionTest.php
+++ b/tests/unit/Auth/Guard/SessionTest.php
@@ -16,17 +16,21 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Auth\Guard;
 
+use DateTimeImmutable;
 use Phalcon\Auth\Adapter\Config\MemoryAdapterConfig;
 use Phalcon\Auth\Adapter\Memory;
 use Phalcon\Auth\Exception;
+use Phalcon\Auth\Guard\Config\SessionGuardConfig;
 use Phalcon\Contracts\Auth\Guard\Guard;
 use Phalcon\Auth\Guard\Session;
 use Phalcon\Encryption\Security;
 use Phalcon\Events\Manager as EventsManager;
 use Phalcon\Tests\AbstractUnitTestCase;
 use Phalcon\Tests\Unit\Auth\Fake\FakeCookies;
+use Phalcon\Tests\Unit\Auth\Fake\FakeRememberAdapter;
 use Phalcon\Tests\Unit\Auth\Fake\FakeRequest;
 use Phalcon\Tests\Unit\Auth\Fake\FakeSessionManager;
+use Phalcon\Time\Clock\FrozenClock;
 
 final class SessionTest extends AbstractUnitTestCase
 {
@@ -446,6 +450,43 @@ final class SessionTest extends AbstractUnitTestCase
         ]);
 
         $this->assertFalse($guard->onceBasic());
+    }
+
+    public function testRememberCookieExpiryUsesInjectedClock(): void
+    {
+        $rememberAdapter = new FakeRememberAdapter(
+            $this->security,
+            new MemoryAdapterConfig(
+                [
+                    [
+                        'id'       => 1,
+                        'email'    => 'alice@example.com',
+                        'password' => $this->security->hash('secret'),
+                    ],
+                ],
+                \Phalcon\Tests\Unit\Auth\Fake\FakeAuthUserModel::class
+            )
+        );
+
+        $clock  = new FrozenClock(new DateTimeImmutable('@1700000000'));
+        $config = new SessionGuardConfig(rememberTtl: 3600);
+
+        $guard = new Session(
+            $rememberAdapter,
+            $this->request,
+            $this->cookies,
+            $this->session,
+            $config,
+            $clock
+        );
+
+        $user = $rememberAdapter->retrieveById(1);
+        $this->assertNotNull($user);
+
+        $guard->login($user, true);
+
+        $cookie = $this->cookies->get($guard->getRememberName());
+        $this->assertSame(1700000000 + 3600, $cookie->getExpiration());
     }
 
     public function testRememberLoginPersistsCookieAndRecallsUser(): void

--- a/tests/unit/Encryption/Security/JWT/Validator/ConstructTest.php
+++ b/tests/unit/Encryption/Security/JWT/Validator/ConstructTest.php
@@ -11,9 +11,12 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Encryption\Security\JWT\Validator;
 
+use DateTimeImmutable;
+use Phalcon\Encryption\Security\JWT\Token\Enum;
 use Phalcon\Encryption\Security\JWT\Validator;
 use Phalcon\Tests\AbstractUnitTestCase;
 use Phalcon\Tests\Unit\Encryption\Fake\JWTTrait;
+use Phalcon\Time\Clock\FrozenClock;
 
 final class ConstructTest extends AbstractUnitTestCase
 {
@@ -53,5 +56,20 @@ final class ConstructTest extends AbstractUnitTestCase
             Validator::class,
             $validator->validateIssuer("Phalcon JWT")
         );
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-14
+     */
+    public function testEncryptionSecurityJWTValidatorConstructWithClock(): void
+    {
+        $token     = $this->newToken();
+        $clock     = new FrozenClock(new DateTimeImmutable('@1700000000'));
+        $validator = new Validator($token, 0, $clock);
+
+        $this->assertSame(1700000000, $validator->get(Enum::EXPIRATION_TIME));
+        $this->assertSame(1700000000, $validator->get(Enum::ISSUED_AT));
+        $this->assertSame(1700000000, $validator->get(Enum::NOT_BEFORE));
     }
 }

--- a/tests/unit/Logger/Logger/LogTest.php
+++ b/tests/unit/Logger/Logger/LogTest.php
@@ -13,11 +13,14 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Logger\Logger;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Phalcon\Logger\Adapter\Stream;
 use Phalcon\Logger\Enum;
 use Phalcon\Logger\Formatter\Line;
 use Phalcon\Logger\Logger;
 use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Time\Clock\FrozenClock;
 use Psr\Log\LogLevel;
 
 use function file_get_contents;
@@ -195,6 +198,42 @@ final class LogTest extends AbstractUnitTestCase
             );
             $this->assertStringNotContainsString($expected, $contents);
         }
+
+        $adapter->close();
+        $this->safeDeleteFile($outputPath);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-14
+     */
+    public function testLoggerUsesInjectedClockForTimestamp(): void
+    {
+        $fileName   = $this->getNewFileName('log', 'log');
+        $outputPath = logsDir($fileName);
+        $adapter    = new Stream($outputPath);
+        $adapter->setFormatter(new Line('[%date%] %message%', 'Y-m-d H:i:s'));
+
+        $clock = new FrozenClock(
+            new DateTimeImmutable('2026-01-02 03:04:05', new DateTimeZone('UTC'))
+        );
+
+        $logger = new Logger(
+            'my-logger',
+            [
+                'one' => $adapter,
+            ],
+            new DateTimeZone('UTC'),
+            $clock
+        );
+
+        $logger->info('clock test');
+
+        $contents = file_get_contents($outputPath);
+        $this->assertStringContainsString(
+            '[2026-01-02 03:04:05] clock test',
+            $contents
+        );
 
         $adapter->close();
         $this->safeDeleteFile($outputPath);


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17151 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Logger\AbstractLogger` to accept an optional `Phalcon\Time\Clock\ClockInterface` constructor parameter; log item timestamps now come from the clock, defaulting to a `Phalcon\Time\Clock\SystemClock` on the logger timezone.

Changed `Phalcon\Encryption\Security\JWT\Validator` to accept an optional `Phalcon\Time\Clock\ClockInterface` constructor parameter for reading the current time; `timeShift` is retained as the legacy clock-skew mechanism.

Changed `Phalcon\Auth\Guard\Session` to accept an optional `Phalcon\Time\Clock\ClockInterface`; the remember-me cookie expiry now reads "now" through the clock, defaulting to `Phalcon\Time\Clock\SystemClock::fromUTC()` (current behavior preserved).

Thanks

