### PR TITLE
CP-17173 bug error when validating form with entity

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -43,6 +43,7 @@
 - Fixed the `loader:pathFound` event in `Phalcon\Autoload\Loader` firing more than once per load (and, for the class-map strategy, before the file was confirmed); it now fires once, from the point that loads the file. [#17149](https://github.com/phalcon/cphalcon/issues/17149) [[doc]](https://docs.phalcon.io/5.15/autoload/)
 - Fixed the `Phalcon\Autoload\Loader` debug trail (`getDebug()`) being wiped by nested autoloads (a class requiring a not-yet-loaded parent); the trail is now reset only on the outermost call. [#17149](https://github.com/phalcon/cphalcon/issues/17149) [[doc]](https://docs.phalcon.io/5.15/autoload/)
 - Fixed `Phalcon\Time\Clock\FrozenClock::adjust()` leaving the process-global `warning.enable` flag clobbered on the pre-PHP-8.3 fallback path; the prior value is now restored on both exits. [#17151](https://github.com/phalcon/cphalcon/issues/17151) [[doc]](https://docs.phalcon.io/5.15/time-clock/)
+- Fixed `Phalcon\Filter\Validation::bind()` emitting an `Invalid arguments supplied for camelize()` warning when the data being validated against an entity contained a numeric (integer) key, as happened with `Phalcon\Forms\Form::isValid($data, $entity)`; integer keys are now skipped during entity binding. [#17173](https://github.com/phalcon/cphalcon/issues/17173) [[doc]](https://docs.phalcon.io/5.15/filter-validation/)
 
 ### Removed
 

--- a/phalcon/Filter/Validation.zep
+++ b/phalcon/Filter/Validation.zep
@@ -204,6 +204,15 @@ class Validation extends Injectable implements ValidationInterface
 
         for field, value in data {
             /**
+             * Skip numeric (integer) keys; entity setters and properties are
+             * always string-named, so camelize() would fail on them. See
+             * cphalcon issue #17173.
+             */
+            if typeof field != "string" {
+                continue;
+            }
+
+            /**
              * Check if the field is in the whitelist
              */
             if !empty whitelist && !in_array(field, whitelist) {

--- a/tests/unit/Forms/Form/IsValidTest.php
+++ b/tests/unit/Forms/Form/IsValidTest.php
@@ -192,6 +192,52 @@ final class IsValidTest extends AbstractUnitTestCase
     }
 
     /**
+     * Tests that isValid() with an entity and submitted data containing a
+     * numeric (integer) key does not emit a camelize() warning, validates
+     * normally and ignores the numeric key when binding to the entity.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17173
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-15
+     */
+    public function testFormsFormIsValidWithEntityAndNumericDataKey(): void
+    {
+        $form = new Form();
+        $name = new Text('name');
+        $name->addValidator(
+            new PresenceOf(['message' => 'The name is required'])
+        );
+        $form->add($name);
+
+        $input = [
+            0      => 'hacked',
+            'name' => 'John',
+        ];
+        $entity = new stdClass();
+
+        $warnings = [];
+        set_error_handler(
+            static function (int $number, string $message) use (&$warnings): bool {
+                $warnings[] = $message;
+
+                return true;
+            },
+            E_WARNING | E_USER_WARNING
+        );
+
+        try {
+            $result = $form->isValid($input, $entity);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $warnings);
+        $this->assertTrue($result);
+        $this->assertObjectNotHasProperty('0', $entity);
+        $this->assertEquals('John', $entity->name);
+    }
+
+    /**
      * @issue  https://github.com/phalcon/cphalcon/issues/13149
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17173 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Filter\Validation::bind()` emitting an `Invalid arguments supplied for camelize()` warning when the data being validated against an entity contained a numeric (integer) key, as happened with `Phalcon\Forms\Form::isValid($data, $entity)`; integer keys are now skipped during entity binding.

Thanks

