### PR TITLE
fix: setting null on relationship returning error

### DIFF
--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -621,6 +621,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 unset this->dirtyRelated[lowerProperty];
 
                 let this->{property} = null;
+
+                return null;
             }
         }
 


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: https://github.com/phalcon/cphalcon/pull/16959

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [ ] I wrote some tests for this PR
- [ ] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Small description of change:

We are using an update version of this https://github.com/stibiumz/phalcon.eager-loading/blob/master/src/EagerLoading/EagerLoad.php#L154-L159

I believe with your PR we can now remove the `->{$alias} = null` stuff but this lead to us finding the issue in the PR, with all the other relationship in the __set we return early. but for null we don't causing it to fall through and hit https://github.com/phalcon/cphalcon/blob/b9e8cc906fe64667013fcc8aa26e154c48fa2947/phalcon/Mvc/Model.zep#L640-L641

This is just a way to test this

```
$domain = Domain::findFirst();
$account = Account::findFirst();

$domain->account = $account;
$domain->account = null;
$domain->account = $account;
```

It will error on `$domain->account = null;` with `Cannot access property 'account' (not public)`
Thanks

