### PR TITLE
CP-17167 session optimizations

### DIFF
--- a/phalcon/Storage/Adapter/AbstractAdapter.zep
+++ b/phalcon/Storage/Adapter/AbstractAdapter.zep
@@ -17,6 +17,7 @@ use Phalcon\Events\ManagerInterface;
 use Phalcon\Storage\Serializer\SerializerInterface;
 use Phalcon\Storage\SerializerFactory;
 use Phalcon\Support\Exception as SupportException;
+use Phalcon\Support\Helper\Arr\Get;
 
 /**
  * Class AbstractAdapter
@@ -403,7 +404,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     {
         var content;
 
-        if true !== this->has(key) {
+        if true !== this->doHas(key) {
             return defaultValue;
         }
 
@@ -587,7 +588,10 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
         if (null !== this->serializer) {
             this->serializer->unserialize(content);
 
-            if unlikely true !== this->serializer->isSuccess() {
+            if (
+                true === method_exists(this->serializer, "isSuccess") &&
+                true !== this->serializer->isSuccess()
+            ) {
                 return defaultValue;
             }
 
@@ -616,7 +620,10 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     }
 
     /**
-     * @todo Remove this when we get traits
+     * Reads an element from an array, optionally casting it. Delegates to the
+     * canonical Support\Helper\Arr\Get helper.
+     *
+     * @todo Remove this wrapper when we get traits
      */
     protected function getArrVal(
         array! collection,
@@ -624,17 +631,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
         var defaultValue = null,
         string! cast = null
     ) -> var {
-        var value;
-
-        if unlikely !fetch value, collection[index] {
-            return defaultValue;
-        }
-
-        if unlikely cast {
-            settype(value, cast);
-        }
-
-        return value;
+        return (new Get())->__invoke(collection, index, defaultValue, cast);
     }
 
     /**

--- a/phalcon/Storage/Adapter/Apcu.zep
+++ b/phalcon/Storage/Adapter/Apcu.zep
@@ -18,6 +18,11 @@ use Phalcon\Support\Exception as SupportException;
 /**
  * Apcu adapter
  *
+ * Capabilities:
+ * - Counters: native atomic (apcu_inc()/apcu_dec()).
+ * - getKeys(): APCUIterator regex scan over the shared APCu store.
+ * - Serializers: Phalcon-side only; no backend-native serializer.
+ *
  * @property array $options
  */
 class Apcu extends AbstractAdapter

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -19,6 +19,12 @@ use Phalcon\Support\Exception as SupportException;
 
 /**
  * Libmemcached adapter
+ *
+ * Capabilities:
+ * - Counters: native atomic (Memcached::increment()/decrement()).
+ * - getKeys(): Memcached::getAllKeys(), which is server-dependent and may be
+ *   incomplete or unavailable on modern memcached builds.
+ * - Serializers: Phalcon-side plus libmemcached's own options.
  */
 class Libmemcached extends AbstractAdapter
 {

--- a/phalcon/Storage/Adapter/Memory.zep
+++ b/phalcon/Storage/Adapter/Memory.zep
@@ -19,6 +19,13 @@ use Phalcon\Support\Exception as SupportException;
  *
  * @property array $data
  * @property array $options
+ *
+ * Capabilities:
+ * - Scope: per-request, in-process; nothing is shared across requests or
+ *   processes and the store is discarded when the request ends.
+ * - Counters: read-modify-write on the in-memory array.
+ * - getKeys(): in-memory array scan (cheap).
+ * - Optional maxItems FIFO cap drops the oldest entry before a new key is set.
  */
 class Memory extends AbstractAdapter
 {

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -21,6 +21,13 @@ use Phalcon\Support\Exception as SupportException;
 /**
  * Redis adapter
  *
+ * Capabilities:
+ * - Counters: native atomic (incrBy()/decrBy()).
+ * - getKeys(): non-blocking SCAN iteration.
+ * - Serializers: Phalcon-side, or backend-native via OPT_SERIALIZER. Native
+ *   serializers change the bytes at rest and are not interchangeable with
+ *   Phalcon-side serializers.
+ *
  * @property array $options
  */
 class Redis extends AbstractAdapter
@@ -141,10 +148,31 @@ class Redis extends AbstractAdapter
      */
     public function getKeys(string! prefix = "") -> array
     {
-        return this->getFilteredKeys(
-            this->getAdapter()->keys("*"),
-            prefix
-        );
+        var adapter, iterator, keys, scanKeys;
+
+        let adapter  = this->getAdapter(),
+            keys     = [],
+            iterator = null;
+
+        /**
+         * SCAN replaces the blocking KEYS command. SCAN_NOPREFIX keeps the
+         * prefix handling explicit: the full physical prefix is matched and
+         * returned unchanged, so getFilteredKeys() sees exactly what KEYS
+         * produced.
+         */
+        adapter->setOption(\Redis::OPT_SCAN, \Redis::SCAN_NOPREFIX);
+
+        loop {
+            let scanKeys = adapter->scan(iterator, this->prefix . "*");
+
+            if (false === scanKeys) {
+                break;
+            }
+
+            let keys = array_merge(keys, scanKeys);
+        }
+
+        return this->getFilteredKeys(keys, prefix);
     }
 
     /**

--- a/phalcon/Storage/Adapter/RedisCluster.zep
+++ b/phalcon/Storage/Adapter/RedisCluster.zep
@@ -16,6 +16,12 @@ use Phalcon\Storage\SerializerFactory;
 /**
  * RedisCluster adapter
  *
+ * Capabilities (in addition to Redis):
+ * - Counters: native atomic (incrBy()/decrBy()).
+ * - getKeys(): blocking KEYS across all master nodes (per-node SCAN is left to
+ *   the redesign); clear() flushes every master.
+ * - Serializers: Phalcon-side, or backend-native via OPT_SERIALIZER.
+ *
  * @property array $options
  */
 class RedisCluster extends Redis
@@ -137,6 +143,25 @@ class RedisCluster extends Redis
         }
 
         return this->adapter;
+    }
+
+    /**
+     * Returns all the keys stored
+     *
+     * RedisCluster::scan() iterates one node at a time, so the blocking KEYS
+     * command is retained here (phpredis routes it across the masters). The
+     * per-node SCAN migration is left to the storage redesign.
+     *
+     * @param string $prefix
+     *
+     * @return array
+     */
+    public function getKeys(string! prefix = "") -> array
+    {
+        return this->getFilteredKeys(
+            this->getAdapter()->keys("*"),
+            prefix
+        );
     }
 
     /**

--- a/phalcon/Storage/Adapter/Stream.zep
+++ b/phalcon/Storage/Adapter/Stream.zep
@@ -21,6 +21,12 @@ use RecursiveIteratorIterator;
 /**
  * Stream adapter
  *
+ * Capabilities:
+ * - Counters: read-modify-write (doHas()/doGet()/doSet()); not atomic and racy
+ *   across concurrent processes.
+ * - getKeys(): recursive directory traversal; cost grows with the entry count.
+ * - Serializers: Phalcon-side only.
+ *
  * @property string $storageDir
  * @property array  $options
  */
@@ -158,14 +164,14 @@ class Stream extends AbstractAdapter
     {
         var data, result;
 
-        if unlikely true !== this->has(key) {
+        if unlikely true !== this->doHas(key) {
             return false;
         }
 
-        let data = this->get(key),
+        let data = this->doGet(key),
             data = (int) data - value;
 
-        let result = this->set(key, data);
+        let result = this->doSet(key, data);
         if likely result !== false {
             let result = data;
         }
@@ -184,7 +190,7 @@ class Stream extends AbstractAdapter
     {
         var filepath;
 
-        if true !== this->has(key) {
+        if true !== this->doHas(key) {
             return false;
         }
 
@@ -260,14 +266,14 @@ class Stream extends AbstractAdapter
     {
         var data, result;
 
-        if unlikely true !== this->has(key) {
+        if unlikely true !== this->doHas(key) {
             return false;
         }
 
-        let data = this->get(key),
+        let data = this->doGet(key),
             data = (int) data + value;
 
-        let result = this->set(key, data);
+        let result = this->doSet(key, data);
         if likely result !== false {
             let result = data;
         }

--- a/phalcon/Storage/Adapter/Weak.zep
+++ b/phalcon/Storage/Adapter/Weak.zep
@@ -18,6 +18,13 @@ use Phalcon\Storage\Serializer\SerializerInterface;
 
 /**
 * Weak Adapter
+*
+* Capabilities:
+* - Stores objects only, as WeakReferences; entries vanish when the referenced
+*   object is garbage-collected.
+* - TTL is ignored; no serializer is used (none/no-op).
+* - Counters unsupported: increment()/decrement() return false.
+* - setForever() is equivalent to set(); getKeys() reads the in-memory list.
 */
 class Weak extends AbstractAdapter
 {


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17167 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Session\Adapter\Redis::read()` to short-circuit a re-entrant read when this instance already holds the lock for the same session id, returning the held lock instead of spinning against its own lock for the full retry budget before throwing `Phalcon\Session\Adapter\Exceptions\AdapterRuntimeError` (the `session_reset()` re-read path). Only the self-deadlock scenario changes.

Changed `Phalcon\Session\Manager::setId()` to validate the supplied id against the PHP session-id alphabet (`[a-zA-Z0-9,-]`), throwing the new `Phalcon\Session\Exceptions\InvalidSessionId`, matching the cookie validation already performed in `start()` instead of passing an invalid id straight to `session_id()`. 

Changed `Phalcon\Session\Manager::setName()` to reject a digits-only name with `Phalcon\Session\Exceptions\InvalidSessionName`, instead of letting PHP emit a `session_name()` warning and silently leave the name unchanged. 


Thanks

