### PR TITLE
CP-17224 model messages

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,7 +5,7 @@
 ### Tools
 
 - Zephir Parser v2.0.4
-- Zephir 0.23.0 (development - f87b27ba9)
+- Zephir 0.23.0 (development - 062ed64e2)
  
 ### Changed
 
@@ -25,6 +25,7 @@
 ### Fixed
 
 - Fixed `Phalcon\Auth` login timing leaking account existence: the credential adapters now perform a throwaway password hash on the user-not-found path, so an attempt for an unknown identifier costs the same as one for a real account with a wrong password (mitigates login-timing user enumeration). [#17220](https://github.com/phalcon/cphalcon/issues/17220) [[doc]](https://docs.phalcon.io/5.16/auth/)
+- Fixed `Phalcon\Mvc\Model::create()` and `Phalcon\Mvc\Model::update()` passing `null` to the `field` argument of `Phalcon\Messages\Message` (typed `string` since v5.14), which raised a `Passing null to parameter #2 ($field) of type string is deprecated` warning when calling `create()` on an existing record or `update()` on a non-existent one; they now pass an empty string. [#17224](https://github.com/phalcon/cphalcon/issues/17224) [[doc]](https://docs.phalcon.io/5.16/db-models/)
 
 ### Removed
 

--- a/composer.lock
+++ b/composer.lock
@@ -2407,12 +2407,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zephir-lang/zephir.git",
-                "reference": "f87b27ba94eebb4126ce8fb0617526be6acd3f87"
+                "reference": "062ed64e2193be07d6830b9095d0b4bacb737908"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/f87b27ba94eebb4126ce8fb0617526be6acd3f87",
-                "reference": "f87b27ba94eebb4126ce8fb0617526be6acd3f87",
+                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/062ed64e2193be07d6830b9095d0b4bacb737908",
+                "reference": "062ed64e2193be07d6830b9095d0b4bacb737908",
                 "shasum": ""
             },
             "require": {
@@ -2486,7 +2486,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-18T23:56:18+00:00"
+            "time": "2026-06-23T23:29:49+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/ext/phalcon/mvc/model.zep.c
+++ b/ext/phalcon/mvc/model.zep.c
@@ -2719,7 +2719,8 @@ PHP_METHOD(Phalcon_Mvc_Model, create)
 		zephir_array_update_string(&_4$$3, SL("model"), &_5$$3, PH_COPY | PH_SEPARATE);
 		ZEPHIR_INIT_NVAR(&_5$$3);
 		ZVAL_STRING(&_5$$3, "Record cannot be created because it already exists");
-		ZVAL_NULL(&_6$$3);
+		ZEPHIR_INIT_VAR(&_6$$3);
+		ZVAL_STRING(&_6$$3, "");
 		ZEPHIR_INIT_VAR(&_7$$3);
 		ZVAL_STRING(&_7$$3, "InvalidCreateAttempt");
 		ZVAL_LONG(&_8$$3, 0);
@@ -6741,7 +6742,8 @@ PHP_METHOD(Phalcon_Mvc_Model, update)
 			zephir_array_update_string(&_5$$4, SL("model"), &_6$$4, PH_COPY | PH_SEPARATE);
 			ZEPHIR_INIT_NVAR(&_6$$4);
 			ZVAL_STRING(&_6$$4, "Record cannot be updated because it does not exist");
-			ZVAL_NULL(&_7$$4);
+			ZEPHIR_INIT_VAR(&_7$$4);
+			ZVAL_STRING(&_7$$4, "");
 			ZEPHIR_INIT_VAR(&_8$$4);
 			ZVAL_STRING(&_8$$4, "InvalidUpdateAttempt");
 			ZVAL_LONG(&_9$$4, 0);

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1460,7 +1460,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let this->errorMessages = [
                 new Message(
                     "Record cannot be created because it already exists",
-                    null,
+                    "",
                     "InvalidCreateAttempt",
                     0,
                     [
@@ -3686,7 +3686,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
                 let this->errorMessages = [
                     new Message(
                         "Record cannot be updated because it does not exist",
-                        null,
+                        "",
                         "InvalidUpdateAttempt",
                         0,
                         [

--- a/tests/database/Mvc/Model/CreateTest.php
+++ b/tests/database/Mvc/Model/CreateTest.php
@@ -60,6 +60,56 @@ final class CreateTest extends AbstractDatabaseTestCase
     }
 
     /**
+     * Calling create() on a record that already exists must return false with
+     * an `InvalidCreateAttempt` message and must not raise a deprecation
+     * warning when constructing the message.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17224
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-25
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testMvcModelCreateAlreadyExists(): void
+    {
+        $date                     = date('Y-m-d H:i:s');
+        $invoice                  = new Invoices();
+        $invoice->inv_cst_id      = 2;
+        $invoice->inv_status_flag = 3;
+        $invoice->inv_title       = uniqid('inv-');
+        $invoice->inv_total       = 100.12;
+        $invoice->inv_created_at  = $date;
+
+        $this->assertNotFalse($invoice->create());
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+
+                return true;
+            },
+            E_DEPRECATED
+        );
+
+        $result = $invoice->create();
+
+        restore_error_handler();
+
+        $this->assertFalse($result);
+        $this->assertEmpty($deprecations);
+
+        $messages = $invoice->getMessages();
+        $this->assertCount(1, $messages);
+
+        $expected = 'Record cannot be created because it already exists';
+        $this->assertSame($expected, $messages[0]->getMessage());
+        $this->assertSame('', $messages[0]->getField());
+        $this->assertSame('InvalidCreateAttempt', $messages[0]->getType());
+    }
+
+    /**
      * Inserting with an explicit primary key on PostgreSQL must not throw a
      * "currval of sequence not yet defined in this session" error.
      *

--- a/tests/database/Mvc/Model/UpdateTest.php
+++ b/tests/database/Mvc/Model/UpdateTest.php
@@ -208,6 +208,49 @@ final class UpdateTest extends AbstractDatabaseTestCase
         );
     }
 
+    /**
+     * Calling update() on a record that does not exist must return false with
+     * an `InvalidUpdateAttempt` message and must not raise a deprecation
+     * warning when constructing the message.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17224
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-25
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testMvcModelUpdateDoesNotExist(): void
+    {
+        $invoice            = new Invoices();
+        $invoice->inv_title = uniqid('inv-');
+
+        $deprecations = [];
+        set_error_handler(
+            static function (int $errno, string $errstr) use (&$deprecations): bool {
+                $deprecations[] = $errstr;
+
+                return true;
+            },
+            E_DEPRECATED
+        );
+
+        $result = $invoice->update();
+
+        restore_error_handler();
+
+        $this->assertFalse($result);
+        $this->assertEmpty($deprecations);
+
+        $messages = $invoice->getMessages();
+        $this->assertCount(1, $messages);
+
+        $expected = 'Record cannot be updated because it does not exist';
+        $this->assertSame($expected, $messages[0]->getMessage());
+        $this->assertSame('', $messages[0]->getField());
+        $this->assertSame('InvalidUpdateAttempt', $messages[0]->getType());
+    }
+
     private function setColumn1(ModelInterface $model, string $value): void
     {
         $model->setColumn1($value);


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17224 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::create()` and `Phalcon\Mvc\Model::update()` passing `null` to the `field` argument of `Phalcon\Messages\Message` (typed `string` since v5.14), which raised a `Passing null to parameter #2 ($field) of type string is deprecated` warning when calling `create()` on an existing record or `update()` on a non-existent one; they now pass an empty string. 

Thanks

