### PR TITLE
CP-17210 select sanitization

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -31,6 +31,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Support\Debug` ignoring the `request` entry of `setBlacklist()`: `$_REQUEST` is now filtered against the `request` blacklist, where previously both superglobals were filtered against the `server` blacklist only. [#17202](https://github.com/phalcon/cphalcon/issues/17202) [[doc]](https://docs.phalcon.io/5.15/support-debug/)
+- Fixed `Phalcon\Tag\Select::selectField()` to invoke the resultset `using` render callback only when it is a `Closure` (previously any object), keeping the dynamically invoked callable out of reach of user-controlled data. [#17210](https://github.com/phalcon/cphalcon/issues/17210)
 
 ### Removed
 

--- a/phalcon/Tag/Select.zep
+++ b/phalcon/Tag/Select.zep
@@ -274,9 +274,13 @@ abstract class Select
             } else {
 
                 /**
-                 * Check if using is a closure
+                 * Render through the developer-supplied closure. Restricting
+                 * this to Closure (rather than any object) keeps the invoked
+                 * callable out of reach of user-controlled data: a closure is
+                 * defined in application code and can never be a name built
+                 * from request input.
                  */
-                if typeof using == "object" {
+                if using instanceof \Closure {
                     if params === null {
                         let params = [];
                     }

--- a/tests/unit/Tag/SelectResultsetUsingClosureTest.php
+++ b/tests/unit/Tag/SelectResultsetUsingClosureTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Tag;
+
+use Phalcon\Di\Di;
+use Phalcon\Html\Escaper;
+use Phalcon\Tag;
+use Phalcon\Tag\Select;
+use Phalcon\Tests\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Html\Helper\Input\Select\Fake\FakeResultset;
+use ReflectionProperty;
+
+/**
+ * Covers the resultset + Closure `using` branch of Tag\Select::selectField
+ * (the `call_user_func_array` path), which renders each option through a
+ * developer-supplied closure.
+ */
+final class SelectResultsetUsingClosureTest extends AbstractUnitTestCase
+{
+    public function setUp(): void
+    {
+        $container = new Di();
+        $container->setShared('escaper', new Escaper());
+
+        Tag::setDI($container);
+        Tag::setAutoescape(false);
+    }
+
+    public function tearDown(): void
+    {
+        Tag::setAutoescape(true);
+
+        (new ReflectionProperty(Tag::class, 'container'))->setValue(null, null);
+    }
+
+    public function testRendersOptionsFromResultsetUsingClosure(): void
+    {
+        $resultset = new FakeResultset(
+            [
+                ['id' => 1, 'name' => 'One'],
+                ['id' => 2, 'name' => 'Two'],
+            ]
+        );
+
+        $html = Select::selectField(
+            [
+                'choices',
+                $resultset,
+                'value' => '',
+                'using' => static function (array $row): string {
+                    return '<option value="' . $row['id'] . '">'
+                        . $row['name'] . '</option>';
+                },
+            ]
+        );
+
+        $this->assertStringContainsString('<select', $html);
+        $this->assertStringContainsString('id="choices"', $html);
+        $this->assertStringContainsString('<option value="1">One</option>', $html);
+        $this->assertStringContainsString('<option value="2">Two</option>', $html);
+        $this->assertStringContainsString('</select>', $html);
+    }
+}


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17210 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Tag\Select::selectField()` to invoke the resultset `using` render callback only when it is a `Closure` (previously any object), keeping the dynamically invoked callable out of reach of user-controlled data. 


Thanks

