### PR TITLE
CP-17232 form fields

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,7 +5,7 @@
 ### Tools
 
 - Zephir Parser v2.0.4
-- Zephir 0.23.0 (development - 062ed64e2)
+- Zephir 1.0.0 (4db98ee31)
  
 ### Changed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -5,7 +5,7 @@
 ### Tools
 
 - Zephir Parser v2.0.4
-- Zephir 1.0.0 (4db98ee31)
+- Zephir 1.0.0 (ec525b881)
  
 ### Changed
 
@@ -29,6 +29,7 @@
 - Fixed `Phalcon\Mvc\Model::create()` and `Phalcon\Mvc\Model::update()` passing `null` to the `field` argument of `Phalcon\Messages\Message` (typed `string` since v5.14), which raised a `Passing null to parameter #2 ($field) of type string is deprecated` warning when calling `create()` on an existing record or `update()` on a non-existent one; they now pass an empty string. [#17224](https://github.com/phalcon/cphalcon/issues/17224) [[doc]](https://docs.phalcon.io/5.16/db-models/)
 - Fixed `Phalcon\Image\Adapter\AbstractAdapter::resize()` truncating the scaled master-mode (`Enum::WIDTH`, `Enum::HEIGHT`, `Enum::PRECISE`) dimension to an `int` before rounding, so a value whose fractional part was `>= 0.5` came out one pixel short (e.g. a `1820x694` source resized to height `80` produced width `209` instead of `210`); the scaled width/height are now rounded before the integer cast. [#17225](https://github.com/phalcon/cphalcon/issues/17225) [[doc]](https://docs.phalcon.io/5.16/image/)
 - Fixed `Phalcon\Db\Dialect::getSqlExpression()` throwing `The argument is not initialized or iterable()` while resolving a `case` expression when the expression array is held as a PHP reference, by fetching the `when-clauses` list through `array_values()` before iterating it. [#17225](https://github.com/phalcon/cphalcon/issues/17225) [[doc]](https://docs.phalcon.io/5.16/db-layer/)
+- Fixed `Phalcon\Forms\Element\AbstractElement::render()` to cast a non-`null` element value to `string` before passing it to the input helper, so a numeric default set via `setDefault()` (e.g. `setDefault(10)` or `setDefault(10.5)` on a `Phalcon\Forms\Element\Numeric`) renders as `value="10"` instead of raising a `TypeError` for passing an `int`/`float` to the helper's `string` `$value` parameter. [#17232](https://github.com/phalcon/cphalcon/issues/17232) [[doc]](https://docs.phalcon.io/5.16/forms/)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Steps:
 ### General
 * [Contributing to Phalcon](CONTRIBUTING.md)
 * [Official Documentation](https://docs.phalcon.io/)
-* [Zephir](https://zephir-lang.com/) — the language Phalcon is written in
-* [Incubator](https://phalcon.io/incubator) — community-driven plugins and classes that extend the framework (written in PHP)
+* [Zephir](https://zephir-lang.com/) - the language Phalcon is written in
+* [Incubator](https://phalcon.io/incubator) - community-driven plugins and classes that extend the framework (written in PHP)
 
 ### Support
 * [Discussions](https://phalcon.io/discussions)

--- a/bin/generate-api-docs.php
+++ b/bin/generate-api-docs.php
@@ -415,7 +415,7 @@ function emitTree(array $class, array $registry): string
     }
 
     if ([] !== $annotations) {
-        $current .= ' — ' . implode('; ', $annotations);
+        $current .= ' - ' . implode('; ', $annotations);
     }
 
     $lines[] = $current;

--- a/composer.lock
+++ b/composer.lock
@@ -465,16 +465,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.4",
+            "version": "v1.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "a044733e080940d1483f56caff0c412ad6982776"
+                "reference": "92f121dde31cd1d89d5d0f9eba64ac40271b236e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/a044733e080940d1483f56caff0c412ad6982776",
-                "reference": "a044733e080940d1483f56caff0c412ad6982776",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/92f121dde31cd1d89d5d0f9eba64ac40271b236e",
+                "reference": "92f121dde31cd1d89d5d0f9eba64ac40271b236e",
                 "shasum": ""
             },
             "require": {
@@ -520,7 +520,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.4"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.5"
             },
             "funding": [
                 {
@@ -528,7 +528,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-06T05:37:57+00:00"
+            "time": "2026-06-27T14:17:20+00:00"
         },
         {
             "name": "amphp/process",
@@ -2407,12 +2407,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zephir-lang/zephir.git",
-                "reference": "1c9f6026220c9c46836209128ec815f55a7a7e62"
+                "reference": "4db98ee311e0783d07759bc55a6b502934c1322b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/1c9f6026220c9c46836209128ec815f55a7a7e62",
-                "reference": "1c9f6026220c9c46836209128ec815f55a7a7e62",
+                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/4db98ee311e0783d07759bc55a6b502934c1322b",
+                "reference": "4db98ee311e0783d07759bc55a6b502934c1322b",
                 "shasum": ""
             },
             "require": {
@@ -2488,7 +2488,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-24T22:34:53+00:00"
+            "time": "2026-06-26T23:09:08+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5424,16 +5424,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.41",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d21b17ed158e79180fac3895ff751707970eeb57"
+                "reference": "9ef84af84a7b66396da483634227650506428639"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d21b17ed158e79180fac3895ff751707970eeb57",
-                "reference": "d21b17ed158e79180fac3895ff751707970eeb57",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9ef84af84a7b66396da483634227650506428639",
+                "reference": "9ef84af84a7b66396da483634227650506428639",
                 "shasum": ""
             },
             "require": {
@@ -5498,7 +5498,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.41"
+                "source": "https://github.com/symfony/console/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -5518,7 +5518,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T08:48:41+00:00"
+            "time": "2026-06-15T05:35:29+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -5827,16 +5827,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v6.4.34",
+            "version": "v6.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896"
+                "reference": "0b73dac42493acbadbba644207a715b254e9b029"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/9590e86be1d1c57bfbb16d0dd040345378c20896",
-                "reference": "9590e86be1d1c57bfbb16d0dd040345378c20896",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/0b73dac42493acbadbba644207a715b254e9b029",
+                "reference": "0b73dac42493acbadbba644207a715b254e9b029",
                 "shasum": ""
             },
             "require": {
@@ -5871,7 +5871,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v6.4.34"
+                "source": "https://github.com/symfony/finder/tree/v6.4.42"
             },
             "funding": [
                 {
@@ -5891,7 +5891,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-28T15:16:37+00:00"
+            "time": "2026-06-26T15:18:24+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/composer.lock
+++ b/composer.lock
@@ -2407,12 +2407,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zephir-lang/zephir.git",
-                "reference": "4db98ee311e0783d07759bc55a6b502934c1322b"
+                "reference": "ec525b88196130ffd615fca7c25e352a595ba4cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/4db98ee311e0783d07759bc55a6b502934c1322b",
-                "reference": "4db98ee311e0783d07759bc55a6b502934c1322b",
+                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/ec525b88196130ffd615fca7c25e352a595ba4cb",
+                "reference": "ec525b88196130ffd615fca7c25e352a595ba4cb",
                 "shasum": ""
             },
             "require": {
@@ -2488,7 +2488,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-06-26T23:09:08+00:00"
+            "time": "2026-06-27T19:27:37+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -5522,16 +5522,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
-                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -5569,7 +5569,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5589,7 +5589,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:52:40+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -5677,16 +5677,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
-                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -5733,7 +5733,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5753,7 +5753,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -6610,16 +6610,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
-                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -6673,7 +6673,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6693,7 +6693,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-28T09:44:51+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/ext/phalcon/annotations/annotation.zep.c
+++ b/ext/phalcon/annotations/annotation.zep.c
@@ -16,9 +16,8 @@
 #include "kernel/memory.h"
 #include "kernel/object.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/operators.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -88,7 +87,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &reflectionData_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&reflectionData, reflectionData_param);
+	zephir_get_arrval(&reflectionData, reflectionData_param);
 	zephir_memory_observe(&name);
 	if (zephir_array_isset_string_fetch(&name, &reflectionData, SL("name"), 0)) {
 		zephir_array_fetch_string(&_0$$3, &reflectionData, SL("name"), PH_NOISY | PH_READONLY, "phalcon/Annotations/Annotation.zep", 50);
@@ -225,7 +224,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, getExpression)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &expr_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	zephir_memory_observe(&type);
 	zephir_array_fetch_string(&type, &expr, SL("type"), PH_NOISY, "phalcon/Annotations/Annotation.zep", 113);
 	do {

--- a/ext/phalcon/annotations/annotationsfactory.zep.c
+++ b/ext/phalcon/annotations/annotationsfactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -61,7 +60,7 @@ PHP_METHOD(Phalcon_Annotations_AnnotationsFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
@@ -168,7 +167,7 @@ PHP_METHOD(Phalcon_Annotations_AnnotationsFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/cache/adapterfactory.zep.c
+++ b/ext/phalcon/cache/adapterfactory.zep.c
@@ -15,8 +15,7 @@
 #include "kernel/object.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/array.h"
 
 
@@ -70,7 +69,7 @@ PHP_METHOD(Phalcon_Cache_AdapterFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	zephir_update_property_zval(this_ptr, ZEND_STRL("serializerFactory"), factory);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
@@ -136,7 +135,7 @@ PHP_METHOD(Phalcon_Cache_AdapterFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/cache/cachefactory.zep.c
+++ b/ext/phalcon/cache/cachefactory.zep.c
@@ -16,8 +16,7 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -184,7 +183,7 @@ PHP_METHOD(Phalcon_Cache_CacheFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("adapterFactory"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&adapter, &_0, "newinstance", NULL, 0, &name_zv, &options);

--- a/ext/phalcon/cli/console.zep.c
+++ b/ext/phalcon/cli/console.zep.c
@@ -22,7 +22,6 @@
 #include "kernel/require.h"
 #include "Zend/zend_closures.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -394,26 +393,16 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 	if (!arguments_param) {
 		ZEPHIR_INIT_VAR(&arguments);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&arguments, arguments_param);
+		zephir_get_arrval(&arguments, arguments_param);
 	}
 	if (!str_param) {
 		str = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(str_param) != IS_TRUE && Z_TYPE_P(str_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'str' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	str = (Z_TYPE_P(str_param) == IS_TRUE);
-	}
+		}
 	if (!shift_param) {
 		shift = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(shift_param) != IS_TRUE && Z_TYPE_P(shift_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'shift' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	shift = (Z_TYPE_P(shift_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_INIT_VAR(&args);
 	array_init(&args);
 	ZEPHIR_INIT_VAR(&opts);

--- a/ext/phalcon/cli/dispatcher.zep.c
+++ b/ext/phalcon/cli/dispatcher.zep.c
@@ -16,9 +16,8 @@
 #include "kernel/memory.h"
 #include "kernel/array.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/operators.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -118,7 +117,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, callActionMethod)
 		ZEPHIR_INIT_VAR(&params);
 		array_init(&params);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&params, params_param);
+		zephir_get_arrval(&params, params_param);
 	}
 	ZEPHIR_CALL_FUNCTION(&localParams, "array_values", NULL, 29, &params);
 	zephir_check_call_status();

--- a/ext/phalcon/cli/router.zep.c
+++ b/ext/phalcon/cli/router.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/operators.h"
 #include "kernel/exception.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -961,7 +960,7 @@ PHP_METHOD(Phalcon_Cli_Router, setDefaults)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &defaults_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&defaults, defaults_param);
+	zephir_get_arrval(&defaults, defaults_param);
 	zephir_memory_observe(&module);
 	if (zephir_array_isset_string_fetch(&module, &defaults, SL("module"), 0)) {
 		zephir_update_property_zval(this_ptr, ZEND_STRL("defaultModule"), &module);

--- a/ext/phalcon/cli/router/route.zep.c
+++ b/ext/phalcon/cli/router/route.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/string.h"
 #include "kernel/concat.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -226,15 +225,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, compilePattern)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &pattern_param);
-	if (UNEXPECTED(Z_TYPE_P(pattern_param) != IS_STRING && Z_TYPE_P(pattern_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'pattern' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(pattern_param) == IS_STRING)) {
-		zephir_get_strval(&pattern, pattern_param);
-	} else {
-		ZEPHIR_INIT_VAR(&pattern);
-	}
+	zephir_get_strval(&pattern, pattern_param);
 	if (zephir_memnstr_str(&pattern, SL(":"), "phalcon/Cli/Router/Route.zep", 131)) {
 		zephir_read_property(&_0$$3, this_ptr, ZEND_STRL("delimiter"), PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&idPattern);
@@ -343,7 +334,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, delimiter)
 	if (!delimiter) {
 		ZEPHIR_INIT_VAR(&delimiter_zv);
 	} else {
-	zephir_memory_observe(&delimiter_zv);
+		zephir_memory_observe(&delimiter_zv);
 	ZVAL_STR_COPY(&delimiter_zv, delimiter);
 	}
 	zephir_update_static_property_ce(phalcon_cli_router_route_ce, ZEND_STRL("delimiterPath"), &delimiter_zv);
@@ -732,15 +723,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, reConfigure)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &pattern_param, &paths);
-	if (UNEXPECTED(Z_TYPE_P(pattern_param) != IS_STRING && Z_TYPE_P(pattern_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'pattern' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(pattern_param) == IS_STRING)) {
-		zephir_get_strval(&pattern, pattern_param);
-	} else {
-		ZEPHIR_INIT_VAR(&pattern);
-	}
+	zephir_get_strval(&pattern, pattern_param);
 	if (!paths) {
 		paths = &paths_sub;
 		ZEPHIR_CPY_WRT(paths, &__$null);

--- a/ext/phalcon/config/adapter/grouped.zep.c
+++ b/ext/phalcon/config/adapter/grouped.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/object.h"
 #include "kernel/array.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -147,13 +146,13 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 	if (ZEND_NUM_ARGS() > 2) {
 		factory = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&arrayConfig, arrayConfig_param);
+	zephir_get_arrval(&arrayConfig, arrayConfig_param);
 	if (!defaultAdapter) {
 		defaultAdapter = zend_string_init(ZEND_STRL("php"), 0);
 		zephir_memory_observe(&defaultAdapter_zv);
 		ZVAL_STR(&defaultAdapter_zv, defaultAdapter);
 	} else {
-	zephir_memory_observe(&defaultAdapter_zv);
+		zephir_memory_observe(&defaultAdapter_zv);
 	ZVAL_STR_COPY(&defaultAdapter_zv, defaultAdapter);
 	}
 	if (!factory) {

--- a/ext/phalcon/config/adapter/yaml.zep.c
+++ b/ext/phalcon/config/adapter/yaml.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/operators.h"
 #include "kernel/exception.h"
 #include "kernel/file.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/object.h"
 
 
@@ -111,7 +110,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Yaml, __construct)
 	if (!callbacks_param) {
 		ZEPHIR_INIT_VAR(&callbacks);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&callbacks, callbacks_param);
+		zephir_get_arrval(&callbacks, callbacks_param);
 	}
 	ndocs = 0;
 	ZEPHIR_INIT_VAR(&_1);

--- a/ext/phalcon/db/adapter/abstractadapter.zep.c
+++ b/ext/phalcon/db/adapter/abstractadapter.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/concat.h"
 #include "kernel/fcall.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/string.h"
 
 
@@ -209,7 +208,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &descriptor_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+	zephir_get_arrval(&descriptor, descriptor_param);
 	zephir_memory_observe(&connectionId);
 	zephir_read_static_property_ce(&connectionId, phalcon_db_adapter_abstractadapter_ce, SL("connectionConsecutive"), PH_NOISY_CC);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("connectionId"), &connectionId);
@@ -513,7 +512,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, createTable)
 	ZVAL_STR_COPY(&tableName_zv, tableName);
 	zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&columns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columns, &definition, SL("columns"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -571,7 +570,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, createView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -904,7 +903,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, describeReferences)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&references);
@@ -1266,7 +1265,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, dropTable)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	if (!ifExists_param) {
@@ -1320,7 +1319,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, dropView)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	if (!ifExists_param) {
@@ -1991,7 +1990,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, insert)
 	}
 	zephir_memory_observe(&table_zv);
 	ZVAL_STR_COPY(&table_zv, table);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!fields) {
 		fields = &fields_sub;
 		fields = &__$null;
@@ -2340,7 +2339,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, listTables)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	ZEPHIR_INIT_VAR(&allTables);
@@ -2424,7 +2423,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, listViews)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	ZEPHIR_INIT_VAR(&allTables);
@@ -2727,7 +2726,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, setup)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	zephir_memory_observe(&escapeIdentifiers);
 	if (zephir_array_isset_string_fetch(&escapeIdentifiers, &options, SL("escapeSqlIdentifiers"), 0)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -2814,7 +2813,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, createMaterializedView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -2967,8 +2966,8 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, onConflictUpdate)
 	updateColumns_param = ZEND_CALL_ARG(execute_data, 3);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&conflictColumns, conflictColumns_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&updateColumns, updateColumns_param);
+	zephir_get_arrval(&conflictColumns, conflictColumns_param);
+	zephir_get_arrval(&updateColumns, updateColumns_param);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("dialect"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "onconflictupdate", NULL, 0, &sqlQuery_zv, &conflictColumns, &updateColumns);
 	zephir_check_call_status();
@@ -3001,7 +3000,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, returning)
 	columns_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&columns, columns_param);
+	zephir_get_arrval(&columns, columns_param);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("dialect"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "returning", NULL, 0, &sqlQuery_zv, &columns);
 	zephir_check_call_status();
@@ -3056,7 +3055,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, tableExists)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("dialect"), PH_NOISY_CC | PH_READONLY);
@@ -3582,7 +3581,7 @@ PHP_METHOD(Phalcon_Db_Adapter_AbstractAdapter, viewExists)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	zephir_read_property(&_1, this_ptr, ZEND_STRL("dialect"), PH_NOISY_CC | PH_READONLY);

--- a/ext/phalcon/db/adapter/pdo/abstractpdo.zep.c
+++ b/ext/phalcon/db/adapter/pdo/abstractpdo.zep.c
@@ -13,11 +13,10 @@
 
 #include "kernel/main.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/memory.h"
 #include "kernel/object.h"
-#include "kernel/operators.h"
+#include "kernel/exception.h"
 #include "kernel/array.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
@@ -112,7 +111,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_AbstractPdo, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &descriptor_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+	zephir_get_arrval(&descriptor, descriptor_param);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "connect", NULL, 0, &descriptor);
 	zephir_check_call_status();
 	ZEPHIR_CALL_PARENT(NULL, phalcon_db_adapter_pdo_abstractpdo_ce, getThis(), "__construct", NULL, 0, &descriptor);
@@ -390,7 +389,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_AbstractPdo, connect)
 		ZEPHIR_INIT_VAR(&descriptor);
 		array_init(&descriptor);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+		zephir_get_arrval(&descriptor, descriptor_param);
 	}
 	ZEPHIR_INIT_VAR(&dsnParts);
 	array_init(&dsnParts);
@@ -708,13 +707,13 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_AbstractPdo, execute)
 		ZEPHIR_INIT_VAR(&bindParams);
 		array_init(&bindParams);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindParams, bindParams_param);
+		zephir_get_arrval(&bindParams, bindParams_param);
 	}
 	if (!bindTypes_param) {
 		ZEPHIR_INIT_VAR(&bindTypes);
 		array_init(&bindTypes);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindTypes, bindTypes_param);
+		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("eventsManager"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
@@ -856,7 +855,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_AbstractPdo, executePrepared)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &statement, &placeholders_param, &dataTypes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&placeholders, placeholders_param);
+	zephir_get_arrval(&placeholders, placeholders_param);
 	if (!dataTypes_param) {
 		ZEPHIR_INIT_VAR(&dataTypes);
 		array_init(&dataTypes);
@@ -1391,7 +1390,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_AbstractPdo, lastInsertId)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("pdo"), PH_NOISY_CC | PH_READONLY);
@@ -1554,13 +1553,13 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_AbstractPdo, query)
 		ZEPHIR_INIT_VAR(&bindParams);
 		array_init(&bindParams);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindParams, bindParams_param);
+		zephir_get_arrval(&bindParams, bindParams_param);
 	}
 	if (!bindTypes_param) {
 		ZEPHIR_INIT_VAR(&bindTypes);
 		array_init(&bindTypes);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindTypes, bindTypes_param);
+		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("eventsManager"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);

--- a/ext/phalcon/db/adapter/pdo/mysql.zep.c
+++ b/ext/phalcon/db/adapter/pdo/mysql.zep.c
@@ -1178,7 +1178,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeIndexes)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&indexes);
@@ -1536,7 +1536,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeReferences)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&references);

--- a/ext/phalcon/db/adapter/pdo/postgresql.zep.c
+++ b/ext/phalcon/db/adapter/pdo/postgresql.zep.c
@@ -15,12 +15,11 @@
 #include "kernel/array.h"
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -81,7 +80,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &descriptor_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+	zephir_get_arrval(&descriptor, descriptor_param);
 	if (zephir_array_isset_value_string(&descriptor, SL("charset"))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZVAL_STRING(&_0$$3, "Postgres does not allow the charset to be changed in the DSN.");
@@ -124,7 +123,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, connect)
 		ZEPHIR_INIT_VAR(&descriptor);
 		array_init(&descriptor);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+		zephir_get_arrval(&descriptor, descriptor_param);
 	}
 	if (ZEPHIR_IS_EMPTY(&descriptor)) {
 		zephir_read_property(&_0$$3, this_ptr, ZEND_STRL("descriptor"), PH_NOISY_CC | PH_READONLY);
@@ -200,7 +199,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, createTable)
 	ZVAL_STR_COPY(&tableName_zv, tableName);
 	zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&columns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columns, &definition, SL("columns"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -1321,7 +1320,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeReferences)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&references);

--- a/ext/phalcon/db/adapter/pdo/sqlite.zep.c
+++ b/ext/phalcon/db/adapter/pdo/sqlite.zep.c
@@ -15,10 +15,9 @@
 #include "kernel/array.h"
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
+#include "kernel/exception.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
 
@@ -77,7 +76,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &descriptor_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+	zephir_get_arrval(&descriptor, descriptor_param);
 	if (zephir_array_isset_value_string(&descriptor, SL("charset"))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZVAL_STRING(&_0$$3, "SQLite does not allow the charset to be changed in the DSN.");
@@ -116,7 +115,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, connect)
 		ZEPHIR_INIT_VAR(&descriptor);
 		array_init(&descriptor);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&descriptor, descriptor_param);
+		zephir_get_arrval(&descriptor, descriptor_param);
 	}
 	if (ZEPHIR_IS_EMPTY(&descriptor)) {
 		zephir_read_property(&_0$$3, this_ptr, ZEND_STRL("descriptor"), PH_NOISY_CC | PH_READONLY);
@@ -268,7 +267,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&oldColumn);
@@ -758,7 +757,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&indexes);
@@ -1052,7 +1051,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeReferences)
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {
-	zephir_memory_observe(&schema_zv);
+		zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
 	}
 	ZEPHIR_INIT_VAR(&references);

--- a/ext/phalcon/db/adapter/pdofactory.zep.c
+++ b/ext/phalcon/db/adapter/pdofactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -58,7 +57,7 @@ PHP_METHOD(Phalcon_Db_Adapter_PdoFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
@@ -165,7 +164,7 @@ PHP_METHOD(Phalcon_Db_Adapter_PdoFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/db/check.zep.c
+++ b/ext/phalcon/db/check.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -108,7 +107,7 @@ PHP_METHOD(Phalcon_Db_Check, __construct)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&expression);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&expression, &definition, SL("expression"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);

--- a/ext/phalcon/db/column.zep.c
+++ b/ext/phalcon/db/column.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/exception.h"
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -628,7 +627,7 @@ PHP_METHOD(Phalcon_Db_Column, __construct)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("name"), &name_zv);
 	zephir_memory_observe(&type);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&type, &definition, SL("type"), 0)))) {

--- a/ext/phalcon/db/dialect.zep.c
+++ b/ext/phalcon/db/dialect.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/operators.h"
 #include "kernel/string.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 
 
@@ -358,7 +357,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getColumnList)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&columnList, columnList_param);
+	zephir_get_arrval(&columnList, columnList_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -369,7 +368,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getColumnList)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_INIT_VAR(&columns);
 	array_init(&columns);
@@ -474,7 +473,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlColumn)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	if (Z_TYPE_P(column) != IS_ARRAY) {
 		ZVAL_NULL(&_0$$3);
@@ -586,7 +585,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpression)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -597,7 +596,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpression)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_memory_observe(&type);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&type, &expression, SL("type"), 0)))) {
@@ -824,15 +823,7 @@ PHP_METHOD(Phalcon_Db_Dialect, limit)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &sqlQuery_param, &number);
-	if (UNEXPECTED(Z_TYPE_P(sqlQuery_param) != IS_STRING && Z_TYPE_P(sqlQuery_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'sqlQuery' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(sqlQuery_param) == IS_STRING)) {
-		zephir_get_strval(&sqlQuery, sqlQuery_param);
-	} else {
-		ZEPHIR_INIT_VAR(&sqlQuery);
-	}
+	zephir_get_strval(&sqlQuery, sqlQuery_param);
 	if (Z_TYPE_P(number) == IS_ARRAY) {
 		zephir_array_fetch_long(&_0$$3, number, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 485);
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -905,7 +896,7 @@ PHP_METHOD(Phalcon_Db_Dialect, createMaterializedView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -1068,8 +1059,8 @@ PHP_METHOD(Phalcon_Db_Dialect, onConflictUpdate)
 	updateColumns_param = ZEND_CALL_ARG(execute_data, 3);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&conflictColumns, conflictColumns_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&updateColumns, updateColumns_param);
+	zephir_get_arrval(&conflictColumns, conflictColumns_param);
+	zephir_get_arrval(&updateColumns, updateColumns_param);
 	if (UNEXPECTED(ZEPHIR_IS_EMPTY(&conflictColumns))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_db_exceptions_conflicttargetcolumnrequired_ce);
@@ -1171,7 +1162,7 @@ PHP_METHOD(Phalcon_Db_Dialect, returning)
 	columns_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&columns, columns_param);
+	zephir_get_arrval(&columns, columns_param);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, phalcon_db_exceptions_returningnotsupported_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 119);
@@ -1257,7 +1248,7 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &definition_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&tables);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&tables, &definition, SL("tables"), 0)))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "tables", "phalcon/Db/Dialect.zep", 605);
@@ -1889,7 +1880,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionAll)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	expression_param = ZEND_CALL_ARG(execute_data, 1);
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -1948,7 +1939,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionBinaryOperations)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -1959,7 +1950,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionBinaryOperations)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_memory_observe(&operator);
 	zephir_array_fetch_string(&operator, &expression, SL("op"), PH_NOISY, "phalcon/Db/Dialect.zep", 926);
@@ -2050,7 +2041,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCase)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -2061,7 +2052,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCase)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_array_fetch_string(&_1, &expression, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 961);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getsqlexpression", NULL, 0, &_1, &escapeChar_zv, &bindCounts);
@@ -2180,7 +2171,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCastValue)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -2191,7 +2182,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCastValue)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_array_fetch_string(&_0, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 993);
 	ZEPHIR_CALL_METHOD(&left, this_ptr, "getsqlexpression", NULL, 0, &_0, &escapeChar_zv, &bindCounts);
@@ -2241,7 +2232,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionConvertValue)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -2252,7 +2243,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionConvertValue)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_array_fetch_string(&_0, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1021);
 	ZEPHIR_CALL_METHOD(&left, this_ptr, "getsqlexpression", NULL, 0, &_0, &escapeChar_zv, &bindCounts);
@@ -2389,7 +2380,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFunctionCall)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -2400,7 +2391,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFunctionCall)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_memory_observe(&name);
 	zephir_array_fetch_string(&name, &expression, SL("name"), PH_NOISY, "phalcon/Db/Dialect.zep", 1070);
@@ -2494,7 +2485,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionGroupBy)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	if (Z_TYPE_P(expression) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&fields);
@@ -2596,7 +2587,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionHaving)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -2607,7 +2598,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionHaving)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getsqlexpression", NULL, 0, &expression, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
@@ -2682,7 +2673,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_INIT_VAR(&joinType);
 	ZVAL_STRING(&joinType, "");
@@ -2908,7 +2899,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionLimit)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_INIT_VAR(&sql);
 	ZVAL_STRING(&sql, "");
@@ -2999,7 +2990,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -3010,7 +3001,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_INIT_VAR(&items);
 	array_init(&items);
@@ -3125,7 +3116,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionObject)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -3136,7 +3127,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionObject)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_INIT_VAR(&domain);
 	ZVAL_NULL(&domain);
@@ -3219,7 +3210,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionOrderBy)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	ZEPHIR_INIT_VAR(&fieldSql);
 	ZVAL_NULL(&fieldSql);
@@ -3335,7 +3326,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionQualified)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	expression_param = ZEND_CALL_ARG(execute_data, 1);
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -3389,7 +3380,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionScalar)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -3400,7 +3391,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionScalar)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	if (zephir_array_isset_value_string(&expression, SL("column"))) {
 		zephir_array_fetch_string(&_0$$3, &expression, SL("column"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1388);
@@ -3467,7 +3458,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionUnaryOperations)
 	if (ZEND_NUM_ARGS() > 2) {
 		bindCounts_param = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&expression, expression_param);
+	zephir_get_arrval(&expression, expression_param);
 	if (!escapeChar) {
 		ZEPHIR_INIT_VAR(&escapeChar_zv);
 	} else {
@@ -3478,7 +3469,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionUnaryOperations)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_memory_observe(&left);
 	if (zephir_array_isset_string_fetch(&left, &expression, SL("left"), 0)) {
@@ -3550,7 +3541,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionWhere)
 		ZEPHIR_INIT_VAR(&bindCounts);
 		array_init(&bindCounts);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&bindCounts, bindCounts_param);
+		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	if (Z_TYPE_P(expression) == IS_ARRAY) {
 		ZEPHIR_CALL_METHOD(&whereSql, this_ptr, "getsqlexpression", NULL, 0, expression, &escapeChar_zv, &bindCounts);
@@ -3641,15 +3632,7 @@ PHP_METHOD(Phalcon_Db_Dialect, prepareTable)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	table_param = ZEND_CALL_ARG(execute_data, 1);
-	if (UNEXPECTED(Z_TYPE_P(table_param) != IS_STRING && Z_TYPE_P(table_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'table' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(table_param) == IS_STRING)) {
-		zephir_get_strval(&table, table_param);
-	} else {
-		ZEPHIR_INIT_VAR(&table);
-	}
+	zephir_get_strval(&table, table_param);
 	if (!schema) {
 		ZEPHIR_INIT_VAR(&schema_zv);
 	} else {

--- a/ext/phalcon/db/dialect/mysql.zep.c
+++ b/ext/phalcon/db/dialect/mysql.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/string.h"
 #include "kernel/array.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -574,7 +573,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, createTable)
 	ZVAL_STR_COPY(&tableName_zv, tableName);
 	zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&columns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columns, &definition, SL("columns"), 0)))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "columns", "phalcon/Db/Dialect/Mysql.zep", 188);
@@ -1087,7 +1086,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, createView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -1438,12 +1437,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, dropTable)
 	if (!ifExists_param) {
 		ifExists = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(ifExists_param) != IS_TRUE && Z_TYPE_P(ifExists_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'ifExists' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	ifExists = (Z_TYPE_P(ifExists_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_CALL_METHOD(&table, this_ptr, "preparetable", NULL, 0, &tableName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	if (ifExists) {
@@ -1492,12 +1486,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, dropView)
 	if (!ifExists_param) {
 		ifExists = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(ifExists_param) != IS_TRUE && Z_TYPE_P(ifExists_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'ifExists' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	ifExists = (Z_TYPE_P(ifExists_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_CALL_METHOD(&view, this_ptr, "preparetable", NULL, 0, &viewName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	if (ifExists) {
@@ -2029,7 +2018,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, listViews)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	if (!(ZEPHIR_IS_EMPTY(&schemaName_zv))) {
@@ -2270,8 +2259,8 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, onConflictUpdate)
 	updateColumns_param = ZEND_CALL_ARG(execute_data, 3);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&conflictColumns, conflictColumns_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&updateColumns, updateColumns_param);
+	zephir_get_arrval(&conflictColumns, conflictColumns_param);
+	zephir_get_arrval(&updateColumns, updateColumns_param);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, phalcon_db_exceptions_mysqlonconflictnotsupported_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 469);
@@ -2514,7 +2503,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getTableOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &definition_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&options);
 	if (!(zephir_array_isset_string_fetch(&options, &definition, SL("options"), 0))) {
 		RETURN_MM_STRING("");

--- a/ext/phalcon/db/dialect/postgresql.zep.c
+++ b/ext/phalcon/db/dialect/postgresql.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/array.h"
 #include "kernel/exception.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -539,7 +538,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, createTable)
 	ZVAL_STR_COPY(&tableName_zv, tableName);
 	zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&columns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columns, &definition, SL("columns"), 0)))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "columns", "phalcon/Db/Dialect/Postgresql.zep", 162);
@@ -1031,7 +1030,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, createMaterializedView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -1078,7 +1077,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, createView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -1402,12 +1401,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, dropTable)
 	if (!ifExists_param) {
 		ifExists = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(ifExists_param) != IS_TRUE && Z_TYPE_P(ifExists_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'ifExists' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	ifExists = (Z_TYPE_P(ifExists_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_CALL_METHOD(&table, this_ptr, "preparetable", NULL, 0, &tableName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	if (ifExists) {
@@ -1505,12 +1499,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, dropView)
 	if (!ifExists_param) {
 		ifExists = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(ifExists_param) != IS_TRUE && Z_TYPE_P(ifExists_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'ifExists' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	ifExists = (Z_TYPE_P(ifExists_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_CALL_METHOD(&view, this_ptr, "preparetable", NULL, 0, &viewName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	if (ifExists) {
@@ -2222,7 +2211,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, returning)
 	columns_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&columns, columns_param);
+	zephir_get_arrval(&columns, columns_param);
 	if (UNEXPECTED(ZEPHIR_IS_EMPTY(&columns))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_db_exceptions_returningrequirescolumn_ce);
@@ -2590,7 +2579,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, getTableOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &definition_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	RETURN_MM_STRING("");
 }
 

--- a/ext/phalcon/db/dialect/sqlite.zep.c
+++ b/ext/phalcon/db/dialect/sqlite.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/string.h"
 #include "kernel/exception.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -477,7 +476,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable)
 	ZVAL_STR_COPY(&tableName_zv, tableName);
 	zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	ZEPHIR_CALL_METHOD(&table, this_ptr, "preparetable", NULL, 0, &tableName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&temporary);
@@ -933,7 +932,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createView)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&viewName_zv);
 	ZVAL_STR_COPY(&viewName_zv, viewName);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
@@ -1275,12 +1274,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, dropTable)
 	if (!ifExists_param) {
 		ifExists = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(ifExists_param) != IS_TRUE && Z_TYPE_P(ifExists_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'ifExists' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	ifExists = (Z_TYPE_P(ifExists_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_CALL_METHOD(&table, this_ptr, "preparetable", NULL, 0, &tableName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	if (ifExists) {
@@ -1329,12 +1323,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, dropView)
 	if (!ifExists_param) {
 		ifExists = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(ifExists_param) != IS_TRUE && Z_TYPE_P(ifExists_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'ifExists' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	ifExists = (Z_TYPE_P(ifExists_param) == IS_TRUE);
-	}
+		}
 	ZEPHIR_CALL_METHOD(&view, this_ptr, "preparetable", NULL, 0, &viewName_zv, &schemaName_zv);
 	zephir_check_call_status();
 	if (ifExists) {
@@ -1744,7 +1733,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, listViews)
 	if (!schemaName) {
 		ZEPHIR_INIT_VAR(&schemaName_zv);
 	} else {
-	zephir_memory_observe(&schemaName_zv);
+		zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
 	}
 	RETURN_MM_STRING("SELECT tbl_name FROM sqlite_master WHERE type = 'view' ORDER BY tbl_name");
@@ -1828,7 +1817,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, returning)
 	columns_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&sqlQuery_zv);
 	ZVAL_STR_COPY(&sqlQuery_zv, sqlQuery);
-	ZEPHIR_OBS_COPY_OR_DUP(&columns, columns_param);
+	zephir_get_arrval(&columns, columns_param);
 	if (UNEXPECTED(ZEPHIR_IS_EMPTY(&columns))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_db_exceptions_returningrequirescolumn_ce);

--- a/ext/phalcon/db/index.zep.c
+++ b/ext/phalcon/db/index.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/exception.h"
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -182,7 +181,7 @@ PHP_METHOD(Phalcon_Db_Index, __construct)
 	columnsOrDefinition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_OBS_COPY_OR_DUP(&columnsOrDefinition, columnsOrDefinition_param);
+	zephir_get_arrval(&columnsOrDefinition, columnsOrDefinition_param);
 	if (!type) {
 		type = zend_string_init(ZEND_STRL(""), 0);
 		zephir_memory_observe(&type_zv);

--- a/ext/phalcon/db/reference.zep.c
+++ b/ext/phalcon/db/reference.zep.c
@@ -17,7 +17,7 @@
 #include "kernel/memory.h"
 #include "kernel/exception.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -139,7 +139,7 @@ PHP_METHOD(Phalcon_Db_Reference, __construct)
 	definition_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("name"), &name_zv);
 	zephir_memory_observe(&referencedTable);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&referencedTable, &definition, SL("referencedTable"), 0)))) {

--- a/ext/phalcon/di/di.zep.c
+++ b/ext/phalcon/di/di.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -301,15 +300,7 @@ PHP_METHOD(Phalcon_Di_Di, get)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &name_param, &parameters);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	if (!parameters) {
 		parameters = &parameters_sub;
 		parameters = &__$null;
@@ -540,15 +531,7 @@ PHP_METHOD(Phalcon_Di_Di, getService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 168, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
@@ -604,15 +587,7 @@ PHP_METHOD(Phalcon_Di_Di, getShared)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &name_param, &parameters);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	if (!parameters) {
 		parameters = &parameters_sub;
 		parameters = &__$null;
@@ -839,7 +814,7 @@ PHP_METHOD(Phalcon_Di_Di, loadFromYaml)
 	if (!callbacks_param) {
 		ZEPHIR_INIT_VAR(&callbacks);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&callbacks, callbacks_param);
+		zephir_get_arrval(&callbacks, callbacks_param);
 	}
 	ZEPHIR_INIT_VAR(&services);
 	object_init_ex(&services, phalcon_config_adapter_yaml_ce);
@@ -870,15 +845,7 @@ PHP_METHOD(Phalcon_Di_Di, has)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 168, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
@@ -910,15 +877,7 @@ PHP_METHOD(Phalcon_Di_Di, hasShared)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 168, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
@@ -1100,15 +1059,7 @@ PHP_METHOD(Phalcon_Di_Di, remove)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("aliases"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&aliases, &_0);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("services"), PH_NOISY_CC | PH_READONLY);
@@ -1199,15 +1150,7 @@ PHP_METHOD(Phalcon_Di_Di, removeShared)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("sharedInstances"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&sharedInstances, &_0);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "resolvealias", NULL, 168, &name);
@@ -1266,15 +1209,7 @@ PHP_METHOD(Phalcon_Di_Di, set)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &name_param, &definition, &shared_param);
-	if (UNEXPECTED(Z_TYPE_P(name_param) != IS_STRING && Z_TYPE_P(name_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'name' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(name_param) == IS_STRING)) {
-		zephir_get_strval(&name, name_param);
-	} else {
-		ZEPHIR_INIT_VAR(&name);
-	}
+	zephir_get_strval(&name, name_param);
 	if (!shared_param) {
 		shared = 0;
 	} else {

--- a/ext/phalcon/di/service.zep.c
+++ b/ext/phalcon/di/service.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "Zend/zend_closures.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -341,7 +340,7 @@ PHP_METHOD(Phalcon_Di_Service, setParameter)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &position_param, &parameter_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&parameter, parameter_param);
+	zephir_get_arrval(&parameter, parameter_param);
 	zephir_memory_observe(&_0);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("definition"), PH_NOISY_CC);
 	if (UNEXPECTED(Z_TYPE_P(&_0) != IS_ARRAY)) {

--- a/ext/phalcon/di/service/builder.zep.c
+++ b/ext/phalcon/di/service/builder.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/fcall.h"
 #include "kernel/object.h"
 #include "kernel/operators.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -116,7 +115,7 @@ PHP_METHOD(Phalcon_Di_Service_Builder, build)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &container, &definition_param, &parameters);
-	ZEPHIR_OBS_COPY_OR_DUP(&definition, definition_param);
+	zephir_get_arrval(&definition, definition_param);
 	if (!parameters) {
 		parameters = &parameters_sub;
 		parameters = &__$null;
@@ -472,7 +471,7 @@ PHP_METHOD(Phalcon_Di_Service_Builder, buildParameter)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &container, &position_param, &argument_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&argument, argument_param);
+	zephir_get_arrval(&argument, argument_param);
 	zephir_memory_observe(&type);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&type, &argument, SL("type"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -585,7 +584,7 @@ PHP_METHOD(Phalcon_Di_Service_Builder, buildParameters)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &container, &arguments_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&arguments, arguments_param);
+	zephir_get_arrval(&arguments, arguments_param);
 	ZEPHIR_INIT_VAR(&buildArguments);
 	array_init(&buildArguments);
 	zephir_is_iterable(&arguments, 0, "phalcon/Di/Service/Builder.zep", 281);

--- a/ext/phalcon/dispatcher/abstractdispatcher.zep.c
+++ b/ext/phalcon/dispatcher/abstractdispatcher.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 #include "kernel/string.h"
 
@@ -230,7 +229,7 @@ PHP_METHOD(Phalcon_Dispatcher_AbstractDispatcher, callActionMethod)
 		ZEPHIR_INIT_VAR(&params);
 		array_init(&params);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&params, params_param);
+		zephir_get_arrval(&params, params_param);
 	}
 	ZEPHIR_CPY_WRT(&altHandler, handler);
 	ZEPHIR_CPY_WRT(&altAction, &actionMethod_zv);

--- a/ext/phalcon/encryption/crypt/padfactory.zep.c
+++ b/ext/phalcon/encryption/crypt/padfactory.zep.c
@@ -14,12 +14,11 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
+#include "kernel/exception.h"
 #include "kernel/concat.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -67,7 +66,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt_PadFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();

--- a/ext/phalcon/encryption/security.zep.c
+++ b/ext/phalcon/encryption/security.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/exception.h"
 #include "kernel/concat.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -1069,11 +1068,6 @@ PHP_METHOD(Phalcon_Encryption_Security, setRandomBytes)
 		Z_PARAM_LONG(randomBytes)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &randomBytes_param);
-	if (UNEXPECTED(Z_TYPE_P(randomBytes_param) != IS_LONG)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'randomBytes' must be of the type int"));
-		RETURN_NULL();
-	}
-	randomBytes = Z_LVAL_P(randomBytes_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, randomBytes);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("numberBytes"), &_0);

--- a/ext/phalcon/encryption/security/jwt/builder.zep.c
+++ b/ext/phalcon/encryption/security/jwt/builder.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/concat.h"
 #include "kernel/array.h"
 #include "kernel/time.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/string.h"
 
 
@@ -784,11 +783,6 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, setIssuedAt)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &timestamp_param);
-	if (UNEXPECTED(Z_TYPE_P(timestamp_param) != IS_LONG)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'timestamp' must be of the type int"));
-		RETURN_MM_NULL();
-	}
-	timestamp = Z_LVAL_P(timestamp_param);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "iat");
 	ZVAL_LONG(&_1, timestamp);
@@ -862,11 +856,6 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, setNotBefore)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &timestamp_param);
-	if (UNEXPECTED(Z_TYPE_P(timestamp_param) != IS_LONG)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'timestamp' must be of the type int"));
-		RETURN_MM_NULL();
-	}
-	timestamp = Z_LVAL_P(timestamp_param);
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_time(&_0);
 	if (ZEPHIR_LT_LONG(&_0, timestamp)) {

--- a/ext/phalcon/encryption/security/jwt/signer/hmac.zep.c
+++ b/ext/phalcon/encryption/security/jwt/signer/hmac.zep.c
@@ -69,7 +69,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Signer_Hmac, __construct)
 		zephir_memory_observe(&algo_zv);
 		ZVAL_STR(&algo_zv, algo);
 	} else {
-	zephir_memory_observe(&algo_zv);
+		zephir_memory_observe(&algo_zv);
 	ZVAL_STR_COPY(&algo_zv, algo);
 	}
 	ZEPHIR_INIT_VAR(&supported);

--- a/ext/phalcon/encryption/security/jwt/token/item.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/item.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/object.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/fcall.h"
 #include "kernel/operators.h"
+#include "kernel/fcall.h"
 #include "kernel/array.h"
 
 
@@ -64,7 +62,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Item, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	payload_param = ZEND_CALL_ARG(execute_data, 1);
-	ZEPHIR_OBS_COPY_OR_DUP(&payload, payload_param);
+	zephir_get_arrval(&payload, payload_param);
 	zephir_memory_observe(&encoded_zv);
 	ZVAL_STR_COPY(&encoded_zv, encoded);
 	ZEPHIR_INIT_VAR(&_0);

--- a/ext/phalcon/encryption/security/jwt/token/parser.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/parser.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/array.h"
 #include "kernel/exception.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -389,15 +388,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Parser, decodeUrl)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &input_param);
-	if (UNEXPECTED(Z_TYPE_P(input_param) != IS_STRING && Z_TYPE_P(input_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'input' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(input_param) == IS_STRING)) {
-		zephir_get_strval(&input, input_param);
-	} else {
-		ZEPHIR_INIT_VAR(&input);
-	}
+	zephir_get_strval(&input, input_param);
 	remainder = (long) (zephir_safe_mod_long_long(zephir_fast_strlen_ev(&input), 4));
 	if (remainder) {
 		ZEPHIR_INIT_VAR(&_0$$3);

--- a/ext/phalcon/encryption/security/jwt/token/signature.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/signature.zep.c
@@ -64,7 +64,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Signature, __construct)
 		zephir_memory_observe(&hash_zv);
 		ZVAL_STR(&hash_zv, hash);
 	} else {
-	zephir_memory_observe(&hash_zv);
+		zephir_memory_observe(&hash_zv);
 	ZVAL_STR_COPY(&hash_zv, hash);
 	}
 	if (!encoded) {
@@ -72,7 +72,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Signature, __construct)
 		zephir_memory_observe(&encoded_zv);
 		ZVAL_STR(&encoded_zv, encoded);
 	} else {
-	zephir_memory_observe(&encoded_zv);
+		zephir_memory_observe(&encoded_zv);
 	ZVAL_STR_COPY(&encoded_zv, encoded);
 	}
 	ZEPHIR_INIT_VAR(&_0);

--- a/ext/phalcon/factory/abstractfactory.zep.c
+++ b/ext/phalcon/factory/abstractfactory.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/operators.h"
 
 
@@ -129,7 +128,7 @@ PHP_METHOD(Phalcon_Factory_AbstractFactory, init)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(&adapters, this_ptr, "getservices", NULL, 0);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation.zep.c
+++ b/ext/phalcon/filter/validation.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/exception.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -895,7 +894,7 @@ PHP_METHOD(Phalcon_Filter_Validation, rules)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &field, &validators_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&validators, validators_param);
+	zephir_get_arrval(&validators, validators_param);
 	zephir_is_iterable(&validators, 0, "phalcon/Filter/Validation.zep", 485);
 	if (Z_TYPE_P(&validators) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&validators), _0)
@@ -1056,7 +1055,7 @@ PHP_METHOD(Phalcon_Filter_Validation, setLabels)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &labels_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&labels, labels_param);
+	zephir_get_arrval(&labels, labels_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("labels"), &labels);
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/filter/validation/validator/alnum.zep.c
+++ b/ext/phalcon/filter/validation/validator/alnum.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 
 
 /**
@@ -98,7 +96,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Alnum, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_alnum_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/alpha.zep.c
+++ b/ext/phalcon/filter/validation/validator/alpha.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/string.h"
 
 
@@ -99,7 +97,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Alpha, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_alpha_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/between.zep.c
+++ b/ext/phalcon/filter/validation/validator/between.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 
 
@@ -112,7 +110,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Between, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_between_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/callback.zep.c
+++ b/ext/phalcon/filter/validation/validator/callback.zep.c
@@ -14,10 +14,9 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -108,7 +107,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_callback_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/confirmation.zep.c
+++ b/ext/phalcon/filter/validation/validator/confirmation.zep.c
@@ -14,11 +14,10 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "kernel/operators.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -106,7 +105,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Confirmation, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_confirmation_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/creditcard.zep.c
+++ b/ext/phalcon/filter/validation/validator/creditcard.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 
 
 /**
@@ -98,7 +96,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_CreditCard, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_creditcard_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/date.zep.c
+++ b/ext/phalcon/filter/validation/validator/date.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 
 
@@ -105,7 +103,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Date, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_date_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/digit.zep.c
+++ b/ext/phalcon/filter/validation/validator/digit.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 
 
 /**
@@ -98,7 +96,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Digit, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_digit_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/email.zep.c
+++ b/ext/phalcon/filter/validation/validator/email.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 
 
 /**
@@ -109,7 +107,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Email, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_email_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/exclusionin.zep.c
+++ b/ext/phalcon/filter/validation/validator/exclusionin.zep.c
@@ -14,11 +14,10 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
+#include "kernel/exception.h"
 #include "kernel/string.h"
 
 
@@ -113,7 +112,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_ExclusionIn, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_exclusionin_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/file.zep.c
+++ b/ext/phalcon/filter/validation/validator/file.zep.c
@@ -17,8 +17,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -223,7 +221,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&included);
 	ZVAL_NULL(&included);

--- a/ext/phalcon/filter/validation/validator/file/resolution/aspectratio.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/aspectratio.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 #include "kernel/string.h"
 
@@ -109,7 +107,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_AspectRatio, __co
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_file_resolution_aspectratio_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/file/resolution/equal.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/equal.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 #include "kernel/string.h"
 
@@ -105,7 +103,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, __construc
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_file_resolution_equal_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/file/resolution/max.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/max.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 #include "kernel/string.h"
 
@@ -111,7 +109,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_file_resolution_max_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/file/resolution/min.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/min.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 #include "kernel/string.h"
 
@@ -111,7 +109,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_file_resolution_min_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/identical.zep.c
+++ b/ext/phalcon/filter/validation/validator/identical.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 
 
@@ -106,7 +104,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Identical, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_identical_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/inclusionin.zep.c
+++ b/ext/phalcon/filter/validation/validator/inclusionin.zep.c
@@ -14,11 +14,10 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
+#include "kernel/exception.h"
 #include "kernel/string.h"
 
 
@@ -107,7 +106,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_InclusionIn, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_inclusionin_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/ip.zep.c
+++ b/ext/phalcon/filter/validation/validator/ip.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 
 
@@ -128,7 +126,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Ip, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_ip_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/numericality.zep.c
+++ b/ext/phalcon/filter/validation/validator/numericality.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/string.h"
 
 
@@ -99,7 +97,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Numericality, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_numericality_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/presenceof.zep.c
+++ b/ext/phalcon/filter/validation/validator/presenceof.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 
 
 /**
@@ -98,7 +96,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_PresenceOf, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_presenceof_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/regex.zep.c
+++ b/ext/phalcon/filter/validation/validator/regex.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 #include "kernel/string.h"
 
@@ -106,7 +104,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Regex, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_regex_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/stringlength.zep.c
+++ b/ext/phalcon/filter/validation/validator/stringlength.zep.c
@@ -17,8 +17,6 @@
 #include "kernel/operators.h"
 #include "kernel/array.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -152,7 +150,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_StringLength, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&included);
 	ZVAL_NULL(&included);

--- a/ext/phalcon/filter/validation/validator/stringlength/max.zep.c
+++ b/ext/phalcon/filter/validation/validator/stringlength/max.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/string.h"
 #include "kernel/array.h"
 
@@ -114,7 +112,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_StringLength_Max, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_stringlength_max_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/stringlength/min.zep.c
+++ b/ext/phalcon/filter/validation/validator/stringlength/min.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/string.h"
 #include "kernel/array.h"
 
@@ -114,7 +112,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_StringLength_Min, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_stringlength_min_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/uniqueness.zep.c
+++ b/ext/phalcon/filter/validation/validator/uniqueness.zep.c
@@ -14,11 +14,10 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
+#include "kernel/exception.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
 
@@ -144,7 +143,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Uniqueness, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_uniqueness_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validator/url.zep.c
+++ b/ext/phalcon/filter/validation/validator/url.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/array.h"
 
 
@@ -100,7 +98,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Url, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_filter_validation_validator_url_ce, getThis(), "__construct", NULL, 0, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/filter/validation/validatorfactory.zep.c
+++ b/ext/phalcon/filter/validation/validatorfactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -58,7 +57,7 @@ PHP_METHOD(Phalcon_Filter_Validation_ValidatorFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();

--- a/ext/phalcon/flash/abstractflash.zep.c
+++ b/ext/phalcon/flash/abstractflash.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
 
@@ -424,7 +423,7 @@ PHP_METHOD(Phalcon_Flash_AbstractFlash, setCssClasses)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &cssClasses_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&cssClasses, cssClasses_param);
+	zephir_get_arrval(&cssClasses, cssClasses_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("cssClasses"), &cssClasses);
 	RETURN_THIS();
 }
@@ -448,7 +447,7 @@ PHP_METHOD(Phalcon_Flash_AbstractFlash, setCssIconClasses)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &cssIconClasses_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&cssIconClasses, cssIconClasses_param);
+	zephir_get_arrval(&cssIconClasses, cssIconClasses_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("cssIconClasses"), &cssIconClasses);
 	RETURN_THIS();
 }

--- a/ext/phalcon/flash/session.zep.c
+++ b/ext/phalcon/flash/session.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 
 
@@ -460,7 +459,7 @@ PHP_METHOD(Phalcon_Flash_Session, setSessionMessages)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &messages_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&messages, messages_param);
+	zephir_get_arrval(&messages, messages_param);
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getsessionservice", NULL, 0);
 	zephir_check_call_status();
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("sessionKey"), PH_NOISY_CC | PH_READONLY);

--- a/ext/phalcon/forms/element/abstractelement.zep.c
+++ b/ext/phalcon/forms/element/abstractelement.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/fcall.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -249,7 +248,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, addValidators)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &validators_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&validators, validators_param);
+	zephir_get_arrval(&validators, validators_param);
 	if (!merge_param) {
 		merge = 1;
 	} else {
@@ -648,7 +647,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, label)
  */
 PHP_METHOD(Phalcon_Forms_Element_AbstractElement, render)
 {
-	zval _1;
+	zval _2, _1$$4;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
 	zval *attributes_param = NULL, helper, merged, method, name, result, tagFactory, value, _0;
@@ -664,7 +663,8 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, render)
 	ZVAL_UNDEF(&tagFactory);
 	ZVAL_UNDEF(&value);
 	ZVAL_UNDEF(&_0);
-	ZVAL_UNDEF(&_1);
+	ZVAL_UNDEF(&_2);
+	ZVAL_UNDEF(&_1$$4);
 	ZEND_PARSE_PARAMETERS_START(0, 1)
 		Z_PARAM_OPTIONAL
 		ZEPHIR_Z_PARAM_ARRAY(attributes, attributes_param)
@@ -693,13 +693,17 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, render)
 		zephir_array_fetch_string(&value, &attributes, SL("value"), PH_NOISY, "phalcon/Forms/Element/AbstractElement.zep", 392);
 		zephir_array_unset_string(&attributes, SL("value"), PH_SEPARATE);
 	}
+	if (Z_TYPE_P(&value) != IS_NULL) {
+		zephir_cast_to_string(&_1$$4, &value);
+		ZEPHIR_CPY_WRT(&value, &_1$$4);
+	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("attributes"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&merged);
 	zephir_fast_array_merge(&merged, &_0, &attributes);
 	ZEPHIR_CALL_METHOD(&result, &helper, "__invoke", NULL, 0, &name, &value, &merged);
 	zephir_check_call_status();
-	zephir_cast_to_string(&_1, &result);
-	RETURN_CTOR(&_1);
+	zephir_cast_to_string(&_2, &result);
+	RETURN_CTOR(&_2);
 }
 
 /**
@@ -740,7 +744,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setAttributes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&attributes, attributes_param);
+	zephir_get_arrval(&attributes, attributes_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("attributes"), &attributes);
 	RETURN_THIS();
 }
@@ -795,7 +799,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setFilters)
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_invalidfiltertype_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 14);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Forms/Element/AbstractElement.zep", 441);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Forms/Element/AbstractElement.zep", 445);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -993,7 +997,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, getLocalTagFactory)
 		if (UNEXPECTED(Z_TYPE_P(&tagFactory) == IS_NULL)) {
 			ZEPHIR_CALL_CE_STATIC(&_7$$7, phalcon_forms_exception_ce, "tagfactorynotfound", NULL, 0);
 			zephir_check_call_status();
-			zephir_throw_exception_debug(&_7$$7, "phalcon/Forms/Element/AbstractElement.zep", 552);
+			zephir_throw_exception_debug(&_7$$7, "phalcon/Forms/Element/AbstractElement.zep", 556);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}

--- a/ext/phalcon/forms/form.zep.c
+++ b/ext/phalcon/forms/form.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/array.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/iterator.h"
 
 
@@ -388,7 +387,7 @@ PHP_METHOD(Phalcon_Forms_Form, bind)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &data_param, &entity, &whitelist_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!entity) {
 		entity = &entity_sub;
 		ZEPHIR_CPY_WRT(entity, &__$null);
@@ -2306,7 +2305,7 @@ PHP_METHOD(Phalcon_Forms_Form, setUserOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("options"), &options);
 	RETURN_THIS();
 }

--- a/ext/phalcon/html/tagfactory.zep.c
+++ b/ext/phalcon/html/tagfactory.zep.c
@@ -15,10 +15,9 @@
 #include "kernel/object.h"
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/array.h"
 #include "kernel/operators.h"
+#include "kernel/array.h"
+#include "kernel/exception.h"
 #include "Zend/zend_closures.h"
 
 
@@ -172,7 +171,7 @@ PHP_METHOD(Phalcon_Html_TagFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	if (!response) {
 		response = &response_sub;

--- a/ext/phalcon/http/cookie.zep.c
+++ b/ext/phalcon/http/cookie.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/time.h"
 #include "kernel/array.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/concat.h"
 
 
@@ -932,7 +931,7 @@ PHP_METHOD(Phalcon_Http_Cookie, setOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("options"), &options);
 	RETURN_THIS();
 }
@@ -1149,7 +1148,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/http/request.zep.c
+++ b/ext/phalcon/http/request.zep.c
@@ -22,7 +22,6 @@
 #include "kernel/exception.h"
 #include "kernel/file.h"
 #include "kernel/math.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -157,7 +156,7 @@ PHP_METHOD(Phalcon_Http_Request, get)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (!filters) {
@@ -1615,7 +1614,7 @@ PHP_METHOD(Phalcon_Http_Request, getPatch)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (!filters) {
@@ -1772,7 +1771,7 @@ PHP_METHOD(Phalcon_Http_Request, getPost)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (!filters) {
@@ -1911,7 +1910,7 @@ PHP_METHOD(Phalcon_Http_Request, getPut)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (!filters) {
@@ -2008,7 +2007,7 @@ PHP_METHOD(Phalcon_Http_Request, getQuery)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (!filters) {
@@ -3708,7 +3707,7 @@ PHP_METHOD(Phalcon_Http_Request, getHelper)
 	if (!name) {
 		ZEPHIR_INIT_VAR(&name_zv);
 	} else {
-	zephir_memory_observe(&name_zv);
+		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (!filters) {
@@ -4589,11 +4588,11 @@ PHP_METHOD(Phalcon_Http_Request, smoothFiles)
 	tmp_names_param = ZEND_CALL_ARG(execute_data, 3);
 	sizes_param = ZEND_CALL_ARG(execute_data, 4);
 	errors_param = ZEND_CALL_ARG(execute_data, 5);
-	ZEPHIR_OBS_COPY_OR_DUP(&names, names_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&types, types_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&tmp_names, tmp_names_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&sizes, sizes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&errors, errors_param);
+	zephir_get_arrval(&names, names_param);
+	zephir_get_arrval(&types, types_param);
+	zephir_get_arrval(&tmp_names, tmp_names_param);
+	zephir_get_arrval(&sizes, sizes_param);
+	zephir_get_arrval(&errors, errors_param);
 	zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	ZEPHIR_INIT_VAR(&files);

--- a/ext/phalcon/http/request/file.zep.c
+++ b/ext/phalcon/http/request/file.zep.c
@@ -17,8 +17,6 @@
 #include "kernel/object.h"
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -124,7 +122,7 @@ PHP_METHOD(Phalcon_Http_Request_File, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	file_param = ZEND_CALL_ARG(execute_data, 1);
-	ZEPHIR_OBS_COPY_OR_DUP(&file, file_param);
+	zephir_get_arrval(&file, file_param);
 	if (!key) {
 		key = zend_string_init(ZEND_STRL(""), 0);
 		zephir_memory_observe(&key_zv);
@@ -352,7 +350,7 @@ PHP_METHOD(Phalcon_Http_Request_File, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/http/response.zep.c
+++ b/ext/phalcon/http/response.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/exception.h"
 #include "kernel/string.h"
 #include "ext/date/php_date.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/array.h"
 
 
@@ -124,7 +123,7 @@ PHP_METHOD(Phalcon_Http_Response, __construct)
 	if (!content) {
 		ZEPHIR_INIT_VAR(&content_zv);
 	} else {
-	zephir_memory_observe(&content_zv);
+		zephir_memory_observe(&content_zv);
 	ZVAL_STR_COPY(&content_zv, content);
 	}
 	if (!code) {
@@ -750,11 +749,6 @@ PHP_METHOD(Phalcon_Http_Response, setCache)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &minutes_param);
-	if (UNEXPECTED(Z_TYPE_P(minutes_param) != IS_LONG)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'minutes' must be of the type int"));
-		RETURN_MM_NULL();
-	}
-	minutes = Z_LVAL_P(minutes_param);
 	ZEPHIR_INIT_VAR(&date);
 	object_init_ex(&date, php_date_get_date_ce());
 	ZEPHIR_CALL_METHOD(NULL, &date, "__construct", NULL, 0);

--- a/ext/phalcon/http/response/cookies.zep.c
+++ b/ext/phalcon/http/response/cookies.zep.c
@@ -496,7 +496,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, set)
 		zephir_memory_observe(&domain_zv);
 		ZVAL_STR(&domain_zv, domain);
 	} else {
-	zephir_memory_observe(&domain_zv);
+		zephir_memory_observe(&domain_zv);
 	ZVAL_STR_COPY(&domain_zv, domain);
 	}
 	if (!httpOnly_param) {

--- a/ext/phalcon/image/imagefactory.zep.c
+++ b/ext/phalcon/image/imagefactory.zep.c
@@ -14,11 +14,9 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -62,7 +60,7 @@ PHP_METHOD(Phalcon_Image_ImageFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
@@ -244,7 +242,7 @@ PHP_METHOD(Phalcon_Image_ImageFactory, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/logger/adapterfactory.zep.c
+++ b/ext/phalcon/logger/adapterfactory.zep.c
@@ -14,11 +14,9 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -64,7 +62,7 @@ PHP_METHOD(Phalcon_Logger_AdapterFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();

--- a/ext/phalcon/logger/loggerfactory.zep.c
+++ b/ext/phalcon/logger/loggerfactory.zep.c
@@ -18,8 +18,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "ext/date/php_date.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -304,7 +302,7 @@ PHP_METHOD(Phalcon_Logger_LoggerFactory, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/messages/message.zep.c
+++ b/ext/phalcon/messages/message.zep.c
@@ -17,8 +17,6 @@
 #include "kernel/object.h"
 #include "kernel/operators.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -295,7 +293,7 @@ PHP_METHOD(Phalcon_Messages_Message, setMetaData)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &metaData_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&metaData, metaData_param);
+	zephir_get_arrval(&metaData, metaData_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("metaData"), &metaData);
 	RETURN_THIS();
 }

--- a/ext/phalcon/mvc/micro/collection.zep.c
+++ b/ext/phalcon/mvc/micro/collection.zep.c
@@ -16,8 +16,6 @@
 #include "kernel/fcall.h"
 #include "kernel/object.h"
 #include "kernel/operators.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/array.h"
 
 
@@ -591,11 +589,6 @@ PHP_METHOD(Phalcon_Mvc_Micro_Collection, setLazy)
 		Z_PARAM_BOOL(isLazy)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &isLazy_param);
-	if (UNEXPECTED(Z_TYPE_P(isLazy_param) != IS_TRUE && Z_TYPE_P(isLazy_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'isLazy' must be of the type bool"));
-		RETURN_NULL();
-	}
-	isLazy = (Z_TYPE_P(isLazy_param) == IS_TRUE);
 	if (isLazy) {
 		zephir_update_property_zval(this_ptr, ZEND_STRL("isLazy"), &__$true);
 	} else {

--- a/ext/phalcon/mvc/model.zep.c
+++ b/ext/phalcon/mvc/model.zep.c
@@ -21,7 +21,6 @@
 #include "kernel/string.h"
 #include "kernel/array.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/iterator.h"
 
 
@@ -1201,7 +1200,7 @@ PHP_METHOD(Phalcon_Mvc_Model, assign)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &data_param, &whiteList, &dataColumnMap);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!whiteList) {
 		whiteList = &whiteList_sub;
 		whiteList = &__$null;
@@ -1557,7 +1556,7 @@ PHP_METHOD(Phalcon_Mvc_Model, cloneResult)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &base, &data_param, &dirtyState_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!dirtyState_param) {
 		dirtyState = 0;
 	} else {
@@ -1747,7 +1746,7 @@ PHP_METHOD(Phalcon_Mvc_Model, cloneResultMap)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 2, &base, &data_param, &columnMap, &dirtyState_param, &keepSnapshots_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!dirtyState_param) {
 		dirtyState = 0;
 	} else {
@@ -2349,7 +2348,7 @@ PHP_METHOD(Phalcon_Mvc_Model, cloneResultMapHydrate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &data_param, &columnMap, &hydrationMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_get_called_class(&_0);
 	ZVAL_LONG(&_1, hydrationMode);
@@ -5388,7 +5387,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setOldSnapshotData)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &data_param, &columnMap);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!columnMap) {
 		columnMap = &columnMap_sub;
 		columnMap = &__$null;
@@ -5586,7 +5585,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setSnapshotData)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &data_param, &columnMap);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!columnMap) {
 		columnMap = &columnMap_sub;
 		columnMap = &__$null;
@@ -6001,7 +6000,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setup)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	zephir_memory_observe(&disableEvents);
 	if (zephir_array_isset_string_fetch(&disableEvents, &options, SL("events"), 0)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -8984,7 +8983,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getRelatedRecords)
 	ZVAL_STR_COPY(&modelName_zv, modelName);
 	zephir_memory_observe(&method_zv);
 	ZVAL_STR_COPY(&method_zv, method);
-	ZEPHIR_OBS_COPY_OR_DUP(&arguments, arguments_param);
+	zephir_get_arrval(&arguments, arguments_param);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("modelsManager"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_INIT_VAR(&relation);
@@ -12377,7 +12376,7 @@ PHP_METHOD(Phalcon_Mvc_Model, allowEmptyStringValues)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&attributes, attributes_param);
+	zephir_get_arrval(&attributes, attributes_param);
 	ZEPHIR_INIT_VAR(&keysAttributes);
 	array_init(&keysAttributes);
 	zephir_is_iterable(&attributes, 0, "phalcon/Mvc/Model.zep", 5770);
@@ -13109,7 +13108,7 @@ PHP_METHOD(Phalcon_Mvc_Model, skipAttributes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&attributes, attributes_param);
+	zephir_get_arrval(&attributes, attributes_param);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "skipattributesoncreate", NULL, 0, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "skipattributesonupdate", NULL, 0, &attributes);
@@ -13156,7 +13155,7 @@ PHP_METHOD(Phalcon_Mvc_Model, skipAttributesOnCreate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&attributes, attributes_param);
+	zephir_get_arrval(&attributes, attributes_param);
 	ZEPHIR_INIT_VAR(&keysAttributes);
 	array_init(&keysAttributes);
 	zephir_is_iterable(&attributes, 0, "phalcon/Mvc/Model.zep", 6229);
@@ -13235,7 +13234,7 @@ PHP_METHOD(Phalcon_Mvc_Model, skipAttributesOnUpdate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&attributes, attributes_param);
+	zephir_get_arrval(&attributes, attributes_param);
 	ZEPHIR_INIT_VAR(&keysAttributes);
 	array_init(&keysAttributes);
 	zephir_is_iterable(&attributes, 0, "phalcon/Mvc/Model.zep", 6264);

--- a/ext/phalcon/mvc/model/behavior.zep.c
+++ b/ext/phalcon/mvc/model/behavior.zep.c
@@ -151,7 +151,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Behavior, getOptions)
 	if (!eventName) {
 		ZEPHIR_INIT_VAR(&eventName_zv);
 	} else {
-	zephir_memory_observe(&eventName_zv);
+		zephir_memory_observe(&eventName_zv);
 	ZVAL_STR_COPY(&eventName_zv, eventName);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("options"), PH_NOISY_CC | PH_READONLY);

--- a/ext/phalcon/mvc/model/binder.zep.c
+++ b/ext/phalcon/mvc/model/binder.zep.c
@@ -137,7 +137,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, bindToHandler)
 	if (!methodName) {
 		ZEPHIR_INIT_VAR(&methodName_zv);
 	} else {
-	zephir_memory_observe(&methodName_zv);
+		zephir_memory_observe(&methodName_zv);
 	ZVAL_STR_COPY(&methodName_zv, methodName);
 	}
 	ZEPHIR_INIT_VAR(&_0);

--- a/ext/phalcon/mvc/model/criteria.zep.c
+++ b/ext/phalcon/mvc/model/criteria.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/concat.h"
 #include "kernel/operators.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 #include "kernel/string.h"
 
@@ -107,15 +106,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, andWhere)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &conditions_param, &bindParams, &bindTypes);
-	if (UNEXPECTED(Z_TYPE_P(conditions_param) != IS_STRING && Z_TYPE_P(conditions_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'conditions' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(conditions_param) == IS_STRING)) {
-		zephir_get_strval(&conditions, conditions_param);
-	} else {
-		ZEPHIR_INIT_VAR(&conditions);
-	}
+	zephir_get_strval(&conditions, conditions_param);
 	if (!bindParams) {
 		bindParams = &bindParams_sub;
 		bindParams = &__$null;
@@ -225,7 +216,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, bind)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &bindParams_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&bindParams, bindParams_param);
+	zephir_get_arrval(&bindParams, bindParams_param);
 	if (!merge_param) {
 		merge = 0;
 	} else {
@@ -280,7 +271,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, bindTypes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &bindTypes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&bindTypes, bindTypes_param);
+	zephir_get_arrval(&bindTypes, bindTypes_param);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "bindTypes");
 	zephir_update_property_array(this_ptr, SL("params"), &_0, &bindTypes);
@@ -306,7 +297,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, cache)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &cache_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&cache, cache_param);
+	zephir_get_arrval(&cache, cache_param);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "cache");
 	zephir_update_property_array(this_ptr, SL("params"), &_0, &cache);
@@ -599,13 +590,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, fromInput)
 	data_param = ZEND_CALL_ARG(execute_data, 3);
 	zephir_memory_observe(&modelName_zv);
 	ZVAL_STR_COPY(&modelName_zv, modelName);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!operator) {
 		operator = zend_string_init(ZEND_STRL("AND"), 0);
 		zephir_memory_observe(&operator_zv);
 		ZVAL_STR(&operator_zv, operator);
 	} else {
-	zephir_memory_observe(&operator_zv);
+		zephir_memory_observe(&operator_zv);
 	ZVAL_STR_COPY(&operator_zv, operator);
 	}
 	ZEPHIR_INIT_VAR(&conditions);
@@ -1032,7 +1023,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, inWhere)
 	values_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!(zephir_fast_count_int(&values))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZEPHIR_CONCAT_VSV(&_0$$3, &expr_zv, " != ", &expr_zv);
@@ -1480,7 +1471,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, notInWhere)
 	values_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	zephir_memory_observe(&hiddenParam);
 	zephir_read_property(&hiddenParam, this_ptr, ZEND_STRL("hiddenParamNumber"), PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&bindParams);
@@ -1571,15 +1562,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, orWhere)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &conditions_param, &bindParams, &bindTypes);
-	if (UNEXPECTED(Z_TYPE_P(conditions_param) != IS_STRING && Z_TYPE_P(conditions_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'conditions' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(conditions_param) == IS_STRING)) {
-		zephir_get_strval(&conditions, conditions_param);
-	} else {
-		ZEPHIR_INIT_VAR(&conditions);
-	}
+	zephir_get_strval(&conditions, conditions_param);
 	if (!bindParams) {
 		bindParams = &bindParams_sub;
 		bindParams = &__$null;

--- a/ext/phalcon/mvc/model/hydration/cloneresultmaphydrate.zep.c
+++ b/ext/phalcon/mvc/model/hydration/cloneresultmaphydrate.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/object.h"
 
 
@@ -80,7 +79,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Hydration_CloneResultMapHydrate, cloneResultMapHydr
 	data_param = ZEND_CALL_ARG(execute_data, 1);
 	columnMap = ZEND_CALL_ARG(execute_data, 2);
 	hydrationMode_param = ZEND_CALL_ARG(execute_data, 3);
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+	zephir_get_arrval(&data, data_param);
 	if (!calledClass) {
 		calledClass = zend_string_init(ZEND_STRL("Phalcon\\Mvc\\Model"), 0);
 		zephir_memory_observe(&calledClass_zv);

--- a/ext/phalcon/mvc/model/metadata.zep.c
+++ b/ext/phalcon/mvc/model/metadata.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/operators.h"
 #include "kernel/array.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -1628,7 +1627,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/mvc/model/metadata/apcu.zep.c
+++ b/ext/phalcon/mvc/model/metadata/apcu.zep.c
@@ -16,8 +16,7 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -86,7 +85,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Apcu, __construct)
 	if (!options_param) {
 		ZEPHIR_INIT_VAR(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "prefix");

--- a/ext/phalcon/mvc/model/metadata/libmemcached.zep.c
+++ b/ext/phalcon/mvc/model/metadata/libmemcached.zep.c
@@ -16,8 +16,7 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -76,7 +75,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Libmemcached, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "persistentId");

--- a/ext/phalcon/mvc/model/metadata/redis.zep.c
+++ b/ext/phalcon/mvc/model/metadata/redis.zep.c
@@ -16,8 +16,7 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -89,7 +88,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Redis, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "prefix");

--- a/ext/phalcon/mvc/model/query.zep.c
+++ b/ext/phalcon/mvc/model/query.zep.c
@@ -18,7 +18,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "ext/pdo/php_pdo_driver.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
@@ -866,7 +865,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setBindParams)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &bindParams_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&bindParams, bindParams_param);
+	zephir_get_arrval(&bindParams, bindParams_param);
 	if (!merge_param) {
 		merge = 0;
 	} else {
@@ -905,7 +904,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setBindTypes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &bindTypes_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&bindTypes, bindTypes_param);
+	zephir_get_arrval(&bindTypes, bindTypes_param);
 	if (!merge_param) {
 		merge = 0;
 	} else {
@@ -997,7 +996,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setIntermediate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &intermediate_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&intermediate, intermediate_param);
+	zephir_get_arrval(&intermediate, intermediate_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("intermediate"), &intermediate);
 	RETURN_THIS();
 }
@@ -2933,7 +2932,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getCallArgument)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &argument_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&argument, argument_param);
+	zephir_get_arrval(&argument, argument_param);
 	zephir_array_fetch_string(&_0, &argument, SL("type"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query.zep", 1611);
 	if (ZEPHIR_IS_LONG(&_0, 352)) {
 		zephir_create_array(return_value, 1, 0);
@@ -2985,7 +2984,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getCaseExpression)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &expr_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	ZEPHIR_INIT_VAR(&whenClauses);
 	array_init(&whenClauses);
 	zephir_array_fetch_string(&_0, &expr, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query.zep", 1629);
@@ -4014,7 +4013,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getFunctionCall)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &expr_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	zephir_memory_observe(&arguments);
 	if (zephir_array_isset_string_fetch(&arguments, &expr, SL("arguments"), 0)) {
 		if (zephir_array_isset_value_string(&expr, SL("distinct"))) {
@@ -4123,7 +4122,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getGroupClause)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &group_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&group, group_param);
+	zephir_get_arrval(&group, group_param);
 	if (zephir_array_isset_value_long(&group, 0)) {
 		ZEPHIR_INIT_VAR(&groupParts);
 		array_init(&groupParts);
@@ -4972,7 +4971,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getLimitClause)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &limitClause_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&limitClause, limitClause_param);
+	zephir_get_arrval(&limitClause, limitClause_param);
 	ZEPHIR_INIT_VAR(&limit);
 	array_init(&limit);
 	zephir_memory_observe(&number);
@@ -5470,7 +5469,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &expr_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	zephir_memory_observe(&columnName);
 	zephir_array_fetch_string(&columnName, &expr, SL("name"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 3086);
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("nestingLevel"), PH_NOISY_CC | PH_READONLY);
@@ -5928,7 +5927,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSelectColumn)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &column_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&column, column_param);
+	zephir_get_arrval(&column, column_param);
 	zephir_memory_observe(&columnType);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columnType, &column, SL("type"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);

--- a/ext/phalcon/mvc/model/query/builder.zep.c
+++ b/ext/phalcon/mvc/model/query/builder.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/operators.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 
 
@@ -487,15 +486,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, andHaving)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &conditions_param, &bindParams_param, &bindTypes_param);
-	if (UNEXPECTED(Z_TYPE_P(conditions_param) != IS_STRING && Z_TYPE_P(conditions_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'conditions' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(conditions_param) == IS_STRING)) {
-		zephir_get_strval(&conditions, conditions_param);
-	} else {
-		ZEPHIR_INIT_VAR(&conditions);
-	}
+	zephir_get_strval(&conditions, conditions_param);
 	if (!bindParams_param) {
 		ZEPHIR_INIT_VAR(&bindParams);
 		array_init(&bindParams);
@@ -558,15 +549,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, andWhere)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &conditions_param, &bindParams_param, &bindTypes_param);
-	if (UNEXPECTED(Z_TYPE_P(conditions_param) != IS_STRING && Z_TYPE_P(conditions_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'conditions' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(conditions_param) == IS_STRING)) {
-		zephir_get_strval(&conditions, conditions_param);
-	} else {
-		ZEPHIR_INIT_VAR(&conditions);
-	}
+	zephir_get_strval(&conditions, conditions_param);
 	if (!bindParams_param) {
 		ZEPHIR_INIT_VAR(&bindParams);
 		array_init(&bindParams);
@@ -665,15 +648,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, betweenHaving)
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Having");
@@ -723,15 +698,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, betweenWhere)
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Where");
@@ -2163,20 +2130,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, inHaving)
 	}
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!operator_param) {
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Having");
@@ -2223,20 +2182,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, inWhere)
 	}
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!operator_param) {
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Where");
@@ -2554,15 +2505,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, notBetweenHaving)
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Having");
@@ -2612,15 +2555,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, notBetweenWhere)
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Where");
@@ -2664,20 +2599,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, notInHaving)
 	}
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!operator_param) {
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Having");
@@ -2721,20 +2648,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, notInWhere)
 	}
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!operator_param) {
 		ZEPHIR_INIT_VAR(&operator);
 		ZVAL_STRING(&operator, "and");
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(operator_param) != IS_STRING && Z_TYPE_P(operator_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'operator' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(operator_param) == IS_STRING)) {
 		zephir_get_strval(&operator, operator_param);
-	} else {
-		ZEPHIR_INIT_VAR(&operator);
-	}
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "Where");
@@ -2804,15 +2723,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, orHaving)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &conditions_param, &bindParams_param, &bindTypes_param);
-	if (UNEXPECTED(Z_TYPE_P(conditions_param) != IS_STRING && Z_TYPE_P(conditions_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'conditions' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(conditions_param) == IS_STRING)) {
-		zephir_get_strval(&conditions, conditions_param);
-	} else {
-		ZEPHIR_INIT_VAR(&conditions);
-	}
+	zephir_get_strval(&conditions, conditions_param);
 	if (!bindParams_param) {
 		ZEPHIR_INIT_VAR(&bindParams);
 		array_init(&bindParams);
@@ -2875,15 +2786,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, orWhere)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 2, &conditions_param, &bindParams_param, &bindTypes_param);
-	if (UNEXPECTED(Z_TYPE_P(conditions_param) != IS_STRING && Z_TYPE_P(conditions_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'conditions' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(conditions_param) == IS_STRING)) {
-		zephir_get_strval(&conditions, conditions_param);
-	} else {
-		ZEPHIR_INIT_VAR(&conditions);
-	}
+	zephir_get_strval(&conditions, conditions_param);
 	if (!bindParams_param) {
 		ZEPHIR_INIT_VAR(&bindParams);
 		array_init(&bindParams);
@@ -3014,7 +2917,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, setBindParams)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &bindParams_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&bindParams, bindParams_param);
+	zephir_get_arrval(&bindParams, bindParams_param);
 	if (!merge_param) {
 		merge = 0;
 	} else {
@@ -3057,7 +2960,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, setBindTypes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &bindTypes_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&bindTypes, bindTypes_param);
+	zephir_get_arrval(&bindTypes, bindTypes_param);
 	if (!merge_param) {
 		merge = 0;
 	} else {
@@ -3313,7 +3216,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn)
 	ZVAL_STR_COPY(&operator_zv, operator);
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	_0 = !ZEPHIR_IS_STRING_IDENTICAL(&operator_zv, "and");
 	if (_0) {
 		_0 = !ZEPHIR_IS_STRING_IDENTICAL(&operator_zv, "or");
@@ -3538,7 +3441,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn)
 	ZVAL_STR_COPY(&operator_zv, operator);
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	_0 = !ZEPHIR_IS_STRING_IDENTICAL(&operator_zv, "and");
 	if (_0) {
 		_0 = !ZEPHIR_IS_STRING_IDENTICAL(&operator_zv, "or");

--- a/ext/phalcon/mvc/model/validationfailed.zep.c
+++ b/ext/phalcon/mvc/model/validationfailed.zep.c
@@ -16,8 +16,6 @@
 #include "kernel/array.h"
 #include "kernel/fcall.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/operators.h"
 
 
@@ -77,7 +75,7 @@ PHP_METHOD(Phalcon_Mvc_Model_ValidationFailed, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &model, &validationMessages_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&validationMessages, validationMessages_param);
+	zephir_get_arrval(&validationMessages, validationMessages_param);
 	if (zephir_fast_count_int(&validationMessages) > 0) {
 		zephir_memory_observe(&message);
 		zephir_array_fetch_long(&message, &validationMessages, 0, PH_NOISY, "phalcon/Mvc/Model/ValidationFailed.zep", 48);

--- a/ext/phalcon/mvc/router.zep.c
+++ b/ext/phalcon/mvc/router.zep.c
@@ -15,10 +15,9 @@
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
+#include "kernel/exception.h"
 #include "Zend/zend_closures.h"
 #include "kernel/concat.h"
 #include "kernel/variables.h"
@@ -329,12 +328,7 @@ PHP_METHOD(Phalcon_Mvc_Router, __construct)
 	if (!defaultRoutes_param) {
 		defaultRoutes = 1;
 	} else {
-	if (UNEXPECTED(Z_TYPE_P(defaultRoutes_param) != IS_TRUE && Z_TYPE_P(defaultRoutes_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'defaultRoutes' must be of the type bool"));
-		RETURN_MM_NULL();
-	}
-	defaultRoutes = (Z_TYPE_P(defaultRoutes_param) == IS_TRUE);
-	}
+		}
 	if (defaultRoutes) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_mvc_router_route_ce);
@@ -3218,7 +3212,7 @@ PHP_METHOD(Phalcon_Mvc_Router, useCache)
 		zephir_memory_observe(&key_zv);
 		ZVAL_STR(&key_zv, key);
 	} else {
-	zephir_memory_observe(&key_zv);
+		zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	}
 	ZEPHIR_CALL_METHOD(&_0, cache, "has", NULL, 0, &key_zv);
@@ -5478,11 +5472,6 @@ PHP_METHOD(Phalcon_Mvc_Router, removeExtraSlashes)
 		Z_PARAM_BOOL(remove)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &remove_param);
-	if (UNEXPECTED(Z_TYPE_P(remove_param) != IS_TRUE && Z_TYPE_P(remove_param) != IS_FALSE)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'remove' must be of the type bool"));
-		RETURN_NULL();
-	}
-	remove = (Z_TYPE_P(remove_param) == IS_TRUE);
 	if (remove) {
 		zephir_update_property_zval(this_ptr, ZEND_STRL("removeExtraSlashes"), &__$true);
 	} else {
@@ -5621,7 +5610,7 @@ PHP_METHOD(Phalcon_Mvc_Router, setDefaults)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &defaults_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&defaults, defaults_param);
+	zephir_get_arrval(&defaults, defaults_param);
 	zephir_memory_observe(&namespaceName);
 	if (zephir_array_isset_string_fetch(&namespaceName, &defaults, SL("namespace"), 0)) {
 		zephir_cast_to_string(&_0$$3, &namespaceName);

--- a/ext/phalcon/mvc/router/annotations.zep.c
+++ b/ext/phalcon/mvc/router/annotations.zep.c
@@ -114,7 +114,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, addModuleResource)
 	if (!prefix) {
 		ZEPHIR_INIT_VAR(&prefix_zv);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_INIT_VAR(&_0);
@@ -154,7 +154,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, addResource)
 	if (!prefix) {
 		ZEPHIR_INIT_VAR(&prefix_zv);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_INIT_VAR(&_0);

--- a/ext/phalcon/mvc/router/route.zep.c
+++ b/ext/phalcon/mvc/router/route.zep.c
@@ -18,9 +18,8 @@
 #include "kernel/operators.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/array.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -229,15 +228,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, compilePattern)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &pattern_param);
-	if (UNEXPECTED(Z_TYPE_P(pattern_param) != IS_STRING && Z_TYPE_P(pattern_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'pattern' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(pattern_param) == IS_STRING)) {
-		zephir_get_strval(&pattern, pattern_param);
-	} else {
-		ZEPHIR_INIT_VAR(&pattern);
-	}
+	zephir_get_strval(&pattern, pattern_param);
 	if (zephir_memnstr_str(&pattern, SL(":"), "phalcon/Mvc/Router/Route.zep", 149)) {
 		ZEPHIR_INIT_VAR(&idPattern);
 		ZVAL_STRING(&idPattern, "/([\\w0-9\\_\\-]+)");

--- a/ext/phalcon/mvc/view.zep.c
+++ b/ext/phalcon/mvc/view.zep.c
@@ -20,7 +20,6 @@
 #include "kernel/file.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 #include "Zend/zend_closures.h"
 
@@ -1475,7 +1474,7 @@ PHP_METHOD(Phalcon_Mvc_View, registerEngines)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &engines_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&engines, engines_param);
+	zephir_get_arrval(&engines, engines_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("registeredEngines"), &engines);
 	RETURN_THIS();
 }
@@ -1894,7 +1893,7 @@ PHP_METHOD(Phalcon_Mvc_View, setVars)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &params_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&params, params_param);
+	zephir_get_arrval(&params, params_param);
 	if (!merge_param) {
 		merge = 1;
 	} else {

--- a/ext/phalcon/mvc/view/engine/volt.zep.c
+++ b/ext/phalcon/mvc/view/engine/volt.zep.c
@@ -21,7 +21,6 @@
 #include "kernel/string.h"
 #include "kernel/concat.h"
 #include "kernel/require.h"
-#include "ext/spl/spl_exceptions.h"
 
 
 /**
@@ -608,7 +607,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, setOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("options"), &options);
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/mvc/view/engine/volt/compiler.zep.c
+++ b/ext/phalcon/mvc/view/engine/volt/compiler.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
 #include "Zend/zend_closures.h"
 #include "kernel/file.h"
 #include "kernel/string.h"
@@ -302,7 +301,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, attributeReader)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &expr_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	ZEPHIR_INIT_VAR(&exprCode);
 	ZVAL_STRING(&exprCode, "");
 	zephir_memory_observe(&left);
@@ -733,7 +732,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileAutoEscape)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &statement_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&autoescape);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&autoescape, &statement, SL("enable"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -780,7 +779,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileCall)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &statement_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	RETURN_MM_STRING("");
 }
 
@@ -813,7 +812,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileCase)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &statement_param, &caseClause_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	if (!caseClause_param) {
 		caseClause = 1;
 	} else {
@@ -862,7 +861,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileDo)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &statement_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&expr);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&expr, &statement, SL("expr"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -911,7 +910,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileEcho)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &statement_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&expr);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&expr, &statement, SL("expr"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -976,7 +975,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileElseIf)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &statement_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&expr);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&expr, &statement, SL("expr"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -1175,7 +1174,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileForeach)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &statement_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	if (!extendsMode_param) {
 		extendsMode = 0;
 	} else {
@@ -1444,7 +1443,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileIf)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &statement_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	if (!extendsMode_param) {
 		extendsMode = 0;
 	} else {
@@ -1523,7 +1522,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileInclude)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &statement_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&pathExpr);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&pathExpr, &statement, SL("path"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -1633,7 +1632,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileMacro)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &statement_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&name);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&name, &statement, SL("name"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -1811,7 +1810,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileReturn)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &statement_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&expr);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&expr, &statement, SL("expr"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -1928,7 +1927,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSet)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &statement_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	zephir_memory_observe(&assignments);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&assignments, &statement, SL("assignments"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -2140,7 +2139,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSwitch)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &statement_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statement, statement_param);
+	zephir_get_arrval(&statement, statement_param);
 	if (!extendsMode_param) {
 		extendsMode = 0;
 	} else {
@@ -2258,7 +2257,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, expression)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &expr_param, &doubleQuotes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	if (!doubleQuotes_param) {
 		doubleQuotes = 0;
 	} else {
@@ -2922,7 +2921,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, functionCall)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &expr_param, &doubleQuotes_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&expr, expr_param);
+	zephir_get_arrval(&expr, expr_param);
 	if (!doubleQuotes_param) {
 		doubleQuotes = 0;
 	} else {
@@ -3403,7 +3402,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, resolveTest)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	test_param = ZEND_CALL_ARG(execute_data, 1);
-	ZEPHIR_OBS_COPY_OR_DUP(&test, test_param);
+	zephir_get_arrval(&test, test_param);
 	zephir_memory_observe(&left_zv);
 	ZVAL_STR_COPY(&left_zv, left);
 	zephir_memory_observe(&type);
@@ -3532,7 +3531,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, setOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("options"), &options);
 	RETURN_THIS();
 }
@@ -3921,7 +3920,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, resolveFilter)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	filter_param = ZEND_CALL_ARG(execute_data, 1);
-	ZEPHIR_OBS_COPY_OR_DUP(&filter, filter_param);
+	zephir_get_arrval(&filter, filter_param);
 	zephir_memory_observe(&left_zv);
 	ZVAL_STR_COPY(&left_zv, left);
 	ZEPHIR_INIT_VAR(&code);
@@ -4321,7 +4320,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &statements_param, &extendsMode_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&statements, statements_param);
+	zephir_get_arrval(&statements, statements_param);
 	if (!extendsMode_param) {
 		extendsMode = 0;
 	} else {

--- a/ext/phalcon/mvc/view/simple.zep.c
+++ b/ext/phalcon/mvc/view/simple.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/operators.h"
 #include "kernel/array.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 #include "Zend/zend_closures.h"
 #include "kernel/concat.h"
@@ -392,7 +391,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, registerEngines)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &engines_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&engines, engines_param);
+	zephir_get_arrval(&engines, engines_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("registeredEngines"), &engines);
 	ZEPHIR_MM_RESTORE();
 }
@@ -585,7 +584,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, setVars)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &params_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&params, params_param);
+	zephir_get_arrval(&params, params_param);
 	if (!merge_param) {
 		merge = 1;
 	} else {

--- a/ext/phalcon/paginator/adapter/abstractadapter.zep.c
+++ b/ext/phalcon/paginator/adapter/abstractadapter.zep.c
@@ -16,9 +16,8 @@
 #include "kernel/array.h"
 #include "kernel/exception.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/memory.h"
 #include "kernel/operators.h"
+#include "kernel/memory.h"
 
 
 /**
@@ -87,7 +86,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_AbstractAdapter, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &config_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&config, config_param);
+	zephir_get_arrval(&config, config_param);
 	zephir_update_property_zval(this_ptr, ZEND_STRL("config"), &config);
 	if (UNEXPECTED(!(zephir_array_isset_value_string(&config, SL("limit"))))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_paginator_exceptions_missingrequiredparameter_ce, "limit", "phalcon/Paginator/Adapter/AbstractAdapter.zep", 62);

--- a/ext/phalcon/paginator/adapter/model.zep.c
+++ b/ext/phalcon/paginator/adapter/model.zep.c
@@ -15,10 +15,9 @@
 #include "kernel/array.h"
 #include "kernel/exception.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
+#include "kernel/operators.h"
 #include "kernel/memory.h"
 #include "kernel/object.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -126,7 +125,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_Model, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &config_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&config, config_param);
+	zephir_get_arrval(&config, config_param);
 	if (UNEXPECTED(!(zephir_array_isset_value_string(&config, SL("model"))))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_paginator_exceptions_missingrequiredparameter_ce, "model", "phalcon/Paginator/Adapter/Model.zep", 100);
 		return;

--- a/ext/phalcon/paginator/paginatorfactory.zep.c
+++ b/ext/phalcon/paginator/paginatorfactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -58,7 +57,7 @@ PHP_METHOD(Phalcon_Paginator_PaginatorFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
@@ -166,7 +165,7 @@ PHP_METHOD(Phalcon_Paginator_PaginatorFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/queue/adapterfactory.zep.c
+++ b/ext/phalcon/queue/adapterfactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -71,7 +70,7 @@ PHP_METHOD(Phalcon_Queue_AdapterFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
@@ -110,7 +109,7 @@ PHP_METHOD(Phalcon_Queue_AdapterFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/queue/queuefactory.zep.c
+++ b/ext/phalcon/queue/queuefactory.zep.c
@@ -17,8 +17,6 @@
 #include "kernel/fcall.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -169,7 +167,7 @@ PHP_METHOD(Phalcon_Queue_QueueFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("adapterFactory"), PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&connectionFactory, &_0, "newinstance", NULL, 0, &name_zv, &options);

--- a/ext/phalcon/session/adapter/abstractadapter.zep.c
+++ b/ext/phalcon/session/adapter/abstractadapter.zep.c
@@ -18,8 +18,6 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 
 
 /**
@@ -255,7 +253,7 @@ PHP_METHOD(Phalcon_Session_Adapter_AbstractAdapter, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/session/adapter/libmemcached.zep.c
+++ b/ext/phalcon/session/adapter/libmemcached.zep.c
@@ -16,8 +16,7 @@
 #include "kernel/fcall.h"
 #include "kernel/array.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -86,7 +85,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Libmemcached, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "prefix");

--- a/ext/phalcon/session/adapter/redis.zep.c
+++ b/ext/phalcon/session/adapter/redis.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/array.h"
 #include "kernel/operators.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/exception.h"
 #include "kernel/concat.h"
 
@@ -133,7 +132,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "prefix");

--- a/ext/phalcon/session/adapter/stream.zep.c
+++ b/ext/phalcon/session/adapter/stream.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/object.h"
 #include "kernel/operators.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/concat.h"
 #include "kernel/file.h"
 #include "kernel/time.h"
@@ -119,7 +118,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "prefix");
@@ -529,7 +528,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, getArrVal)
 	if (ZEND_NUM_ARGS() > 2) {
 		defaultValue = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
@@ -537,7 +536,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, getArrVal)
 	if (!cast) {
 		ZEPHIR_INIT_VAR(&cast_zv);
 	} else {
-	zephir_memory_observe(&cast_zv);
+		zephir_memory_observe(&cast_zv);
 	ZVAL_STR_COPY(&cast_zv, cast);
 	}
 	zephir_memory_observe(&value);

--- a/ext/phalcon/session/bag.zep.c
+++ b/ext/phalcon/session/bag.zep.c
@@ -15,8 +15,7 @@
 #include "kernel/object.h"
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 
 
 /**
@@ -171,7 +170,7 @@ PHP_METHOD(Phalcon_Session_Bag, init)
 		ZEPHIR_INIT_VAR(&data);
 		array_init(&data);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+		zephir_get_arrval(&data, data_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_session_bag_ce, getThis(), "init", NULL, 0, &data);
 	zephir_check_call_status();

--- a/ext/phalcon/session/manager.zep.c
+++ b/ext/phalcon/session/manager.zep.c
@@ -20,7 +20,6 @@
 #include "ext/session/php_session.h"
 #include "kernel/exception.h"
 #include "kernel/string.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/concat.h"
 
 
@@ -854,7 +853,7 @@ PHP_METHOD(Phalcon_Session_Manager, getArrVal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &collection_param, &index, &defaultValue);
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;

--- a/ext/phalcon/storage/adapter/abstractadapter.zep.c
+++ b/ext/phalcon/storage/adapter/abstractadapter.zep.c
@@ -18,8 +18,6 @@
 #include "kernel/operators.h"
 #include "kernel/array.h"
 #include "kernel/concat.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/string.h"
 #include "ext/date/php_date.h"
 
@@ -239,15 +237,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, decrement)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &key_param, &value_param);
-	if (UNEXPECTED(Z_TYPE_P(key_param) != IS_STRING && Z_TYPE_P(key_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'key' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(key_param) == IS_STRING)) {
-		zephir_get_strval(&key, key_param);
-	} else {
-		ZEPHIR_INIT_VAR(&key);
-	}
+	zephir_get_strval(&key, key_param);
 	if (!value_param) {
 		value = 1;
 	} else {
@@ -299,15 +289,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, delete)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key_param);
-	if (UNEXPECTED(Z_TYPE_P(key_param) != IS_STRING && Z_TYPE_P(key_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'key' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(key_param) == IS_STRING)) {
-		zephir_get_strval(&key, key_param);
-	} else {
-		ZEPHIR_INIT_VAR(&key);
-	}
+	zephir_get_strval(&key, key_param);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getkeywithoutprefix", NULL, 0, &key);
 	zephir_check_call_status();
 	zephir_get_strval(&key, &_0);
@@ -634,15 +616,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, has)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key_param);
-	if (UNEXPECTED(Z_TYPE_P(key_param) != IS_STRING && Z_TYPE_P(key_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'key' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(key_param) == IS_STRING)) {
-		zephir_get_strval(&key, key_param);
-	} else {
-		ZEPHIR_INIT_VAR(&key);
-	}
+	zephir_get_strval(&key, key_param);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getkeywithoutprefix", NULL, 0, &key);
 	zephir_check_call_status();
 	zephir_get_strval(&key, &_0);
@@ -692,15 +666,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, increment)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &key_param, &value_param);
-	if (UNEXPECTED(Z_TYPE_P(key_param) != IS_STRING && Z_TYPE_P(key_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'key' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(key_param) == IS_STRING)) {
-		zephir_get_strval(&key, key_param);
-	} else {
-		ZEPHIR_INIT_VAR(&key);
-	}
+	zephir_get_strval(&key, key_param);
 	if (!value_param) {
 		value = 1;
 	} else {
@@ -765,15 +731,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, set)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 1, &key_param, &value, &ttl);
-	if (UNEXPECTED(Z_TYPE_P(key_param) != IS_STRING && Z_TYPE_P(key_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'key' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(key_param) == IS_STRING)) {
-		zephir_get_strval(&key, key_param);
-	} else {
-		ZEPHIR_INIT_VAR(&key);
-	}
+	zephir_get_strval(&key, key_param);
 	if (!ttl) {
 		ttl = &ttl_sub;
 		ttl = &__$null;
@@ -1348,7 +1306,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, getArrVal)
 	if (ZEND_NUM_ARGS() > 2) {
 		defaultValue = ZEND_CALL_ARG(execute_data, 3);
 	}
-	ZEPHIR_OBS_COPY_OR_DUP(&collection, collection_param);
+	zephir_get_arrval(&collection, collection_param);
 	if (!defaultValue) {
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
@@ -1356,7 +1314,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_AbstractAdapter, getArrVal)
 	if (!cast) {
 		ZEPHIR_INIT_VAR(&cast_zv);
 	} else {
-	zephir_memory_observe(&cast_zv);
+		zephir_memory_observe(&cast_zv);
 	ZVAL_STR_COPY(&cast_zv, cast);
 	}
 	ZEPHIR_INIT_VAR(&_0);

--- a/ext/phalcon/storage/adapter/apcu.zep.c
+++ b/ext/phalcon/storage/adapter/apcu.zep.c
@@ -14,13 +14,11 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/concat.h"
 #include "kernel/iterator.h"
 #include "kernel/array.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -82,7 +80,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_storage_adapter_apcu_ce, getThis(), "__construct", NULL, 0, factory, &options);
 	zephir_check_call_status();
@@ -178,7 +176,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, getKeys)
 		zephir_memory_observe(&prefix_zv);
 		ZVAL_STR(&prefix_zv, prefix);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_INIT_VAR(&apc);

--- a/ext/phalcon/storage/adapter/libmemcached.zep.c
+++ b/ext/phalcon/storage/adapter/libmemcached.zep.c
@@ -269,7 +269,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Libmemcached, getKeys)
 		zephir_memory_observe(&prefix_zv);
 		ZVAL_STR(&prefix_zv, prefix);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getadapter", NULL, 0);

--- a/ext/phalcon/storage/adapter/memory.zep.c
+++ b/ext/phalcon/storage/adapter/memory.zep.c
@@ -14,11 +14,9 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -93,7 +91,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Memory, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_storage_adapter_memory_ce, getThis(), "__construct", NULL, 0, factory, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/storage/adapter/redis.zep.c
+++ b/ext/phalcon/storage/adapter/redis.zep.c
@@ -15,12 +15,11 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 #include "kernel/string.h"
 #include "kernel/concat.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -113,7 +112,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Redis, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "host");
@@ -374,7 +373,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Redis, getKeys)
 		zephir_memory_observe(&prefix_zv);
 		ZVAL_STR(&prefix_zv, prefix);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_CALL_METHOD(&adapter, this_ptr, "getadapter", NULL, 0);
@@ -455,15 +454,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Redis, setForever)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &key_param, &value);
-	if (UNEXPECTED(Z_TYPE_P(key_param) != IS_STRING && Z_TYPE_P(key_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'key' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(key_param) == IS_STRING)) {
-		zephir_get_strval(&key, key_param);
-	} else {
-		ZEPHIR_INIT_VAR(&key);
-	}
+	zephir_get_strval(&key, key_param);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getkeywithoutprefix", NULL, 0, &key);
 	zephir_check_call_status();
 	zephir_get_strval(&key, &_0);

--- a/ext/phalcon/storage/adapter/rediscluster.zep.c
+++ b/ext/phalcon/storage/adapter/rediscluster.zep.c
@@ -15,10 +15,9 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
+#include "kernel/exception.h"
 #include "kernel/concat.h"
 #include "kernel/string.h"
 
@@ -129,7 +128,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_RedisCluster, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "name");
@@ -366,7 +365,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_RedisCluster, getKeys)
 		zephir_memory_observe(&prefix_zv);
 		ZVAL_STR(&prefix_zv, prefix);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getadapter", NULL, 0);

--- a/ext/phalcon/storage/adapter/stream.zep.c
+++ b/ext/phalcon/storage/adapter/stream.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/operators.h"
 #include "kernel/exception.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/concat.h"
 #include "kernel/array.h"
 #include "kernel/time.h"
@@ -101,7 +100,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "storageDir");
@@ -259,7 +258,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getKeys)
 		zephir_memory_observe(&prefix_zv);
 		ZVAL_STR(&prefix_zv, prefix);
 	} else {
-	zephir_memory_observe(&prefix_zv);
+		zephir_memory_observe(&prefix_zv);
 	ZVAL_STR_COPY(&prefix_zv, prefix);
 	}
 	ZEPHIR_INIT_VAR(&files);
@@ -739,7 +738,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getDir)
 		zephir_memory_observe(&key_zv);
 		ZVAL_STR(&key_zv, key);
 	} else {
-	zephir_memory_observe(&key_zv);
+		zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	}
 	zephir_read_property(&_0, this_ptr, ZEND_STRL("storageDir"), PH_NOISY_CC | PH_READONLY);
@@ -934,7 +933,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, isExpired)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &payload_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&payload, payload_param);
+	zephir_get_arrval(&payload, payload_param);
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_time(&_0);
 	ZEPHIR_INIT_VAR(&_1);

--- a/ext/phalcon/storage/adapter/weak.zep.c
+++ b/ext/phalcon/storage/adapter/weak.zep.c
@@ -15,10 +15,8 @@
 #include "kernel/object.h"
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/array.h"
 #include "kernel/operators.h"
+#include "kernel/array.h"
 #include "kernel/string.h"
 
 
@@ -94,7 +92,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Weak, __construct)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);

--- a/ext/phalcon/storage/adapterfactory.zep.c
+++ b/ext/phalcon/storage/adapterfactory.zep.c
@@ -15,8 +15,7 @@
 #include "kernel/object.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/array.h"
 
 
@@ -64,7 +63,7 @@ PHP_METHOD(Phalcon_Storage_AdapterFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	zephir_update_property_zval(this_ptr, ZEND_STRL("serializerFactory"), factory);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
@@ -129,7 +128,7 @@ PHP_METHOD(Phalcon_Storage_AdapterFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/storage/serializerfactory.zep.c
+++ b/ext/phalcon/storage/serializerfactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -60,7 +59,7 @@ PHP_METHOD(Phalcon_Storage_SerializerFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();

--- a/ext/phalcon/support/debug/dump.zep.c
+++ b/ext/phalcon/support/debug/dump.zep.c
@@ -15,8 +15,6 @@
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/operators.h"
 #include "kernel/array.h"
 #include "kernel/main.h"
@@ -113,7 +111,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, __construct)
 		ZEPHIR_INIT_VAR(&styles);
 		array_init(&styles);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&styles, styles_param);
+		zephir_get_arrval(&styles, styles_param);
 	}
 	if (!detailed_param) {
 		detailed = 0;
@@ -284,7 +282,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, setStyles)
 		ZEPHIR_INIT_VAR(&styles);
 		array_init(&styles);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&styles, styles_param);
+		zephir_get_arrval(&styles, styles_param);
 	}
 	ZEPHIR_INIT_VAR(&defaultStyles);
 	zephir_create_array(&defaultStyles, 11, 0);

--- a/ext/phalcon/support/helper/str/friendly.zep.c
+++ b/ext/phalcon/support/helper/str/friendly.zep.c
@@ -17,9 +17,8 @@
 #include "kernel/fcall.h"
 #include "kernel/string.h"
 #include "kernel/array.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
 #include "kernel/object.h"
+#include "kernel/exception.h"
 
 
 /**
@@ -92,21 +91,13 @@ PHP_METHOD(Phalcon_Support_Helper_Str_Friendly, __invoke)
 	if (ZEND_NUM_ARGS() > 3) {
 		replace = ZEND_CALL_ARG(execute_data, 4);
 	}
-	if (UNEXPECTED(Z_TYPE_P(text_param) != IS_STRING && Z_TYPE_P(text_param) != IS_NULL)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'text' must be of the type string"));
-		RETURN_MM_NULL();
-	}
-	if (EXPECTED(Z_TYPE_P(text_param) == IS_STRING)) {
-		zephir_get_strval(&text, text_param);
-	} else {
-		ZEPHIR_INIT_VAR(&text);
-	}
+	zephir_get_strval(&text, text_param);
 	if (!separator) {
 		separator = zend_string_init(ZEND_STRL("-"), 0);
 		zephir_memory_observe(&separator_zv);
 		ZVAL_STR(&separator_zv, separator);
 	} else {
-	zephir_memory_observe(&separator_zv);
+		zephir_memory_observe(&separator_zv);
 	ZVAL_STR_COPY(&separator_zv, separator);
 	}
 	if (!lowercase_param) {

--- a/ext/phalcon/support/helperfactory.zep.c
+++ b/ext/phalcon/support/helperfactory.zep.c
@@ -14,11 +14,9 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
-#include "kernel/operators.h"
 
 
 /**
@@ -124,7 +122,7 @@ PHP_METHOD(Phalcon_Support_HelperFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();

--- a/ext/phalcon/support/registry.zep.c
+++ b/ext/phalcon/support/registry.zep.c
@@ -14,10 +14,8 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
-#include "kernel/object.h"
 #include "kernel/operators.h"
+#include "kernel/object.h"
 
 
 /**
@@ -105,7 +103,7 @@ PHP_METHOD(Phalcon_Support_Registry, __construct)
 		ZEPHIR_INIT_VAR(&data);
 		array_init(&data);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+		zephir_get_arrval(&data, data_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_support_registry_ce, getThis(), "__construct", NULL, 0, &data);
 	zephir_check_call_status();
@@ -274,7 +272,7 @@ PHP_METHOD(Phalcon_Support_Registry, get)
 	if (!cast) {
 		ZEPHIR_INIT_VAR(&cast_zv);
 	} else {
-	zephir_memory_observe(&cast_zv);
+		zephir_memory_observe(&cast_zv);
 	ZVAL_STR_COPY(&cast_zv, cast);
 	}
 	ZEPHIR_RETURN_CALL_PARENT(phalcon_support_registry_ce, getThis(), "get", NULL, 0, &element_zv, defaultValue, &cast_zv);
@@ -342,7 +340,7 @@ PHP_METHOD(Phalcon_Support_Registry, init)
 		ZEPHIR_INIT_VAR(&data);
 		array_init(&data);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&data, data_param);
+		zephir_get_arrval(&data, data_param);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_support_registry_ce, getThis(), "init", NULL, 0, &data);
 	zephir_check_call_status();

--- a/ext/phalcon/tag.zep.c
+++ b/ext/phalcon/tag.zep.c
@@ -19,7 +19,6 @@
 #include "kernel/array.h"
 #include "kernel/concat.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/string.h"
 
 
@@ -738,7 +737,7 @@ PHP_METHOD(Phalcon_Tag, getEscaper)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &params_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&params, params_param);
+	zephir_get_arrval(&params, params_param);
 	zephir_memory_observe(&autoescape);
 	if (!(zephir_array_isset_string_fetch(&autoescape, &params, SL("escape"), 0))) {
 		ZEPHIR_OBS_NVAR(&autoescape);
@@ -1844,7 +1843,7 @@ PHP_METHOD(Phalcon_Tag, renderAttributes)
 	attributes_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&code_zv);
 	ZVAL_STR_COPY(&code_zv, code);
-	ZEPHIR_OBS_COPY_OR_DUP(&attributes, attributes_param);
+	zephir_get_arrval(&attributes, attributes_param);
 	ZEPHIR_INIT_VAR(&order);
 	zephir_create_array(&order, 10, 0);
 	zephir_array_update_string(&order, SL("rel"), &__$null, PH_COPY | PH_SEPARATE);
@@ -2242,7 +2241,7 @@ PHP_METHOD(Phalcon_Tag, setDefaults)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &values_param, &merge_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&values, values_param);
+	zephir_get_arrval(&values, values_param);
 	if (!merge_param) {
 		merge = 0;
 	} else {

--- a/ext/phalcon/translate/adapter/gettext.zep.c
+++ b/ext/phalcon/translate/adapter/gettext.zep.c
@@ -16,7 +16,6 @@
 #include "kernel/fcall.h"
 #include "kernel/operators.h"
 #include "kernel/exception.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/object.h"
 #include "kernel/concat.h"
 #include "kernel/array.h"
@@ -108,7 +107,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &interpolator, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "gettext");
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "phpfunctionexists", NULL, 0, &_1);
@@ -266,11 +265,6 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, nquery)
 	ZVAL_STR_COPY(&msgid1_zv, msgid1);
 	zephir_memory_observe(&msgid2_zv);
 	ZVAL_STR_COPY(&msgid2_zv, msgid2);
-	if (UNEXPECTED(Z_TYPE_P(count_param) != IS_LONG)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'count' must be of the type int"));
-		RETURN_MM_NULL();
-	}
-	count = Z_LVAL_P(count_param);
 	if (!placeholders_param) {
 		ZEPHIR_INIT_VAR(&placeholders);
 		array_init(&placeholders);
@@ -280,7 +274,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, nquery)
 	if (!domain) {
 		ZEPHIR_INIT_VAR(&domain_zv);
 	} else {
-	zephir_memory_observe(&domain_zv);
+		zephir_memory_observe(&domain_zv);
 	ZVAL_STR_COPY(&domain_zv, domain);
 	}
 	if (!(!(ZEPHIR_IS_EMPTY(&domain_zv)))) {
@@ -569,11 +563,6 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, setLocale)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 1, &category_param, &localeArray_param);
-	if (UNEXPECTED(Z_TYPE_P(category_param) != IS_LONG)) {
-		zephir_throw_exception_string(spl_ce_InvalidArgumentException, SL("Parameter 'category' must be of the type int"));
-		RETURN_MM_NULL();
-	}
-	category = Z_LVAL_P(category_param);
 	if (!localeArray_param) {
 		ZEPHIR_INIT_VAR(&localeArray);
 		array_init(&localeArray);
@@ -656,7 +645,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, prepareOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	if (UNEXPECTED(!(zephir_array_isset_value_string(&options, SL("locale"))))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_translate_exceptions_missingrequiredparameter_ce, "locale", "phalcon/Translate/Adapter/Gettext.zep", 328);
 		return;

--- a/ext/phalcon/translate/adapter/nativearray.zep.c
+++ b/ext/phalcon/translate/adapter/nativearray.zep.c
@@ -17,7 +17,6 @@
 #include "kernel/memory.h"
 #include "kernel/exception.h"
 #include "kernel/object.h"
-#include "ext/spl/spl_exceptions.h"
 #include "kernel/operators.h"
 
 
@@ -78,7 +77,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_NativeArray, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &interpolator, &options_param);
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+	zephir_get_arrval(&options, options_param);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_translate_adapter_nativearray_ce, getThis(), "__construct", NULL, 0, interpolator, &options);
 	zephir_check_call_status();
 	zephir_memory_observe(&data);

--- a/ext/phalcon/translate/interpolatorfactory.zep.c
+++ b/ext/phalcon/translate/interpolatorfactory.zep.c
@@ -14,8 +14,7 @@
 #include "kernel/main.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/object.h"
 #include "kernel/array.h"
 
@@ -58,7 +57,7 @@ PHP_METHOD(Phalcon_Translate_InterpolatorFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();

--- a/ext/phalcon/translate/translatefactory.zep.c
+++ b/ext/phalcon/translate/translatefactory.zep.c
@@ -15,8 +15,7 @@
 #include "kernel/object.h"
 #include "kernel/fcall.h"
 #include "kernel/memory.h"
-#include "ext/spl/spl_exceptions.h"
-#include "kernel/exception.h"
+#include "kernel/operators.h"
 #include "kernel/array.h"
 
 
@@ -81,7 +80,7 @@ PHP_METHOD(Phalcon_Translate_TranslateFactory, __construct)
 		ZEPHIR_INIT_VAR(&services);
 		array_init(&services);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&services, services_param);
+		zephir_get_arrval(&services, services_param);
 	}
 	zephir_update_property_zval(this_ptr, ZEND_STRL("interpolator"), interpolator);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
@@ -173,7 +172,7 @@ PHP_METHOD(Phalcon_Translate_TranslateFactory, newInstance)
 		ZEPHIR_INIT_VAR(&options);
 		array_init(&options);
 	} else {
-	ZEPHIR_OBS_COPY_OR_DUP(&options, options_param);
+		zephir_get_arrval(&options, options_param);
 	}
 	ZEPHIR_CALL_METHOD(&definition, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();

--- a/phalcon/Acl/Component.zep
+++ b/phalcon/Acl/Component.zep
@@ -20,7 +20,7 @@ class Component extends AbstractElement implements ComponentInterface
     /**
      * Phalcon\Acl\Component constructor
      */
-    public function __construct(string! name, string description = null)
+    public function __construct( string name, string description = null)
     {
         if unlikely name === "*" {
             throw new ForbiddenWildcard("component");

--- a/phalcon/Acl/Role.zep
+++ b/phalcon/Acl/Role.zep
@@ -20,7 +20,7 @@ class Role extends AbstractElement implements RoleInterface
     /**
      * Phalcon\Acl\Role constructor
      */
-    public function __construct(string! name, string description = null)
+    public function __construct( string name, string description = null)
     {
         if unlikely name === "*" {
             throw new ForbiddenWildcard("role");

--- a/phalcon/Annotations/Adapter/Apcu.zep
+++ b/phalcon/Annotations/Adapter/Apcu.zep
@@ -57,7 +57,7 @@ class Apcu extends AbstractAdapter
     /**
      * Reads parsed annotations from APCu
      */
-    public function read(string! key) -> <Reflection> | bool
+    public function read( string key) -> <Reflection> | bool
     {
         return apcu_fetch(
             strtolower(
@@ -69,7 +69,7 @@ class Apcu extends AbstractAdapter
     /**
      * Writes parsed annotations to APCu
      */
-    public function write(string! key, <Reflection> data) -> bool
+    public function write( string key, <Reflection> data) -> bool
     {
         return apcu_store(
             strtolower(

--- a/phalcon/Annotations/Adapter/Memory.zep
+++ b/phalcon/Annotations/Adapter/Memory.zep
@@ -30,7 +30,7 @@ class Memory extends AbstractAdapter
     /**
      * Reads parsed annotations from memory
      */
-    public function read(string! key) -> <Reflection> | bool
+    public function read( string key) -> <Reflection> | bool
     {
         var data;
 
@@ -44,7 +44,7 @@ class Memory extends AbstractAdapter
     /**
      * Writes parsed annotations to memory
      */
-    public function write(string! key, <Reflection> data) -> void
+    public function write( string key, <Reflection> data) -> void
     {
         var lowercasedKey;
 

--- a/phalcon/Annotations/Adapter/Stream.zep
+++ b/phalcon/Annotations/Adapter/Stream.zep
@@ -97,7 +97,7 @@ class Stream extends AbstractAdapter
     /**
      * Writes parsed annotations to files
      */
-    public function write(string! key, <Reflection> data) -> void
+    public function write( string key, <Reflection> data) -> void
     {
         var code;
         string path;

--- a/phalcon/Annotations/Annotation.zep
+++ b/phalcon/Annotations/Annotation.zep
@@ -41,7 +41,7 @@ class Annotation
     /**
      * Phalcon\Annotations\Annotation constructor
      */
-    public function __construct(array! reflectionData)
+    public function __construct( array reflectionData)
     {
         var name, exprArguments, argument, resolvedArgument;
         array arguments;
@@ -106,7 +106,7 @@ class Annotation
     /**
      * Resolves an annotation expression
      */
-    public function getExpression(array! expr) -> var
+    public function getExpression( array expr) -> var
     {
         var value, item, resolvedItem, arrayValue, name, type;
 
@@ -170,7 +170,7 @@ class Annotation
     /**
      * Returns a named argument
      */
-    public function getNamedArgument(string! name) -> var | null
+    public function getNamedArgument( string name) -> var | null
     {
         var argument;
 
@@ -184,7 +184,7 @@ class Annotation
     /**
      * Returns a named parameter
      */
-    public function getNamedParameter(string! name) -> var
+    public function getNamedParameter( string name) -> var
     {
         return this->getNamedArgument(name);
     }

--- a/phalcon/Annotations/AnnotationsFactory.zep
+++ b/phalcon/Annotations/AnnotationsFactory.zep
@@ -22,7 +22,7 @@ class AnnotationsFactory extends AbstractFactory
     /**
      * AdapterFactory constructor.
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -63,7 +63,7 @@ class AnnotationsFactory extends AbstractFactory
      *     'annotationsDir' => 'phalconDir'
      * ]
      */
-    public function newInstance(string! name, array! options = []) -> <AdapterInterface>
+    public function newInstance( string name,  array options = []) -> <AdapterInterface>
     {
         var definition;
 

--- a/phalcon/Application/AbstractApplication.zep
+++ b/phalcon/Application/AbstractApplication.zep
@@ -69,7 +69,7 @@ abstract class AbstractApplication extends Injectable implements EventsAwareInte
      *
      * @return array|object
      */
-    public function getModule(string! name) -> array | object
+    public function getModule( string name) -> array | object
     {
         var module;
 
@@ -120,7 +120,7 @@ abstract class AbstractApplication extends Injectable implements EventsAwareInte
     /**
      * Sets the module name to be used if the router does not return a valid module
      */
-    public function setDefaultModule(string! defaultModule) -> <static>
+    public function setDefaultModule( string defaultModule) -> <static>
     {
         let this->defaultModule = defaultModule;
 

--- a/phalcon/Assets/Asset/Css.zep
+++ b/phalcon/Assets/Asset/Css.zep
@@ -21,7 +21,7 @@ class Css extends AssetBase
      * Phalcon\Assets\Asset\Css constructor
      */
     public function __construct(
-        string! path,
+         string path,
         bool local = true,
         bool filter = true,
         array attributes = [],

--- a/phalcon/Assets/Asset/Js.zep
+++ b/phalcon/Assets/Asset/Js.zep
@@ -21,7 +21,7 @@ class Js extends AssetBase
      * Phalcon\Assets\Asset\Js constructor
      */
     public function __construct(
-        string! path,
+         string path,
         bool local = true,
         bool filter = true,
         array attributes = [],

--- a/phalcon/Assets/Collection.zep
+++ b/phalcon/Assets/Collection.zep
@@ -288,7 +288,7 @@ class Collection implements Countable, IteratorAggregate
      *
      * @return string
      */
-    public function getRealTargetPath(string! basePath) -> string
+    public function getRealTargetPath( string basePath) -> string
     {
         var completePath;
 

--- a/phalcon/Assets/Filters/CssMin.zep
+++ b/phalcon/Assets/Filters/CssMin.zep
@@ -28,7 +28,7 @@ class Cssmin implements FilterInterface
     /**
      * Filters the content using CSSMIN
      */
-    public function filter(string! content) -> string
+    public function filter( string content) -> string
     {
         return content;
     }

--- a/phalcon/Assets/Filters/JsMin.zep
+++ b/phalcon/Assets/Filters/JsMin.zep
@@ -29,7 +29,7 @@ class Jsmin implements FilterInterface
     /**
      * Filters the content using JSMIN
      */
-    public function filter(string! content) -> string
+    public function filter( string content) -> string
     {
         return content;
     }

--- a/phalcon/Assets/Filters/None.zep
+++ b/phalcon/Assets/Filters/None.zep
@@ -20,7 +20,7 @@ class None implements FilterInterface
     /**
      * Returns the content as is
      */
-    public function filter(string! content) -> string
+    public function filter( string content) -> string
     {
         return content;
     }

--- a/phalcon/Assets/Manager.zep
+++ b/phalcon/Assets/Manager.zep
@@ -85,7 +85,7 @@ class Manager extends AbstractInjectionAware
      * @param string $type
      * @param Asset  $asset
      */
-    public function addAssetByType(string! type, <Asset> asset) -> <static>
+    public function addAssetByType( string type, <Asset> asset) -> <static>
     {
         var collection;
 
@@ -107,7 +107,7 @@ class Manager extends AbstractInjectionAware
      * @param bool        $autoVersion
      */
     public function addCss(
-        string! path,
+         string path,
         bool local = true,
         bool filter = true,
         array attributes = [],
@@ -144,7 +144,7 @@ class Manager extends AbstractInjectionAware
      * @param string $type
      * @param Inline $code
      */
-    public function addInlineCodeByType(string! type, <$Inline> code) -> <static>
+    public function addInlineCodeByType( string type, <$Inline> code) -> <static>
     {
         var collection;
 
@@ -211,7 +211,7 @@ class Manager extends AbstractInjectionAware
      * @param bool        $autoVersion
      */
     public function addJs(
-        string! path,
+         string path,
         bool local = true,
         bool filter = true,
         array attributes = [],
@@ -273,7 +273,7 @@ class Manager extends AbstractInjectionAware
      * @param string $name
      * @deprecated
      */
-    public function exists(string! name) -> bool
+    public function exists( string name) -> bool
     {
         return this->has(name);
     }
@@ -290,7 +290,7 @@ class Manager extends AbstractInjectionAware
      * @return Collection
      * @throws Exception
      */
-    public function get(string! name) -> <Collection>
+    public function get( string name) -> <Collection>
     {
         if unlikely true !== isset(this->collections[name]) {
             throw new CollectionNotFound(name);
@@ -349,7 +349,7 @@ class Manager extends AbstractInjectionAware
      *
      * @param string $name
      */
-    public function has(string! name) -> bool
+    public function has( string name) -> bool
     {
         return isset this->collections[name];
     }
@@ -815,7 +815,7 @@ class Manager extends AbstractInjectionAware
      * @param string     $name
      * @param Collection $collection
      */
-    public function set(string! name, <Collection> collection) -> <static>
+    public function set( string name, <Collection> collection) -> <static>
     {
         let this->collections[name] = collection;
 

--- a/phalcon/Cache/AdapterFactory.zep
+++ b/phalcon/Cache/AdapterFactory.zep
@@ -31,7 +31,7 @@ class AdapterFactory extends AbstractFactory
      * @param SerializerFactory $factory
      * @param array             $services
      */
-    public function __construct(<SerializerFactory> factory, array! services = [])
+    public function __construct(<SerializerFactory> factory,  array services = [])
     {
         let this->serializerFactory = factory;
 
@@ -66,7 +66,7 @@ class AdapterFactory extends AbstractFactory
      * @return AdapterInterface
      * @throws Exception
      */
-    public function newInstance(string! name, array! options = []) -> <AdapterInterface>
+    public function newInstance( string name,  array options = []) -> <AdapterInterface>
     {
         var definition;
 

--- a/phalcon/Cache/CacheFactory.zep
+++ b/phalcon/Cache/CacheFactory.zep
@@ -107,7 +107,7 @@ class CacheFactory extends AbstractConfigFactory
      * @return CacheInterface
      * @throws Exception
      */
-    public function newInstance(string! name, array! options = []) -> <CacheInterface>
+    public function newInstance( string name,  array options = []) -> <CacheInterface>
     {
         var adapter;
 

--- a/phalcon/Cli/Console.zep
+++ b/phalcon/Cli/Console.zep
@@ -188,7 +188,7 @@ class Console extends AbstractApplication
     /**
      * Set an specific argument
      */
-    public function setArgument(array! arguments = null, bool! str = true, bool! shift = true) -> <static>
+    public function setArgument( array arguments = null,  bool str = true,  bool shift = true) -> <static>
     {
         var arg, pos, args, opts, handleArgs;
 

--- a/phalcon/Cli/Dispatcher.zep
+++ b/phalcon/Cli/Dispatcher.zep
@@ -66,7 +66,7 @@ class Dispatcher extends CliDispatcher implements DispatcherInterface
      * positional `params` before the call, so a task action receives any
      * options as trailing arguments after its declared parameters.
      */
-    public function callActionMethod(handler, string actionMethod, array! params = []) -> var
+    public function callActionMethod(handler, string actionMethod,  array params = []) -> var
     {
         var localParams;
 

--- a/phalcon/Cli/Router.zep
+++ b/phalcon/Cli/Router.zep
@@ -140,7 +140,7 @@ class Router extends AbstractInjectionAware implements RouterInterface
      *
      * @phpstan-param array|string|null $paths
      */
-    public function add(string! pattern, paths = null) -> <RouteInterface>
+    public function add( string pattern, paths = null) -> <RouteInterface>
     {
         var route;
 
@@ -217,7 +217,7 @@ class Router extends AbstractInjectionAware implements RouterInterface
     /**
      * Returns a route object by its name
      */
-    public function getRouteByName(string! name) -> <RouteInterface> | bool
+    public function getRouteByName( string name) -> <RouteInterface> | bool
     {
         var route;
 
@@ -487,7 +487,7 @@ class Router extends AbstractInjectionAware implements RouterInterface
      * );
      *```
      */
-    public function setDefaults(array! defaults) -> <static>
+    public function setDefaults( array defaults) -> <static>
     {
         var module, task, action, params;
 

--- a/phalcon/Cli/Router/Route.zep
+++ b/phalcon/Cli/Router/Route.zep
@@ -81,7 +81,7 @@ class Route implements RouteInterface
     /**
      * @param array|string paths
      */
-    public function __construct(string! pattern, paths = null)
+    public function __construct( string pattern, paths = null)
     {
         var routeId, uniqueId;
 
@@ -122,7 +122,7 @@ class Route implements RouteInterface
      * Replaces placeholders from pattern returning a valid PCRE regular
      * expression
      */
-    public function compilePattern(string! pattern) -> string
+    public function compilePattern( string pattern) -> string
     {
         var idPattern;
         array map;
@@ -166,7 +166,7 @@ class Route implements RouteInterface
      *
      * @param callable converter
      */
-    public function convert(string! name, converter) -> <RouteInterface>
+    public function convert( string name, converter) -> <RouteInterface>
     {
         let this->converters[name] = converter;
 
@@ -182,7 +182,7 @@ class Route implements RouteInterface
      * delimiter, and `Console::setArgument()` reads the current value when it
      * parses arguments.
      */
-    public static function delimiter(string! delimiter = null) -> void
+    public static function delimiter( string delimiter = null) -> void
     {
         let self::delimiterPath = delimiter;
     }
@@ -190,7 +190,7 @@ class Route implements RouteInterface
     /**
      * Extracts parameters from a string
      */
-    public function extractNamedParams(string! pattern) -> array | bool
+    public function extractNamedParams( string pattern) -> array | bool
     {
         char ch;
         var tmp;
@@ -409,7 +409,7 @@ class Route implements RouteInterface
      *
      * @return void
      */
-    public function reConfigure(string! pattern, paths = null) -> void
+    public function reConfigure( string pattern, paths = null) -> void
     {
         var moduleName, taskName, actionName, parts, routePaths, realClassName,
             namespaceName, pcrePattern, compiledPattern, extracted;
@@ -554,7 +554,7 @@ class Route implements RouteInterface
     /**
      * Sets the route's description
      */
-    public function setDescription(string! description) -> <RouteInterface>
+    public function setDescription( string description) -> <RouteInterface>
     {
         let this->description = description;
 
@@ -573,7 +573,7 @@ class Route implements RouteInterface
      * )->setName("about");
      *```
      */
-    public function setName(string! name) -> <RouteInterface>
+    public function setName( string name) -> <RouteInterface>
     {
         let this->name = name;
 

--- a/phalcon/Cli/Router/RouteInterface.zep
+++ b/phalcon/Cli/Router/RouteInterface.zep
@@ -26,12 +26,12 @@ interface RouteInterface
      * Replaces placeholders from pattern returning a valid PCRE regular
      * expression
      */
-    public function compilePattern(string! pattern) -> string;
+    public function compilePattern( string pattern) -> string;
 
     /**
      * Set the routing delimiter
      */
-    public static function delimiter(string! delimiter = null);
+    public static function delimiter( string delimiter = null);
 
     /**
      * Returns the route's pattern
@@ -81,7 +81,7 @@ interface RouteInterface
      *
      * @return void
      */
-    public function reConfigure(string! pattern, var paths = null) -> void;
+    public function reConfigure( string pattern, var paths = null) -> void;
 
     /**
      * Resets the internal route id generator
@@ -91,7 +91,7 @@ interface RouteInterface
     /**
      * Sets the route's description
      */
-    public function setDescription(string! description) -> <RouteInterface>;
+    public function setDescription( string description) -> <RouteInterface>;
 
     /**
      * Sets the route's name

--- a/phalcon/Cli/RouterInterface.zep
+++ b/phalcon/Cli/RouterInterface.zep
@@ -22,7 +22,7 @@ interface RouterInterface
      *
      * @phpstan-param array|string|null $paths
      */
-    public function add(string! pattern, var paths = null) -> <RouteInterface>;
+    public function add( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Returns processed action name
@@ -67,7 +67,7 @@ interface RouterInterface
     /**
      * Returns a route object by its name
      */
-    public function getRouteByName(string! name) -> <RouteInterface> | bool;
+    public function getRouteByName( string name) -> <RouteInterface> | bool;
 
     /**
      * Return all the routes defined in the router
@@ -95,22 +95,22 @@ interface RouterInterface
     /**
      * Sets the default action name
      */
-    public function setDefaultAction(string! actionName) -> <RouterInterface>;
+    public function setDefaultAction( string actionName) -> <RouterInterface>;
 
     /**
      * Sets the name of the default module
      */
-    public function setDefaultModule(string! moduleName) -> <RouterInterface>;
+    public function setDefaultModule( string moduleName) -> <RouterInterface>;
 
     /**
      * Sets an array of default paths
      */
-    public function setDefaults(array! defaults) -> <RouterInterface>;
+    public function setDefaults( array defaults) -> <RouterInterface>;
 
     /**
      * Sets the default task name
      */
-    public function setDefaultTask(string! taskName) -> <RouterInterface>;
+    public function setDefaultTask( string taskName) -> <RouterInterface>;
 
     /**
      * Check if the router matches any of the defined routes

--- a/phalcon/Config/Adapter/Grouped.zep
+++ b/phalcon/Config/Adapter/Grouped.zep
@@ -81,8 +81,8 @@ class Grouped extends Config
      *                                           provided
      */
     public function __construct(
-        array! arrayConfig,
-        string! defaultAdapter = "php",
+         array arrayConfig,
+         string defaultAdapter = "php",
         <ConfigFactory> factory = null
     ) {
         var configArray, configFactory, configInstance, configName;

--- a/phalcon/Config/Adapter/Json.zep
+++ b/phalcon/Config/Adapter/Json.zep
@@ -41,7 +41,7 @@ class Json extends Config
      *
      * @throws CannotLoadConfigFile
      */
-    public function __construct(string! filePath)
+    public function __construct( string filePath)
     {
         var content;
 

--- a/phalcon/Config/Adapter/Php.zep
+++ b/phalcon/Config/Adapter/Php.zep
@@ -55,7 +55,7 @@ class Php extends Config
      *
      * @throws CannotLoadConfigFile
      */
-    public function __construct(string! filePath)
+    public function __construct( string filePath)
     {
         if unlikely true !== is_file(filePath) {
             throw new CannotLoadConfigFile(basename(filePath));

--- a/phalcon/Config/Adapter/Yaml.zep
+++ b/phalcon/Config/Adapter/Yaml.zep
@@ -57,7 +57,7 @@ class Yaml extends Config
     /**
      * Phalcon\Config\Adapter\Yaml constructor
      */
-    public function __construct(string! filePath, array! callbacks = null)
+    public function __construct( string filePath,  array callbacks = null)
     {
         var yamlConfig;
         int ndocs = 0;

--- a/phalcon/Contracts/Assets/Filter.zep
+++ b/phalcon/Contracts/Assets/Filter.zep
@@ -19,5 +19,5 @@ interface Filter
     /**
      * Filters the content returning a string with the filtered content
      */
-    public function filter(string! content) -> string;
+    public function filter( string content) -> string;
 }

--- a/phalcon/Contracts/Db/Adapter/Adapter.zep
+++ b/phalcon/Contracts/Db/Adapter/Adapter.zep
@@ -36,22 +36,22 @@ interface Adapter
     /**
      * Adds a column to a table
      */
-    public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> bool;
+    public function addColumn( string tableName,  string schemaName, <ColumnInterface> column) -> bool;
 
     /**
      * Adds a foreign key to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> bool;
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> bool;
 
     /**
      * Adds an index to a table
      */
-    public function addIndex(string! tableName, string! schemaName, <IndexInterface> index) -> bool;
+    public function addIndex( string tableName,  string schemaName, <IndexInterface> index) -> bool;
 
     /**
      * Adds a primary key to a table
      */
-    public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> bool;
+    public function addPrimaryKey( string tableName,  string schemaName, <IndexInterface> index) -> bool;
 
     /**
      * Returns the number of affected rows by the last INSERT/UPDATE/DELETE
@@ -79,22 +79,22 @@ interface Adapter
      * This method is automatically called in \Phalcon\Db\Adapter\Pdo
      * constructor. Call it when you need to restore a database connection
      */
-    public function connect(array! descriptor = []) -> void;
+    public function connect( array descriptor = []) -> void;
 
     /**
      * Creates a new savepoint
      */
-    public function createSavepoint(string! name) -> bool;
+    public function createSavepoint( string name) -> bool;
 
     /**
      * Creates a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> bool;
+    public function createTable( string tableName,  string schemaName,  array definition) -> bool;
 
     /**
      * Creates a view
      */
-    public function createView(string! viewName, array! definition, string schemaName = null) -> bool;
+    public function createView( string viewName,  array definition, string schemaName = null) -> bool;
 
     /**
      * Deletes data from a table using custom RDBMS SQL syntax
@@ -116,47 +116,47 @@ interface Adapter
     /**
      * Returns an array of Phalcon\Db\Column objects describing a table
      */
-    public function describeColumns(string! table, string schema = null) -> <ColumnInterface[]>;
+    public function describeColumns( string table, string schema = null) -> <ColumnInterface[]>;
 
     /**
      * Lists table indexes
      */
-    public function describeIndexes(string! table, string schema = null) -> <IndexInterface[]>;
+    public function describeIndexes( string table, string schema = null) -> <IndexInterface[]>;
 
     /**
      * Lists table references
      */
-    public function describeReferences(string! table, string schema = null) -> <ReferenceInterface[]>;
+    public function describeReferences( string table, string schema = null) -> <ReferenceInterface[]>;
 
     /**
      * Drops a column from a table
      */
-    public function dropColumn(string! tableName, string! schemaName, string columnName) -> bool;
+    public function dropColumn( string tableName,  string schemaName, string columnName) -> bool;
 
     /**
      * Drops a foreign key from a table
      */
-    public function dropForeignKey(string! tableName, string! schemaName, string referenceName) -> bool;
+    public function dropForeignKey( string tableName,  string schemaName, string referenceName) -> bool;
 
     /**
      * Drop an index from a table
      */
-    public function dropIndex(string! tableName, string! schemaName, string indexName) -> bool;
+    public function dropIndex( string tableName,  string schemaName, string indexName) -> bool;
 
     /**
      * Drops primary key from a table
      */
-    public function dropPrimaryKey(string! tableName, string! schemaName) -> bool;
+    public function dropPrimaryKey( string tableName,  string schemaName) -> bool;
 
     /**
      * Drops a table from a schema/database
      */
-    public function dropTable(string! tableName, string! schemaName = null, bool ifExists = true) -> bool;
+    public function dropTable( string tableName,  string schemaName = null, bool ifExists = true) -> bool;
 
     /**
      * Drops a view
      */
-    public function dropView(string! viewName, string! schemaName = null, bool ifExists = true) -> bool;
+    public function dropView( string viewName,  string schemaName = null, bool ifExists = true) -> bool;
 
     /**
      * Escapes a column/table/schema name
@@ -166,19 +166,19 @@ interface Adapter
     /**
      * Escapes a value to avoid SQL injections
      */
-    public function escapeString(string! str) -> string;
+    public function escapeString( string str) -> string;
 
     /**
      * Sends SQL statements to the database server returning the success state.
      * Use this method only when the SQL statement sent to the server does not
      * return any rows
      */
-    public function execute(string! sqlStatement, array! bindParams = [], array! bindTypes = []) -> bool;
+    public function execute( string sqlStatement,  array bindParams = [],  array bindTypes = []) -> bool;
 
     /**
      * Dumps the complete result of a query into an array
      */
-    public function fetchAll(string! sqlQuery, int fetchMode = 2, array bindParams = [], array bindTypes = []) -> array;
+    public function fetchAll( string sqlQuery, int fetchMode = 2, array bindParams = [], array bindTypes = []) -> array;
 
     /**
      * Returns the n'th field of first row in a SQL query result
@@ -201,14 +201,14 @@ interface Adapter
     /**
      * Returns the first row in a SQL query result
      */
-    public function fetchOne(string! sqlQuery, int fetchMode = 2, array bindParams = [], array bindTypes = []) -> array;
+    public function fetchOne( string sqlQuery, int fetchMode = 2, array bindParams = [], array bindTypes = []) -> array;
 
     /**
      * Returns a SQL modified with a FOR UPDATE clause. The optional `modifier`
      * appends a row-lock disposition keyword - pass `Dialect::LOCK_NOWAIT`
      * or `Dialect::LOCK_SKIP_LOCKED` (or leave as `Dialect::LOCK_NONE`).
      */
-    public function forUpdate(string! sqlQuery, string modifier = "") -> string;
+    public function forUpdate( string sqlQuery, string modifier = "") -> string;
 
     /**
      * Returns the SQL column definition from a column
@@ -306,7 +306,7 @@ interface Adapter
     /**
      * Inserts data into a table using custom RDBMS SQL syntax
      */
-    public function insert(string table, array! values, fields = null, dataTypes = null) -> bool;
+    public function insert(string table,  array values, fields = null, dataTypes = null) -> bool;
 
     /**
      * Inserts data into a table using custom RBDM SQL syntax
@@ -343,29 +343,29 @@ interface Adapter
      *
      * @param string|null $name Name of the sequence object from which the ID should be returned.
      */
-    public function lastInsertId(string! name = null) -> string|bool;
+    public function lastInsertId( string name = null) -> string|bool;
 
     /**
      * Appends a LIMIT clause to sqlQuery argument
      */
-    public function limit(string! sqlQuery, var number) -> string;
+    public function limit( string sqlQuery, var number) -> string;
 
     /**
      * List all tables on a database
      */
-    public function listTables(string! schemaName = null) -> array;
+    public function listTables( string schemaName = null) -> array;
 
     /**
      * List all views on a database
      */
-    public function listViews(string! schemaName = null) -> array;
+    public function listViews( string schemaName = null) -> array;
 
     /**
      * Modifies a table column based on a definition
      */
     public function modifyColumn(
-        string! tableName,
-        string! schemaName,
+         string tableName,
+         string schemaName,
         <ColumnInterface> column,
         <ColumnInterface> currentColumn = null
     ) -> bool;
@@ -376,15 +376,15 @@ interface Adapter
      * rows
      */
     public function query(
-        string! sqlStatement,
-        array! bindParams = [],
-        array! bindTypes = []
+         string sqlStatement,
+         array bindParams = [],
+         array bindTypes = []
     ) -> <ResultInterface> | bool;
 
     /**
      * Releases given savepoint
      */
-    public function releaseSavepoint(string! name) -> bool;
+    public function releaseSavepoint( string name) -> bool;
 
     /**
      * Rollbacks the active transaction in the connection
@@ -394,7 +394,7 @@ interface Adapter
     /**
      * Rollbacks given savepoint
      */
-    public function rollbackSavepoint(string! name) -> bool;
+    public function rollbackSavepoint( string name) -> bool;
 
     /**
      * Returns a SQL modified with a shared-lock clause. See the dialect's
@@ -402,7 +402,7 @@ interface Adapter
      * passed straight through (use `Dialect::LOCK_NOWAIT` /
      * `Dialect::LOCK_SKIP_LOCKED` for PostgreSQL).
      */
-    public function sharedLock(string! sqlQuery, string modifier = "") -> string;
+    public function sharedLock( string sqlQuery, string modifier = "") -> string;
 
     /**
      * Set if nested transactions should use savepoints
@@ -418,12 +418,12 @@ interface Adapter
     /**
      * Generates SQL checking for the existence of a schema.table
      */
-    public function tableExists(string! tableName, string! schemaName = null) -> bool;
+    public function tableExists( string tableName,  string schemaName = null) -> bool;
 
     /**
      * Gets creation options from a table
      */
-    public function tableOptions(string! tableName, string schemaName = null) -> array;
+    public function tableOptions( string tableName, string schemaName = null) -> array;
 
     /**
      * Updates data on a table using custom RDBMS SQL syntax
@@ -466,5 +466,5 @@ interface Adapter
     /**
      * Generates SQL checking for the existence of a schema.view
      */
-    public function viewExists(string! viewName, string! schemaName = null) -> bool;
+    public function viewExists( string viewName,  string schemaName = null) -> bool;
 }

--- a/phalcon/Contracts/Db/Dialect.zep
+++ b/phalcon/Contracts/Db/Dialect.zep
@@ -59,42 +59,42 @@ interface Dialect
     /**
      * Generates SQL to add a column to a table
      */
-    public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> string;
+    public function addColumn( string tableName,  string schemaName, <ColumnInterface> column) -> string;
 
     /**
      * Generates SQL to add an index to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> string;
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> string;
 
     /**
      * Generates SQL to add an index to a table
      */
-    public function addIndex(string! tableName, string! schemaName, <IndexInterface> index) -> string;
+    public function addIndex( string tableName,  string schemaName, <IndexInterface> index) -> string;
 
     /**
      * Generates SQL to add the primary key to a table
      */
-    public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> string;
+    public function addPrimaryKey( string tableName,  string schemaName, <IndexInterface> index) -> string;
 
     /**
      * Generate SQL to create a new savepoint
      */
-    public function createSavepoint(string! name) -> string;
+    public function createSavepoint( string name) -> string;
 
     /**
      * Generates SQL to create a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> string;
+    public function createTable( string tableName,  string schemaName,  array definition) -> string;
 
     /**
      * Generates SQL to create a view
      */
-    public function createView(string! viewName, array! definition, string schemaName = null) -> string;
+    public function createView( string viewName,  array definition, string schemaName = null) -> string;
 
     /**
      * Generates SQL to describe a table
      */
-    public function describeColumns(string! table, string schema = null) -> string;
+    public function describeColumns( string table, string schema = null) -> string;
 
     /**
      * Generates SQL to query indexes on a table.
@@ -103,7 +103,7 @@ interface Dialect
      * column index 2 must be the index key name and column index 4 the indexed
      * column name.
      */
-    public function describeIndexes(string! table, string schema = null) -> string;
+    public function describeIndexes( string table, string schema = null) -> string;
 
     /**
      * Generates SQL to query foreign keys on a table.
@@ -113,44 +113,44 @@ interface Dialect
      * referenced schema, index 4 the referenced table, and index 5 the
      * referenced column.
      */
-    public function describeReferences(string! table, string schema = null) -> string;
+    public function describeReferences( string table, string schema = null) -> string;
 
     /**
      * Generates SQL to delete a column from a table
      */
-    public function dropColumn(string! tableName, string! schemaName, string! columnName) -> string;
+    public function dropColumn( string tableName,  string schemaName,  string columnName) -> string;
 
     /**
      * Generates SQL to delete a foreign key from a table
      */
-    public function dropForeignKey(string! tableName, string! schemaName, string! referenceName) -> string;
+    public function dropForeignKey( string tableName,  string schemaName,  string referenceName) -> string;
 
     /**
       * Generates SQL to delete an index from a table
      */
-    public function dropIndex(string! tableName, string! schemaName, string! indexName) -> string;
+    public function dropIndex( string tableName,  string schemaName,  string indexName) -> string;
 
     /**
      * Generates SQL to delete primary key from a table
      */
-    public function dropPrimaryKey(string! tableName, string! schemaName) -> string;
+    public function dropPrimaryKey( string tableName,  string schemaName) -> string;
 
     /**
      * Generates SQL to drop a table
      */
-    public function dropTable(string! tableName, string! schemaName, bool ifExists = true) -> string;
+    public function dropTable( string tableName,  string schemaName, bool ifExists = true) -> string;
 
     /**
      * Generates SQL to drop a view
      */
-    public function dropView(string! viewName, string schemaName = null, bool! ifExists = true) -> string;
+    public function dropView( string viewName, string schemaName = null,  bool ifExists = true) -> string;
 
     /**
      * Returns a SQL modified with a FOR UPDATE clause. The optional `modifier`
      * appends a row-lock disposition keyword - pass `Dialect::LOCK_NOWAIT`
      * or `Dialect::LOCK_SKIP_LOCKED` (or leave as `Dialect::LOCK_NONE`).
      */
-    public function forUpdate(string! sqlQuery, string modifier = "") -> string;
+    public function forUpdate( string sqlQuery, string modifier = "") -> string;
 
     /**
      * Gets the column name in RDBMS
@@ -160,7 +160,7 @@ interface Dialect
     /**
      * Gets a list of columns
      */
-    public function getColumnList(array! columnList) -> string;
+    public function getColumnList( array columnList) -> string;
 
     /**
      * Returns registered functions
@@ -171,12 +171,12 @@ interface Dialect
      * Transforms an intermediate representation for an expression into a
      * database system valid expression
      */
-    public function getSqlExpression(array! expression, string escapeChar = null, array! bindCounts = []) -> string;
+    public function getSqlExpression( array expression, string escapeChar = null,  array bindCounts = []) -> string;
 
     /**
      * Generates the SQL for LIMIT clause
      */
-    public function limit(string! sqlQuery, var number) -> string;
+    public function limit( string sqlQuery, var number) -> string;
 
     /**
      * List all tables in database
@@ -187,8 +187,8 @@ interface Dialect
      * Generates SQL to modify a column in a table
      */
     public function modifyColumn(
-        string! tableName,
-        string! schemaName,
+         string tableName,
+         string schemaName,
         <ColumnInterface> column,
         <ColumnInterface> currentColumn = null
     ) -> string;
@@ -201,17 +201,17 @@ interface Dialect
     /**
      * Generate SQL to release a savepoint
      */
-    public function releaseSavepoint(string! name) -> string;
+    public function releaseSavepoint( string name) -> string;
 
     /**
      * Generate SQL to rollback a savepoint
      */
-    public function rollbackSavepoint(string! name) -> string;
+    public function rollbackSavepoint( string name) -> string;
 
     /**
      * Builds a SELECT statement
      */
-    public function select(array! definition) -> string;
+    public function select( array definition) -> string;
 
     /**
      * Returns a SQL modified with a shared-lock clause. MySQL emits
@@ -221,7 +221,7 @@ interface Dialect
      * for PostgreSQL - MySQL's legacy `LOCK IN SHARE MODE` does not support
      * modifiers, so non-empty values are silently ignored on MySQL.
      */
-    public function sharedLock(string! sqlQuery, string modifier = "") -> string;
+    public function sharedLock( string sqlQuery, string modifier = "") -> string;
 
     /**
      * Checks whether the platform supports releasing savepoints.
@@ -236,15 +236,15 @@ interface Dialect
     /**
      * Generates SQL checking for the existence of a schema.table
      */
-    public function tableExists(string! tableName, string schemaName = null) -> string;
+    public function tableExists( string tableName, string schemaName = null) -> string;
 
     /**
      * Generates the SQL to describe the table creation options
      */
-    public function tableOptions(string! table, string schema = null) -> string;
+    public function tableOptions( string table, string schema = null) -> string;
 
     /**
      * Generates SQL checking for the existence of a schema.view
      */
-    public function viewExists(string! viewName, string schemaName = null) -> string;
+    public function viewExists( string viewName, string schemaName = null) -> string;
 }

--- a/phalcon/Contracts/Encryption/Security/CryptoUtils.zep
+++ b/phalcon/Contracts/Encryption/Security/CryptoUtils.zep
@@ -25,7 +25,7 @@ interface CryptoUtils
 
     public function getRandomBytes() -> int;
 
-    public function setRandomBytes(int! randomBytes) -> <Security>;
+    public function setRandomBytes( int randomBytes) -> <Security>;
 
     public function getSaltBytes(int numberBytes = 0) -> string;
 }

--- a/phalcon/Contracts/Encryption/Security/JWT/Signer/Signer.zep
+++ b/phalcon/Contracts/Encryption/Security/JWT/Signer/Signer.zep
@@ -37,7 +37,7 @@ interface Signer
      *
      * @return string
      */
-    public function sign(string! payload, string! passphrase) -> string;
+    public function sign( string payload,  string passphrase) -> string;
 
     /**
      * Verify a passed source with a payload and passphrase

--- a/phalcon/Contracts/Messages/Messages.zep
+++ b/phalcon/Contracts/Messages/Messages.zep
@@ -40,5 +40,5 @@ interface Messages extends ArrayAccess, Countable, Iterator
     /**
      * Filters the message collection by field name
      */
-    public function filter(string! fieldName) -> array;
+    public function filter( string fieldName) -> array;
 }

--- a/phalcon/Contracts/Mvc/Dispatcher.zep
+++ b/phalcon/Contracts/Mvc/Dispatcher.zep
@@ -36,15 +36,15 @@ interface Dispatcher extends DispatcherContract
     /**
      * Sets the controller name to be dispatched
      */
-    public function setControllerName(string! controllerName) -> <DispatcherContract>;
+    public function setControllerName( string controllerName) -> <DispatcherContract>;
 
     /**
      * Sets the default controller suffix
      */
-    public function setControllerSuffix(string! controllerSuffix) -> <DispatcherContract>;
+    public function setControllerSuffix( string controllerSuffix) -> <DispatcherContract>;
 
     /**
      * Sets the default controller name
      */
-    public function setDefaultController(string! controllerName) -> <DispatcherContract>;
+    public function setDefaultController( string controllerName) -> <DispatcherContract>;
 }

--- a/phalcon/Db/Adapter/AbstractAdapter.zep
+++ b/phalcon/Db/Adapter/AbstractAdapter.zep
@@ -189,7 +189,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * which writes process-global settings affecting every connection in the
      * process. See `setup()`.
      */
-    public function __construct(array! descriptor)
+    public function __construct( array descriptor)
     {
         var dialectClass, connectionId;
 
@@ -227,7 +227,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Adds a column to a table
      */
-    public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> bool
+    public function addColumn( string tableName,  string schemaName, <ColumnInterface> column) -> bool
     {
         return this->{"execute"}(
             this->dialect->addColumn(
@@ -242,7 +242,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * Adds a CHECK constraint to a table. MySQL 8.0.16+ and PostgreSQL
      * issue `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)`; SQLite throws.
      */
-    public function addCheck(string! tableName, string! schemaName, <CheckInterface> check) -> bool
+    public function addCheck( string tableName,  string schemaName, <CheckInterface> check) -> bool
     {
         return this->{"execute"}(
             this->dialect->addCheck(
@@ -256,7 +256,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Adds a foreign key to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> bool
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> bool
     {
         return this->{"execute"}(
             this->dialect->addForeignKey(
@@ -270,7 +270,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Adds an index to a table
      */
-    public function addIndex(string! tableName, string! schemaName, <IndexInterface> index) -> bool
+    public function addIndex( string tableName,  string schemaName, <IndexInterface> index) -> bool
     {
         return this->{"execute"}(
             this->dialect->addIndex(
@@ -284,7 +284,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Adds a primary key to a table
      */
-    public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> bool
+    public function addPrimaryKey( string tableName,  string schemaName, <IndexInterface> index) -> bool
     {
         return this->{"execute"}(
             this->dialect->addPrimaryKey(
@@ -298,7 +298,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Creates a new savepoint
      */
-    public function createSavepoint(string! name) -> bool
+    public function createSavepoint( string name) -> bool
     {
         var dialect;
 
@@ -316,7 +316,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Creates a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> bool
+    public function createTable( string tableName,  string schemaName,  array definition) -> bool
     {
         var columns;
 
@@ -340,7 +340,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Creates a view
      */
-    public function createView(string! viewName, array! definition, string schemaName = null) -> bool
+    public function createView( string viewName,  array definition, string schemaName = null) -> bool
     {
         if unlikely !isset definition["sql"] {
             throw new TableMustHaveColumn();
@@ -412,7 +412,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * adapter must override this method. All bundled adapters except PostgreSQL
      * override it.
      */
-    public function describeIndexes(string! table, string schema = null) -> <IndexInterface[]>
+    public function describeIndexes( string table, string schema = null) -> <IndexInterface[]>
     {
         var indexes, index, keyName, indexObjects, name, indexColumns, columns;
 
@@ -461,7 +461,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * PostgreSQL, SQLite) overrides it, so this base implementation has no
      * in-tree caller and effectively assumes the PostgreSQL row shape.
      */
-    public function describeReferences(string! table, string! schema = null) -> <ReferenceInterface[]>
+    public function describeReferences( string table,  string schema = null) -> <ReferenceInterface[]>
     {
         var references, reference, arrayReference, constraintName,
             referenceObjects, name, referencedSchema, referencedTable, columns,
@@ -515,7 +515,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a column from a table
      */
-    public function dropColumn(string! tableName, string! schemaName, string columnName) -> bool
+    public function dropColumn( string tableName,  string schemaName, string columnName) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropColumn(
@@ -529,7 +529,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a CHECK constraint from a table. SQLite throws.
      */
-    public function dropCheck(string! tableName, string! schemaName, string! checkName) -> bool
+    public function dropCheck( string tableName,  string schemaName,  string checkName) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropCheck(
@@ -543,7 +543,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a foreign key from a table
      */
-    public function dropForeignKey(string! tableName, string! schemaName, string! referenceName) -> bool
+    public function dropForeignKey( string tableName,  string schemaName,  string referenceName) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropForeignKey(
@@ -557,7 +557,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drop an index from a table
      */
-    public function dropIndex(string! tableName, string! schemaName, indexName) -> bool
+    public function dropIndex( string tableName,  string schemaName, indexName) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropIndex(
@@ -571,7 +571,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a table's primary key
      */
-    public function dropPrimaryKey(string! tableName, string! schemaName) -> bool
+    public function dropPrimaryKey( string tableName,  string schemaName) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropPrimaryKey(
@@ -584,7 +584,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a table from a schema/database
      */
-    public function dropTable(string! tableName, string! schemaName = null, bool ifExists = true) -> bool
+    public function dropTable( string tableName,  string schemaName = null, bool ifExists = true) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropTable(
@@ -598,7 +598,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a view
      */
-    public function dropView(string! viewName, string! schemaName = null, bool ifExists = true) -> bool
+    public function dropView( string viewName,  string schemaName = null, bool ifExists = true) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropView(
@@ -725,7 +725,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * print_r($robot);
      *```
      */
-    public function fetchOne(string! sqlQuery, var fetchMode = Enum::FETCH_ASSOC, array bindParams = [], array bindTypes = []) -> array
+    public function fetchOne( string sqlQuery, var fetchMode = Enum::FETCH_ASSOC, array bindParams = [], array bindTypes = []) -> array
     {
         var result;
 
@@ -747,7 +747,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * `modifier` is passed straight to the dialect (use `Dialect::LOCK_NOWAIT`
      * / `Dialect::LOCK_SKIP_LOCKED` / `Dialect::LOCK_NONE`).
      */
-    public function forUpdate(string! sqlQuery, string modifier = "") -> string
+    public function forUpdate( string sqlQuery, string modifier = "") -> string
     {
         return this->dialect->forUpdate(sqlQuery, modifier);
     }
@@ -922,7 +922,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * INSERT INTO `robots` (`name`, `year`) VALUES ("Astro boy", 1952);
      * ```
      */
-    public function insert(string table, array! values, var fields = null, var dataTypes = null) -> bool
+    public function insert(string table,  array values, var fields = null, var dataTypes = null) -> bool
     {
         var bindDataTypes, escapedTable, escapedFields, field,
             insertSql, insertValues, joinedValues, placeholder, placeholders,
@@ -1041,7 +1041,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * echo $connection->limit("SELECT * FROM robots", 5);
      * ```
      */
-    public function limit(string! sqlQuery, var number) -> string
+    public function limit( string sqlQuery, var number) -> string
     {
         return this->dialect->limit(sqlQuery, number);
     }
@@ -1055,7 +1055,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * );
      *```
      */
-    public function listTables(string! schemaName = null) -> array
+    public function listTables( string schemaName = null) -> array
     {
         var tables, table, allTables;
 
@@ -1082,7 +1082,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * );
      *```
      */
-    public function listViews(string! schemaName = null) -> array
+    public function listViews( string schemaName = null) -> array
     {
         var tables, table, allTables;
 
@@ -1103,7 +1103,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Modifies a table column based on a definition
      */
-    public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> bool
+    public function modifyColumn( string tableName,  string schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> bool
     {
         return this->{"execute"}(
             this->dialect->modifyColumn(
@@ -1118,7 +1118,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Releases given savepoint
      */
-    public function releaseSavepoint(string! name) -> bool
+    public function releaseSavepoint( string name) -> bool
     {
         var dialect;
 
@@ -1140,7 +1140,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Rollbacks given savepoint
      */
-    public function rollbackSavepoint(string! name) -> bool
+    public function rollbackSavepoint( string name) -> bool
     {
         var dialect;
 
@@ -1200,7 +1200,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * key, constructing one adapter with `options` can change the SQL another,
      * already-configured connection generates.
      */
-    public static function setup(array! options) -> void
+    public static function setup( array options) -> void
     {
         var escapeIdentifiers, forceCasting;
 
@@ -1224,7 +1224,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * `modifier` is passed straight to the dialect (use
      * `Dialect::LOCK_NOWAIT` / `Dialect::LOCK_SKIP_LOCKED` for PostgreSQL).
      */
-    public function sharedLock(string! sqlQuery, string modifier = "") -> string
+    public function sharedLock( string sqlQuery, string modifier = "") -> string
     {
         return this->dialect->sharedLock(sqlQuery, modifier);
     }
@@ -1233,7 +1233,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * Creates a materialized view (PostgreSQL only - MySQL and SQLite
      * throw via the dialect).
      */
-    public function createMaterializedView(string! viewName, array! definition, string schemaName = null) -> bool
+    public function createMaterializedView( string viewName,  array definition, string schemaName = null) -> bool
     {
         return this->{"execute"}(
             this->dialect->createMaterializedView(
@@ -1247,7 +1247,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
     /**
      * Drops a materialized view (PostgreSQL only).
      */
-    public function dropMaterializedView(string! viewName, string schemaName = null, bool ifExists = true) -> bool
+    public function dropMaterializedView( string viewName, string schemaName = null, bool ifExists = true) -> bool
     {
         return this->{"execute"}(
             this->dialect->dropMaterializedView(
@@ -1262,7 +1262,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * Refreshes a materialized view (PostgreSQL only). Pass
      * `concurrent = true` for non-blocking refresh.
      */
-    public function refreshMaterializedView(string! viewName, string schemaName = null, bool concurrent = false) -> bool
+    public function refreshMaterializedView( string viewName, string schemaName = null, bool concurrent = false) -> bool
     {
         return this->{"execute"}(
             this->dialect->refreshMaterializedView(
@@ -1278,7 +1278,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * upsert clause to the supplied INSERT statement. Supported by
      * PostgreSQL and SQLite 3.24+; MySQL throws.
      */
-    public function onConflictUpdate(string! sqlQuery, array! conflictColumns, array! updateColumns) -> string
+    public function onConflictUpdate( string sqlQuery,  array conflictColumns,  array updateColumns) -> string
     {
         return this->dialect->onConflictUpdate(
             sqlQuery,
@@ -1292,7 +1292,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * and returns the modified SQL. Supported by PostgreSQL and SQLite 3.35+;
      * MySQL throws (no RETURNING construct). Pass `["*"]` for `RETURNING *`.
      */
-    public function returning(string! sqlQuery, array! columns) -> string
+    public function returning( string sqlQuery,  array columns) -> string
     {
         return this->dialect->returning(sqlQuery, columns);
     }
@@ -1315,7 +1315,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * );
      *```
      */
-    public function tableExists(string! tableName, string! schemaName = null) -> bool
+    public function tableExists( string tableName,  string schemaName = null) -> bool
     {
         var result;
 
@@ -1340,7 +1340,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * );
      *```
      */
-    public function tableOptions(string! tableName, string schemaName = null) -> array
+    public function tableOptions( string tableName, string schemaName = null) -> array
     {
         var sql, options;
 
@@ -1556,7 +1556,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * );
      *```
      */
-    public function viewExists(string! viewName, string! schemaName = null) -> bool
+    public function viewExists( string viewName,  string schemaName = null) -> bool
     {
         return this->fetchOne(this->dialect->viewExists(viewName, schemaName), Enum::FETCH_NUM)[0] > 0;
     }

--- a/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
+++ b/phalcon/Db/Adapter/Pdo/AbstractPdo.zep
@@ -84,7 +84,7 @@ abstract class AbstractPdo extends AbstractAdapter
      *     'charset' => 'utf8mb4'
      * ]
      */
-    public function __construct(array! descriptor)
+    public function __construct( array descriptor)
     {
         this->connect(descriptor);
 
@@ -251,7 +251,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * $connection->connect();
      * ```
      */
-    public function connect(array! descriptor = []) -> void
+    public function connect( array descriptor = []) -> void
     {
         var username, password, dsnAttributes, dsnAttributesCustomRaw,
             dsnAttributesMap, key, options, persistent, value, autoReconnect;
@@ -349,7 +349,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * );
      *```
      */
-    public function convertBoundParams(string! sql, array params = []) -> array
+    public function convertBoundParams( string sql, array params = []) -> array
     {
         var boundSql, placeHolders, bindPattern, matches, setOrder, placeMatch,
             value;
@@ -428,7 +428,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * );
      *```
      */
-    public function execute(string! sqlStatement, array! bindParams = [], array! bindTypes = []) -> bool
+    public function execute( string sqlStatement,  array bindParams = [],  array bindTypes = []) -> bool
     {
         var eventsManager, affectedRows, e;
 
@@ -501,7 +501,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * );
      *```
      */
-    public function executePrepared(<\PDOStatement> statement, array! placeholders, array dataTypes = []) -> <\PDOStatement>
+    public function executePrepared(<\PDOStatement> statement,  array placeholders, array dataTypes = []) -> <\PDOStatement>
     {
         var wildcard, value, type, castValue, parameter, position, itemValue;
 
@@ -670,7 +670,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * @param string|null $name
      * @return string|bool
      */
-    public function lastInsertId(string! name = null) -> string | bool
+    public function lastInsertId( string name = null) -> string | bool
     {
         return this->pdo->lastInsertId(name);
     }
@@ -715,7 +715,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * );
      *```
      */
-    public function prepare(string! sqlStatement) -> <\PDOStatement>
+    public function prepare( string sqlStatement) -> <\PDOStatement>
     {
         return this->pdo->prepare(sqlStatement);
     }
@@ -739,7 +739,7 @@ abstract class AbstractPdo extends AbstractAdapter
      * );
      *```
      */
-    public function query(string! sqlStatement, array! bindParams = [], array! bindTypes = []) -> <ResultInterface> | bool
+    public function query( string sqlStatement,  array bindParams = [],  array bindTypes = []) -> <ResultInterface> | bool
     {
         var eventsManager, statement, params, types, e;
 

--- a/phalcon/Db/Adapter/Pdo/Mysql.zep
+++ b/phalcon/Db/Adapter/Pdo/Mysql.zep
@@ -53,7 +53,7 @@ class Mysql extends PdoAdapter
     /**
      * Adds a foreign key to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> bool
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> bool
     {
         var foreignKeyCheck;
 
@@ -564,7 +564,7 @@ class Mysql extends PdoAdapter
      * );
      * ```
      */
-    public function describeIndexes(string! table, string! schema = null) -> <IndexInterface[]>
+    public function describeIndexes( string table,  string schema = null) -> <IndexInterface[]>
     {
         var indexes, index, keyName, indexType, indexObjects, columns, name,
             directions, collation;
@@ -683,7 +683,7 @@ class Mysql extends PdoAdapter
      * );
      *```
      */
-    public function describeReferences(string! table, string! schema = null) -> <ReferenceInterface[]>
+    public function describeReferences( string table,  string schema = null) -> <ReferenceInterface[]>
     {
         var references, reference, arrayReference, constraintName,
             referenceObjects, name, referencedSchema, referencedTable, columns,

--- a/phalcon/Db/Adapter/Pdo/Postgresql.zep
+++ b/phalcon/Db/Adapter/Pdo/Postgresql.zep
@@ -53,7 +53,7 @@ class Postgresql extends PdoAdapter
     /**
      * Constructor for Phalcon\Db\Adapter\Pdo\Postgresql
      */
-    public function __construct(array! descriptor)
+    public function __construct( array descriptor)
     {
         if isset descriptor["charset"] {
             trigger_error(
@@ -68,7 +68,7 @@ class Postgresql extends PdoAdapter
      * This method is automatically called in Phalcon\Db\Adapter\Pdo
      * constructor. Call it when you need to restore a database connection.
      */
-    public function connect(array! descriptor = []) -> void
+    public function connect( array descriptor = []) -> void
     {
         var schema, sql;
 
@@ -100,7 +100,7 @@ class Postgresql extends PdoAdapter
     /**
      * Creates a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> bool
+    public function createTable( string tableName,  string schemaName,  array definition) -> bool
     {
         var sql, queries, query, exception, columns;
 
@@ -638,7 +638,7 @@ class Postgresql extends PdoAdapter
      * );
      *```
      */
-    public function describeReferences(string! table, string! schema = null) -> <ReferenceInterface[]>
+    public function describeReferences( string table,  string schema = null) -> <ReferenceInterface[]>
     {
         var references, reference, arrayReference, constraintName,
             referenceObjects, name, referencedSchema, referencedTable, columns,
@@ -725,7 +725,7 @@ class Postgresql extends PdoAdapter
     /**
      * Modifies a table column based on a definition
      */
-    public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> bool
+    public function modifyColumn( string tableName,  string schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> bool
     {
         var sql, queries, query, exception;
 

--- a/phalcon/Db/Adapter/Pdo/Sqlite.zep
+++ b/phalcon/Db/Adapter/Pdo/Sqlite.zep
@@ -50,7 +50,7 @@ class Sqlite extends PdoAdapter
     /**
      * Constructor for Phalcon\Db\Adapter\Pdo\Sqlite
      */
-    public function __construct(array! descriptor)
+    public function __construct( array descriptor)
     {
         if isset descriptor["charset"] {
             trigger_error(
@@ -65,7 +65,7 @@ class Sqlite extends PdoAdapter
      * This method is automatically called in Phalcon\Db\Adapter\Pdo
      * constructor. Call it when you need to restore a database connection.
      */
-    public function connect(array! descriptor = []) -> void
+    public function connect( array descriptor = []) -> void
     {
         var dbname;
 
@@ -93,7 +93,7 @@ class Sqlite extends PdoAdapter
      * );
      * ```
      */
-    public function describeColumns(string! table, string! schema = null) -> <ColumnInterface[]>
+    public function describeColumns( string table,  string schema = null) -> <ColumnInterface[]>
     {
         var columns, columnType, fields, field, definition, oldColumn,
             sizePattern, matches, matchOne, matchTwo, columnName, hiddenFlag;
@@ -344,7 +344,7 @@ class Sqlite extends PdoAdapter
      * );
      * ```
      */
-    public function describeIndexes(string! table, string! schema = null) -> <IndexInterface[]>
+    public function describeIndexes( string table,  string schema = null) -> <IndexInterface[]>
     {
         var indexes, index, keyName, indexObjects, name, columns,
             describeIndexes, describeIndex, indexSql;
@@ -406,7 +406,7 @@ class Sqlite extends PdoAdapter
     /**
      * Lists table references
      */
-    public function describeReferences(string! table, string! schema = null) -> <ReferenceInterface[]>
+    public function describeReferences( string table,  string schema = null) -> <ReferenceInterface[]>
     {
         var references, reference, arrayReference, constraintName,
             referenceObjects, name, referencedSchema, referencedTable, columns,

--- a/phalcon/Db/Adapter/PdoFactory.zep
+++ b/phalcon/Db/Adapter/PdoFactory.zep
@@ -18,7 +18,7 @@ class PdoFactory extends AbstractFactory
     /**
      * Constructor
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -59,7 +59,7 @@ class PdoFactory extends AbstractFactory
     /**
      * Create a new instance of the adapter
      */
-    public function newInstance(string! name, array! options = []) ->  <AdapterInterface>
+    public function newInstance( string name,  array options = []) ->  <AdapterInterface>
     {
         var definition;
 

--- a/phalcon/Db/Check.zep
+++ b/phalcon/Db/Check.zep
@@ -64,7 +64,7 @@ class Check implements CheckInterface
     /**
      * Phalcon\Db\Check constructor
      */
-    public function __construct(string! name, array! definition)
+    public function __construct( string name,  array definition)
     {
         var expression;
 

--- a/phalcon/Db/Column.zep
+++ b/phalcon/Db/Column.zep
@@ -579,7 +579,7 @@ class Column implements ColumnInterface
     /**
      * Phalcon\Db\Column constructor
      */
-    public function __construct(string! name, array! definition)
+    public function __construct( string name,  array definition)
     {
         var type, notNull, primary, size, scale, dunsigned, first, after,
             bindType, isNumeric, autoIncrement, defaultValue, typeReference,

--- a/phalcon/Db/Dialect.zep
+++ b/phalcon/Db/Dialect.zep
@@ -59,7 +59,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generate SQL to create a new savepoint
      */
-    public function createSavepoint(string! name) -> string
+    public function createSavepoint( string name) -> string
     {
         return "SAVEPOINT " . name;
     }
@@ -67,7 +67,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Escape identifiers
      */
-    final public function escape(string! str, string escapeChar = null) -> string
+    final public function escape( string str, string escapeChar = null) -> string
     {
         var parts, key, part, newParts;
 
@@ -105,7 +105,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Escape Schema
      */
-    final public function escapeSchema(string! str, string escapeChar = null) -> string
+    final public function escapeSchema( string str, string escapeChar = null) -> string
     {
         if !Settings::get("db.escape_identifiers") {
             return str;
@@ -139,7 +139,7 @@ abstract class Dialect implements DialectInterface
      * echo $sql; // SELECT * FROM robots FOR UPDATE SKIP LOCKED
      *```
      */
-    public function forUpdate(string! sqlQuery, string modifier = "") -> string
+    public function forUpdate( string sqlQuery, string modifier = "") -> string
     {
         if modifier !== "" {
             return sqlQuery . " FOR UPDATE " . modifier;
@@ -160,7 +160,7 @@ abstract class Dialect implements DialectInterface
      * );
      * ```
      */
-    final public function getColumnList(array! columnList, string escapeChar = null, array! bindCounts = []) -> string
+    final public function getColumnList( array columnList, string escapeChar = null,  array bindCounts = []) -> string
     {
         var column;
         array columns;
@@ -191,7 +191,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final public function getSqlColumn(var column, string escapeChar = null, array! bindCounts = []) -> string
+    final public function getSqlColumn(var column, string escapeChar = null,  array bindCounts = []) -> string
     {
         var columnExpression, columnAlias, columnField, columnDomain;
 
@@ -260,7 +260,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Transforms an intermediate representation for an expression into a database system valid expression
      */
-    public function getSqlExpression(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    public function getSqlExpression( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         int i;
         var type, times, postTimes, rawValue, value, nestedDefinition;
@@ -479,7 +479,7 @@ abstract class Dialect implements DialectInterface
      * );
      * ```
      */
-    public function limit(string! sqlQuery, var number) -> string
+    public function limit( string sqlQuery, var number) -> string
     {
         if typeof number == "array" {
             let sqlQuery .= " LIMIT " . number[0];
@@ -509,7 +509,7 @@ abstract class Dialect implements DialectInterface
      * (`CREATE MATERIALIZED VIEW name AS <sql>`). Other dialects inherit
      * this throw - MySQL and SQLite have no materialized-view concept.
      */
-    public function createMaterializedView(string! viewName, array! definition, string schemaName = null) -> string
+    public function createMaterializedView( string viewName,  array definition, string schemaName = null) -> string
     {
         throw new MaterializedViewsNotSupported();
     }
@@ -517,7 +517,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generates SQL to drop a materialized view. Supported by PostgreSQL.
      */
-    public function dropMaterializedView(string! viewName, string schemaName = null, bool ifExists = true) -> string
+    public function dropMaterializedView( string viewName, string schemaName = null, bool ifExists = true) -> string
     {
         throw new MaterializedViewsNotSupported();
     }
@@ -528,7 +528,7 @@ abstract class Dialect implements DialectInterface
      * CONCURRENTLY ...`, which avoids blocking concurrent SELECTs (requires
      * the view to have a unique index).
      */
-    public function refreshMaterializedView(string! viewName, string schemaName = null, bool concurrent = false) -> string
+    public function refreshMaterializedView( string viewName, string schemaName = null, bool concurrent = false) -> string
     {
         throw new MaterializedViewsNotSupported();
     }
@@ -540,7 +540,7 @@ abstract class Dialect implements DialectInterface
      * MySQL overrides this method to throw because its `ON DUPLICATE KEY
      * UPDATE` has a different shape (deferred to parser item #23).
      */
-    public function onConflictUpdate(string! sqlQuery, array! conflictColumns, array! updateColumns) -> string
+    public function onConflictUpdate( string sqlQuery,  array conflictColumns,  array updateColumns) -> string
     {
         var col;
         array assignments;
@@ -571,7 +571,7 @@ abstract class Dialect implements DialectInterface
      * names. The base implementation throws - MySQL inherits it because
      * MySQL has no RETURNING construct.
      */
-    public function returning(string! sqlQuery, array! columns) -> string
+    public function returning( string sqlQuery,  array columns) -> string
     {
         throw new ReturningNotSupported();
     }
@@ -579,7 +579,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generate SQL to release a savepoint
      */
-    public function releaseSavepoint(string! name) -> string
+    public function releaseSavepoint( string name) -> string
     {
         return "RELEASE SAVEPOINT " . name;
     }
@@ -587,7 +587,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generate SQL to rollback a savepoint
      */
-    public function rollbackSavepoint(string! name) -> string
+    public function rollbackSavepoint( string name) -> string
     {
         return "ROLLBACK TO SAVEPOINT " . name;
     }
@@ -595,7 +595,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Builds a SELECT statement
      */
-    public function select(array! definition) -> string
+    public function select( array definition) -> string
     {
         var tables, columns, sql, distinct, joins, where, escapeChar, groupBy,
             having, orderBy, limit, forUpdate, bindCounts;
@@ -901,7 +901,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Resolve *
      */
-    final protected function getSqlExpressionAll(array! expression, string escapeChar = null) -> string
+    final protected function getSqlExpressionAll( array expression, string escapeChar = null) -> string
     {
         var domain;
 
@@ -919,7 +919,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionBinaryOperations(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionBinaryOperations( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right, operator;
 
@@ -953,7 +953,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionCase(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionCase( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var whenClause, whenClauses;
         string sql;
@@ -985,7 +985,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionCastValue(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionCastValue( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right;
 
@@ -1013,7 +1013,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionConvertValue(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionConvertValue( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right;
 
@@ -1063,7 +1063,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionFunctionCall(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionFunctionCall( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var name, customFunction, arguments;
 
@@ -1103,7 +1103,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionGroupBy(var expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionGroupBy(var expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var field, fields;
 
@@ -1139,7 +1139,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionHaving(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionHaving( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         return "HAVING " . this->getSqlExpression(expression, escapeChar, bindCounts);
     }
@@ -1153,7 +1153,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionJoins(var expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionJoins(var expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var condition, join, joinCondition, joinTable, joinType = "",
             joinConditionsArray;
@@ -1208,7 +1208,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionLimit(var expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionLimit(var expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var sql = "", value, limit, offset = null;
 
@@ -1256,7 +1256,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionList(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionList( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var item, values, separator;
         array items;
@@ -1293,7 +1293,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionObject(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionObject( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var domain = null, objectExpression;
 
@@ -1317,7 +1317,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionOrderBy(var expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionOrderBy(var expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var field, fields, type, fieldSql = null;
 
@@ -1357,7 +1357,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Resolve qualified expressions
      */
-    final protected function getSqlExpressionQualified(array! expression, string escapeChar = null) -> string
+    final protected function getSqlExpressionQualified( array expression, string escapeChar = null) -> string
     {
         var column, domain;
 
@@ -1380,7 +1380,7 @@ abstract class Dialect implements DialectInterface
      * @param string|null escapeChar
      * @param array bindCounts
      */
-    final protected function getSqlExpressionScalar(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionScalar( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var value;
 
@@ -1408,7 +1408,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionUnaryOperations(array! expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionUnaryOperations( array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right;
 
@@ -1438,7 +1438,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionWhere(var expression, string escapeChar = null, array! bindCounts = []) -> string
+    final protected function getSqlExpressionWhere(var expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var whereSql;
 
@@ -1454,7 +1454,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Prepares column for this RDBMS
      */
-    protected function prepareColumnAlias(string! qualified, string alias = null, string escapeChar = null) -> string
+    protected function prepareColumnAlias( string qualified, string alias = null, string escapeChar = null) -> string
     {
         if alias != "" {
             return qualified . " AS " . this->escape(alias, escapeChar);
@@ -1466,7 +1466,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Prepares table for this RDBMS
      */
-    protected function prepareTable(string! table, string schema = null, string alias = null, string escapeChar = null) -> string
+    protected function prepareTable( string table, string schema = null, string alias = null, string escapeChar = null) -> string
     {
         let table = this->escape(table, escapeChar);
 
@@ -1490,7 +1490,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Prepares qualified for this RDBMS
      */
-    protected function prepareQualified(string! column, string domain = null, string escapeChar = null) -> string
+    protected function prepareQualified( string column, string domain = null, string escapeChar = null) -> string
     {
         if domain != "" {
             return this->escape(domain . "." . column, escapeChar);

--- a/phalcon/Db/Dialect/Mysql.zep
+++ b/phalcon/Db/Dialect/Mysql.zep
@@ -41,7 +41,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to add a column to a table
      */
-    public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> string
+    public function addColumn( string tableName,  string schemaName, <ColumnInterface> column) -> string
     {
         var afterPosition, defaultValue, upperDefaultValue;
         string sql;
@@ -103,7 +103,7 @@ class Mysql extends Dialect
      * Generates SQL to add a CHECK constraint to an existing table.
      * Enforced by MySQL 8.0.16+.
      */
-    public function addCheck(string! tableName, string! schemaName, <CheckInterface> check) -> string
+    public function addCheck( string tableName,  string schemaName, <CheckInterface> check) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName)
             . " ADD " . this->getCheckClause(check, "`");
@@ -112,7 +112,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to add an index to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> string
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> string
     {
         var onDelete, onUpdate;
         string sql;
@@ -140,7 +140,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to add an index to a table
      */
-    public function addIndex(string! tableName, string! schemaName, <IndexInterface> index) -> string
+    public function addIndex( string tableName,  string schemaName, <IndexInterface> index) -> string
     {
         var indexType;
         string sql;
@@ -168,7 +168,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to add the primary key to a table
      */
-    public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> string
+    public function addPrimaryKey( string tableName,  string schemaName, <IndexInterface> index) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
     }
@@ -176,7 +176,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to create a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> string
+    public function createTable( string tableName,  string schemaName,  array definition) -> string
     {
         var temporary, options, table, columns, column, indexes, index,
             reference, references, indexName, columnLine, indexType, onDelete,
@@ -344,7 +344,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to create a view
      */
-    public function createView(string! viewName, array! definition, string schemaName = null) -> string
+    public function createView( string viewName,  array definition, string schemaName = null) -> string
     {
         var viewSql;
 
@@ -364,7 +364,7 @@ class Mysql extends Dialect
      * );
      * ```
      */
-    public function describeColumns(string! table, string schema = null) -> string
+    public function describeColumns( string table, string schema = null) -> string
     {
         string sql, schemaClause;
 
@@ -401,7 +401,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to query indexes on a table
      */
-    public function describeIndexes(string! table, string schema = null) -> string
+    public function describeIndexes( string table, string schema = null) -> string
     {
         return "SHOW INDEXES FROM " . this->prepareTable(table, schema);
     }
@@ -409,7 +409,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to query foreign keys on a table
      */
-    public function describeReferences(string! table, string schema = null) -> string
+    public function describeReferences( string table, string schema = null) -> string
     {
         string sql;
 
@@ -427,7 +427,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to delete a column from a table
      */
-    public function dropColumn(string! tableName, string! schemaName, string! columnName) -> string
+    public function dropColumn( string tableName,  string schemaName,  string columnName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP COLUMN `" . columnName . "`";
     }
@@ -435,7 +435,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to delete a CHECK constraint from a table
      */
-    public function dropCheck(string! tableName, string! schemaName, string! checkName) -> string
+    public function dropCheck( string tableName,  string schemaName,  string checkName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName)
             . " DROP CHECK `" . checkName . "`";
@@ -444,7 +444,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to delete a foreign key from a table
      */
-    public function dropForeignKey(string! tableName, string! schemaName, string! referenceName) -> string
+    public function dropForeignKey( string tableName,  string schemaName,  string referenceName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP FOREIGN KEY `" . referenceName . "`";
     }
@@ -452,7 +452,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to delete an index from a table
      */
-    public function dropIndex(string! tableName, string! schemaName, string! indexName) -> string
+    public function dropIndex( string tableName,  string schemaName,  string indexName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP INDEX `" . indexName . "`";
     }
@@ -460,7 +460,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to delete primary key from a table
      */
-    public function dropPrimaryKey(string! tableName, string! schemaName) -> string
+    public function dropPrimaryKey( string tableName,  string schemaName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP PRIMARY KEY";
     }
@@ -468,7 +468,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to drop a table
      */
-    public function dropTable(string! tableName, string schemaName = null, bool! ifExists = true) -> string
+    public function dropTable( string tableName, string schemaName = null,  bool ifExists = true) -> string
     {
         var table;
 
@@ -484,7 +484,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to drop a view
      */
-    public function dropView(string! viewName, string schemaName = null, bool! ifExists = true) -> string
+    public function dropView( string viewName, string schemaName = null,  bool ifExists = true) -> string
     {
         var view;
 
@@ -838,7 +838,7 @@ class Mysql extends Dialect
     /**
      * Generates the SQL to list all views of a schema or user
      */
-    public function listViews(string! schemaName = null) -> string
+    public function listViews( string schemaName = null) -> string
     {
         if schemaName {
             return "SELECT `TABLE_NAME` AS view_name FROM `INFORMATION_SCHEMA`.`VIEWS` WHERE `TABLE_SCHEMA` = '" . schemaName . "' ORDER BY view_name";
@@ -850,7 +850,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to modify a column in a table
      */
-    public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
+    public function modifyColumn( string tableName,  string schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
     {
         var afterPosition, defaultValue, upperDefaultValue, columnDefinition;
         string sql;
@@ -931,7 +931,7 @@ class Mysql extends Dialect
      * overridden here to throw, preventing accidental emission of invalid
      * SQL on MySQL connections.
      */
-    public function onConflictUpdate(string! sqlQuery, array! conflictColumns, array! updateColumns) -> string
+    public function onConflictUpdate( string sqlQuery,  array conflictColumns,  array updateColumns) -> string
     {
         throw new MysqlOnConflictNotSupported();
     }
@@ -958,7 +958,7 @@ class Mysql extends Dialect
      * echo $sql; // SELECT * FROM robots LOCK IN SHARE MODE
      *```
      */
-    public function sharedLock(string! sqlQuery, string modifier = "") -> string
+    public function sharedLock( string sqlQuery, string modifier = "") -> string
     {
         return sqlQuery . " LOCK IN SHARE MODE";
     }
@@ -972,7 +972,7 @@ class Mysql extends Dialect
      * echo $dialect->tableExists("posts");
      * ```
      */
-    public function tableExists(string! tableName, string schemaName = null) -> string
+    public function tableExists( string tableName, string schemaName = null) -> string
     {
         if schemaName {
             return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`TABLES` WHERE `TABLE_NAME`= '"
@@ -986,7 +986,7 @@ class Mysql extends Dialect
     /**
      * Generates the SQL to describe the table creation options
      */
-    public function tableOptions(string! table, string schema = null) -> string
+    public function tableOptions( string table, string schema = null) -> string
     {
         string sql;
 
@@ -1004,7 +1004,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to truncate a table
      */
-    public function truncateTable(string! tableName, string! schemaName) -> string
+    public function truncateTable( string tableName,  string schemaName) -> string
     {
         string table;
 
@@ -1020,7 +1020,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL checking for the existence of a schema.view
      */
-    public function viewExists(string! viewName, string schemaName = null) -> string
+    public function viewExists( string viewName, string schemaName = null) -> string
     {
         if schemaName {
             return "SELECT IF(COUNT(*) > 0, 1, 0) FROM `INFORMATION_SCHEMA`.`VIEWS` WHERE `TABLE_NAME`= '"
@@ -1034,7 +1034,7 @@ class Mysql extends Dialect
     /**
      * Generates SQL to add the table creation options
      */
-    protected function getTableOptions(array! definition) -> string
+    protected function getTableOptions( array definition) -> string
     {
         var options, engine, autoIncrement, tableCollation, collationParts, tableComment;
         array tableOptions;

--- a/phalcon/Db/Dialect/Postgresql.zep
+++ b/phalcon/Db/Dialect/Postgresql.zep
@@ -41,7 +41,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to add a column to a table
      */
-    public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> string
+    public function addColumn( string tableName,  string schemaName, <ColumnInterface> column) -> string
     {
         var columnDefinition;
         string sql;
@@ -68,7 +68,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to add a CHECK constraint to an existing table.
      */
-    public function addCheck(string! tableName, string! schemaName, <CheckInterface> check) -> string
+    public function addCheck( string tableName,  string schemaName, <CheckInterface> check) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName)
             . " ADD " . this->getCheckClause(check, "\"");
@@ -77,7 +77,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to add an index to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> string
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> string
     {
         var onDelete, onUpdate;
         string sql;
@@ -107,7 +107,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to add an index to a table
      */
-    public function addIndex(string! tableName, string! schemaName, <IndexInterface> index) -> string
+    public function addIndex( string tableName,  string schemaName, <IndexInterface> index) -> string
     {
         var indexType;
         string sql;
@@ -142,7 +142,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to add the primary key to a table
      */
-    public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> string
+    public function addPrimaryKey( string tableName,  string schemaName, <IndexInterface> index) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " ADD CONSTRAINT \"" . tableName . "_PRIMARY\" PRIMARY KEY (" . this->getColumnList(index->getColumns()) . ")";
     }
@@ -150,7 +150,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to create a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> string
+    public function createTable( string tableName,  string schemaName,  array definition) -> string
     {
         var temporary, options, table, columns, column, indexes, index,
             reference, references, indexName, indexType, onDelete, onUpdate,
@@ -311,7 +311,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to create a materialized view.
      */
-    public function createMaterializedView(string! viewName, array! definition, string schemaName = null) -> string
+    public function createMaterializedView( string viewName,  array definition, string schemaName = null) -> string
     {
         var viewSql;
 
@@ -327,7 +327,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to create a view
      */
-    public function createView(string! viewName, array! definition, string schemaName = null) -> string
+    public function createView( string viewName,  array definition, string schemaName = null) -> string
     {
         var viewSql;
 
@@ -347,7 +347,7 @@ class Postgresql extends Dialect
      * );
      * ```
      */
-    public function describeColumns(string! table, string schema = null) -> string
+    public function describeColumns( string table, string schema = null) -> string
     {
         if schema === null {
             let schema = "public";
@@ -401,7 +401,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to query indexes on a table
      */
-    public function describeIndexes(string! table, string schema = null) -> string
+    public function describeIndexes( string table, string schema = null) -> string
     {
         return "SELECT 0 as c0, t.relname as table_name, i.relname as key_name, 3 as c3, a.attname as column_name FROM pg_class t, pg_class i, pg_index ix, pg_attribute a WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND a.attnum = ANY(ix.indkey) AND t.relkind = 'r' AND t.relname = '" . table . "' ORDER BY t.relname, i.relname;";
     }
@@ -409,7 +409,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to query foreign keys on a table
      */
-    public function describeReferences(string! table, string schema = null) -> string
+    public function describeReferences( string table, string schema = null) -> string
     {
         if schema === null {
             let schema = "public";
@@ -421,7 +421,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to delete a column from a table
      */
-    public function dropColumn(string! tableName, string! schemaName, string! columnName) -> string
+    public function dropColumn( string tableName,  string schemaName,  string columnName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP COLUMN \"" . columnName . "\"";
     }
@@ -429,7 +429,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to delete a CHECK constraint from a table
      */
-    public function dropCheck(string! tableName, string! schemaName, string! checkName) -> string
+    public function dropCheck( string tableName,  string schemaName,  string checkName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName)
             . " DROP CONSTRAINT \"" . checkName . "\"";
@@ -438,7 +438,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to delete a foreign key from a table
      */
-    public function dropForeignKey(string! tableName, string! schemaName, string! referenceName) -> string
+    public function dropForeignKey( string tableName,  string schemaName,  string referenceName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP CONSTRAINT \"" . referenceName . "\"";
     }
@@ -446,7 +446,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to delete an index from a table
      */
-    public function dropIndex(string! tableName, string! schemaName, string! indexName) -> string
+    public function dropIndex( string tableName,  string schemaName,  string indexName) -> string
     {
         return "DROP INDEX \"" . indexName . "\"";
     }
@@ -454,7 +454,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to delete primary key from a table
      */
-    public function dropPrimaryKey(string! tableName, string! schemaName) -> string
+    public function dropPrimaryKey( string tableName,  string schemaName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName) . " DROP CONSTRAINT \"" . tableName . "_PRIMARY\"";
     }
@@ -462,7 +462,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to drop a table
      */
-    public function dropTable(string! tableName, string schemaName = null, bool! ifExists = true) -> string
+    public function dropTable( string tableName, string schemaName = null,  bool ifExists = true) -> string
     {
         var table;
 
@@ -478,7 +478,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to drop a materialized view.
      */
-    public function dropMaterializedView(string! viewName, string schemaName = null, bool ifExists = true) -> string
+    public function dropMaterializedView( string viewName, string schemaName = null, bool ifExists = true) -> string
     {
         var view;
 
@@ -494,7 +494,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to drop a view
      */
-    public function dropView(string! viewName, string schemaName = null, bool! ifExists = true) -> string
+    public function dropView( string viewName, string schemaName = null,  bool ifExists = true) -> string
     {
         var view;
 
@@ -512,7 +512,7 @@ class Postgresql extends Dialect
      * true, emits `REFRESH MATERIALIZED VIEW CONCURRENTLY ...` (avoids
      * blocking concurrent SELECTs; requires a unique index on the view).
      */
-    public function refreshMaterializedView(string! viewName, string schemaName = null, bool concurrent = false) -> string
+    public function refreshMaterializedView( string viewName, string schemaName = null, bool concurrent = false) -> string
     {
         var view;
 
@@ -845,7 +845,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to modify a column in a table
      */
-    public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
+    public function modifyColumn( string tableName,  string schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
     {
         var defaultValue, columnDefinition;
         string sql = "", sqlAlterTable;
@@ -902,7 +902,7 @@ class Postgresql extends Dialect
      * Appends a `RETURNING` clause to the supplied INSERT/UPDATE/DELETE
      * statement. Pass `["*"]` for `RETURNING *`, or a list of column names.
      */
-    public function returning(string! sqlQuery, array! columns) -> string
+    public function returning( string sqlQuery,  array columns) -> string
     {
         var first;
 
@@ -954,7 +954,7 @@ class Postgresql extends Dialect
      * // SELECT * FROM robots FOR SHARE NOWAIT
      *```
      */
-    public function sharedLock(string! sqlQuery, string modifier = "") -> string
+    public function sharedLock( string sqlQuery, string modifier = "") -> string
     {
         if modifier !== "" {
             return sqlQuery . " FOR SHARE " . modifier;
@@ -972,7 +972,7 @@ class Postgresql extends Dialect
      * echo $dialect->tableExists("posts");
      * ```
      */
-    public function tableExists(string! tableName, string schemaName = null) -> string
+    public function tableExists( string tableName, string schemaName = null) -> string
     {
         if schemaName === null {
             let schemaName = "public";
@@ -984,7 +984,7 @@ class Postgresql extends Dialect
     /**
      * Generates the SQL to describe the table creation options
      */
-    public function tableOptions(string! table, string schema = null) -> string
+    public function tableOptions( string table, string schema = null) -> string
     {
         string sql;
 
@@ -1000,7 +1000,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL to truncate a table
      */
-    public function truncateTable(string! tableName, string! schemaName) -> string
+    public function truncateTable( string tableName,  string schemaName) -> string
     {
         var table;
 
@@ -1016,7 +1016,7 @@ class Postgresql extends Dialect
     /**
      * Generates SQL checking for the existence of a schema.view
      */
-    public function viewExists(string! viewName, string schemaName = null) -> string
+    public function viewExists( string viewName, string schemaName = null) -> string
     {
         if schemaName === null {
             let schemaName = "public";
@@ -1067,7 +1067,7 @@ class Postgresql extends Dialect
         return preparedValue;
     }
 
-    protected function getTableOptions(array! definition) -> string
+    protected function getTableOptions( array definition) -> string
     {
         return "";
     }

--- a/phalcon/Db/Dialect/Sqlite.zep
+++ b/phalcon/Db/Dialect/Sqlite.zep
@@ -48,7 +48,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to add a column to a table
      */
-    public function addColumn(string! tableName, string! schemaName, <ColumnInterface> column) -> string
+    public function addColumn( string tableName,  string schemaName, <ColumnInterface> column) -> string
     {
         var defaultValue;
         string sql;
@@ -88,7 +88,7 @@ class Sqlite extends Dialect
      * SQLite cannot ALTER an existing table to add a CHECK constraint;
      * the constraint must be declared at CREATE TABLE time.
      */
-    public function addCheck(string! tableName, string! schemaName, <CheckInterface> check) -> string
+    public function addCheck( string tableName,  string schemaName, <CheckInterface> check) -> string
     {
         throw new SqliteAlterCheckNotSupported();
     }
@@ -96,7 +96,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to add an index to a table
      */
-    public function addForeignKey(string! tableName, string! schemaName, <ReferenceInterface> reference) -> string
+    public function addForeignKey( string tableName,  string schemaName, <ReferenceInterface> reference) -> string
     {
         throw new SqliteAlterForeignKeyNotSupported();
     }
@@ -104,7 +104,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to add an index to a table
      */
-    public function addIndex(string! tableName, string! schemaName, <IndexInterface> index) -> string
+    public function addIndex( string tableName,  string schemaName, <IndexInterface> index) -> string
     {
         var indexType;
         string sql;
@@ -136,7 +136,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to add the primary key to a table
      */
-    public function addPrimaryKey(string! tableName, string! schemaName, <IndexInterface> index) -> string
+    public function addPrimaryKey( string tableName,  string schemaName, <IndexInterface> index) -> string
     {
         throw new SqliteAlterPrimaryKeyNotSupported();
     }
@@ -144,7 +144,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to create a table
      */
-    public function createTable(string! tableName, string! schemaName, array! definition) -> string
+    public function createTable( string tableName,  string schemaName,  array definition) -> string
     {
         var columns, table, temporary, options, createLines, columnLine,
             column, indexes, index, indexName, indexType, references, reference,
@@ -286,7 +286,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to create a view
      */
-    public function createView(string! viewName, array! definition, string schemaName = null) -> string
+    public function createView( string viewName,  array definition, string schemaName = null) -> string
     {
         var viewSql;
 
@@ -306,7 +306,7 @@ class Sqlite extends Dialect
      * );
      * ```
      */
-    public function describeColumns(string! table, string schema = null) -> string
+    public function describeColumns( string table, string schema = null) -> string
     {
         /**
          * `table_xinfo` mirrors `table_info` but exposes the `hidden` column:
@@ -323,7 +323,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to query indexes detail on a table
      */
-    public function describeIndex(string! index) -> string
+    public function describeIndex( string index) -> string
     {
         return "PRAGMA index_info('" . index . "')";
     }
@@ -331,7 +331,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to query indexes on a table
      */
-    public function describeIndexes(string! table, string schema = null) -> string
+    public function describeIndexes( string table, string schema = null) -> string
     {
         return "PRAGMA index_list('" . table . "')";
     }
@@ -339,7 +339,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to query foreign keys on a table
      */
-    public function describeReferences(string! table, string schema = null) -> string
+    public function describeReferences( string table, string schema = null) -> string
     {
         return "PRAGMA foreign_key_list('" . table . "')";
     }
@@ -352,7 +352,7 @@ class Sqlite extends Dialect
      * cphalcon no longer pre-empts that rejection at the dialect level so
      * callers on 3.35+ can use the feature.
      */
-    public function dropColumn(string! tableName, string! schemaName, string! columnName) -> string
+    public function dropColumn( string tableName,  string schemaName,  string columnName) -> string
     {
         return "ALTER TABLE " . this->prepareTable(tableName, schemaName)
             . " DROP COLUMN \"" . columnName . "\"";
@@ -361,7 +361,7 @@ class Sqlite extends Dialect
     /**
      * SQLite cannot DROP a CHECK constraint from an existing table.
      */
-    public function dropCheck(string! tableName, string! schemaName, string! checkName) -> string
+    public function dropCheck( string tableName,  string schemaName,  string checkName) -> string
     {
         throw new SqliteDropCheckNotSupported();
     }
@@ -369,7 +369,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to delete a foreign key from a table
      */
-    public function dropForeignKey(string! tableName, string! schemaName, string! referenceName) -> string
+    public function dropForeignKey( string tableName,  string schemaName,  string referenceName) -> string
     {
         throw new SqliteDropForeignKeyNotSupported();
     }
@@ -377,7 +377,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to delete an index from a table
      */
-    public function dropIndex(string! tableName, string! schemaName, string! indexName) -> string
+    public function dropIndex( string tableName,  string schemaName,  string indexName) -> string
     {
         if schemaName {
             return "DROP INDEX \"" . schemaName . "\".\"" . indexName . "\"";
@@ -389,7 +389,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to delete primary key from a table
      */
-    public function dropPrimaryKey(string! tableName, string! schemaName) -> string
+    public function dropPrimaryKey( string tableName,  string schemaName) -> string
     {
         throw new SqliteDropPrimaryKeyNotSupported();
     }
@@ -397,7 +397,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to drop a table
      */
-    public function dropTable(string! tableName, string schemaName = null, bool! ifExists = true) -> string
+    public function dropTable( string tableName, string schemaName = null,  bool ifExists = true) -> string
     {
         var table;
 
@@ -413,7 +413,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to drop a view
      */
-    public function dropView(string! viewName, string schemaName = null, bool! ifExists = true) -> string
+    public function dropView( string viewName, string schemaName = null,  bool ifExists = true) -> string
     {
         var view;
 
@@ -432,7 +432,7 @@ class Sqlite extends Dialect
      * regardless of the `modifier` argument (`NOWAIT` / `SKIP LOCKED` are
      * silently ignored).
      */
-    public function forUpdate(string! sqlQuery, string modifier = "") -> string
+    public function forUpdate( string sqlQuery, string modifier = "") -> string
     {
         return sqlQuery;
     }
@@ -613,7 +613,7 @@ class Sqlite extends Dialect
      * );
      * ```
      */
-    public function listIndexesSql(string! table, string schema = null, string keyName = null) -> string
+    public function listIndexesSql( string table, string schema = null, string keyName = null) -> string
     {
         string sql;
 
@@ -643,7 +643,7 @@ class Sqlite extends Dialect
     /**
      * Generates the SQL to list all views of a schema or user
      */
-    public function listViews(string! schemaName = null) -> string
+    public function listViews( string schemaName = null) -> string
     {
         return "SELECT tbl_name FROM sqlite_master WHERE type = 'view' ORDER BY tbl_name";
     }
@@ -651,7 +651,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to modify a column in a table
      */
-    public function modifyColumn(string! tableName, string! schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
+    public function modifyColumn( string tableName,  string schemaName, <ColumnInterface> column, <ColumnInterface> currentColumn = null) -> string
     {
         throw new SqliteAlterColumnNotSupported();
     }
@@ -661,7 +661,7 @@ class Sqlite extends Dialect
      * statement. Supported by SQLite 3.35+. Pass `["*"]` for `RETURNING *`,
      * or a list of column names.
      */
-    public function returning(string! sqlQuery, array! columns) -> string
+    public function returning( string sqlQuery,  array columns) -> string
     {
         var first;
 
@@ -702,7 +702,7 @@ class Sqlite extends Dialect
      * SQLite has no row-level shared-lock construct, so the original query
      * is returned unchanged regardless of the `modifier` argument.
      */
-    public function sharedLock(string! sqlQuery, string modifier = "") -> string
+    public function sharedLock( string sqlQuery, string modifier = "") -> string
     {
         return sqlQuery;
     }
@@ -716,7 +716,7 @@ class Sqlite extends Dialect
      * echo $dialect->tableExists("posts");
      * ```
      */
-    public function tableExists(string! tableName, string schemaName = null) -> string
+    public function tableExists( string tableName, string schemaName = null) -> string
     {
         return "SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM sqlite_master WHERE type='table' AND tbl_name='" . tableName . "'";
     }
@@ -724,7 +724,7 @@ class Sqlite extends Dialect
     /**
      * Generates the SQL to describe the table creation options
      */
-    public function tableOptions(string! table, string schema = null) -> string
+    public function tableOptions( string table, string schema = null) -> string
     {
         return "";
     }
@@ -732,7 +732,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL to truncate a table
      */
-    public function truncateTable(string! tableName, string! schemaName) -> string
+    public function truncateTable( string tableName,  string schemaName) -> string
     {
         string table;
 
@@ -748,7 +748,7 @@ class Sqlite extends Dialect
     /**
      * Generates SQL checking for the existence of a schema.view
      */
-    public function viewExists(string! viewName, string schemaName = null) -> string
+    public function viewExists( string viewName, string schemaName = null) -> string
     {
         return "SELECT CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END FROM sqlite_master WHERE type='view' AND tbl_name='" . viewName . "'";
     }

--- a/phalcon/Db/Index.zep
+++ b/phalcon/Db/Index.zep
@@ -129,7 +129,7 @@ class Index implements IndexInterface
      * `columns` key in the second argument; when present, the third
      * positional `type` argument is ignored in favor of the definition.
      */
-    public function __construct(string! name, array! columnsOrDefinition, string type = "")
+    public function __construct( string name,  array columnsOrDefinition, string type = "")
     {
         var definitionType, invisible, directions, where, concurrent;
 

--- a/phalcon/Db/Reference.zep
+++ b/phalcon/Db/Reference.zep
@@ -97,7 +97,7 @@ class Reference implements ReferenceInterface
     /**
      * Phalcon\Db\Reference constructor
      */
-    public function __construct(string! name, array! definition)
+    public function __construct( string name,  array definition)
     {
         var columns, schema, referencedTable, referencedSchema,
             referencedColumns, onDelete, onUpdate;

--- a/phalcon/Di/Di.zep
+++ b/phalcon/Di/Di.zep
@@ -115,7 +115,7 @@ class Di implements DiInterface
     /**
      * Magic method to get or set services using setters/getters
      */
-    public function __call(string! method, array arguments = []) -> var | null
+    public function __call( string method, array arguments = []) -> var | null
     {
         var instance, possibleService, definition;
 
@@ -158,7 +158,7 @@ class Di implements DiInterface
      * Only is successful if a service hasn't been registered previously
      * with the same name
      */
-    public function attempt(string! name, definition, bool shared = false) -> <ServiceInterface> | bool
+    public function attempt( string name, definition, bool shared = false) -> <ServiceInterface> | bool
     {
         if isset this->services[name] {
             return false;
@@ -172,7 +172,7 @@ class Di implements DiInterface
     /**
      * Resolves the service based on its configuration
      */
-    public function get(string! name, parameters = null) -> var
+    public function get( string name, parameters = null) -> var
     {
         var service, isShared, instance = null;
 
@@ -306,7 +306,7 @@ class Di implements DiInterface
     /**
      * Returns a service definition without resolving
      */
-    public function getRaw(string! name) -> var
+    public function getRaw( string name) -> var
     {
         return this->getService(name)
                    ->getDefinition()
@@ -316,7 +316,7 @@ class Di implements DiInterface
     /**
      * Returns a Phalcon\Di\Service instance
      */
-    public function getService(string! name) -> <ServiceInterface>
+    public function getService( string name) -> <ServiceInterface>
     {
         /**
          * Resolve the alias, if any
@@ -342,7 +342,7 @@ class Di implements DiInterface
      * Resolves a service, the resolved service is stored in the DI, subsequent
      * requests for this service will return the same instance
      */
-    public function getShared(string! name, parameters = null) -> var
+    public function getShared( string name, parameters = null) -> var
     {
         /**
          * Resolve the alias, if any
@@ -407,7 +407,7 @@ class Di implements DiInterface
      *
      * @link https://docs.phalcon.io/latest/di/
      */
-    public function loadFromPhp(string! filePath) -> void
+    public function loadFromPhp( string filePath) -> void
     {
         var services;
 
@@ -449,7 +449,7 @@ class Di implements DiInterface
      *
      * @link https://docs.phalcon.io/latest/di/
      */
-    public function loadFromYaml(string! filePath, array! callbacks = null) -> void
+    public function loadFromYaml( string filePath,  array callbacks = null) -> void
     {
         var services;
 
@@ -461,7 +461,7 @@ class Di implements DiInterface
     /**
      * Check whether the DI contains a service by a name
      */
-    public function has(string! name) -> bool
+    public function has( string name) -> bool
     {
         /**
          * Resolve the alias, if any
@@ -478,7 +478,7 @@ class Di implements DiInterface
      * this method reports only on the resolved-instance cache populated by
      * `getShared()`.
      */
-    public function hasShared(string! name) -> bool
+    public function hasShared( string name) -> bool
     {
         /**
          * Resolve the alias, if any
@@ -558,7 +558,7 @@ class Di implements DiInterface
      * Removes a service in the services container
      * It also removes any shared instance created for the service
      */
-    public function remove(string! name) -> void
+    public function remove( string name) -> void
     {
         var alias, aliases, services, sharedInstances, target;
 
@@ -593,7 +593,7 @@ class Di implements DiInterface
      * Removes the cached shared instance for a service, leaving the service
      * definition intact so the next `getShared()` call rebuilds it.
      */
-    public function removeShared(string! name) -> void
+    public function removeShared( string name) -> void
     {
         var sharedInstances, service;
 
@@ -630,7 +630,7 @@ class Di implements DiInterface
     /**
      * Registers a service in the services container
      */
-    public function set(string! name, var definition, bool shared = false) -> <ServiceInterface>
+    public function set( string name, var definition, bool shared = false) -> <ServiceInterface>
     {
         /**
          * Resolve the alias, if any
@@ -702,7 +702,7 @@ class Di implements DiInterface
     /**
      * Sets a service using a raw Phalcon\Di\Service definition
      */
-    public function setService(string! name, <ServiceInterface> rawDefinition) -> <ServiceInterface>
+    public function setService( string name, <ServiceInterface> rawDefinition) -> <ServiceInterface>
     {
         let this->services[name] = rawDefinition;
 
@@ -712,7 +712,7 @@ class Di implements DiInterface
     /**
      * Registers an "always shared" service in the services container
      */
-    public function setShared(string! name, var definition) -> <ServiceInterface>
+    public function setShared( string name, var definition) -> <ServiceInterface>
     {
         return this->set(name, definition, true);
     }

--- a/phalcon/Di/DiInterface.zep
+++ b/phalcon/Di/DiInterface.zep
@@ -24,12 +24,12 @@ interface DiInterface extends ArrayAccess
      *
      * @param mixed definition
      */
-    public function attempt(string! name, definition, bool shared = false) -> <ServiceInterface> | bool;
+    public function attempt( string name, definition, bool shared = false) -> <ServiceInterface> | bool;
 
     /**
      * Resolves the service based on its configuration
      */
-    public function get(string! name, parameters = null) -> var;
+    public function get( string name, parameters = null) -> var;
 
     /**
      * Return the last DI created
@@ -39,12 +39,12 @@ interface DiInterface extends ArrayAccess
     /**
      * Returns a service definition without resolving
      */
-    public function getRaw(string! name) -> var;
+    public function getRaw( string name) -> var;
 
     /**
      * Returns the corresponding Phalcon\Di\Service instance for a service
      */
-    public function getService(string! name) -> <ServiceInterface>;
+    public function getService( string name) -> <ServiceInterface>;
 
     /**
      * Return the services registered in the DI
@@ -54,12 +54,12 @@ interface DiInterface extends ArrayAccess
     /**
      * Returns a shared service based on their configuration
      */
-    public function getShared(string! name, parameters = null) -> var;
+    public function getShared( string name, parameters = null) -> var;
 
     /**
      * Check whether the DI contains a service by a name
      */
-    public function has(string! name) -> bool;
+    public function has( string name) -> bool;
 
     /**
      * Check whether the DI has a cached shared instance for a service name.
@@ -69,12 +69,12 @@ interface DiInterface extends ArrayAccess
      * `getShared()`. A service can be registered (`has()` returns true)
      * without yet having a shared instance (`hasShared()` returns false).
      */
-    public function hasShared(string! name) -> bool;
+    public function hasShared( string name) -> bool;
 
     /**
      * Removes a service in the services container
      */
-    public function remove(string! name) -> void;
+    public function remove( string name) -> void;
 
     /**
      * Removes the cached shared instance for a service, leaving the service
@@ -84,7 +84,7 @@ interface DiInterface extends ArrayAccess
      * parent's resource handle (e.g. a database connection) and needs to
      * discard the cached instance without re-registering the service.
      */
-    public function removeShared(string! name) -> void;
+    public function removeShared( string name) -> void;
 
     /**
      * Resets the internal default DI
@@ -94,7 +94,7 @@ interface DiInterface extends ArrayAccess
     /**
      * Registers a service in the services container
      */
-    public function set(string! name, definition, bool shared = false) -> <ServiceInterface>;
+    public function set( string name, definition, bool shared = false) -> <ServiceInterface>;
 
     /**
      * Set a default dependency injection container to be obtained into static
@@ -105,10 +105,10 @@ interface DiInterface extends ArrayAccess
     /**
      * Sets a service using a raw Phalcon\Di\Service definition
      */
-    public function setService(string! name, <ServiceInterface> rawDefinition) -> <ServiceInterface>;
+    public function setService( string name, <ServiceInterface> rawDefinition) -> <ServiceInterface>;
 
     /**
      * Registers an "always shared" service in the services container
      */
-    public function setShared(string! name, definition) -> <ServiceInterface>;
+    public function setShared( string name, definition) -> <ServiceInterface>;
 }

--- a/phalcon/Di/Injectable.zep
+++ b/phalcon/Di/Injectable.zep
@@ -57,7 +57,7 @@ abstract class Injectable extends stdClass implements InjectionAwareInterface
     /**
      * Magic method __get
      */
-    public function __get(string! propertyName) -> var | null
+    public function __get( string propertyName) -> var | null
     {
         var container, service;
 
@@ -112,7 +112,7 @@ abstract class Injectable extends stdClass implements InjectionAwareInterface
     /**
      * Magic method __isset
      */
-    public function __isset(string! name) -> bool
+    public function __isset( string name) -> bool
     {
         return this->getDI()->has(name);
     }

--- a/phalcon/Di/Service.zep
+++ b/phalcon/Di/Service.zep
@@ -218,7 +218,7 @@ class Service implements ServiceInterface
     /**
      * Changes a parameter in the definition without resolve the service
      */
-    public function setParameter(int position, array! parameter) -> <ServiceInterface>
+    public function setParameter(int position,  array parameter) -> <ServiceInterface>
     {
         var arguments;
 

--- a/phalcon/Di/Service/Builder.zep
+++ b/phalcon/Di/Service/Builder.zep
@@ -39,7 +39,7 @@ class Builder
      * @param array parameters
      * @return mixed
      */
-    public function build(<DiInterface> container, array! definition, parameters = null)
+    public function build(<DiInterface> container,  array definition, parameters = null)
     {
         var className, arguments, paramCalls, methodPosition, method,
             methodName, methodCall, instance, propertyPosition, property,
@@ -198,7 +198,7 @@ class Builder
      *
      * @return mixed
      */
-    private function buildParameter(<DiInterface> container, int position, array! argument)
+    private function buildParameter(<DiInterface> container, int position,  array argument)
     {
         var type, name, value, instanceArguments;
 
@@ -263,7 +263,7 @@ class Builder
     /**
      * Resolves an array of parameters
      */
-    private function buildParameters(<DiInterface> container, array! arguments) -> array
+    private function buildParameters(<DiInterface> container,  array arguments) -> array
     {
         var position, argument;
         array buildArguments;

--- a/phalcon/Di/ServiceInterface.zep
+++ b/phalcon/Di/ServiceInterface.zep
@@ -52,7 +52,7 @@ interface ServiceInterface
     /**
      * Changes a parameter in the definition without resolve the service
      */
-    public function setParameter(int position, array! parameter) -> <ServiceInterface>;
+    public function setParameter(int position,  array parameter) -> <ServiceInterface>;
 
     /**
      * Sets if the service is shared or not

--- a/phalcon/Dispatcher/AbstractDispatcher.zep
+++ b/phalcon/Dispatcher/AbstractDispatcher.zep
@@ -184,7 +184,7 @@ abstract class AbstractDispatcher extends AbstractInjectionAware implements Disp
      */
     protected returnedValue = null;
 
-    public function callActionMethod(handler, string actionMethod, array! params = [])
+    public function callActionMethod(handler, string actionMethod,  array params = [])
     {
         var result, observer, altHandler, altAction, altParams;
 

--- a/phalcon/Encryption/Crypt/PadFactory.zep
+++ b/phalcon/Encryption/Crypt/PadFactory.zep
@@ -27,7 +27,7 @@ class PadFactory extends AbstractFactory
     /**
      * AdapterFactory constructor.
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -35,7 +35,7 @@ class PadFactory extends AbstractFactory
     /**
      * Create a new instance of the adapter
      */
-    public function newInstance(string! name) -> <PadInterface>
+    public function newInstance( string name) -> <PadInterface>
     {
         var definition;
 

--- a/phalcon/Encryption/Security.zep
+++ b/phalcon/Encryption/Security.zep
@@ -650,7 +650,7 @@ class Security extends AbstractInjectionAware implements SecurityContract
      *
      * @return static
      */
-    public function setRandomBytes(int! randomBytes) -> <static>
+    public function setRandomBytes( int randomBytes) -> <static>
     {
         let this->numberBytes = randomBytes;
 

--- a/phalcon/Encryption/Security/JWT/Builder.zep
+++ b/phalcon/Encryption/Security/JWT/Builder.zep
@@ -84,7 +84,7 @@ class Builder
      *
      * @return static
      */
-    public function addClaim(string! name, var value) -> <static>
+    public function addClaim( string name, var value) -> <static>
     {
         this->claims->set(name, value);
 
@@ -99,7 +99,7 @@ class Builder
      *
      * @return static
      */
-    public function addHeader(string! name, var value) -> <static>
+    public function addHeader( string name, var value) -> <static>
     {
         this->jose->set(name, value);
 
@@ -324,7 +324,7 @@ class Builder
      *
      * @return static
      */
-    public function setId(string! jwtId) -> <static>
+    public function setId( string jwtId) -> <static>
     {
         return this->setClaim(Enum::ID, jwtId);
     }
@@ -339,7 +339,7 @@ class Builder
      *
      * @return static
      */
-    public function setIssuedAt(int! timestamp) -> <static>
+    public function setIssuedAt( int timestamp) -> <static>
     {
         return this->setClaim(Enum::ISSUED_AT, timestamp);
     }
@@ -354,7 +354,7 @@ class Builder
      *
      * @return static
      */
-    public function setIssuer(string! issuer) -> <static>
+    public function setIssuer( string issuer) -> <static>
     {
         return this->setClaim(Enum::ISSUER, issuer);
     }
@@ -373,7 +373,7 @@ class Builder
      * @return static
      * @throws ValidatorException
      */
-    public function setNotBefore(int! timestamp) -> <static>
+    public function setNotBefore( int timestamp) -> <static>
     {
         if timestamp > time() {
             throw new InvalidNotBefore();
@@ -388,7 +388,7 @@ class Builder
      * @return static
      * @throws ValidatorException
      */
-    public function setPassphrase(string! passphrase) -> <static>
+    public function setPassphrase( string passphrase) -> <static>
     {
         if !preg_match(
             "/^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[\W_]).{16,}$/",
@@ -415,7 +415,7 @@ class Builder
      *
      * @return static
      */
-    public function setSubject(string! subject) -> <static>
+    public function setSubject( string subject) -> <static>
     {
         return this->setClaim(Enum::SUBJECT, subject);
     }
@@ -428,7 +428,7 @@ class Builder
      *
      * @return Builder
      */
-    protected function setClaim(string! name, var value) -> <Builder>
+    protected function setClaim( string name, var value) -> <Builder>
     {
         this->claims->set(name, value);
 
@@ -438,7 +438,7 @@ class Builder
     /**
      * @todo This will be removed when traits are introduced
      */
-    private function encodeUrl(string! input) -> string
+    private function encodeUrl( string input) -> string
     {
         return str_replace("=", "", strtr(base64_encode(input), "+/", "-_"));
     }

--- a/phalcon/Encryption/Security/JWT/Signer/Hmac.zep
+++ b/phalcon/Encryption/Security/JWT/Signer/Hmac.zep
@@ -25,7 +25,7 @@ class Hmac extends AbstractSigner
      *
      * @throws UnsupportedAlgorithmException
      */
-    public function __construct(string! algo = "sha512")
+    public function __construct( string algo = "sha512")
     {
         array supported;
 
@@ -60,7 +60,7 @@ class Hmac extends AbstractSigner
      *
      * @return string
      */
-    public function sign(string! payload, string! passphrase) -> string
+    public function sign( string payload,  string passphrase) -> string
     {
         return this->getHash(payload, passphrase);
     }

--- a/phalcon/Encryption/Security/JWT/Signer/None.zep
+++ b/phalcon/Encryption/Security/JWT/Signer/None.zep
@@ -43,7 +43,7 @@ class None implements SignerInterface
      *
      * @return string
      */
-    public function sign(string! payload, string passphrase) -> string
+    public function sign( string payload, string passphrase) -> string
     {
         return "";
     }

--- a/phalcon/Encryption/Security/JWT/Token/Item.zep
+++ b/phalcon/Encryption/Security/JWT/Token/Item.zep
@@ -21,7 +21,7 @@ class Item extends AbstractItem
      * @param array  $payload
      * @param string $encoded
      */
-    public function __construct(array! payload, string! encoded)
+    public function __construct( array payload,  string encoded)
     {
         let this->data["encoded"] = encoded,
             this->data["payload"] = payload;
@@ -33,7 +33,7 @@ class Item extends AbstractItem
      *
      * @return mixed|null
      */
-    public function get(string! name, var defaultValue = null) -> var | null
+    public function get( string name, var defaultValue = null) -> var | null
     {
         if !this->has(name) {
             return defaultValue;
@@ -55,7 +55,7 @@ class Item extends AbstractItem
      *
      * @return bool
      */
-    public function has(string! name) -> bool
+    public function has( string name) -> bool
     {
         return isset this->data["payload"][name];
     }

--- a/phalcon/Encryption/Security/JWT/Token/Parser.zep
+++ b/phalcon/Encryption/Security/JWT/Token/Parser.zep
@@ -50,7 +50,7 @@ class Parser
      *
      * @return Token
      */
-    public function parse(string! token) -> <Token>
+    public function parse( string token) -> <Token>
     {
         var claims, encodedClaims, encodedHeaders, encodedSignature,
             headers, results, signature;
@@ -125,7 +125,7 @@ class Parser
      *
      * @return Signature
      */
-    private function decodeSignature(<Item> headers, string! signature) -> <Signature>
+    private function decodeSignature(<Item> headers,  string signature) -> <Signature>
     {
         var algo, decoded, encodedSignature;
 
@@ -148,7 +148,7 @@ class Parser
      *
      * @return array
      */
-    private function parseToken(string! token) -> array
+    private function parseToken( string token) -> array
     {
         var parts;
 
@@ -164,7 +164,7 @@ class Parser
     /**
      * @todo This will be removed when traits are introduced
      */
-    private function decodeUrl(string! input) -> string
+    private function decodeUrl( string input) -> string
     {
         var data, remainder;
 

--- a/phalcon/Encryption/Security/JWT/Token/Signature.zep
+++ b/phalcon/Encryption/Security/JWT/Token/Signature.zep
@@ -21,7 +21,7 @@ class Signature extends AbstractItem
      * @param string $hash
      * @param string $encoded
      */
-    public function __construct(string! hash = "", string! encoded = "")
+    public function __construct( string hash = "",  string encoded = "")
     {
         let this->data["encoded"] = encoded,
             this->data["hash"]    = hash;

--- a/phalcon/Encryption/Security/JWT/Validator.zep
+++ b/phalcon/Encryption/Security/JWT/Validator.zep
@@ -261,7 +261,7 @@ class Validator
      * @return static
      * @throws ValidatorException
      */
-    public function validateIssuer(string! issuer) -> <static>
+    public function validateIssuer( string issuer) -> <static>
     {
         var tokenIssuer;
 

--- a/phalcon/Encryption/Security/Uuid.zep
+++ b/phalcon/Encryption/Security/Uuid.zep
@@ -40,7 +40,7 @@ class Uuid
     /**
      * Generates a version 3 (name-based MD5) UUID.
      */
-    public function v3(string! namespaceName, string! name) -> <Version3>
+    public function v3( string namespaceName,  string name) -> <Version3>
     {
         return new Version3(namespaceName, name);
     }
@@ -56,7 +56,7 @@ class Uuid
     /**
      * Generates a version 5 (name-based SHA-1) UUID.
      */
-    public function v5(string! namespaceName, string! name) -> <Version5>
+    public function v5( string namespaceName,  string name) -> <Version5>
     {
         return new Version5(namespaceName, name);
     }

--- a/phalcon/Encryption/Security/Uuid/Version3.zep
+++ b/phalcon/Encryption/Security/Uuid/Version3.zep
@@ -23,7 +23,7 @@ namespace Phalcon\Encryption\Security\Uuid;
  */
 class Version3 extends AbstractUuid
 {
-    public function __construct(string! namespaceName, string! name)
+    public function __construct( string namespaceName,  string name)
     {
         var hash;
 

--- a/phalcon/Encryption/Security/Uuid/Version5.zep
+++ b/phalcon/Encryption/Security/Uuid/Version5.zep
@@ -24,7 +24,7 @@ namespace Phalcon\Encryption\Security\Uuid;
  */
 class Version5 extends AbstractUuid
 {
-    public function __construct(string! namespaceName, string! name)
+    public function __construct( string namespaceName,  string name)
     {
         var hash;
 

--- a/phalcon/Events/Event.zep
+++ b/phalcon/Events/Event.zep
@@ -144,7 +144,7 @@ class Event implements EventInterface, Stoppable
     /**
      * Sets event type.
      */
-    public function setType(string! type) -> <EventInterface>
+    public function setType( string type) -> <EventInterface>
     {
         let this->type = type;
 

--- a/phalcon/Events/Manager.zep
+++ b/phalcon/Events/Manager.zep
@@ -746,7 +746,7 @@ class Manager implements ManagerInterface
     /**
      * Check whether certain type of event has listeners
      */
-    public function hasListeners(string! type) -> bool
+    public function hasListeners( string type) -> bool
     {
         return isset this->events[type];
     }

--- a/phalcon/Factory/AbstractFactory.zep
+++ b/phalcon/Factory/AbstractFactory.zep
@@ -34,7 +34,7 @@ abstract class AbstractFactory extends AbstractConfigFactory
     /**
      * Checks if a service exists and throws an exception
      */
-    protected function getService(string! name) -> var
+    protected function getService( string name) -> var
     {
         if unlikely !isset this->mapper[name] {
             throw this->getException("Service " . name . " is not registered");
@@ -46,7 +46,7 @@ abstract class AbstractFactory extends AbstractConfigFactory
     /**
      * Initialize services/add new services
      */
-    protected function init(array! services = []) -> void
+    protected function init( array services = []) -> void
     {
         var adapters, name, service;
 

--- a/phalcon/Filter/Sanitize/Lower.zep
+++ b/phalcon/Filter/Sanitize/Lower.zep
@@ -24,7 +24,7 @@ class Lower implements Sanitizer
      *
      * @return false|string|string[]
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         if true === function_exists("mb_convert_case") {
             return mb_convert_case(input, MB_CASE_LOWER, "UTF-8");

--- a/phalcon/Filter/Sanitize/LowerFirst.zep
+++ b/phalcon/Filter/Sanitize/LowerFirst.zep
@@ -24,7 +24,7 @@ class LowerFirst implements Sanitizer
      *
      * @return string
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         return lcfirst(input);
     }

--- a/phalcon/Filter/Sanitize/Striptags.zep
+++ b/phalcon/Filter/Sanitize/Striptags.zep
@@ -24,7 +24,7 @@ class Striptags implements Sanitizer
      *
      * @return string
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         return strip_tags(input);
     }

--- a/phalcon/Filter/Sanitize/Trim.zep
+++ b/phalcon/Filter/Sanitize/Trim.zep
@@ -24,7 +24,7 @@ class Trim implements Sanitizer
      *
      * @return string
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         return trim(input);
     }

--- a/phalcon/Filter/Sanitize/Upper.zep
+++ b/phalcon/Filter/Sanitize/Upper.zep
@@ -24,7 +24,7 @@ class Upper implements Sanitizer
      *
      * @return false|string|string[]
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         if true === function_exists("mb_convert_case") {
             return mb_convert_case(input, MB_CASE_UPPER, "UTF-8");

--- a/phalcon/Filter/Sanitize/UpperFirst.zep
+++ b/phalcon/Filter/Sanitize/UpperFirst.zep
@@ -24,7 +24,7 @@ class UpperFirst implements Sanitizer
      *
      * @return string
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         return ucfirst(input);
     }

--- a/phalcon/Filter/Sanitize/UpperWords.zep
+++ b/phalcon/Filter/Sanitize/UpperWords.zep
@@ -24,7 +24,7 @@ class UpperWords implements Sanitizer
      *
      * @return false|string|string[]
      */
-    public function __invoke(string! input)
+    public function __invoke( string input)
     {
         if true === function_exists("mb_convert_case") {
             return mb_convert_case(input, MB_CASE_TITLE, "UTF-8");

--- a/phalcon/Filter/Validation.zep
+++ b/phalcon/Filter/Validation.zep
@@ -472,7 +472,7 @@ class Validation extends Injectable implements ValidationInterface
     /**
      * Adds the validators to a field
      */
-    public function rules(var field, array! validators) -> <static>
+    public function rules(var field,  array validators) -> <static>
     {
         var validator;
 
@@ -525,7 +525,7 @@ class Validation extends Injectable implements ValidationInterface
     /**
      * Adds labels for fields
      */
-    public function setLabels(array! labels) -> void
+    public function setLabels( array labels) -> void
     {
         let this->labels = labels;
     }

--- a/phalcon/Filter/Validation/ValidationInterface.zep
+++ b/phalcon/Filter/Validation/ValidationInterface.zep
@@ -57,7 +57,7 @@ interface ValidationInterface
     /**
      * Get label for field
      */
-    public function getLabel(string! field) -> string;
+    public function getLabel( string field) -> string;
 
     /**
      * Returns the registered validators
@@ -85,7 +85,7 @@ interface ValidationInterface
     /**
      * Adds the validators to a field
      */
-    public function rules(string! field, array! validators) -> <ValidationInterface>;
+    public function rules( string field,  array validators) -> <ValidationInterface>;
 
     /**
      * Adds filters to the field
@@ -97,7 +97,7 @@ interface ValidationInterface
     /**
      * Adds labels for fields
      */
-    public function setLabels(array! labels) -> void;
+    public function setLabels( array labels) -> void;
 
     /**
      * Validate a set of data according to a set of rules

--- a/phalcon/Filter/Validation/Validator/Alnum.zep
+++ b/phalcon/Filter/Validation/Validator/Alnum.zep
@@ -60,7 +60,7 @@ class Alnum extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Alpha.zep
+++ b/phalcon/Filter/Validation/Validator/Alpha.zep
@@ -61,7 +61,7 @@ class Alpha extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Between.zep
+++ b/phalcon/Filter/Validation/Validator/Between.zep
@@ -74,7 +74,7 @@ class Between extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Callback.zep
+++ b/phalcon/Filter/Validation/Validator/Callback.zep
@@ -73,7 +73,7 @@ class Callback extends AbstractValidator
      *     'callback' => null
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Confirmation.zep
+++ b/phalcon/Filter/Validation/Validator/Confirmation.zep
@@ -70,7 +70,7 @@ class Confirmation extends AbstractValidator
      *     'ignoreCase' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/CreditCard.zep
+++ b/phalcon/Filter/Validation/Validator/CreditCard.zep
@@ -61,7 +61,7 @@ class CreditCard extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Date.zep
+++ b/phalcon/Filter/Validation/Validator/Date.zep
@@ -68,7 +68,7 @@ class Date extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Digit.zep
+++ b/phalcon/Filter/Validation/Validator/Digit.zep
@@ -61,7 +61,7 @@ class Digit extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Email.zep
+++ b/phalcon/Filter/Validation/Validator/Email.zep
@@ -72,7 +72,7 @@ class Email extends AbstractValidator
      *     'allowUTF8' => false,
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/ExclusionIn.zep
+++ b/phalcon/Filter/Validation/Validator/ExclusionIn.zep
@@ -77,7 +77,7 @@ class ExclusionIn extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/File.zep
+++ b/phalcon/Filter/Validation/Validator/File.zep
@@ -125,7 +125,7 @@ class File extends AbstractValidatorComposite
      *     'messageValid' => ''
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         var helper, included = null, key, message = null,
             messageFileEmpty = null, messageIniSize = null, messageValid = null,

--- a/phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep
@@ -69,7 +69,7 @@ class AspectRatio extends AbstractFile
      *     'ratio' => '16x9'
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep
@@ -66,7 +66,7 @@ class Equal extends AbstractFile
      *     'resolution' => '1000x1000'
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/File/Resolution/Max.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/Max.zep
@@ -72,7 +72,7 @@ class Max extends AbstractFile
      *     'included' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/File/Resolution/Min.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/Min.zep
@@ -72,7 +72,7 @@ class Min extends AbstractFile
      *     'included' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Identical.zep
+++ b/phalcon/Filter/Validation/Validator/Identical.zep
@@ -68,7 +68,7 @@ class Identical extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/InclusionIn.zep
+++ b/phalcon/Filter/Validation/Validator/InclusionIn.zep
@@ -71,7 +71,7 @@ class InclusionIn extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Ip.zep
+++ b/phalcon/Filter/Validation/Validator/Ip.zep
@@ -89,7 +89,7 @@ class Ip extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Numericality.zep
+++ b/phalcon/Filter/Validation/Validator/Numericality.zep
@@ -61,7 +61,7 @@ class Numericality extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/PresenceOf.zep
+++ b/phalcon/Filter/Validation/Validator/PresenceOf.zep
@@ -61,7 +61,7 @@ class PresenceOf extends AbstractValidator
      *     'allowEmpty' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Regex.zep
+++ b/phalcon/Filter/Validation/Validator/Regex.zep
@@ -67,7 +67,7 @@ class Regex extends AbstractValidator
      *     'pattern' => ''
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/StringLength.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength.zep
@@ -95,7 +95,7 @@ class StringLength extends AbstractValidatorComposite
      *     'includedMaximum' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         var included = null, key, message = null, validator, value;
 

--- a/phalcon/Filter/Validation/Validator/StringLength/Max.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength/Max.zep
@@ -76,7 +76,7 @@ class Max extends AbstractValidator
      *     'included' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/StringLength/Min.zep
+++ b/phalcon/Filter/Validation/Validator/StringLength/Min.zep
@@ -76,7 +76,7 @@ class Min extends AbstractValidator
      *     'included' => false
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/Validator/Uniqueness.zep
+++ b/phalcon/Filter/Validation/Validator/Uniqueness.zep
@@ -114,7 +114,7 @@ class Uniqueness extends AbstractCombinedFieldsValidator
      *     'except'     => null
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }
@@ -169,7 +169,7 @@ class Uniqueness extends AbstractCombinedFieldsValidator
     /**
      * The column map is used in the case to get real column name
      */
-    protected function getColumnNameReal(var record, string! field) -> string
+    protected function getColumnNameReal(var record,  string field) -> string
     {
         // Caching columnMap
         if Settings::get("orm.column_renaming") && !this->columnMap {

--- a/phalcon/Filter/Validation/Validator/Url.zep
+++ b/phalcon/Filter/Validation/Validator/Url.zep
@@ -62,7 +62,7 @@ class Url extends AbstractValidator
      *     'options' => []
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         parent::__construct(options);
     }

--- a/phalcon/Filter/Validation/ValidatorFactory.zep
+++ b/phalcon/Filter/Validation/ValidatorFactory.zep
@@ -17,7 +17,7 @@ class ValidatorFactory extends AbstractFactory
     /**
      * TagFactory constructor.
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -25,7 +25,7 @@ class ValidatorFactory extends AbstractFactory
     /**
      * Creates a new instance
      */
-    public function newInstance(string! name) -> <ValidatorInterface>
+    public function newInstance( string name) -> <ValidatorInterface>
     {
         var definition;
 

--- a/phalcon/Filter/Validation/ValidatorInterface.zep
+++ b/phalcon/Filter/Validation/ValidatorInterface.zep
@@ -23,7 +23,7 @@ interface ValidatorInterface
      *
      * @return mixed
      */
-    public function getOption(string! key, var defaultValue = null) -> var;
+    public function getOption( string key, var defaultValue = null) -> var;
 
     /**
      * Get the template message
@@ -31,7 +31,7 @@ interface ValidatorInterface
      * @return string
      * @throw InvalidArgumentException When the field does not exists
      */
-    public function getTemplate(string! field) -> string;
+    public function getTemplate( string field) -> string;
 
     /**
      * Get message templates
@@ -45,21 +45,21 @@ interface ValidatorInterface
      *
      * @return boolean
      */
-    public function hasOption(string! key) -> bool;
+    public function hasOption( string key) -> bool;
 
     /**
      * Set a new template message
      *
      * @return ValidatorInterface
      */
-    public function setTemplate(string! template) -> <ValidatorInterface>;
+    public function setTemplate( string template) -> <ValidatorInterface>;
 
     /**
      * Clear current template and set new from an array,
      *
      * @return ValidatorInterface
      */
-    public function setTemplates(array! templates) -> <ValidatorInterface>;
+    public function setTemplates( array templates) -> <ValidatorInterface>;
 
     /**
      * Executes the validation

--- a/phalcon/Flash/AbstractFlash.zep
+++ b/phalcon/Flash/AbstractFlash.zep
@@ -251,7 +251,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *
      * @param array $cssClasses
      */
-    public function setCssClasses(array! cssClasses) -> <static>
+    public function setCssClasses( array cssClasses) -> <static>
     {
         let this->cssClasses = cssClasses;
 
@@ -263,7 +263,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *
      * @param array $cssIconClasses
      */
-    public function setCssIconClasses(array! cssIconClasses) -> <static>
+    public function setCssIconClasses( array cssIconClasses) -> <static>
     {
         let this->cssIconClasses  = cssIconClasses;
 
@@ -275,7 +275,7 @@ abstract class AbstractFlash extends AbstractInjectionAware implements FlashInte
      *
      * @param string $customTemplate
      */
-    public function setCustomTemplate(string! customTemplate) -> <static>
+    public function setCustomTemplate( string customTemplate) -> <static>
     {
         let this->customTemplate = customTemplate;
 

--- a/phalcon/Flash/Session.zep
+++ b/phalcon/Flash/Session.zep
@@ -203,7 +203,7 @@ class Session extends AbstractFlash
      * @return array
      * @throws Exception
      */
-    protected function setSessionMessages(array! messages) -> array
+    protected function setSessionMessages( array messages) -> array
     {
         var session;
 

--- a/phalcon/Forms/Element/AbstractElement.zep
+++ b/phalcon/Forms/Element/AbstractElement.zep
@@ -147,7 +147,7 @@ abstract class AbstractElement implements ElementInterface
      * @param \Phalcon\Filter\Validation\ValidatorInterface[] validators
      * @param bool                                            merge
      */
-    public function addValidators(array! validators, bool merge = true) -> <ElementInterface>
+    public function addValidators( array validators, bool merge = true) -> <ElementInterface>
     {
         var validator;
 
@@ -412,7 +412,7 @@ abstract class AbstractElement implements ElementInterface
     /**
      * Sets default attributes for the element
      */
-    public function setAttributes(array! attributes) -> <ElementInterface>
+    public function setAttributes( array attributes) -> <ElementInterface>
     {
         let this->attributes = attributes;
 
@@ -483,7 +483,7 @@ abstract class AbstractElement implements ElementInterface
     /**
      * Sets the element name
      */
-    public function setName(string! name) -> <ElementInterface>
+    public function setName( string name) -> <ElementInterface>
     {
         let this->name = name;
 

--- a/phalcon/Forms/Element/AbstractElement.zep
+++ b/phalcon/Forms/Element/AbstractElement.zep
@@ -393,6 +393,10 @@ abstract class AbstractElement implements ElementInterface
             unset attributes["value"];
         }
 
+        if value !== null {
+            let value = (string) value;
+        }
+
         let merged = array_merge(this->attributes, attributes),
             result = helper->__invoke(name, value, merged);
 

--- a/phalcon/Forms/Element/ElementInterface.zep
+++ b/phalcon/Forms/Element/ElementInterface.zep
@@ -38,7 +38,7 @@ interface ElementInterface
      *
      * @return ElementInterface
      */
-    public function addValidators(array! validators, bool merge = true) -> <ElementInterface>;
+    public function addValidators( array validators, bool merge = true) -> <ElementInterface>;
 
     /**
      * Appends a message to the internal message list
@@ -136,7 +136,7 @@ interface ElementInterface
     /**
      * Sets default attributes for the element
      */
-    public function setAttributes(array! attributes) -> <ElementInterface>;
+    public function setAttributes( array attributes) -> <ElementInterface>;
 
     /**
      * Sets a default value in case the form does not use an entity
@@ -169,7 +169,7 @@ interface ElementInterface
     /**
      * Sets the element's name
      */
-    public function setName(string! name) -> <ElementInterface>;
+    public function setName( string name) -> <ElementInterface>;
 
     /**
      * Sets an option for the element

--- a/phalcon/Forms/Form.zep
+++ b/phalcon/Forms/Form.zep
@@ -192,7 +192,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
      * @param object entity
      * @param array whitelist
      */
-    public function bind(array! data, var entity = null, array whitelist = []) -> <static>
+    public function bind( array data, var entity = null, array whitelist = []) -> <static>
     {
         var filter, key, value, element, candidate, filters, container, filteredValue;
         var elementName, dataKey;
@@ -400,7 +400,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Returns an element added to the form by its name
      */
-    public function get(string! name) -> <ElementInterface>
+    public function get( string name) -> <ElementInterface>
     {
         var element;
 
@@ -452,7 +452,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Gets a value from the internal filtered data or calls getValue(name)
      */
-    public function getFilteredValue(string! name) -> var | null
+    public function getFilteredValue( string name) -> var | null
     {
         var filteredData, value;
 
@@ -473,7 +473,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Returns a label for an element
      */
-    public function getLabel(string! name) -> string
+    public function getLabel( string name) -> string
     {
         var element, label;
 
@@ -514,7 +514,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Returns the messages generated for a specific element
      */
-    public function getMessagesFor(string! name) -> <Messages>
+    public function getMessagesFor( string name) -> <Messages>
     {
         if !this->has(name) {
             return new Messages();
@@ -556,7 +556,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Gets a value from the internal related entity or from the default value
      */
-    public function getValue(string! name) -> var | null
+    public function getValue( string name) -> var | null
     {
         var entity, value, data, internalEntity, element;
         array forbidden;
@@ -667,7 +667,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Check if the form contains an element
      */
-    public function has(string! name) -> bool
+    public function has( string name) -> bool
     {
         /**
          * Checks if the element is in the form
@@ -678,7 +678,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Check if messages were generated for a specific element
      */
-    public function hasMessagesFor(string! name) -> bool
+    public function hasMessagesFor( string name) -> bool
     {
         return this->getMessagesFor(name)->count() > 0;
     }
@@ -864,7 +864,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Generate the label of an element added to the form including HTML
      */
-    public function label(string! name, array attributes = []) -> string
+    public function label( string name, array attributes = []) -> string
     {
         var element;
 
@@ -886,7 +886,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Renders a specific item in the form
      */
-    public function render(string! name, array attributes = []) -> string
+    public function render( string name, array attributes = []) -> string
     {
         var element;
 
@@ -900,7 +900,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Removes an element from the form
      */
-    public function remove(string! name) -> bool
+    public function remove( string name) -> bool
     {
         /**
          * Checks if the element is in the form
@@ -934,7 +934,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
      *
      * @return static
      */
-    public function setAction(string! action) -> <static>
+    public function setAction( string action) -> <static>
     {
         this->getAttributes()->set("action", action);
 
@@ -1010,7 +1010,7 @@ class Form extends Injectable implements Countable, Iterator, AttributesInterfac
     /**
      * Sets options for the element
      */
-    public function setUserOptions(array! options) -> <static>
+    public function setUserOptions( array options) -> <static>
     {
         let this->options = options;
 

--- a/phalcon/Html/TagFactory.zep
+++ b/phalcon/Html/TagFactory.zep
@@ -151,7 +151,7 @@ class TagFactory
      */
     public function __construct(
         <EscaperInterface> escaper,
-        array! services = [],
+         array services = [],
         <ResponseInterface> response = null,
         <UrlInterface> url = null
     ) {

--- a/phalcon/Http/Cookie.zep
+++ b/phalcon/Http/Cookie.zep
@@ -99,7 +99,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
      * Phalcon\Http\Cookie constructor.
      */
     public function __construct(
-        string! name,
+         string name,
         var value = null,
         int expire = 0,
         string path = "/",
@@ -474,7 +474,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
     /**
      * Sets the domain that the cookie is available to
      */
-    public function setDomain(string! domain) -> <CookieInterface>
+    public function setDomain( string domain) -> <CookieInterface>
     {
         if !this->isRestored {
             this->restore();
@@ -516,7 +516,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
     /**
      * Sets the cookie's options
      */
-    public function setOptions(array! options) -> <CookieInterface>
+    public function setOptions( array options) -> <CookieInterface>
     {
         let this->options = options;
 
@@ -526,7 +526,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
     /**
      * Sets the cookie's path
      */
-    public function setPath(string! path) -> <CookieInterface>
+    public function setPath( string path) -> <CookieInterface>
     {
         if !this->isRestored {
             this->restore();
@@ -601,7 +601,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
      *
      * @throws \Phalcon\Http\Cookie\Exception
      */
-    protected function assertSignKeyIsLongEnough(string! signKey) -> void
+    protected function assertSignKeyIsLongEnough( string signKey) -> void
     {
         var length;
 
@@ -616,7 +616,7 @@ class Cookie extends AbstractInjectionAware implements CookieInterface
      * @todo Remove this when we get traits
      */
     private function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Http/Cookie/CookieInterface.zep
+++ b/phalcon/Http/Cookie/CookieInterface.zep
@@ -74,7 +74,7 @@ interface CookieInterface
     /**
      * Sets the domain that the cookie is available to
      */
-    public function setDomain(string! domain) -> <CookieInterface>;
+    public function setDomain( string domain) -> <CookieInterface>;
 
     /**
      * Sets the cookie's expiration time
@@ -89,12 +89,12 @@ interface CookieInterface
     /**
      * Sets the cookie's options
      */
-    public function setOptions(array! options) -> <CookieInterface>;
+    public function setOptions( array options) -> <CookieInterface>;
 
     /**
      * Sets the cookie's expiration time
      */
-    public function setPath(string! path) -> <CookieInterface>;
+    public function setPath( string path) -> <CookieInterface>;
 
     /**
      * Sets if the cookie must only be sent when the connection is secure

--- a/phalcon/Http/Request.zep
+++ b/phalcon/Http/Request.zep
@@ -107,7 +107,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      *```
      */
     public function get(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -419,7 +419,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Gets HTTP header from request data
      */
-    public function getHeader(string! header) -> string
+    public function getHeader( string header) -> string
     {
         var value, name, server;
 
@@ -707,7 +707,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      *```
      */
     public function getPatch(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -765,7 +765,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      *```
      */
     public function getPost(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -818,7 +818,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      *```
      */
     public function getPut(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -852,7 +852,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      *```
      */
     public function getQuery(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -910,7 +910,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Gets variable from $_SERVER superglobal
      */
-    public function getServer(string! name) -> string | null
+    public function getServer( string name) -> string | null
     {
         var serverValue, server;
 
@@ -1057,7 +1057,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether $_REQUEST superglobal has certain index
      */
-    public function has(string! name) -> bool
+    public function has( string name) -> bool
     {
         return array_key_exists(name, _REQUEST);
     }
@@ -1073,7 +1073,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether headers has certain index
      */
-    final public function hasHeader(string! header) -> bool
+    final public function hasHeader( string header) -> bool
     {
         var name;
 
@@ -1085,7 +1085,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether the PATCH data has certain index
      */
-    public function hasPatch(string! name) -> bool
+    public function hasPatch( string name) -> bool
     {
         var patch;
 
@@ -1097,7 +1097,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether $_POST superglobal has certain index
      */
-    public function hasPost(string! name) -> bool
+    public function hasPost( string name) -> bool
     {
         var post;
 
@@ -1109,7 +1109,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether the PUT data has certain index
      */
-    public function hasPut(string! name) -> bool
+    public function hasPut( string name) -> bool
     {
         var put;
 
@@ -1121,7 +1121,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether $_GET superglobal has certain index
      */
-    public function hasQuery(string! name) -> bool
+    public function hasQuery( string name) -> bool
     {
         return array_key_exists(name, _GET);
     }
@@ -1129,7 +1129,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Checks whether $_SERVER superglobal has certain index
      */
-    final public function hasServer(string! name) -> bool
+    final public function hasServer( string name) -> bool
     {
         var server;
 
@@ -1395,7 +1395,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      * particular methods
      */
     public function setParameterFilters(
-        string! name,
+         string name,
         array filters = [],
         array scope = []
     ) -> <static> {
@@ -1490,7 +1490,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Process a request header and return the one with best quality
      */
-    protected function getBestQuality(array qualityParts, string! name) -> string
+    protected function getBestQuality(array qualityParts,  string name) -> string
     {
         int i;
         double quality, acceptQuality;
@@ -1525,7 +1525,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
      */
     protected function getHelper(
         array source,
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -1564,7 +1564,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Process a request header and return an array of values with their qualities
      */
-    protected function getQualityHeader(string! serverIndex, string! name) -> array
+    protected function getQualityHeader( string serverIndex,  string name) -> array
     {
         var headerPart, headerParts, headerSplit, part, parts, returnedParts, serverValue, split;
 
@@ -1783,7 +1783,7 @@ class Request extends AbstractInjectionAware implements RequestInterface, Reques
     /**
      * Smooth out $_FILES to have plain array with all files uploaded
      */
-    protected function smoothFiles(array! names, array! types, array! tmp_names, array! sizes, array! errors, string prefix) -> array
+    protected function smoothFiles( array names,  array types,  array tmp_names,  array sizes,  array errors, string prefix) -> array
     {
         var idx, name, file, files, parentFiles, p;
 

--- a/phalcon/Http/Request/File.zep
+++ b/phalcon/Http/Request/File.zep
@@ -78,7 +78,7 @@ class File implements FileInterface
     /**
      * Phalcon\Http\Request\File constructor
      */
-    public function __construct(array! file, string key = "")
+    public function __construct( array file, string key = "")
     {
         var name;
 
@@ -196,7 +196,7 @@ class File implements FileInterface
     /**
      * Moves the temporary file to a destination within the application
      */
-    public function moveTo(string! destination) -> bool
+    public function moveTo( string destination) -> bool
     {
         return move_uploaded_file(this->tmpName, destination);
     }
@@ -205,7 +205,7 @@ class File implements FileInterface
      * @todo Remove this when we get traits
      */
     private function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Http/Request/FileInterface.zep
+++ b/phalcon/Http/Request/FileInterface.zep
@@ -49,5 +49,5 @@ interface FileInterface
     /**
      * Move the temporary file to a destination
      */
-    public function moveTo(string! destination) -> bool;
+    public function moveTo( string destination) -> bool;
 }

--- a/phalcon/Http/RequestInterface.zep
+++ b/phalcon/Http/RequestInterface.zep
@@ -31,7 +31,7 @@ interface RequestInterface
      *```
      */
     public function get(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -95,7 +95,7 @@ interface RequestInterface
     /**
      * Gets HTTP header from request data
      */
-    public function getHeader(string! header) -> string;
+    public function getHeader( string header) -> string;
 
     /**
      * Returns the available headers in the request
@@ -196,7 +196,7 @@ interface RequestInterface
      *```
      */
     public function getPost(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -215,7 +215,7 @@ interface RequestInterface
      *```
      */
     public function getPut(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -238,7 +238,7 @@ interface RequestInterface
      *```
      */
     public function getQuery(
-        string! name = null,
+         string name = null,
         var filters = null,
         var defaultValue = null,
         bool notAllowEmpty = false,
@@ -259,7 +259,7 @@ interface RequestInterface
     /**
      * Gets variable from $_SERVER superglobal
      */
-    public function getServer(string! name) -> string | null;
+    public function getServer( string name) -> string | null;
 
     /**
      * Gets active server address IP
@@ -304,7 +304,7 @@ interface RequestInterface
     /**
      * Checks whether $_REQUEST superglobal has certain index
      */
-    public function has(string! name) -> bool;
+    public function has( string name) -> bool;
 
     /**
      * Checks whether request include attached files
@@ -314,27 +314,27 @@ interface RequestInterface
     /**
      * Checks whether headers has certain index
      */
-    public function hasHeader(string! header) -> bool;
+    public function hasHeader( string header) -> bool;
 
     /**
      * Checks whether $_POST superglobal has certain index
      */
-    public function hasPost(string! name) -> bool;
+    public function hasPost( string name) -> bool;
 
     /**
      * Checks whether the PUT data has certain index
      */
-    public function hasPut(string! name) -> bool;
+    public function hasPut( string name) -> bool;
 
     /**
      * Checks whether $_GET superglobal has certain index
      */
-    public function hasQuery(string! name) -> bool;
+    public function hasQuery( string name) -> bool;
 
     /**
      * Checks whether $_SERVER superglobal has certain index
      */
-    public function hasServer(string! name) -> bool;
+    public function hasServer( string name) -> bool;
 
     /**
      * Checks whether request has been made using ajax. Checks if $_SERVER["HTTP_X_REQUESTED_WITH"] === "XMLHttpRequest"

--- a/phalcon/Http/Response.zep
+++ b/phalcon/Http/Response.zep
@@ -88,7 +88,7 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
     /**
      * Phalcon\Http\Response constructor
      */
-    public function __construct(string! content = null, code = null, status = null)
+    public function __construct( string content = null, code = null, status = null)
     {
         // Note: Don't remove exclamation mark above otherwise NULL will be coerced.
 
@@ -414,7 +414,7 @@ class Response implements ResponseInterface, InjectionAwareInterface, EventsAwar
      * $this->response->setCache(60);
      *```
      */
-    public function setCache(int! minutes) -> <ResponseInterface>
+    public function setCache( int minutes) -> <ResponseInterface>
     {
         var date;
 

--- a/phalcon/Http/Response/Cookies.zep
+++ b/phalcon/Http/Response/Cookies.zep
@@ -104,7 +104,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
      * Deletes a cookie by its name
      * This method does not removes cookies from the _COOKIE superglobal
      */
-    public function delete(string! name) -> bool
+    public function delete( string name) -> bool
     {
         var cookie;
 
@@ -123,7 +123,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
     /**
      * Gets a cookie from the bag
      */
-    public function get(string! name) -> <CookieInterface>
+    public function get( string name) -> <CookieInterface>
     {
         var container, encryption, cookie;
 
@@ -172,7 +172,7 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
      * Check if a cookie is defined in the bag or exists in the _COOKIE
      * superglobal
      */
-    public function has(string! name) -> bool
+    public function has( string name) -> bool
     {
         return isset this->cookies[name] || isset _COOKIE[name];
     }
@@ -244,12 +244,12 @@ class Cookies extends AbstractInjectionAware implements CookiesInterface
      * ```
      */
     public function set(
-        string! name,
+         string name,
         var value = null,
         int expire = 0,
         string path = "/",
         bool secure = false,
-        string! domain = "",
+         string domain = "",
         bool httpOnly = false,
         array options = []
     ) -> <CookiesInterface> {

--- a/phalcon/Http/Response/CookiesInterface.zep
+++ b/phalcon/Http/Response/CookiesInterface.zep
@@ -21,17 +21,17 @@ interface CookiesInterface
      * Deletes a cookie by its name
      * This method does not removes cookies from the _COOKIE superglobal
      */
-    public function delete(string! name) -> bool;
+    public function delete( string name) -> bool;
 
     /**
      * Gets a cookie from the bag
      */
-    public function get(string! name) -> <CookieInterface>;
+    public function get( string name) -> <CookieInterface>;
 
     /**
      * Check if a cookie is defined in the bag or exists in the _COOKIE superglobal
      */
-    public function has(string! name) -> bool;
+    public function has( string name) -> bool;
 
     /**
      * Returns if the bag is automatically encrypting/decrypting cookies
@@ -52,12 +52,12 @@ interface CookiesInterface
      * Sets a cookie to be sent at the end of the request
      */
     public function set(
-        string! name,
+         string name,
         var value = null,
         int expire = 0,
         string path = "/",
         bool secure = false,
-        string! domain = "",
+         string domain = "",
         bool httpOnly = false,
         array options = []
     ) -> <CookiesInterface>;

--- a/phalcon/Image/ImageFactory.zep
+++ b/phalcon/Image/ImageFactory.zep
@@ -22,7 +22,7 @@ class ImageFactory extends AbstractFactory
     /**
      * Constructor
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -60,8 +60,8 @@ class ImageFactory extends AbstractFactory
      * Creates a new instance
      */
     public function newInstance(
-        string! name,
-        string! file,
+         string name,
+         string file,
         int width = null,
         int height = null
     ) -> <AdapterInterface>
@@ -105,7 +105,7 @@ class ImageFactory extends AbstractFactory
      * @todo Remove this when we get traits
      */
     private function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Logger/Adapter/Syslog.zep
+++ b/phalcon/Logger/Adapter/Syslog.zep
@@ -52,7 +52,7 @@ class Syslog extends AbstractAdapter
      * @param string $name
      * @param array  $options
      */
-    public function __construct(string! name, array options = [])
+    public function __construct( string name, array options = [])
     {
         var facility, option;
 

--- a/phalcon/Logger/AdapterFactory.zep
+++ b/phalcon/Logger/AdapterFactory.zep
@@ -24,7 +24,7 @@ class AdapterFactory extends AbstractFactory
      *
      * @param array $services
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -40,8 +40,8 @@ class AdapterFactory extends AbstractFactory
      * @throws Exception
      */
     public function newInstance(
-        string! name,
-        string! fileName,
+         string name,
+         string fileName,
         array options = []
     ) -> <AdapterInterface>
     {

--- a/phalcon/Logger/LoggerFactory.zep
+++ b/phalcon/Logger/LoggerFactory.zep
@@ -102,7 +102,7 @@ class LoggerFactory extends AbstractConfigFactory
      * @todo Remove this when we get traits
      */
     protected function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Messages/Message.zep
+++ b/phalcon/Messages/Message.zep
@@ -47,7 +47,7 @@ class Message implements MessageInterface, JsonSerializable
     /**
      * Phalcon\Messages\Message constructor
      */
-    public function __construct(string! message, string field = "", string type = "", int code = 0, array metaData = [])
+    public function __construct( string message, string field = "", string type = "", int code = 0, array metaData = [])
     {
         let this->message  = message,
             this->field    = field,
@@ -131,7 +131,7 @@ class Message implements MessageInterface, JsonSerializable
     /**
      * Sets field name related to message
      */
-    public function setField(string! field) -> <MessageInterface>
+    public function setField( string field) -> <MessageInterface>
     {
         let this->field = field;
 
@@ -141,7 +141,7 @@ class Message implements MessageInterface, JsonSerializable
     /**
      * Sets verbose message
      */
-    public function setMessage(string! message) -> <MessageInterface>
+    public function setMessage( string message) -> <MessageInterface>
     {
         let this->message = message;
 
@@ -151,7 +151,7 @@ class Message implements MessageInterface, JsonSerializable
     /**
      * Sets message metadata
      */
-    public function setMetaData(array! metaData) -> <MessageInterface>
+    public function setMetaData( array metaData) -> <MessageInterface>
     {
         let this->metaData = metaData;
 
@@ -161,7 +161,7 @@ class Message implements MessageInterface, JsonSerializable
     /**
      * Sets message type
      */
-    public function setType(string! type) -> <MessageInterface>
+    public function setType( string type) -> <MessageInterface>
     {
         let this->type = type;
 

--- a/phalcon/Messages/MessageInterface.zep
+++ b/phalcon/Messages/MessageInterface.zep
@@ -59,20 +59,20 @@ interface MessageInterface
     /**
      * Sets field name related to message
      */
-    public function setField(string! field) -> <MessageInterface>;
+    public function setField( string field) -> <MessageInterface>;
 
     /**
      * Sets verbose message
      */
-    public function setMessage(string! message) -> <MessageInterface>;
+    public function setMessage( string message) -> <MessageInterface>;
 
     /**
      * Sets message metadata
      */
-    public function setMetaData(array! metaData) -> <MessageInterface>;
+    public function setMetaData( array metaData) -> <MessageInterface>;
 
     /**
      * Sets message type
      */
-    public function setType(string! type) -> <MessageInterface>;
+    public function setType( string type) -> <MessageInterface>;
 }

--- a/phalcon/Messages/Messages.zep
+++ b/phalcon/Messages/Messages.zep
@@ -124,7 +124,7 @@ class Messages implements MessagesContract, JsonSerializable
     /**
      * Filters the message collection by field name
      */
-    public function filter(string! fieldName) -> array
+    public function filter( string fieldName) -> array
     {
         var filtered, messages, message;
 

--- a/phalcon/Mvc/Application.zep
+++ b/phalcon/Mvc/Application.zep
@@ -88,7 +88,7 @@ class Application extends AbstractApplication
     /**
      * Handles a MVC request
      */
-    public function handle(string! uri) -> <ResponseInterface> | bool
+    public function handle( string uri) -> <ResponseInterface> | bool
     {
         var container, eventsManager, router, dispatcher, response, view,
             module, moduleObject, moduleName, className, path, implicitView,

--- a/phalcon/Mvc/Dispatcher.zep
+++ b/phalcon/Mvc/Dispatcher.zep
@@ -163,7 +163,7 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
     /**
      * Sets the controller name to be dispatched
      */
-    public function setControllerName(string! controllerName) -> <DispatcherInterface>
+    public function setControllerName( string controllerName) -> <DispatcherInterface>
     {
         let this->handlerName = controllerName;
 
@@ -173,7 +173,7 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
     /**
      * Sets the default controller suffix
      */
-    public function setControllerSuffix(string! controllerSuffix) -> <DispatcherInterface>
+    public function setControllerSuffix( string controllerSuffix) -> <DispatcherInterface>
     {
         let this->handlerSuffix = controllerSuffix;
 
@@ -183,7 +183,7 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
     /**
      * Sets the default controller name
      */
-    public function setDefaultController(string! controllerName) -> <DispatcherInterface>
+    public function setDefaultController( string controllerName) -> <DispatcherInterface>
     {
         let this->defaultHandler = controllerName;
 
@@ -209,7 +209,7 @@ class Dispatcher extends BaseDispatcher implements DispatcherInterface
     /**
      * Throws an internal exception
      */
-    protected function throwDispatchException(string! message, int exceptionCode = 0)
+    protected function throwDispatchException( string message, int exceptionCode = 0)
     {
         var container, response, exception;
 

--- a/phalcon/Mvc/EntityInterface.zep
+++ b/phalcon/Mvc/EntityInterface.zep
@@ -20,10 +20,10 @@ interface EntityInterface
     /**
      * Reads an attribute value by its name
      */
-    public function readAttribute(string! attribute) -> var | null;
+    public function readAttribute( string attribute) -> var | null;
 
     /**
      * Writes an attribute value by its name
      */
-    public function writeAttribute(string! attribute, var value);
+    public function writeAttribute( string attribute, var value);
 }

--- a/phalcon/Mvc/Micro.zep
+++ b/phalcon/Mvc/Micro.zep
@@ -187,7 +187,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable handler
      */
-    public function delete(string! routePattern, handler) -> <RouteInterface>
+    public function delete( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addDelete", routePattern, handler);
     }
@@ -222,7 +222,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable handler
      */
-    public function get(string! routePattern, handler) -> <RouteInterface>
+    public function get( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addGet", routePattern, handler);
     }
@@ -322,7 +322,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @return object
      */
-    public function getService(string! serviceName)
+    public function getService( string serviceName)
     {
         this->checkDiContainer();
 
@@ -334,7 +334,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @return mixed
      */
-    public function getSharedService(string! serviceName)
+    public function getSharedService( string serviceName)
     {
         this->checkDiContainer();
 
@@ -347,7 +347,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      * @param string uri
      * @return mixed
      */
-    public function handle(string! uri)
+    public function handle( string uri)
     {
         var container, status = null, router, matchedRoute,
             handler, beforeHandlers, params, returnedValue, e,
@@ -740,7 +740,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
     /**
      * Checks if a service is registered in the DI
      */
-    public function hasService(string! serviceName) -> bool
+    public function hasService( string serviceName) -> bool
     {
         this->checkDiContainer();
 
@@ -752,7 +752,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable handler
      */
-    public function head(string! routePattern, handler) -> <RouteInterface>
+    public function head( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addHead", routePattern, handler);
     }
@@ -762,7 +762,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable handler
      */
-    public function map(string! routePattern, handler) -> <RouteInterface>
+    public function map( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("add", routePattern, handler);
     }
@@ -916,7 +916,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable handler
      */
-    public function options(string! routePattern, handler) -> <RouteInterface>
+    public function options( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addOptions", routePattern, handler);
     }
@@ -926,7 +926,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable $handler
      */
-    public function patch(string! routePattern, handler) -> <RouteInterface>
+    public function patch( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addPatch", routePattern, handler);
     }
@@ -936,7 +936,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable handler
      */
-    public function post(string! routePattern, handler) -> <RouteInterface>
+    public function post( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addPost", routePattern, handler);
     }
@@ -946,7 +946,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @param callable $handler
      */
-    public function put(string! routePattern, handler) -> <RouteInterface>
+    public function put( string routePattern, handler) -> <RouteInterface>
     {
         return this->addRoute("addPut", routePattern, handler);
     }
@@ -1014,7 +1014,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
     /**
      * Sets a service from the DI
      */
-    public function setService(string! serviceName, var definition, bool isShared = false) -> <ServiceInterface>
+    public function setService( string serviceName, var definition, bool isShared = false) -> <ServiceInterface>
     {
         this->checkDiContainer();
 
@@ -1039,7 +1039,7 @@ class Micro extends Injectable implements ArrayAccess, EventsAwareInterface
      *
      * @return RouteInterface
      */
-    private function addRoute(string! method, string! routePattern, handler) -> <RouteInterface>
+    private function addRoute( string method,  string routePattern, handler) -> <RouteInterface>
     {
         var router, route;
 

--- a/phalcon/Mvc/Micro/Collection.zep
+++ b/phalcon/Mvc/Micro/Collection.zep
@@ -60,7 +60,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function delete(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function delete( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("DELETE", routePattern, handler, name);
 
@@ -76,7 +76,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function get(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function get( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("GET", routePattern, handler, name);
 
@@ -118,7 +118,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function head(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function head( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("HEAD", routePattern, handler, name);
 
@@ -142,7 +142,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function map(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function map( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap(null, routePattern, handler, name);
 
@@ -168,7 +168,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function mapVia(string! routePattern, callable handler, var method, string name = null) -> <CollectionInterface>
+    public function mapVia( string routePattern, callable handler, var method, string name = null) -> <CollectionInterface>
     {
         this->addMap(method, routePattern, handler, name);
 
@@ -185,7 +185,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function options(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function options( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("OPTIONS", routePattern, handler, name);
 
@@ -201,7 +201,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function patch(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function patch( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("PATCH", routePattern, handler, name);
 
@@ -217,7 +217,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function post(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function post( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("POST", routePattern, handler, name);
 
@@ -233,7 +233,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function put(string! routePattern, callable handler, string name = null) -> <CollectionInterface>
+    public function put( string routePattern, callable handler, string name = null) -> <CollectionInterface>
     {
         this->addMap("PUT", routePattern, handler, name);
 
@@ -263,7 +263,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function setLazy(bool! isLazy) -> <CollectionInterface>
+    public function setLazy( bool isLazy) -> <CollectionInterface>
     {
         let this->isLazy = isLazy;
 
@@ -277,7 +277,7 @@ class Collection implements CollectionInterface
      *
      * @return CollectionInterface
      */
-    public function setPrefix(string! prefix) -> <CollectionInterface>
+    public function setPrefix( string prefix) -> <CollectionInterface>
     {
         let this->prefix = prefix;
 
@@ -292,7 +292,7 @@ class Collection implements CollectionInterface
      * @param callable handler
      * @param string|null name
      */
-    protected function addMap(var method, string! routePattern, callable handler, string name = null) -> void
+    protected function addMap(var method,  string routePattern, callable handler, string name = null) -> void
     {
         let this->handlers[] = [method, routePattern, handler, name];
     }

--- a/phalcon/Mvc/Micro/CollectionInterface.zep
+++ b/phalcon/Mvc/Micro/CollectionInterface.zep
@@ -20,12 +20,12 @@ interface CollectionInterface
     /**
      * Maps a route to a handler that only matches if the HTTP method is DELETE
      */
-    public function delete(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function delete( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Maps a route to a handler that only matches if the HTTP method is GET
      */
-    public function get(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function get( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Returns the main handler
@@ -45,7 +45,7 @@ interface CollectionInterface
     /**
      * Maps a route to a handler that only matches if the HTTP method is HEAD
      */
-    public function head(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function head( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Returns if the main handler must be lazy loaded
@@ -55,27 +55,27 @@ interface CollectionInterface
     /**
      * Maps a route to a handler
      */
-    public function map(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function map( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Maps a route to a handler that only matches if the HTTP method is OPTIONS
      */
-    public function options(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function options( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Maps a route to a handler that only matches if the HTTP method is PATCH
      */
-    public function patch(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function patch( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Maps a route to a handler that only matches if the HTTP method is POST
      */
-    public function post(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function post( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Maps a route to a handler that only matches if the HTTP method is PUT
      */
-    public function put(string! routePattern, callable handler, string name = null) -> <CollectionInterface>;
+    public function put( string routePattern, callable handler, string name = null) -> <CollectionInterface>;
 
     /**
      * Sets the main handler
@@ -90,10 +90,10 @@ interface CollectionInterface
     /**
      * Sets if the main handler must be lazy loaded
      */
-    public function setLazy(bool! isLazy) -> <CollectionInterface>;
+    public function setLazy( bool isLazy) -> <CollectionInterface>;
 
     /**
      * Sets a prefix for all routes added to the collection
      */
-    public function setPrefix(string! prefix) -> <CollectionInterface>;
+    public function setPrefix( string prefix) -> <CollectionInterface>;
 }

--- a/phalcon/Mvc/Micro/LazyLoader.zep
+++ b/phalcon/Mvc/Micro/LazyLoader.zep
@@ -33,7 +33,7 @@ class LazyLoader
     /**
      * Phalcon\Mvc\Micro\LazyLoader constructor
      */
-    public function __construct(string! definition)
+    public function __construct( string definition)
     {
         let this->definition = definition;
     }
@@ -44,7 +44,7 @@ class LazyLoader
      * @param  array arguments
      * @return mixed
      */
-    public function callMethod(string! method, arguments, <BinderInterface> modelBinder = null)
+    public function callMethod( string method, arguments, <BinderInterface> modelBinder = null)
     {
          var handler, definition, bindCacheKey;
 

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -372,7 +372,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @return mixed
      */
-    public function __get(string! property)
+    public function __get( string property)
     {
         var modelName, manager, lowerProperty, relation;
         string method;
@@ -439,7 +439,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Magic method to check if a property is a valid relation
      */
-    public function __isset(string! property) -> bool
+    public function __isset( string property) -> bool
     {
         var manager, method, modelName, relation, result;
 
@@ -854,7 +854,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @return ModelInterface
      */
-    public function assign(array! data, var whiteList = null, var dataColumnMap = null) -> <ModelInterface>
+    public function assign( array data, var whiteList = null, var dataColumnMap = null) -> <ModelInterface>
     {
         var key, keyMapped, value, attribute, attributeField, metaData,
             columnMap, disableAssignSetters, rawValues;
@@ -999,7 +999,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * );
      *```
      */
-    public static function cloneResult(<ModelInterface> base, array! data, int dirtyState = 0) -> <ModelInterface>
+    public static function cloneResult(<ModelInterface> base,  array data, int dirtyState = 0) -> <ModelInterface>
     {
         var instance, key, value;
 
@@ -1053,7 +1053,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      */
     public static function cloneResultMap(
         var base,
-        array! data,
+         array data,
         var columnMap,
         int dirtyState = 0,
         bool keepSnapshots = null
@@ -1272,7 +1272,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @return mixed
      */
-    public static function cloneResultMapHydrate(array! data, var columnMap, int hydrationMode)
+    public static function cloneResultMapHydrate( array data, var columnMap, int hydrationMode)
     {
         return CloneResultMapHydrate::cloneResultMapHydrate(data, columnMap, hydrationMode, get_called_class());
     }
@@ -1933,7 +1933,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * Fires an event, implicitly calls behaviors and listeners in the events
      * manager are notified
      */
-    public function fireEvent(string! eventName) -> bool
+    public function fireEvent( string eventName) -> bool
     {
         /**
          * Check if there is a method with the same name of the event
@@ -1956,7 +1956,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * manager are notified
      * This method stops if one of the callbacks/listeners returns bool false
      */
-    public function fireEventCancel(string! eventName) -> bool
+    public function fireEventCancel( string eventName) -> bool
     {
         /**
          * Check if there is a method with the same name of the event
@@ -2615,7 +2615,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * echo $robot->readAttribute("name");
      * ```
      */
-    public function readAttribute(string! attribute) -> var | null
+    public function readAttribute( string attribute) -> var | null
     {
         if !isset this->{attribute} {
             return null;
@@ -3080,7 +3080,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Sets the DependencyInjection connection service name
      */
-    final public function setConnectionService(string! connectionService) -> void
+    final public function setConnectionService( string connectionService) -> void
     {
         (<ManagerInterface> this->modelsManager)->setConnectionService(
             this,
@@ -3109,7 +3109,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Sets the DependencyInjection connection service name used to read data
      */
-    final public function setReadConnectionService(string! connectionService) -> void
+    final public function setReadConnectionService( string connectionService) -> void
     {
         (<ManagerInterface> this->modelsManager)->setReadConnectionService(
             this,
@@ -3125,7 +3125,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * @param array data
      * @param array columnMap
      */
-    public function setOldSnapshotData(array! data, columnMap = null)
+    public function setOldSnapshotData( array data, columnMap = null)
     {
         var key, value, attribute;
         array snapshot;
@@ -3181,7 +3181,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @param array columnMap
      */
-    public function setSnapshotData(array! data, columnMap = null) -> void
+    public function setSnapshotData( array data, columnMap = null) -> void
     {
         var key, value, attribute;
         array snapshot;
@@ -3343,7 +3343,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * configuration, and one application's `setup()` reconfigures the ORM for
      * every other user in the same process.
      */
-    public static function setup(array! options) -> void
+    public static function setup( array options) -> void
     {
         var disableEvents, columnRenaming, notNullValidations,
             exceptionOnFailedSave, exceptionOnFailedMetaDataSave, phqlLiterals,
@@ -3449,7 +3449,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Sets the DependencyInjection connection service name used to write data
      */
-    final public function setWriteConnectionService(string! connectionService) -> void
+    final public function setWriteConnectionService( string connectionService) -> void
     {
         (<ManagerInterface> this->modelsManager)->setWriteConnectionService(
             this,
@@ -3654,7 +3654,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * $robot->writeAttribute("name", "Rosey");
      *```
      */
-    public function writeAttribute(string! attribute, var value) -> void
+    public function writeAttribute( string attribute, var value) -> void
     {
         let this->{attribute} = value;
     }
@@ -4738,7 +4738,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @return ResultsetInterface|ModelInterface|bool|null
      */
-    protected function getRelatedRecords(string! modelName, string! method, array! arguments)
+    protected function getRelatedRecords( string modelName,  string method,  array arguments)
     {
         var manager, relation, queryMethod, extraArgs, alias;
 
@@ -4808,7 +4808,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *
      * @return int|float|string|null|ResultsetInterface
      */
-    protected static function groupResult(string! functionName, string! alias, var parameters = null) -> var
+    protected static function groupResult( string functionName,  string alias, var parameters = null) -> var
     {
         var params, distinctColumn, groupColumn, columns,
             resultset, cache, firstRow, groupColumns, builder, query, container,
@@ -5757,7 +5757,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * }
      *```
      */
-    protected function allowEmptyStringValues(array! attributes) -> void
+    protected function allowEmptyStringValues( array attributes) -> void
     {
         var keysAttributes, attribute;
 
@@ -5829,7 +5829,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *     ]
      * ]
      */
-    protected function belongsTo(var fields, string! referenceModel, var referencedFields, array options = []) -> <Relation>
+    protected function belongsTo(var fields,  string referenceModel, var referencedFields, array options = []) -> <Relation>
     {
         return (<ManagerInterface> this->modelsManager)->addBelongsTo(
             this,
@@ -5941,7 +5941,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *     ]
      * ]
      */
-    protected function hasMany(var fields, string! referenceModel, var referencedFields, array options = []) -> <Relation>
+    protected function hasMany(var fields,  string referenceModel, var referencedFields, array options = []) -> <Relation>
     {
         return (<ManagerInterface> this->modelsManager)->addHasMany(
             this,
@@ -6009,10 +6009,10 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      */
     protected function hasManyToMany(
         var fields,
-        string! intermediateModel,
+         string intermediateModel,
         var intermediateFields,
         var intermediateReferencedFields,
-        string! referenceModel,
+         string referenceModel,
         var referencedFields,
         array options = []
     ) -> <Relation>
@@ -6073,7 +6073,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      *     ]
      * ]
      */
-    protected function hasOne(var fields, string! referenceModel, var referencedFields, array options = []) -> <Relation>
+    protected function hasOne(var fields,  string referenceModel, var referencedFields, array options = []) -> <Relation>
     {
         return (<ManagerInterface> this->modelsManager)->addHasOne(
             this,
@@ -6112,8 +6112,8 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * @param    string|array $referencedFields
      * @param    array $options
      */
-    protected function hasOneThrough(var fields, string! intermediateModel, var intermediateFields, var intermediateReferencedFields,
-        string! referenceModel, var referencedFields, array options = []) -> <Relation>
+    protected function hasOneThrough(var fields,  string intermediateModel, var intermediateFields, var intermediateReferencedFields,
+         string referenceModel, var referencedFields, array options = []) -> <Relation>
     {
         return (<ManagerInterface> this->modelsManager)->addHasOneThrough(
             this,
@@ -6153,7 +6153,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Sets schema name where the mapped table is located
      */
-    final protected function setSchema(string! schema) -> <ModelInterface>
+    final protected function setSchema( string schema) -> <ModelInterface>
     {
         (<ManagerInterface> this->modelsManager)->setModelSchema(
             this,
@@ -6166,7 +6166,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
     /**
      * Sets the table name to which model should be mapped
      */
-    final protected function setSource(string! source) -> <ModelInterface>
+    final protected function setSource( string source) -> <ModelInterface>
     {
         (<ManagerInterface> this->modelsManager)->setModelSource(this, source);
 
@@ -6191,7 +6191,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * }
      *```
      */
-    protected function skipAttributes(array! attributes) -> void
+    protected function skipAttributes( array attributes) -> void
     {
         this->skipAttributesOnCreate(attributes);
         this->skipAttributesOnUpdate(attributes);
@@ -6215,7 +6215,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * }
      *```
      */
-    protected function skipAttributesOnCreate(array! attributes) -> void
+    protected function skipAttributesOnCreate( array attributes) -> void
     {
         var attribute;
         array keysAttributes;
@@ -6250,7 +6250,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
      * }
      *```
      */
-    protected function skipAttributesOnUpdate(array! attributes) -> void
+    protected function skipAttributesOnUpdate( array attributes) -> void
     {
         var attribute;
         array keysAttributes;

--- a/phalcon/Mvc/Model/Behavior.zep
+++ b/phalcon/Mvc/Model/Behavior.zep
@@ -53,7 +53,7 @@ abstract class Behavior implements BehaviorInterface
      *
      * @return array
      */
-    protected function getOptions(string! eventName = null)
+    protected function getOptions( string eventName = null)
     {
         var options, eventOptions;
 
@@ -73,7 +73,7 @@ abstract class Behavior implements BehaviorInterface
     /**
      * Checks whether the behavior must take action on certain event
      */
-    protected function mustTakeAction(string! eventName) -> bool
+    protected function mustTakeAction( string eventName) -> bool
     {
         return isset this->options[eventName];
     }

--- a/phalcon/Mvc/Model/Behavior/SoftDelete.zep
+++ b/phalcon/Mvc/Model/Behavior/SoftDelete.zep
@@ -27,7 +27,7 @@ class SoftDelete extends Behavior
     /**
      * Listens for notifications from the models manager
      */
-    public function notify(string! type, <ModelInterface> model)
+    public function notify( string type, <ModelInterface> model)
     {
         var options, value, field, updateModel, message, modelsManager, metaData;
 

--- a/phalcon/Mvc/Model/Behavior/Timestampable.zep
+++ b/phalcon/Mvc/Model/Behavior/Timestampable.zep
@@ -27,7 +27,7 @@ class Timestampable extends Behavior
     /**
      * Listens for notifications from the models manager
      */
-    public function notify(string! type, <ModelInterface> model)
+    public function notify( string type, <ModelInterface> model)
     {
         var options, timestamp, singleField, field;
 

--- a/phalcon/Mvc/Model/BehaviorInterface.zep
+++ b/phalcon/Mvc/Model/BehaviorInterface.zep
@@ -22,10 +22,10 @@ interface BehaviorInterface
     /**
      * Calls a method when it's missing in the model
      */
-    public function missingMethod(<ModelInterface> model, string! method, array arguments = []);
+    public function missingMethod(<ModelInterface> model,  string method, array arguments = []);
 
     /**
      * This method receives the notifications from the EventsManager
      */
-    public function notify(string! type, <ModelInterface> model);
+    public function notify( string type, <ModelInterface> model);
 }

--- a/phalcon/Mvc/Model/Binder.zep
+++ b/phalcon/Mvc/Model/Binder.zep
@@ -68,7 +68,7 @@ class Binder implements BinderInterface
     /**
      * Bind models into params in proper handler
      */
-    public function bindToHandler(object handler, array params, string cacheKey, string! methodName = null) -> array
+    public function bindToHandler(object handler, array params, string cacheKey,  string methodName = null) -> array
     {
         var paramKey, className, boundModel, paramsCache, paramValue;
 
@@ -175,7 +175,7 @@ class Binder implements BinderInterface
     /**
      * Get modified params for handler using reflection
      */
-    protected function getParamsFromReflection(object handler, array params, string cacheKey, string! methodName) -> array
+    protected function getParamsFromReflection(object handler, array params, string cacheKey,  string methodName) -> array
     {
         var methodParams, reflection, paramKey, methodParam, className,
             realClasses = null, boundModel, cache, handlerClass,

--- a/phalcon/Mvc/Model/BinderInterface.zep
+++ b/phalcon/Mvc/Model/BinderInterface.zep
@@ -22,7 +22,7 @@ interface BinderInterface
     /**
      * Bind models into params in proper handler
      */
-    public function bindToHandler(object handler, array params, string cacheKey, string! methodName = null) -> array;
+    public function bindToHandler(object handler, array params, string cacheKey,  string methodName = null) -> array;
 
     /**
      * Gets active bound models

--- a/phalcon/Mvc/Model/Criteria.zep
+++ b/phalcon/Mvc/Model/Criteria.zep
@@ -64,7 +64,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Appends a condition to the current conditions using an AND operator
      */
-    public function andWhere(string! conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>
+    public function andWhere( string conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>
     {
         var currentConditions;
 
@@ -82,7 +82,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * $criteria->betweenWhere("price", 100.25, 200.50);
      *```
      */
-    public function betweenWhere(string! expr, var minimum, var maximum) -> <CriteriaInterface>
+    public function betweenWhere( string expr, var minimum, var maximum) -> <CriteriaInterface>
     {
         var hiddenParam, minimumKey, nextHiddenParam, maximumKey;
 
@@ -121,7 +121,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * Sets the bound parameters in the criteria
      * This method replaces all previously set bound parameters
      */
-    public function bind(array! bindParams, bool merge = false) -> <CriteriaInterface>
+    public function bind( array bindParams, bool merge = false) -> <CriteriaInterface>
     {
         if !isset this->params["bind"] {
             let this->params["bind"] = [];
@@ -140,7 +140,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * Sets the bind types in the criteria
      * This method replaces all previously set bound parameters
      */
-    public function bindTypes(array! bindTypes) -> <CriteriaInterface>
+    public function bindTypes( array bindTypes) -> <CriteriaInterface>
     {
         let this->params["bindTypes"] = bindTypes;
 
@@ -151,7 +151,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * Sets the cache options in the criteria
      * This method replaces all previously set cache options
      */
-    public function cache(array! cache) -> <CriteriaInterface>
+    public function cache( array cache) -> <CriteriaInterface>
     {
         let this->params["cache"] = cache;
 
@@ -215,7 +215,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Adds the conditions parameter to the criteria
      */
-    public function conditions(string! conditions) -> <CriteriaInterface>
+    public function conditions( string conditions) -> <CriteriaInterface>
     {
         let this->params["conditions"] = conditions;
 
@@ -300,9 +300,9 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      */
     public static function fromInput(
         <DiInterface> container,
-        string! modelName,
-        array! data,
-        string! operator = "AND"
+         string modelName,
+         array data,
+         string operator = "AND"
     ) -> <CriteriaInterface> {
         var attribute, field, value, type, metaData, model, dataTypes,
             criteria, columnMap;
@@ -531,7 +531,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * $criteria->inWhere("id", [1, 2, 3]);
      * ```
      */
-    public function inWhere(string! expr, array! values) -> <CriteriaInterface>
+    public function inWhere( string expr,  array values) -> <CriteriaInterface>
     {
         var hiddenParam, value;
         array bindParams, bindKeys;
@@ -598,7 +598,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function innerJoin(string! model, var conditions = null, var alias = null) -> <CriteriaInterface>
+    public function innerJoin( string model, var conditions = null, var alias = null) -> <CriteriaInterface>
     {
         return this->addJoinClause(model, conditions, alias, "INNER");
     }
@@ -632,7 +632,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function join(string! model, var conditions = null, var alias = null, var type = null) -> <CriteriaInterface>
+    public function join( string model, var conditions = null, var alias = null, var type = null) -> <CriteriaInterface>
     {
         return this->addJoinClause(model, conditions, alias, type);
     }
@@ -650,7 +650,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function leftJoin(string! model, var conditions = null, var alias = null) -> <CriteriaInterface>
+    public function leftJoin( string model, var conditions = null, var alias = null) -> <CriteriaInterface>
     {
         return this->addJoinClause(model, conditions, alias, "LEFT");
     }
@@ -692,7 +692,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * $criteria->notBetweenWhere("price", 100.25, 200.50);
      *```
      */
-    public function notBetweenWhere(string! expr, var minimum, var maximum) -> <CriteriaInterface>
+    public function notBetweenWhere( string expr, var minimum, var maximum) -> <CriteriaInterface>
     {
         var hiddenParam, nextHiddenParam;
         string minimumKey, maximumKey;
@@ -737,7 +737,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * $criteria->notInWhere("id", [1, 2, 3]);
      *```
      */
-    public function notInWhere(string! expr, array! values) -> <CriteriaInterface>
+    public function notInWhere( string expr,  array values) -> <CriteriaInterface>
     {
         var hiddenParam, value;
         array bindParams, bindKeys;
@@ -776,7 +776,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Appends a condition to the current conditions using an OR operator
      */
-    public function orWhere(string! conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>
+    public function orWhere( string conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>
     {
         var currentConditions;
 
@@ -790,7 +790,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Adds the order-by clause to the criteria
      */
-    public function orderBy(string! orderColumns) -> <CriteriaInterface>
+    public function orderBy( string orderColumns) -> <CriteriaInterface>
     {
         let this->params["order"] = orderColumns;
 
@@ -810,7 +810,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function rightJoin(string! model, conditions = null, alias = null) -> <CriteriaInterface>
+    public function rightJoin( string model, conditions = null, alias = null) -> <CriteriaInterface>
     {
         return this->addJoinClause(model, conditions, alias, "RIGHT");
     }
@@ -826,7 +826,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Set a model on which the query will be executed
      */
-    public function setModelName(string! modelName) -> <CriteriaInterface>
+    public function setModelName( string modelName) -> <CriteriaInterface>
     {
         let this->model = modelName;
 
@@ -846,7 +846,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
     /**
      * Sets the conditions parameter in the criteria
      */
-    public function where(string! conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>
+    public function where( string conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>
     {
         var currentBindParams, currentBindTypes;
 
@@ -890,7 +890,7 @@ class Criteria implements CriteriaInterface, InjectionAwareInterface
      * name collision between the public `join()` method and PHP's
      * built-in `join()` function.
      */
-    private function addJoinClause(string! model, var conditions = null, var alias = null, var type = null) -> <CriteriaInterface>
+    private function addJoinClause( string model, var conditions = null, var alias = null, var type = null) -> <CriteriaInterface>
     {
         var mergedJoins, currentJoins;
         array join;

--- a/phalcon/Mvc/Model/CriteriaInterface.zep
+++ b/phalcon/Mvc/Model/CriteriaInterface.zep
@@ -25,7 +25,7 @@ interface CriteriaInterface
      * @param array bindParams
      * @param array bindTypes
      */
-    public function andWhere(string! conditions, bindParams = null, bindTypes = null) -> <CriteriaInterface>;
+    public function andWhere( string conditions, bindParams = null, bindTypes = null) -> <CriteriaInterface>;
 
     /**
      * Appends a BETWEEN condition to the current conditions
@@ -37,30 +37,30 @@ interface CriteriaInterface
      * @param mixed minimum
      * @param mixed maximum
      */
-    public function betweenWhere(string! expr, minimum, maximum) -> <CriteriaInterface>;
+    public function betweenWhere( string expr, minimum, maximum) -> <CriteriaInterface>;
 
     /**
      * Sets the bound parameters in the criteria
      * This method replaces all previously set bound parameters
      */
-    public function bind(array! bindParams) -> <CriteriaInterface>;
+    public function bind( array bindParams) -> <CriteriaInterface>;
 
     /**
      * Sets the bind types in the criteria
      * This method replaces all previously set bound parameters
      */
-    public function bindTypes(array! bindTypes) -> <CriteriaInterface>;
+    public function bindTypes( array bindTypes) -> <CriteriaInterface>;
 
     /**
      * Sets the cache options in the criteria
      * This method replaces all previously set cache options
      */
-    public function cache(array! cache) -> <CriteriaInterface>;
+    public function cache( array cache) -> <CriteriaInterface>;
 
     /**
      * Adds the conditions parameter to the criteria
      */
-    public function conditions(string! conditions) -> <CriteriaInterface>;
+    public function conditions( string conditions) -> <CriteriaInterface>;
 
     /**
      * Sets SELECT DISTINCT / SELECT ALL flag
@@ -143,7 +143,7 @@ interface CriteriaInterface
      * $criteria->inWhere("id", [1, 2, 3]);
      *```
      */
-    public function inWhere(string! expr, array! values) -> <CriteriaInterface>;
+    public function inWhere( string expr,  array values) -> <CriteriaInterface>;
 
     /**
      * Adds an INNER join to the query
@@ -165,7 +165,7 @@ interface CriteriaInterface
      * );
      *```
      */
-    public function innerJoin(string! model, var conditions = null, var alias = null) -> <CriteriaInterface>;
+    public function innerJoin( string model, var conditions = null, var alias = null) -> <CriteriaInterface>;
 
     /**
      * Adds a LEFT join to the query
@@ -178,7 +178,7 @@ interface CriteriaInterface
      * );
      *```
      */
-    public function leftJoin(string! model, var conditions = null, var alias = null) -> <CriteriaInterface>;
+    public function leftJoin( string model, var conditions = null, var alias = null) -> <CriteriaInterface>;
 
     /**
      * Sets the limit parameter to the criteria
@@ -195,7 +195,7 @@ interface CriteriaInterface
      * @param mixed minimum
      * @param mixed maximum
      */
-    public function notBetweenWhere(string! expr, minimum, maximum) -> <CriteriaInterface>;
+    public function notBetweenWhere( string expr, minimum, maximum) -> <CriteriaInterface>;
 
     /**
      * Appends a NOT IN condition to the current conditions
@@ -204,7 +204,7 @@ interface CriteriaInterface
      * $criteria->notInWhere("id", [1, 2, 3]);
      *```
      */
-    public function notInWhere(string! expr, array! values) -> <CriteriaInterface>;
+    public function notInWhere( string expr,  array values) -> <CriteriaInterface>;
 
     /**
      * Appends a condition to the current conditions using an OR operator
@@ -212,12 +212,12 @@ interface CriteriaInterface
      * @param array bindParams
      * @param array bindTypes
      */
-    public function orWhere(string! conditions, bindParams = null, bindTypes = null) -> <CriteriaInterface>;
+    public function orWhere( string conditions, bindParams = null, bindTypes = null) -> <CriteriaInterface>;
 
     /**
      * Adds the order-by parameter to the criteria
      */
-    public function orderBy(string! orderColumns) -> <CriteriaInterface>;
+    public function orderBy( string orderColumns) -> <CriteriaInterface>;
 
     /**
      * Adds a RIGHT join to the query
@@ -230,12 +230,12 @@ interface CriteriaInterface
      * );
      *```
      */
-    public function rightJoin(string! model, conditions = null, alias = null) -> <CriteriaInterface>;
+    public function rightJoin( string model, conditions = null, alias = null) -> <CriteriaInterface>;
 
     /**
      * Set a model on which the query will be executed
      */
-    public function setModelName(string! modelName) -> <CriteriaInterface>;
+    public function setModelName( string modelName) -> <CriteriaInterface>;
 
     /**
      * Sets the "shared_lock" parameter to the criteria
@@ -245,5 +245,5 @@ interface CriteriaInterface
     /**
      * Sets the conditions parameter in the criteria
      */
-    public function where(string! conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>;
+    public function where( string conditions, var bindParams = null, var bindTypes = null) -> <CriteriaInterface>;
 }

--- a/phalcon/Mvc/Model/Hydration/CloneResultMapHydrate.zep
+++ b/phalcon/Mvc/Model/Hydration/CloneResultMapHydrate.zep
@@ -16,7 +16,7 @@ use Phalcon\Support\Settings;
 
 class CloneResultMapHydrate
 {
-    public static function cloneResultMapHydrate(array! data, var columnMap, int hydrationMode, string calledClass = "Phalcon\\Mvc\\Model")
+    public static function cloneResultMapHydrate( array data, var columnMap, int hydrationMode, string calledClass = "Phalcon\\Mvc\\Model")
     {
         var key, value, attribute, attributeName;
         array hydrateArray;

--- a/phalcon/Mvc/Model/Manager.zep
+++ b/phalcon/Mvc/Model/Manager.zep
@@ -277,7 +277,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     public function addBelongsTo(
         <ModelInterface> model,
         var fields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface> {
@@ -370,7 +370,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     public function addHasMany(
         <ModelInterface> model,
         var fields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface> {
@@ -467,10 +467,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     public function addHasManyToMany(
         <ModelInterface> model,
         var fields,
-        string! intermediateModel,
+         string intermediateModel,
         var intermediateFields,
         var intermediateReferencedFields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface> {
@@ -591,7 +591,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     public function addHasOne(
         <ModelInterface> model,
         var fields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface> {
@@ -687,10 +687,10 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     public function addHasOneThrough(
         <ModelInterface> model,
         var fields,
-        string! intermediateModel,
+         string intermediateModel,
         var intermediateFields,
         var intermediateReferencedFields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface> {
@@ -841,7 +841,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return QueryInterface
      */
-    public function createQuery(string! phql) -> <QueryInterface>
+    public function createQuery( string phql) -> <QueryInterface>
     {
         var container, query;
 
@@ -893,7 +893,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return ResultsetInterface|StatusInterface
      */
-    public function executeQuery(string! phql, var placeholders = null, var types = null) -> var
+    public function executeQuery( string phql, var placeholders = null, var types = null) -> var
     {
         var query;
 
@@ -917,7 +917,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Checks whether a model has a belongsTo relation with another model
      * @deprecated
      */
-    public function existsBelongsTo(string! modelName, string! modelRelation) -> bool
+    public function existsBelongsTo( string modelName,  string modelRelation) -> bool
     {
         return this->hasBelongsTo(modelName, modelRelation);
     }
@@ -926,7 +926,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Checks whether a model has a hasMany relation with another model
      * @deprecated
      */
-    public function existsHasMany(string! modelName, string! modelRelation) -> bool
+    public function existsHasMany( string modelName,  string modelRelation) -> bool
     {
         return this->hasHasMany(modelName, modelRelation);
     }
@@ -935,7 +935,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Checks whether a model has a hasManyToMany relation with another model
      * @deprecated
      */
-    public function existsHasManyToMany(string! modelName, string! modelRelation) -> bool
+    public function existsHasManyToMany( string modelName,  string modelRelation) -> bool
     {
         return this->hasHasManyToMany(modelName, modelRelation);
     }
@@ -944,7 +944,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Checks whether a model has a hasOne relation with another model
      * @deprecated
      */
-    public function existsHasOne(string! modelName, string! modelRelation) -> bool
+    public function existsHasOne( string modelName,  string modelRelation) -> bool
     {
         return this->hasHasOne(modelName, modelRelation);
     }
@@ -953,7 +953,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * Checks whether a model has a hasOneThrough relation with another model
      * @deprecated
      */
-    public function existsHasOneThrough(string! modelName, string! modelRelation) -> bool
+    public function existsHasOneThrough( string modelName,  string modelRelation) -> bool
     {
         return this->hasHasOneThrough(modelName, modelRelation);
     }
@@ -994,8 +994,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * @return ResultsetInterface | bool
      */
     public function getBelongsToRecords(
-        string! modelName,
-        string! modelRelation,
+         string modelName,
+         string modelRelation,
         <ModelInterface> record,
         parameters = null,
         string method = null
@@ -1108,7 +1108,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Gets hasMany related records from a model
      */
-    public function getHasManyRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
+    public function getHasManyRecords( string modelName,  string modelRelation, <ModelInterface> record, parameters = null, string method = null)
         -> <ResultsetInterface> | bool
     {
         var relations;
@@ -1177,7 +1177,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
     /**
      * Gets belongsTo related records from a model
      */
-    public function getHasOneRecords(string! modelName, string! modelRelation, <ModelInterface> record, parameters = null, string method = null)
+    public function getHasOneRecords( string modelName,  string modelRelation, <ModelInterface> record, parameters = null, string method = null)
         -> <ModelInterface> | bool
     {
         var relations;
@@ -1304,7 +1304,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return RelationInterface|bool
      */
-    public function getRelationByAlias(string! modelName, string! alias) -> <RelationInterface> | bool
+    public function getRelationByAlias( string modelName,  string alias) -> <RelationInterface> | bool
     {
         var relation;
 
@@ -1585,7 +1585,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return RelationInterface[]
      */
-    public function getRelations(string! modelName) -> <RelationInterface[]>
+    public function getRelations( string modelName) -> <RelationInterface[]>
     {
         var entityName, relations, relation;
         array allRelations;
@@ -1649,7 +1649,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return RelationInterface[] | bool
      */
-    public function getRelationsBetween(string! first, string! second) -> <RelationInterface[]> | bool
+    public function getRelationsBetween( string first,  string second) -> <RelationInterface[]> | bool
     {
         var relations;
         string keyRelation;
@@ -1702,7 +1702,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
 	 *
 	 * @return mixed
      */
-    public function getReusableRecords(string! modelName, string! key)
+    public function getReusableRecords( string modelName,  string key)
     {
         var records;
 
@@ -1748,7 +1748,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return bool
      */
-    public function hasBelongsTo(string! modelName, string! modelRelation) -> bool
+    public function hasBelongsTo( string modelName,  string modelRelation) -> bool
     {
         return this->checkHasRelationship("belongsTo", modelName, modelRelation);
     }
@@ -1761,7 +1761,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return bool
      */
-    public function hasHasMany(string! modelName, string! modelRelation) -> bool
+    public function hasHasMany( string modelName,  string modelRelation) -> bool
     {
         return this->checkHasRelationship("hasMany", modelName, modelRelation);
     }
@@ -1774,7 +1774,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return bool
      */
-    public function hasHasManyToMany(string! modelName, string! modelRelation) -> bool
+    public function hasHasManyToMany( string modelName,  string modelRelation) -> bool
     {
         return this->checkHasRelationship("hasManyToMany", modelName, modelRelation);
     }
@@ -1787,7 +1787,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return bool
      */
-    public function hasHasOne(string! modelName, string! modelRelation) -> bool
+    public function hasHasOne( string modelName,  string modelRelation) -> bool
     {
         return this->checkHasRelationship("hasOne", modelName, modelRelation);
     }
@@ -1800,7 +1800,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return bool
      */
-    public function hasHasOneThrough(string! modelName, string! modelRelation) -> bool
+    public function hasHasOneThrough( string modelName,  string modelRelation) -> bool
     {
         return this->checkHasRelationship("hasOneThrough", modelName, modelRelation);
     }
@@ -1870,7 +1870,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return bool
      */
-    public function isInitialized(string! className) -> bool
+    public function isInitialized( string className) -> bool
     {
         return isset this->initialized[strtolower(className)];
     }
@@ -1976,7 +1976,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return ModelInterface
      */
-    public function load(string! modelName) -> <ModelInterface>
+    public function load( string modelName) -> <ModelInterface>
     {
         var model;
 
@@ -2011,7 +2011,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * @param string         $eventName
      * @param mixed          $data
      */
-    public function missingMethod(<ModelInterface> model, string! eventName, var data)
+    public function missingMethod(<ModelInterface> model,  string eventName, var data)
     {
         var modelsBehaviors, result, eventsManager, behavior;
 
@@ -2055,7 +2055,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      * @param string         $eventName
      * @param ModelInterface $model
      */
-    public function notifyEvent(string! eventName, <ModelInterface> model)
+    public function notifyEvent( string eventName, <ModelInterface> model)
     {
         var status, behavior, modelsBehaviors, eventsManager,
             customEventsManager;
@@ -2119,7 +2119,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function removeBehavior(<ModelInterface> model, string! behaviorClass) -> void
+    public function removeBehavior(<ModelInterface> model,  string behaviorClass) -> void
     {
         var entityName, key, behavior;
 
@@ -2144,7 +2144,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setConnectionService(<ModelInterface> model, string! connectionService) -> void
+    public function setConnectionService(<ModelInterface> model,  string connectionService) -> void
     {
         this->setReadConnectionService(model, connectionService);
         this->setWriteConnectionService(model, connectionService);
@@ -2213,7 +2213,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setModelPrefix(string! prefix) -> void
+    public function setModelPrefix( string prefix) -> void
     {
         let this->prefix = prefix;
     }
@@ -2226,7 +2226,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setModelSchema(<ModelInterface> model, string! schema) -> void
+    public function setModelSchema(<ModelInterface> model,  string schema) -> void
     {
         let this->schemas[get_class_lower(model)] = schema;
     }
@@ -2239,7 +2239,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setModelSource(<ModelInterface> model, string! source) -> void
+    public function setModelSource(<ModelInterface> model,  string source) -> void
     {
         let this->sources[get_class_lower(model)] = source;
     }
@@ -2252,7 +2252,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setReadConnectionService(<ModelInterface> model, string! connectionService) -> void
+    public function setReadConnectionService(<ModelInterface> model,  string connectionService) -> void
     {
         let this->readConnectionServices[get_class_lower(model)] = connectionService;
     }
@@ -2266,7 +2266,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setReusableRecords(string! modelName, string! key, var records) -> void
+    public function setReusableRecords( string modelName,  string key, var records) -> void
     {
         let this->reusable[key] = records;
     }
@@ -2279,7 +2279,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      *
      * @return void
      */
-    public function setWriteConnectionService(<ModelInterface> model, string! connectionService) -> void
+    public function setWriteConnectionService(<ModelInterface> model,  string connectionService) -> void
     {
         let this->writeConnectionServices[get_class_lower(model)] = connectionService;
     }
@@ -2414,8 +2414,8 @@ class Manager implements ManagerInterface, InjectionAwareInterface, EventsAwareI
      */
     private function checkHasRelationship(
         string collection,
-        string! modelName,
-        string! modelRelation
+         string modelName,
+         string modelRelation
     ) -> bool {
         var entityName;
         string keyRelation;

--- a/phalcon/Mvc/Model/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/ManagerInterface.zep
@@ -40,7 +40,7 @@ interface ManagerInterface
     public function addBelongsTo(
         <ModelInterface> model,
         var fields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface>;
@@ -55,7 +55,7 @@ interface ManagerInterface
     public function addHasMany(
         <ModelInterface> model,
         var fields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface>;
@@ -72,10 +72,10 @@ interface ManagerInterface
     public function addHasManyToMany(
         <ModelInterface> model,
         var fields,
-        string! intermediateModel,
+         string intermediateModel,
         var intermediateFields,
         var intermediateReferencedFields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface>;
@@ -90,7 +90,7 @@ interface ManagerInterface
     public function addHasOne(
         <ModelInterface> model,
         var fields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface>;
@@ -107,10 +107,10 @@ interface ManagerInterface
     public function addHasOneThrough(
         <ModelInterface> model,
         var fields,
-        string! intermediateModel,
+         string intermediateModel,
         var intermediateFields,
         var intermediateReferencedFields,
-        string! referencedModel,
+         string referencedModel,
         var referencedFields,
         array options = []
     ) -> <RelationInterface>;
@@ -130,7 +130,7 @@ interface ManagerInterface
     /**
      * Creates a Phalcon\Mvc\Model\Query without execute it
      */
-    public function createQuery(string! phql) -> <QueryInterface>;
+    public function createQuery( string phql) -> <QueryInterface>;
 
     /**
      * Creates a Phalcon\Mvc\Model\Query and execute it
@@ -139,7 +139,7 @@ interface ManagerInterface
      * @param array|null $types
      * @return ResultsetInterface|StatusInterface
      */
-    public function executeQuery(string! phql, var placeholders = null, var types = null) -> var;
+    public function executeQuery( string phql, var placeholders = null, var types = null) -> var;
 
     /**
      * Gets belongsTo relations defined on a model
@@ -156,8 +156,8 @@ interface ManagerInterface
      * @param string|null       $method
      */
     public function getBelongsToRecords(
-        string! modelName,
-        string! modelRelation,
+         string modelName,
+         string modelRelation,
         <ModelInterface> record,
         var parameters = null,
         string method = null
@@ -183,8 +183,8 @@ interface ManagerInterface
      * @param string|null       $method
      */
     public function getHasManyRecords(
-        string! modelName,
-        string! modelRelation,
+         string modelName,
+         string modelRelation,
         <ModelInterface> record,
         var parameters = null,
         string method = null
@@ -215,8 +215,8 @@ interface ManagerInterface
      * @param string|null       $method
      */
     public function getHasOneRecords(
-        string! modelName,
-        string! modelRelation,
+         string modelName,
+         string modelRelation,
         <ModelInterface> record,
         var parameters = null,
         string method = null
@@ -265,7 +265,7 @@ interface ManagerInterface
      *
      * @return RelationInterface|bool
      */
-    public function getRelationByAlias(string! modelName, string! alias) -> <RelationInterface> | bool;
+    public function getRelationByAlias( string modelName,  string alias) -> <RelationInterface> | bool;
 
     /**
      * Helper method to query records based on a relation definition
@@ -282,12 +282,12 @@ interface ManagerInterface
     /**
      * Query all the relationships defined on a model
      */
-    public function getRelations(string! modelName) -> <RelationInterface[]>;
+    public function getRelations( string modelName) -> <RelationInterface[]>;
 
     /**
      * Query the relations between two models
      */
-    public function getRelationsBetween(string! first, string! second) -> <RelationInterface[]> | bool;
+    public function getRelationsBetween( string first,  string second) -> <RelationInterface[]> | bool;
 
     /**
      * Returns a reusable object from the internal list
@@ -297,7 +297,7 @@ interface ManagerInterface
      *
      * @return mixed
      */
-    public function getReusableRecords(string! modelName, string! key);
+    public function getReusableRecords( string modelName,  string key);
 
     /**
      * Returns the connection to write data related to a model
@@ -312,27 +312,27 @@ interface ManagerInterface
     /**
      * Checks whether a model has a belongsTo relation with another model
      */
-    public function hasBelongsTo(string! modelName, string! modelRelation) -> bool;
+    public function hasBelongsTo( string modelName,  string modelRelation) -> bool;
 
     /**
      * Checks whether a model has a hasMany relation with another model
      */
-    public function hasHasMany(string! modelName, string! modelRelation) -> bool;
+    public function hasHasMany( string modelName,  string modelRelation) -> bool;
 
     /**
      * Checks whether a model has a hasManyToMany relation with another model
      */
-    public function hasHasManyToMany(string! modelName, string! modelRelation) -> bool;
+    public function hasHasManyToMany( string modelName,  string modelRelation) -> bool;
 
     /**
      * Checks whether a model has a hasOne relation with another model
      */
-    public function hasHasOne(string! modelName, string! modelRelation) -> bool;
+    public function hasHasOne( string modelName,  string modelRelation) -> bool;
 
     /**
      * Checks whether a model has a hasOneThrough relation with another model
      */
-    public function hasHasOneThrough(string! modelName, string! modelRelation) -> bool;
+    public function hasHasOneThrough( string modelName,  string modelRelation) -> bool;
 
     /**
      * Initializes a model in the model manager
@@ -342,7 +342,7 @@ interface ManagerInterface
     /**
      * Check of a model is already initialized
      */
-    public function isInitialized(string! className) -> bool;
+    public function isInitialized( string className) -> bool;
 
     /**
      * Checks if a model is keeping snapshots for the queried records
@@ -384,38 +384,38 @@ interface ManagerInterface
      * @param array data
      * @return bool
      */
-    public function missingMethod(<ModelInterface> model, string! eventName, data);
+    public function missingMethod(<ModelInterface> model,  string eventName, data);
 
     /**
      * Receives events generated in the models and dispatches them to an events-manager if available
      * Notify the behaviors that are listening in the model
      */
-    public function notifyEvent(string! eventName, <ModelInterface> model);
+    public function notifyEvent( string eventName, <ModelInterface> model);
 
     /**
      * Removes a behavior from a model
      */
-    public function removeBehavior(<ModelInterface> model, string! behaviorClass) -> void;
+    public function removeBehavior(<ModelInterface> model,  string behaviorClass) -> void;
 
     /**
      * Sets both write and read connection service for a model
      */
-    public function setConnectionService(<ModelInterface> model, string! connectionService) -> void;
+    public function setConnectionService(<ModelInterface> model,  string connectionService) -> void;
 
     /**
      * Sets the mapped schema for a model
      */
-    public function setModelSchema(<ModelInterface> model, string! schema) -> void;
+    public function setModelSchema(<ModelInterface> model,  string schema) -> void;
 
     /**
      * Sets the mapped source for a model
      */
-    public function setModelSource(<ModelInterface> model, string! source) -> void;
+    public function setModelSource(<ModelInterface> model,  string source) -> void;
 
     /**
      * Sets read connection service for a model
      */
-    public function setReadConnectionService(<ModelInterface> model, string! connectionService) -> void;
+    public function setReadConnectionService(<ModelInterface> model,  string connectionService) -> void;
 
     /**
      * Stores a reusable record in the internal list
@@ -426,12 +426,12 @@ interface ManagerInterface
      *
      * @return void
      */
-    public function setReusableRecords(string! modelName, string! key, var records) -> void;
+    public function setReusableRecords( string modelName,  string key, var records) -> void;
 
     /**
      * Sets write connection service for a model
      */
-    public function setWriteConnectionService(<ModelInterface> model, string! connectionService);
+    public function setWriteConnectionService(<ModelInterface> model,  string connectionService);
 
     /**
      * Sets if a model must use dynamic update instead of the all-field update

--- a/phalcon/Mvc/Model/MetaData.zep
+++ b/phalcon/Mvc/Model/MetaData.zep
@@ -860,7 +860,7 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
     /**
      * Writes the metadata to adapter
      */
-    public function write(string! key, array data) -> void
+    public function write( string key, array data) -> void
     {
         var result, option;
 
@@ -911,7 +911,7 @@ abstract class MetaData implements InjectionAwareInterface, MetaDataInterface
      * @todo Remove this when we get traits
      */
     protected function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Mvc/Model/MetaData/Apcu.zep
+++ b/phalcon/Mvc/Model/MetaData/Apcu.zep
@@ -38,7 +38,7 @@ class Apcu extends MetaData
      *
      * @param array options
      */
-    public function __construct(<AdapterFactory> factory, array! options = null)
+    public function __construct(<AdapterFactory> factory,  array options = null)
     {
         let options["prefix"]   = this->getArrVal(options, "prefix", "ph-mm-apcu-"),
             options["lifetime"] = this->getArrVal(options, "lifetime", 172800),

--- a/phalcon/Mvc/Model/MetaData/Libmemcached.zep
+++ b/phalcon/Mvc/Model/MetaData/Libmemcached.zep
@@ -27,7 +27,7 @@ class Libmemcached extends MetaData
      *
      * @param array options
      */
-    public function __construct(<AdapterFactory> factory, array! options = [])
+    public function __construct(<AdapterFactory> factory,  array options = [])
     {
         let options["persistentId"] = this->getArrVal(options, "persistentId", "ph-mm-mcid-"),
             options["prefix"]       = this->getArrVal(options, "prefix", "ph-mm-memc-"),

--- a/phalcon/Mvc/Model/MetaData/Redis.zep
+++ b/phalcon/Mvc/Model/MetaData/Redis.zep
@@ -41,7 +41,7 @@ class Redis extends MetaData
      *
      * @param array options
      */
-    public function __construct(<AdapterFactory> factory, array! options = [])
+    public function __construct(<AdapterFactory> factory,  array options = [])
     {
         let options["prefix"]   = this->getArrVal(options, "prefix", "ph-mm-reds-"),
             options["lifetime"] = this->getArrVal(options, "lifetime", 172800),

--- a/phalcon/Mvc/Model/MetaDataInterface.zep
+++ b/phalcon/Mvc/Model/MetaDataInterface.zep
@@ -158,7 +158,7 @@ interface MetaDataInterface
     /**
      * Writes meta-data to the adapter
      */
-    public function write(string! key, array data) -> void;
+    public function write( string key, array data) -> void;
 
     /**
      * Writes meta-data for certain model using a MODEL_* constant

--- a/phalcon/Mvc/Model/Query.zep
+++ b/phalcon/Mvc/Model/Query.zep
@@ -705,7 +705,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Set default bind parameters
      */
-    public function setBindParams(array! bindParams, bool merge = false) -> <QueryInterface>
+    public function setBindParams( array bindParams, bool merge = false) -> <QueryInterface>
     {
         var currentBindParams;
 
@@ -722,7 +722,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Set default bind parameters
      */
-    public function setBindTypes(array! bindTypes, bool merge = false) -> <QueryInterface>
+    public function setBindTypes( array bindTypes, bool merge = false) -> <QueryInterface>
     {
         var currentBindTypes;
 
@@ -769,7 +769,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Allows to set the IR to be executed
      */
-    public function setIntermediate(array! intermediate) -> <QueryInterface>
+    public function setIntermediate( array intermediate) -> <QueryInterface>
     {
         let this->intermediate = intermediate;
 
@@ -1606,7 +1606,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Resolves an expression in a single call argument
      */
-    final protected function getCallArgument(array! argument) -> array
+    final protected function getCallArgument( array argument) -> array
     {
         if argument["type"] == PHQL_T_STARALL {
             return [
@@ -1620,7 +1620,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Resolves an expression in a single call argument
      */
-    final protected function getCaseExpression(array! expr) -> array
+    final protected function getCaseExpression( array expr) -> array
     {
         var whenClauses, whenExpr;
 
@@ -2340,7 +2340,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Resolves an expression in a single call argument
      */
-    final protected function getFunctionCall(array! expr) -> array
+    final protected function getFunctionCall( array expr) -> array
     {
         var arguments, argument;
         array functionArgs;
@@ -2392,7 +2392,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Returns a processed group clause for a SELECT statement
      */
-    final protected function getGroupClause(array! group) -> array
+    final protected function getGroupClause( array group) -> array
     {
         var groupItem;
         array groupParts;
@@ -2832,7 +2832,7 @@ class Query implements QueryInterface, InjectionAwareInterface
     /**
      * Returns a processed limit clause for a SELECT statement
      */
-    final protected function getLimitClause(array! limitClause) -> array
+    final protected function getLimitClause( array limitClause) -> array
     {
         var number, offset;
         array limit = [];
@@ -2853,7 +2853,7 @@ class Query implements QueryInterface, InjectionAwareInterface
      *
      * @param string joinSource
      */
-    final protected function getMultiJoin(string! joinType, joinSource, string modelAlias, string joinAlias, <RelationInterface> relation) -> array
+    final protected function getMultiJoin( string joinType, joinSource, string modelAlias, string joinAlias, <RelationInterface> relation) -> array
     {
         var fields, referencedFields, intermediateModelName,
             intermediateModel, intermediateSource, intermediateSchema,
@@ -3076,7 +3076,7 @@ class Query implements QueryInterface, InjectionAwareInterface
      * Replaces the model's name to its source name in a qualified-name
      * expression
      */
-    final protected function getQualified(array! expr) -> array
+    final protected function getQualified( array expr) -> array
     {
         var columnName, nestingLevel, sqlColumnAliases, metaData, sqlAliases,
             source, sqlAliasesModelsInstances, realColumnName, columnDomain,
@@ -3324,7 +3324,7 @@ class Query implements QueryInterface, InjectionAwareInterface
      * Resolves a column from its intermediate representation into an array
      * used to determine if the resultset produced is simple or complex
      */
-    final protected function getSelectColumn(array! column) -> array
+    final protected function getSelectColumn( array column) -> array
     {
         var columnType, sqlAliases, modelName, source, columnDomain,
             sqlColumnAlias, preparedAlias, sqlExprColumn, sqlAliasesModels,
@@ -3464,7 +3464,7 @@ class Query implements QueryInterface, InjectionAwareInterface
      *
      * @param string joinSource
      */
-    final protected function getSingleJoin(string! joinType, joinSource, string modelAlias, string joinAlias, <RelationInterface> relation) -> array
+    final protected function getSingleJoin( string joinType, joinSource, string modelAlias, string joinAlias, <RelationInterface> relation) -> array
     {
         var fields, referencedFields, sqlJoinConditions = null,
             sqlJoinPartialConditions, position, field, referencedField;

--- a/phalcon/Mvc/Model/Query/Builder.zep
+++ b/phalcon/Mvc/Model/Query/Builder.zep
@@ -368,7 +368,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function andHaving(string! conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
+    public function andHaving( string conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
     {
         var currentConditions;
 
@@ -399,7 +399,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function andWhere(string! conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
+    public function andWhere( string conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
     {
         var currentConditions;
 
@@ -434,7 +434,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->betweenHaving("SUM(Robots.price)", 100.25, 200.50);
      *```
      */
-    public function betweenHaving(string! expr, var minimum, var maximum, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function betweenHaving( string expr, var minimum, var maximum,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionBetween("Having", operator, expr, minimum, maximum);
     }
@@ -446,7 +446,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->betweenWhere("price", 100.25, 200.50);
      *```
      */
-    public function betweenWhere(string! expr, var minimum, var maximum, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function betweenWhere( string expr, var minimum, var maximum,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionBetween("Where", operator, expr, minimum, maximum);
     }
@@ -1186,7 +1186,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->inHaving("SUM(Robots.price)", [100, 200]);
      *```
      */
-    public function inHaving(string! expr, array! values, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function inHaving( string expr,  array values,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionIn("Having", operator, expr, values);
     }
@@ -1201,7 +1201,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function inWhere(string! expr, array! values, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function inWhere( string expr,  array values,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionIn("Where", operator, expr, values);
     }
@@ -1229,7 +1229,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function innerJoin(string! model, string conditions = null, string alias = null) -> <BuilderInterface>
+    public function innerJoin( string model, string conditions = null, string alias = null) -> <BuilderInterface>
     {
         let this->joins[] = [model, conditions, alias, "INNER"];
 
@@ -1267,7 +1267,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function join(string! model, string conditions = null, string alias = null, string type = null) -> <BuilderInterface>
+    public function join( string model, string conditions = null, string alias = null, string type = null) -> <BuilderInterface>
     {
         let this->joins[] = [model, conditions, alias, type];
 
@@ -1285,7 +1285,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function leftJoin(string! model, string conditions = null, string alias = null) -> <BuilderInterface>
+    public function leftJoin( string model, string conditions = null, string alias = null) -> <BuilderInterface>
     {
         let this->joins[] = [model, conditions, alias, "LEFT"];
 
@@ -1325,7 +1325,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->notBetweenHaving("SUM(Robots.price)", 100.25, 200.50);
      *```
      */
-    public function notBetweenHaving(string! expr, var minimum, var maximum, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function notBetweenHaving( string expr, var minimum, var maximum,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionNotBetween(
             "Having",
@@ -1343,7 +1343,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->notBetweenWhere("price", 100.25, 200.50);
      *```
      */
-    public function notBetweenWhere(string! expr, var minimum, var maximum, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function notBetweenWhere( string expr, var minimum, var maximum,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionNotBetween(
             "Where",
@@ -1361,7 +1361,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->notInHaving("SUM(Robots.price)", [100, 200]);
      *```
      */
-    public function notInHaving(string! expr, array! values, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function notInHaving( string expr,  array values,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionNotIn("Having", operator, expr, values);
     }
@@ -1373,7 +1373,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * $builder->notInWhere("id", [1, 2, 3]);
      *```
      */
-    public function notInWhere(string! expr, array! values, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
+    public function notInWhere( string expr,  array values,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>
     {
         return this->conditionNotIn("Where", operator, expr, values);
     }
@@ -1406,7 +1406,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function orHaving(string! conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
+    public function orHaving( string conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
     {
         var currentConditions;
 
@@ -1437,7 +1437,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function orWhere(string! conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
+    public function orWhere( string conditions, array bindParams = [], array bindTypes = []) -> <BuilderInterface>
     {
         var currentConditions;
 
@@ -1482,7 +1482,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
      * );
      *```
      */
-    public function rightJoin(string! model, string conditions = null, string alias = null) -> <BuilderInterface>
+    public function rightJoin( string model, string conditions = null, string alias = null) -> <BuilderInterface>
     {
         let this->joins[] = [model, conditions, alias, "RIGHT"];
 
@@ -1492,7 +1492,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Set default bind parameters
      */
-    public function setBindParams(array! bindParams, bool merge = false) -> <BuilderInterface>
+    public function setBindParams( array bindParams, bool merge = false) -> <BuilderInterface>
     {
         var currentBindParams;
 
@@ -1513,7 +1513,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Set default bind types
      */
-    public function setBindTypes(array! bindTypes, bool merge = false) -> <BuilderInterface>
+    public function setBindTypes( array bindTypes, bool merge = false) -> <BuilderInterface>
     {
         var currentBindTypes;
 
@@ -1595,7 +1595,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Appends a BETWEEN condition
      */
-    protected function conditionBetween(string! clause, string! operator, string! expr, var minimum, var maximum) -> <BuilderInterface>
+    protected function conditionBetween( string clause,  string operator,  string expr, var minimum, var maximum) -> <BuilderInterface>
     {
         var hiddenParam, nextHiddenParam, minimumKey, maximumKey, operatorMethod;
 
@@ -1637,7 +1637,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Appends an IN condition
      */
-    protected function conditionIn(string! clause, string! operator, string! expr, array! values) -> <BuilderInterface>
+    protected function conditionIn( string clause,  string operator,  string expr,  array values) -> <BuilderInterface>
     {
         var key, queryKey, value, bindKeys, bindParams, operatorMethod;
         int hiddenParam;
@@ -1687,7 +1687,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Appends a NOT BETWEEN condition
      */
-    protected function conditionNotBetween(string! clause, string! operator, string! expr, var minimum, var maximum) -> <BuilderInterface>
+    protected function conditionNotBetween( string clause,  string operator,  string expr, var minimum, var maximum) -> <BuilderInterface>
     {
         var hiddenParam, nextHiddenParam, minimumKey, maximumKey, operatorMethod;
 
@@ -1728,7 +1728,7 @@ class Builder implements BuilderInterface, InjectionAwareInterface
     /**
      * Appends a NOT IN condition
      */
-    protected function conditionNotIn(string! clause, string! operator, string! expr, array! values) -> <BuilderInterface>
+    protected function conditionNotIn( string clause,  string operator,  string expr,  array values) -> <BuilderInterface>
     {
         var key, queryKey, value, bindKeys, bindParams, operatorMethod;
         int hiddenParam;

--- a/phalcon/Mvc/Model/Query/BuilderInterface.zep
+++ b/phalcon/Mvc/Model/Query/BuilderInterface.zep
@@ -42,7 +42,7 @@ interface BuilderInterface
      * @param mixed minimum
      * @param mixed maximum
      */
-    public function betweenWhere(string! expr, minimum, maximum, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
+    public function betweenWhere( string expr, minimum, maximum,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
 
     /**
      * Sets the columns to be queried. The columns can be either a `string` or
@@ -223,7 +223,7 @@ interface BuilderInterface
     /**
      * Appends an IN condition to the current conditions
      */
-    public function inWhere(string! expr, array! values, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
+    public function inWhere( string expr,  array values,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
 
     /**
      * Adds an :type: join (by default type - INNER) to the query
@@ -253,12 +253,12 @@ interface BuilderInterface
      * @param mixed minimum
      * @param mixed maximum
      */
-    public function notBetweenWhere(string! expr, minimum, maximum, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
+    public function notBetweenWhere( string expr, minimum, maximum,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
 
     /**
      * Appends a NOT IN condition to the current conditions
      */
-    public function notInWhere(string! expr, array! values, string! operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
+    public function notInWhere( string expr,  array values,  string operator = BuilderInterface::OPERATOR_AND) -> <BuilderInterface>;
 
     /**
      * Sets an OFFSET clause
@@ -285,12 +285,12 @@ interface BuilderInterface
     /**
      * Set default bind parameters
      */
-    public function setBindParams(array! bindParams, bool merge = false) -> <BuilderInterface>;
+    public function setBindParams( array bindParams, bool merge = false) -> <BuilderInterface>;
 
     /**
      * Set default bind types
      */
-    public function setBindTypes(array! bindTypes, bool merge = false) -> <BuilderInterface>;
+    public function setBindTypes( array bindTypes, bool merge = false) -> <BuilderInterface>;
 
     /**
      * Sets conditions for the query

--- a/phalcon/Mvc/Model/Query/Lang.zep
+++ b/phalcon/Mvc/Model/Query/Lang.zep
@@ -36,7 +36,7 @@ abstract class Lang
     /**
      * Parses a PHQL statement returning an intermediate representation (IR)
      */
-    public static function parsePHQL(string! phql) -> array
+    public static function parsePHQL( string phql) -> array
     {
         return phql_parse_phql(phql);
     }

--- a/phalcon/Mvc/Model/QueryInterface.zep
+++ b/phalcon/Mvc/Model/QueryInterface.zep
@@ -70,12 +70,12 @@ interface QueryInterface
     /**
      * Set default bind parameters
      */
-    public function setBindParams(array! bindParams, bool merge = false) -> <QueryInterface>;
+    public function setBindParams( array bindParams, bool merge = false) -> <QueryInterface>;
 
     /**
      * Set default bind parameters
      */
-    public function setBindTypes(array! bindTypes, bool merge = false) -> <QueryInterface>;
+    public function setBindTypes( array bindTypes, bool merge = false) -> <QueryInterface>;
 
     /**
      * Set SHARED LOCK clause

--- a/phalcon/Mvc/Model/Relation.zep
+++ b/phalcon/Mvc/Model/Relation.zep
@@ -99,7 +99,7 @@ class Relation implements RelationInterface
      * @param array|string referencedFields
      * @param array options
      */
-    public function __construct(int type, string! referencedModel, var fields, var referencedFields, array options = [])
+    public function __construct(int type,  string referencedModel, var fields, var referencedFields, array options = [])
     {
         let this->type = type,
             this->referencedModel = referencedModel,
@@ -170,7 +170,7 @@ class Relation implements RelationInterface
      * Returns an option by the specified name
      * If the option does not exist null is returned
      */
-    public function getOption(string! name)
+    public function getOption( string name)
     {
         var option;
 
@@ -288,7 +288,7 @@ class Relation implements RelationInterface
      * @param string       intermediateModel
      * @param array|string intermediateReferencedFields
      */
-    public function setIntermediateRelation(var intermediateFields, string! intermediateModel, var intermediateReferencedFields)
+    public function setIntermediateRelation(var intermediateFields,  string intermediateModel, var intermediateReferencedFields)
     {
         let this->intermediateFields = intermediateFields,
             this->intermediateModel = intermediateModel,

--- a/phalcon/Mvc/Model/RelationInterface.zep
+++ b/phalcon/Mvc/Model/RelationInterface.zep
@@ -54,7 +54,7 @@ interface RelationInterface
      * Returns an option by the specified name
      * If the option does not exist null is returned
      */
-    public function getOption(string! name);
+    public function getOption( string name);
 
     /**
      * Returns the options
@@ -106,5 +106,5 @@ interface RelationInterface
      * @param string|array intermediateFields
      * @param string|array intermediateReferencedFields
      */
-    public function setIntermediateRelation(var intermediateFields, string! intermediateModel, var intermediateReferencedFields);
+    public function setIntermediateRelation(var intermediateFields,  string intermediateModel, var intermediateReferencedFields);
 }

--- a/phalcon/Mvc/Model/Row.zep
+++ b/phalcon/Mvc/Model/Row.zep
@@ -89,7 +89,7 @@ class Row extends \stdClass implements EntityInterface, ResultInterface, ArrayAc
      *
      * @return mixed
      */
-    public function readAttribute(string! attribute)
+    public function readAttribute( string attribute)
     {
         var value;
 
@@ -125,7 +125,7 @@ class Row extends \stdClass implements EntityInterface, ResultInterface, ArrayAc
      *
      * @param mixed value
      */
-    public function writeAttribute(string! attribute, value) -> void
+    public function writeAttribute( string attribute, value) -> void
     {
         let this->{attribute} = value;
     }

--- a/phalcon/Mvc/Model/Transaction/Failed.zep
+++ b/phalcon/Mvc/Model/Transaction/Failed.zep
@@ -31,7 +31,7 @@ class Failed extends Exception
      * @param string message
      * @param ModelInterface|null record
      */
-    public function __construct(string! message, <ModelInterface> record = null)
+    public function __construct( string message, <ModelInterface> record = null)
     {
         let this->record = record;
 

--- a/phalcon/Mvc/Model/Transaction/Manager.zep
+++ b/phalcon/Mvc/Model/Transaction/Manager.zep
@@ -303,7 +303,7 @@ class Manager implements ManagerInterface, InjectionAwareInterface
      *
      * @param string service
      */
-    public function setDbService(string! service) -> <ManagerInterface>
+    public function setDbService( string service) -> <ManagerInterface>
     {
         let this->service = service;
 

--- a/phalcon/Mvc/Model/Transaction/ManagerInterface.zep
+++ b/phalcon/Mvc/Model/Transaction/ManagerInterface.zep
@@ -73,7 +73,7 @@ interface ManagerInterface
     /**
      * Sets the database service used to run the isolated transactions
      */
-    public function setDbService(string! service) -> <ManagerInterface>;
+    public function setDbService( string service) -> <ManagerInterface>;
 
     /**
      * Set if the transaction manager must register a shutdown function to clean up pendent transactions

--- a/phalcon/Mvc/Model/ValidationFailed.zep
+++ b/phalcon/Mvc/Model/ValidationFailed.zep
@@ -37,7 +37,7 @@ class ValidationFailed extends Exception
      * @param ModelInterface model
      * @param Message[] validationMessages
      */
-    public function __construct(<ModelInterface> model, array! validationMessages)
+    public function __construct(<ModelInterface> model,  array validationMessages)
     {
         var messageStr, message;
 

--- a/phalcon/Mvc/ModelInterface.zep
+++ b/phalcon/Mvc/ModelInterface.zep
@@ -43,7 +43,7 @@ interface ModelInterface
      *
      * @return ModelInterface
      */
-    public function assign(array! data, var whiteList = null, var dataColumnMap = null) -> <ModelInterface>;
+    public function assign( array data, var whiteList = null, var dataColumnMap = null) -> <ModelInterface>;
 
     /**
      * Allows to calculate the average value on a column matching the specified
@@ -57,7 +57,7 @@ interface ModelInterface
     /**
      * Assigns values to a model from an array returning a new model
      */
-    public static function cloneResult(<ModelInterface> base, array! data, int dirtyState = 0) -> <ModelInterface>;
+    public static function cloneResult(<ModelInterface> base,  array data, int dirtyState = 0) -> <ModelInterface>;
 
     /**
      * Assigns values to a model from an array returning a new model
@@ -71,7 +71,7 @@ interface ModelInterface
      */
     public static function cloneResultMap(
         var base,
-        array! data,
+         array data,
         var columnMap,
         int dirtyState = 0,
         bool keepSnapshots = false
@@ -82,7 +82,7 @@ interface ModelInterface
      *
      * @param array columnMap
      */
-    public static function cloneResultMapHydrate(array! data, var columnMap, int hydrationMode);
+    public static function cloneResultMapHydrate( array data, var columnMap, int hydrationMode);
 
     /**
      * Allows to count how many records match the specified conditions
@@ -140,14 +140,14 @@ interface ModelInterface
      * Fires an event, implicitly calls behaviors and listeners in the events
      * manager are notified
      */
-    public function fireEvent(string! eventName) -> bool;
+    public function fireEvent( string eventName) -> bool;
 
     /**
      * Fires an event, implicitly calls behaviors and listeners in the events
      * manager are notified. This method stops if one of the callbacks/listeners
      * returns bool false
      */
-    public function fireEventCancel(string! eventName) -> bool;
+    public function fireEventCancel( string eventName) -> bool;
 
     /**
      * Returns one of the DIRTY_STATE_* constants telling if the record exists
@@ -266,7 +266,7 @@ interface ModelInterface
      *
      * @param array columnMap
      */
-    public function setSnapshotData(array! data, columnMap = null) -> void;
+    public function setSnapshotData( array data, columnMap = null) -> void;
 
     /**
      * Marks one or more many-to-many relationships to be synchronized (or not)

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -328,7 +328,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @param bool defaultRoutes
      */
-    public function __construct(bool! defaultRoutes = true)
+    public function __construct( bool defaultRoutes = true)
     {
         if defaultRoutes {
             /**
@@ -392,7 +392,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function add(
-        string! pattern,
+         string pattern,
         var paths = null,
         var httpMethods = null,
         int position = Router::POSITION_LAST
@@ -424,7 +424,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addConnect(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -446,7 +446,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addDelete(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -468,7 +468,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addGet(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -490,7 +490,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addHead(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -512,7 +512,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addOptions(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -534,7 +534,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addPatch(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -556,7 +556,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addPost(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -579,7 +579,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addPurge(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -601,7 +601,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addPut(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -623,7 +623,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      * @return RouteInterface
      */
     public function addTrace(
-        string! pattern,
+         string pattern,
         var paths = null,
         int position = Router::POSITION_LAST
     ) -> <RouteInterface> {
@@ -917,7 +917,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @throws \Phalcon\Mvc\Router\Exception
      */
-    public function dumpDispatcher(string! path) -> void
+    public function dumpDispatcher( string path) -> void
     {
         var dump, php, tmpPath;
 
@@ -941,7 +941,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @throws \Phalcon\Mvc\Router\Exception
      */
-    public function loadDispatcher(string! path) -> void
+    public function loadDispatcher( string path) -> void
     {
         var dump;
 
@@ -968,7 +968,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @throws \Phalcon\Mvc\Router\Exception
      */
-    public function useCache(<CacheAdapterInterface> cache, string! key = "phalcon.router.dispatcher") -> void
+    public function useCache(<CacheAdapterInterface> cache,  string key = "phalcon.router.dispatcher") -> void
     {
         var stored;
 
@@ -1163,7 +1163,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return RouteInterface|bool
      */
-    public function getRouteByName(string! name) -> <RouteInterface> | bool
+    public function getRouteByName( string name) -> <RouteInterface> | bool
     {
         var route, routeName, key;
 
@@ -1208,7 +1208,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return void
      */
-    public function handle(string! uri) -> void
+    public function handle( string uri) -> void
     {
         var action, beforeMatch, candidateRoutes, container,
             controller, converter, converters, currentHostName, eventsManager,
@@ -1868,7 +1868,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return static
      */
-    public function removeExtraSlashes(bool! remove) -> <static>
+    public function removeExtraSlashes( bool remove) -> <static>
     {
         let this->removeExtraSlashes = remove;
 
@@ -1882,7 +1882,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return static
      */
-    public function setDefaultAction(string! actionName) -> <static>
+    public function setDefaultAction( string actionName) -> <static>
     {
         let this->defaultAction = actionName;
 
@@ -1896,7 +1896,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return static
      */
-    public function setDefaultController(string! controllerName) -> <static>
+    public function setDefaultController( string controllerName) -> <static>
     {
         let this->defaultController = controllerName;
 
@@ -1910,7 +1910,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return static
      */
-    public function setDefaultModule(string! moduleName) -> <static>
+    public function setDefaultModule( string moduleName) -> <static>
     {
         let this->defaultModule = moduleName;
 
@@ -1924,7 +1924,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return static
      */
-    public function setDefaultNamespace(string! namespaceName) -> <static>
+    public function setDefaultNamespace( string namespaceName) -> <static>
     {
         let this->defaultNamespace = namespaceName;
 
@@ -1949,7 +1949,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
      *
      * @return static
      */
-    public function setDefaults(array! defaults) -> <static>
+    public function setDefaults( array defaults) -> <static>
     {
         var namespaceName, module, controller, action, params;
 
@@ -2094,7 +2094,7 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
         }
     }
 
-    protected function extractRealUri(string! uri) -> string
+    protected function extractRealUri( string uri) -> string
     {
         var urlParts, realUri;
 

--- a/phalcon/Mvc/Router/Annotations.zep
+++ b/phalcon/Mvc/Router/Annotations.zep
@@ -70,7 +70,7 @@ class Annotations extends Router
      * A resource is a class that contains routing annotations
      * The class is located in a module
      */
-    public function addModuleResource(string! module, string! handler, string! prefix = null) -> <static>
+    public function addModuleResource( string module,  string handler,  string prefix = null) -> <static>
     {
         let this->handlers[] = [prefix, handler, module];
 
@@ -81,7 +81,7 @@ class Annotations extends Router
      * Adds a resource to the annotations handler
      * A resource is a class that contains routing annotations
      */
-    public function addResource(string! handler, string! prefix = null) -> <static>
+    public function addResource( string handler,  string prefix = null) -> <static>
     {
         let this->handlers[] = [prefix, handler];
 
@@ -99,7 +99,7 @@ class Annotations extends Router
     /**
      * Produce the routing parameters from the rewrite information
      */
-    public function handle(string! uri) -> void
+    public function handle( string uri) -> void
     {
         var annotationsService, handlers, controllerSuffix, scope, prefix,
             route, compiledPattern, container, handler, controllerName,
@@ -266,10 +266,10 @@ class Annotations extends Router
      * Checks for annotations in the public methods of the controller
      */
     public function processActionAnnotation(
-        string! module,
-        string! namespaceName,
-        string! controller,
-        string! action,
+         string module,
+         string namespaceName,
+         string controller,
+         string action,
         <Annotation> annotation
     ) -> void {
         var name, proxyActionName, actionName, routePrefix, paths, value, uri, route, methods,
@@ -414,7 +414,7 @@ class Annotations extends Router
     /**
      * Checks for annotations in the controller docblock
      */
-    public function processControllerAnnotation(string! handler, <Annotation> annotation)
+    public function processControllerAnnotation( string handler, <Annotation> annotation)
     {
         /**
          * @RoutePrefix add a prefix for all the routes defined in the model
@@ -427,7 +427,7 @@ class Annotations extends Router
     /**
      * Changes the action method suffix
      */
-    public function setActionSuffix(string! actionSuffix) -> <self>
+    public function setActionSuffix( string actionSuffix) -> <self>
     {
         let this->actionSuffix = actionSuffix;
 
@@ -489,7 +489,7 @@ class Annotations extends Router
     /**
      * Changes the controller class suffix
      */
-    public function setControllerSuffix(string! controllerSuffix) -> <self>
+    public function setControllerSuffix( string controllerSuffix) -> <self>
     {
         let this->controllerSuffix = controllerSuffix;
 

--- a/phalcon/Mvc/Router/Group.zep
+++ b/phalcon/Mvc/Router/Group.zep
@@ -117,7 +117,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function add(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
+    public function add( string pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, httpMethods);
     }
@@ -135,7 +135,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addConnect(string! pattern, var paths = null) -> <RouteInterface>
+    public function addConnect( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "CONNECT");
     }
@@ -153,7 +153,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addDelete(string! pattern, var paths = null) -> <RouteInterface>
+    public function addDelete( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "DELETE");
     }
@@ -171,7 +171,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addGet(string! pattern, var paths = null) -> <RouteInterface>
+    public function addGet( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "GET");
     }
@@ -189,7 +189,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addHead(string! pattern, var paths = null) -> <RouteInterface>
+    public function addHead( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "HEAD");
     }
@@ -207,7 +207,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addOptions(string! pattern, var paths = null) -> <RouteInterface>
+    public function addOptions( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "OPTIONS");
     }
@@ -225,7 +225,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPatch(string! pattern, var paths = null) -> <RouteInterface>
+    public function addPatch( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "PATCH");
     }
@@ -243,7 +243,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPost(string! pattern, var paths = null) -> <RouteInterface>
+    public function addPost( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "POST");
     }
@@ -261,7 +261,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPurge(string! pattern, var paths = null) -> <RouteInterface>
+    public function addPurge( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "PURGE");
     }
@@ -279,7 +279,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPut(string! pattern, var paths = null) -> <RouteInterface>
+    public function addPut( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "PUT");
     }
@@ -297,7 +297,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    public function addTrace(string! pattern, var paths = null) -> <RouteInterface>
+    public function addTrace( string pattern, var paths = null) -> <RouteInterface>
     {
         return this->addRoute(pattern, paths, "TRACE");
     }
@@ -422,7 +422,7 @@ class Group implements GroupInterface
      *
      * @return RouteInterface
      */
-    protected function addRoute(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
+    protected function addRoute( string pattern, var paths = null, var httpMethods = null) -> <RouteInterface>
     {
         var mergedPaths, route, defaultPaths, processedPaths;
 

--- a/phalcon/Mvc/Router/GroupInterface.zep
+++ b/phalcon/Mvc/Router/GroupInterface.zep
@@ -69,7 +69,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function add(string! pattern, var paths = null, var httpMethods = null) -> <RouteInterface>;
+    public function add( string pattern, var paths = null, var httpMethods = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is CONNECT
@@ -79,7 +79,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addConnect(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addConnect( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is DELETE
@@ -89,7 +89,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addDelete(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addDelete( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is GET
@@ -99,7 +99,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addGet(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addGet( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is HEAD
@@ -109,7 +109,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addHead(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addHead( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Add a route to the router that only match if the HTTP method is OPTIONS
@@ -119,7 +119,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addOptions(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addOptions( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PATCH
@@ -129,7 +129,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPatch(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPatch( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is POST
@@ -139,7 +139,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPost(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPost( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PURGE
@@ -149,7 +149,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPurge(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPurge( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PUT
@@ -159,7 +159,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addPut(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addPut( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is TRACE
@@ -169,7 +169,7 @@ interface GroupInterface
      *
      * @return RouteInterface
      */
-    public function addTrace(string! pattern, var paths = null) -> <RouteInterface>;
+    public function addTrace( string pattern, var paths = null) -> <RouteInterface>;
 
     /**
      * Sets a callback that is called if the route is matched.

--- a/phalcon/Mvc/Router/Route.zep
+++ b/phalcon/Mvc/Router/Route.zep
@@ -89,7 +89,7 @@ class Route implements RouteInterface
     /**
      * Phalcon\Mvc\Router\Route constructor
      */
-    public function __construct(string! pattern, var paths = null, var httpMethods = null) // TODO: Make paths array
+    public function __construct( string pattern, var paths = null, var httpMethods = null) // TODO: Make paths array
     {
         var uniqueId;
 
@@ -141,7 +141,7 @@ class Route implements RouteInterface
     /**
      * Replaces placeholders from pattern returning a valid PCRE regular expression
      */
-    public function compilePattern(string! pattern) -> string
+    public function compilePattern( string pattern) -> string
     {
         string idPattern;
 
@@ -197,7 +197,7 @@ class Route implements RouteInterface
     /**
      * {@inheritdoc}
      */
-    public function convert(string! name, var converter) -> <RouteInterface>
+    public function convert( string name, var converter) -> <RouteInterface>
     {
         let this->converters[name] = converter;
 
@@ -207,7 +207,7 @@ class Route implements RouteInterface
     /**
      * Extracts parameters from a string
      */
-    public function extractNamedParams(string! pattern) -> array | bool
+    public function extractNamedParams( string pattern) -> array | bool
     {
         char ch, prevCh = '\0';
         var tmp, matches;
@@ -590,7 +590,7 @@ class Route implements RouteInterface
     /**
      * Reconfigure the route adding a new pattern and a set of paths
      */
-    public function reConfigure(string! pattern, var paths = null) -> void
+    public function reConfigure( string pattern, var paths = null) -> void
     {
         var routePaths, pcrePattern, compiledPattern, extracted;
 
@@ -660,7 +660,7 @@ class Route implements RouteInterface
      * $route->setHostname("localhost");
      *```
      */
-    public function setHostname(string! hostname) -> <RouteInterface>
+    public function setHostname( string hostname) -> <RouteInterface>
     {
         let this->hostname        = hostname,
             this->compiledHostName = false;
@@ -711,7 +711,7 @@ class Route implements RouteInterface
      * applications should rely on the auto-incrementing id assigned by
      * the constructor.
      */
-    public function setRouteId(string! routeId) -> <RouteInterface>
+    public function setRouteId( string routeId) -> <RouteInterface>
     {
         let this->routeId = routeId;
 

--- a/phalcon/Mvc/Router/RouteInterface.zep
+++ b/phalcon/Mvc/Router/RouteInterface.zep
@@ -18,12 +18,12 @@ interface RouteInterface
     /**
      * Replaces placeholders from pattern returning a valid PCRE regular expression
      */
-    public function compilePattern(string! pattern) -> string;
+    public function compilePattern( string pattern) -> string;
 
     /**
      * Adds a converter to perform an additional transformation for certain parameter.
      */
-    public function convert(string! name, var converter) -> <RouteInterface>;
+    public function convert( string name, var converter) -> <RouteInterface>;
 
     /**
      * Returns the route's pattern
@@ -68,7 +68,7 @@ interface RouteInterface
     /**
      * Reconfigure the route adding a new pattern and a set of paths
      */
-    public function reConfigure(string! pattern, var paths = null) -> void;
+    public function reConfigure( string pattern, var paths = null) -> void;
 
     /**
      * Resets the internal route id generator
@@ -93,7 +93,7 @@ interface RouteInterface
     /**
      * Sets the route's id (intended for restoring cached routes)
      */
-    public function setRouteId(string! routeId) -> <RouteInterface>;
+    public function setRouteId( string routeId) -> <RouteInterface>;
 
     /**
      * Set one or more HTTP methods that constraint the matching of the route

--- a/phalcon/Mvc/RouterInterface.zep
+++ b/phalcon/Mvc/RouterInterface.zep
@@ -27,7 +27,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function add(string! pattern, var paths = null, var httpMethods = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function add( string pattern, var paths = null, var httpMethods = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is CONNECT
@@ -37,7 +37,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addConnect(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addConnect( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is DELETE
@@ -47,7 +47,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addDelete(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addDelete( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is GET
@@ -57,7 +57,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addGet(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addGet( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is HEAD
@@ -67,7 +67,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addHead(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addHead( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Add a route to the router that only match if the HTTP method is OPTIONS
@@ -77,7 +77,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addOptions(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addOptions( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PATCH
@@ -87,7 +87,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPatch(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addPatch( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is POST
@@ -97,7 +97,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPost(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addPost( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PURGE
@@ -108,7 +108,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPurge(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addPurge( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is PUT
@@ -118,7 +118,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addPut(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addPut( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Adds a route to the router that only match if the HTTP method is TRACE
@@ -128,7 +128,7 @@ interface RouterInterface
      *
      * @return RouteInterface
      */
-    public function addTrace(string! pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
+    public function addTrace( string pattern, var paths = null, int position = Router::POSITION_LAST) -> <RouteInterface>;
 
     /**
      * Attach Route object to the routes stack.
@@ -192,7 +192,7 @@ interface RouterInterface
      *
      * @return RouteInterface|bool
      */
-    public function getRouteByName(string! name) -> <RouteInterface> | bool;
+    public function getRouteByName( string name) -> <RouteInterface> | bool;
 
     /**
      * Return all the routes defined in the router
@@ -202,7 +202,7 @@ interface RouterInterface
     /**
      * Handles routing information received from the rewrite engine
      */
-    public function handle(string! uri) -> void;
+    public function handle( string uri) -> void;
 
     /**
      * Loads routes from an array or Phalcon\Config\Config instance.
@@ -221,22 +221,22 @@ interface RouterInterface
     /**
      * Sets the default action name
      */
-    public function setDefaultAction(string! actionName) -> <RouterInterface>;
+    public function setDefaultAction( string actionName) -> <RouterInterface>;
 
     /**
      * Sets the default controller name
      */
-    public function setDefaultController(string! controllerName) -> <RouterInterface>;
+    public function setDefaultController( string controllerName) -> <RouterInterface>;
 
     /**
      * Sets the name of the default module
      */
-    public function setDefaultModule(string! moduleName) -> <RouterInterface>;
+    public function setDefaultModule( string moduleName) -> <RouterInterface>;
 
     /**
      * Sets an array of default paths
      */
-    public function setDefaults(array! defaults) -> <RouterInterface>;
+    public function setDefaults( array defaults) -> <RouterInterface>;
 
     /**
      * Check if the router matches any of the defined routes

--- a/phalcon/Mvc/Url.zep
+++ b/phalcon/Mvc/Url.zep
@@ -329,7 +329,7 @@ class Url extends AbstractInjectionAware implements UrlInterface
      * $url->setBasePath("/var/www/htdocs/");
      *```
      */
-    public function setBasePath(string! basePath) -> <UrlInterface>
+    public function setBasePath( string basePath) -> <UrlInterface>
     {
         let this->basePath = basePath;
 
@@ -345,7 +345,7 @@ class Url extends AbstractInjectionAware implements UrlInterface
      * $url->setBaseUri("/invo/index.php/");
      *```
      */
-    public function setBaseUri(string! baseUri) -> <UrlInterface>
+    public function setBaseUri( string baseUri) -> <UrlInterface>
     {
         let this->baseUri = baseUri;
 
@@ -363,7 +363,7 @@ class Url extends AbstractInjectionAware implements UrlInterface
      * $url->setStaticBaseUri("/invo/");
      *```
      */
-    public function setStaticBaseUri(string! staticBaseUri) -> <UrlInterface>
+    public function setStaticBaseUri( string staticBaseUri) -> <UrlInterface>
     {
         let this->staticBaseUri = staticBaseUri;
 

--- a/phalcon/Mvc/Url/UrlInterface.zep
+++ b/phalcon/Mvc/Url/UrlInterface.zep
@@ -47,10 +47,10 @@ interface UrlInterface
     /**
      * Sets a base paths for all the generated paths
      */
-    public function setBasePath(string! basePath) -> <UrlInterface>;
+    public function setBasePath( string basePath) -> <UrlInterface>;
 
     /**
      * Sets a prefix to all the urls generated
      */
-    public function setBaseUri(string! baseUri) -> <UrlInterface>;
+    public function setBaseUri( string baseUri) -> <UrlInterface>;
 }

--- a/phalcon/Mvc/View.zep
+++ b/phalcon/Mvc/View.zep
@@ -221,7 +221,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * echo $this->view->products;
      *```
      */
-    public function __get(string! key) -> var | null
+    public function __get( string key) -> var | null
     {
         return this->getVar(key);
     }
@@ -233,7 +233,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * echo isset($this->view->products);
      *```
      */
-    public function __isset(string! key) -> bool
+    public function __isset( string key) -> bool
     {
         return isset this->viewParams[key];
     }
@@ -245,7 +245,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * $this->view->products = $products;
      *```
      */
-    public function __set(string! key, var value)
+    public function __set( string key, var value)
     {
         this->setVar(key, value);
     }
@@ -315,7 +315,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * Checks whether view exists
      * @deprecated
      */
-    public function exists(string! view) -> bool
+    public function exists( string view) -> bool
     {
         return this->has(view);
     }
@@ -452,7 +452,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * );
      * ```
      */
-    public function getPartial(string! partialPath, var params = null) -> string
+    public function getPartial( string partialPath, var params = null) -> string
     {
         // not liking the ob_* functions here, but it will greatly reduce the
         // amount of double code.
@@ -494,7 +494,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      *
      * @param mixed configCallback
      */
-    public function getRender(string! controllerName, string! actionName, array params = [], configCallback = null) -> string
+    public function getRender( string controllerName,  string actionName, array params = [], configCallback = null) -> string
     {
         var view;
 
@@ -554,7 +554,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      *
      * @return mixed|null
      */
-    public function getVar(string! key) -> var | null
+    public function getVar( string key) -> var | null
     {
         var value;
 
@@ -576,7 +576,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
     /**
      * Checks whether view exists
      */
-    public function has(string! view) -> bool
+    public function has( string view) -> bool
     {
         var basePath, viewsDir, engines, extension;
 
@@ -628,7 +628,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * );
      * ```
      */
-    public function partial(string! partialPath, var params = null)
+    public function partial( string partialPath, var params = null)
     {
         var viewParams;
 
@@ -722,8 +722,8 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * Processes the view and templates; Fires events if needed
      */
     public function processRender(
-        string! controllerName,
-        string! actionName,
+         string controllerName,
+         string actionName,
         array params = [],
         bool fireEvents = true
     ) -> bool
@@ -945,7 +945,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * );
      * ```
      */
-    public function registerEngines(array! engines) -> <static>
+    public function registerEngines( array engines) -> <static>
     {
         let this->registeredEngines = engines;
 
@@ -961,8 +961,8 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      *```
      */
     public function render(
-        string! controllerName,
-        string! actionName,
+         string controllerName,
+         string actionName,
         array params = []
     ) -> <static> | false
     {
@@ -1083,7 +1083,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * $this->view->setParamToView("products", $products);
      *```
      */
-    public function setParamToView(string! key, var value) -> <static>
+    public function setParamToView( string key, var value) -> <static>
     {
         let this->viewParams[key] = value;
 
@@ -1158,7 +1158,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * $this->view->setVar("products", $products);
      *```
      */
-    public function setVar(string! key, var value) -> <static>
+    public function setVar( string key, var value) -> <static>
     {
         let this->viewParams[key] = value;
 
@@ -1176,7 +1176,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * );
      *```
      */
-    public function setVars(array! params, bool merge = true) -> <static>
+    public function setVars( array params, bool merge = true) -> <static>
     {
         if merge {
             let this->viewParams = array_merge(this->viewParams, params);
@@ -1234,8 +1234,8 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
      * Renders the view and returns it as a string
      */
     public function toString(
-        string! controllerName,
-        string! actionName,
+         string controllerName,
+         string actionName,
         array params = []
     ) -> string
     {
@@ -1425,7 +1425,7 @@ class View extends Injectable implements ViewInterface, EventsAwareInterface
     /**
      * @todo Remove this when we get traits
      */
-    private function getDirSeparator(string! directory) -> string
+    private function getDirSeparator( string directory) -> string
     {
         return rtrim(directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }

--- a/phalcon/Mvc/View/Engine/AbstractEngine.zep
+++ b/phalcon/Mvc/View/Engine/AbstractEngine.zep
@@ -82,7 +82,7 @@ abstract class AbstractEngine extends Injectable implements EngineInterface, Eve
      *
      * @return void
      */
-    public function partial(string! partialPath, var params = null) -> void // TODO: Make params array
+    public function partial( string partialPath, var params = null) -> void // TODO: Make params array
     {
         this->view->partial(partialPath, params);
     }

--- a/phalcon/Mvc/View/Engine/EngineInterface.zep
+++ b/phalcon/Mvc/View/Engine/EngineInterface.zep
@@ -23,7 +23,7 @@ interface EngineInterface
     /**
      * Renders a partial inside another view
      */
-    public function partial(string! partialPath, var params = null) -> void;
+    public function partial( string partialPath, var params = null) -> void;
 
     /**
      * Renders a view using the template engine

--- a/phalcon/Mvc/View/Engine/Php.zep
+++ b/phalcon/Mvc/View/Engine/Php.zep
@@ -18,7 +18,7 @@ class Php extends AbstractEngine
     /**
      * Renders a view using the template engine
      */
-    public function render(string! path, var params, bool mustClean = false)
+    public function render( string path, var params, bool mustClean = false)
     {
         var key, value;
 

--- a/phalcon/Mvc/View/Engine/Volt.zep
+++ b/phalcon/Mvc/View/Engine/Volt.zep
@@ -54,7 +54,7 @@ class Volt extends AbstractEngine implements EventsAwareInterface
      *
      * @return mixed
      */
-    public function callMacro(string! name, array arguments = []) -> var
+    public function callMacro( string name, array arguments = []) -> var
     {
         var macro;
 
@@ -70,7 +70,7 @@ class Volt extends AbstractEngine implements EventsAwareInterface
      *
      * @return string
      */
-    public function convertEncoding(string text, string! from, string! to) -> string
+    public function convertEncoding(string text,  string from,  string to) -> string
     {
         if unlikely !function_exists("mb_convert_encoding") {
             throw new MbstringRequired();
@@ -249,7 +249,7 @@ class Volt extends AbstractEngine implements EventsAwareInterface
      *
      * @return void
      */
-    public function render(string! path, var params, bool mustClean = false) // TODO: Make params array
+    public function render( string path, var params, bool mustClean = false) // TODO: Make params array
     {
         var compiler, compiledTemplatePath, eventsManager, key, value;
 
@@ -314,7 +314,7 @@ class Volt extends AbstractEngine implements EventsAwareInterface
      *
      * @return void
      */
-    public function setOptions(array! options)
+    public function setOptions( array options)
     {
         let this->options = options;
     }

--- a/phalcon/Mvc/View/Engine/Volt/Compiler.zep
+++ b/phalcon/Mvc/View/Engine/Volt/Compiler.zep
@@ -201,7 +201,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return static
      */
-    public function addFilter(string! name, var definition) -> <static>
+    public function addFilter( string name, var definition) -> <static>
     {
         let this->filters[name] = definition;
 
@@ -216,7 +216,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return static
      */
-    public function addFunction(string! name, var definition) -> <static>
+    public function addFunction( string name, var definition) -> <static>
     {
         let this->functions[name] = definition;
 
@@ -230,7 +230,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function attributeReader(array! expr) -> string
+    public function attributeReader( array expr) -> string
     {
         var left, leftType, variable, level, leftCode, right;
         string exprCode;
@@ -300,7 +300,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return mixed
      */
-    public function compile(string! templatePath, bool extendsMode = false)
+    public function compile( string templatePath, bool extendsMode = false)
     {
         var blocksCode, compilation, compileAlways, compiledExtension,
             compiledPath, compiledSeparator, compiledTemplatePath, options,
@@ -519,7 +519,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileAutoEscape(array! statement, bool extendsMode) -> string
+    public function compileAutoEscape( array statement, bool extendsMode) -> string
     {
         var autoescape, oldAutoescape, compilation;
 
@@ -552,7 +552,7 @@ class Compiler implements InjectionAwareInterface
      * @param array statement
      * @param bool extendsMode
      */
-    public function compileCall(array! statement, bool extendsMode) -> string
+    public function compileCall( array statement, bool extendsMode) -> string
     {
         // Not implemented?
         return "";
@@ -566,7 +566,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileCase(array! statement, bool caseClause = true) -> string
+    public function compileCase( array statement, bool caseClause = true) -> string
     {
         var expr;
 
@@ -597,7 +597,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileDo(array! statement) -> string
+    public function compileDo( array statement) -> string
     {
         var expr;
 
@@ -621,7 +621,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileEcho(array! statement) -> string
+    public function compileEcho( array statement) -> string
     {
         var expr, exprCode, name;
 
@@ -671,7 +671,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileElseIf(array! statement) -> string
+    public function compileElseIf( array statement) -> string
     {
         var expr;
 
@@ -705,7 +705,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string|array
      */
-    public function compileFile(string! path, string! compiledPath, bool extendsMode = false)
+    public function compileFile( string path,  string compiledPath, bool extendsMode = false)
     {
         var viewCode, compilation, finalCompilation;
 
@@ -762,7 +762,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileForeach(array! statement, bool extendsMode = false) -> string
+    public function compileForeach( array statement, bool extendsMode = false) -> string
     {
         var prefix, level, prefixLevel, expr, exprCode, bstatement, type,
             blockStatements, forElse, code, loopContext, iterator, key, ifExpr,
@@ -941,7 +941,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string
      */
-    public function compileIf(array! statement, bool extendsMode = false) -> string
+    public function compileIf( array statement, bool extendsMode = false) -> string
     {
         var blockStatements, expr;
         string compilation;
@@ -981,7 +981,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string
      */
-    public function compileInclude(array! statement) -> string
+    public function compileInclude( array statement) -> string
     {
         var pathExpr, path, subCompiler, finalPath, compilation, params;
 
@@ -1055,7 +1055,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileMacro(array! statement, bool extendsMode) -> string
+    public function compileMacro( array statement, bool extendsMode) -> string
     {
         var name, defaultValue, parameters, position, parameter, variableName,
             blockStatements;
@@ -1138,7 +1138,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string
      */
-    public function compileReturn(array! statement) -> string
+    public function compileReturn( array statement) -> string
     {
         var expr;
 
@@ -1214,7 +1214,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string
      */
-    public function compileSet(array! statement) -> string
+    public function compileSet( array statement) -> string
     {
         var assignments, assignment, exprCode, target;
         string compilation;
@@ -1289,7 +1289,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    public function compileString(string! viewCode, bool extendsMode = false) -> string
+    public function compileString( string viewCode, bool extendsMode = false) -> string
     {
         let this->currentPath = "eval code";
 
@@ -1305,7 +1305,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string
      */
-    public function compileSwitch(array! statement, bool extendsMode = false) -> string
+    public function compileSwitch( array statement, bool extendsMode = false) -> string
     {
         var compilation, caseClauses, expr, lines;
 
@@ -1368,7 +1368,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string
      */
-    final public function expression(array! expr, bool doubleQuotes = false) -> string
+    final public function expression( array expr, bool doubleQuotes = false) -> string
     {
         var end, endCode, exprCode, extensions, items, left, leftCode, name,
             right, rightCode, singleExpr, singleExprCode, start, startCode, type;
@@ -1725,7 +1725,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return mixed
      */
-    final public function fireExtensionEvent(string! name, array arguments = [])
+    final public function fireExtensionEvent( string name, array arguments = [])
     {
         var extensions, extension, status;
 
@@ -1765,7 +1765,7 @@ class Compiler implements InjectionAwareInterface
      * @throws \Phalcon\Mvc\View\Engine\Volt\Exception
      * @return string
      */
-    public function functionCall(array! expr, bool doubleQuotes = false) -> string
+    public function functionCall( array expr, bool doubleQuotes = false) -> string
     {
         var arguments, arrayHelpers, block, code, currentBlock, definition,
             escapedCode, exprLevel, extendedBlocks, extensions, funcArguments,
@@ -2068,7 +2068,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return string|null
      */
-    public function getOption(string! option) -> string | null
+    public function getOption( string option) -> string | null
     {
         var value;
 
@@ -2150,7 +2150,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @return array
      */
-    public function parse(string! viewCode) -> array
+    public function parse( string viewCode) -> array
     {
         var currentPath = "eval code";
 
@@ -2160,7 +2160,7 @@ class Compiler implements InjectionAwareInterface
     /**
      * Resolves filter intermediate code into a valid PHP expression
      */
-    public function resolveTest(array! test, string left) -> string
+    public function resolveTest( array test, string left) -> string
     {
         var type, name, testName;
 
@@ -2226,7 +2226,7 @@ class Compiler implements InjectionAwareInterface
      *
      * @param mixed value
      */
-    public function setOption(string! option, value) -> <static>
+    public function setOption( string option, value) -> <static>
     {
         let this->options[option] = value;
 
@@ -2236,7 +2236,7 @@ class Compiler implements InjectionAwareInterface
     /**
      * Sets the compiler options
      */
-    public function setOptions(array! options) -> <static>
+    public function setOptions( array options) -> <static>
     {
         let this->options = options;
 
@@ -2246,7 +2246,7 @@ class Compiler implements InjectionAwareInterface
     /**
      * Set a unique prefix to be used as prefix for compiled variables
      */
-    public function setUniquePrefix(string! prefix) -> <static>
+    public function setUniquePrefix( string prefix) -> <static>
     {
         let this->prefix = prefix;
 
@@ -2256,7 +2256,7 @@ class Compiler implements InjectionAwareInterface
     /**
      * Compiles a Volt source code returning a PHP plain version
      */
-    protected function compileSource(string! viewCode, bool extendsMode = false) -> array | string
+    protected function compileSource( string viewCode, bool extendsMode = false) -> array | string
     {
         var currentPath, intermediate, extended, finalCompilation, blocks,
             extendedBlocks, name, block, blockCompilation, localBlock,
@@ -2406,7 +2406,7 @@ class Compiler implements InjectionAwareInterface
     /**
      * Resolves filter intermediate code into PHP function calls
      */
-    final protected function resolveFilter(array! filter, string left) -> string
+    final protected function resolveFilter( array filter, string left) -> string
     {
         var code, type, functionName, name, file, line, extensions, filters,
             funcArguments, arguments, definition;
@@ -2594,7 +2594,7 @@ class Compiler implements InjectionAwareInterface
     /**
      * Traverses a statement list compiling each of its nodes
      */
-    final protected function statementList(array! statements, bool extendsMode = false) -> string
+    final protected function statementList( array statements, bool extendsMode = false) -> string
     {
         var extended, blockMode, compilation, extensions, statement,
             tempCompilation, type, blockName, blockStatements, blocks, path,

--- a/phalcon/Mvc/View/Simple.zep
+++ b/phalcon/Mvc/View/Simple.zep
@@ -108,7 +108,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return mixed|null
      */
-    public function __get(string! key) -> var | null
+    public function __get( string key) -> var | null
     {
         var value;
 
@@ -128,7 +128,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return void
      */
-    public function __set(string! key, var value) -> void
+    public function __set( string key, var value) -> void
     {
         let this->viewParams[key] = value;
     }
@@ -186,7 +186,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return mixed|null
      */
-    public function getVar(string! key) -> var | null
+    public function getVar( string key) -> var | null
     {
         var value;
 
@@ -227,7 +227,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return void
      */
-    public function partial(string! partialPath, var params = null) -> void
+    public function partial( string partialPath, var params = null) -> void
     {
         var viewParams, mergedParams;
 
@@ -294,7 +294,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return void
      */
-    public function registerEngines(array! engines) -> void
+    public function registerEngines( array engines) -> void
     {
         let this->registeredEngines = engines;
     }
@@ -304,7 +304,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return string
      */
-    public function render(string! path, array params = []) -> string
+    public function render( string path, array params = []) -> string
     {
         var mergedParams, viewParams;
 
@@ -341,7 +341,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return static
      */
-    public function setContent(string! content) -> <static>
+    public function setContent( string content) -> <static>
     {
         let this->content = content;
 
@@ -367,7 +367,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return static
      */
-    public function setParamToView(string! key, var value) -> <static>
+    public function setParamToView( string key, var value) -> <static>
     {
         return this->setVar(key, value);
     }
@@ -381,7 +381,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return static
      */
-    public function setVar(string! key, var value) -> <static>
+    public function setVar( string key, var value) -> <static>
     {
         let this->viewParams[key] = value;
 
@@ -401,7 +401,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return static
      */
-    public function setVars(array! params, bool merge = true) -> <static>
+    public function setVars( array params, bool merge = true) -> <static>
     {
         if merge {
             let params = array_merge(this->viewParams, params);
@@ -417,7 +417,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return void
      */
-    public function setViewsDir(string! viewsDir) -> void
+    public function setViewsDir( string viewsDir) -> void
     {
         let this->viewsDir = this->getDirSeparator(viewsDir);
     }
@@ -502,7 +502,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
      *
      * @return void
      */
-    final protected function internalRender(string! path, params) -> void
+    final protected function internalRender( string path, params) -> void
     {
         var eventsManager, engines, extension, engine;
         bool notExists, mustClean;
@@ -590,7 +590,7 @@ class Simple extends Injectable implements ViewBaseInterface, EventsAwareInterfa
     /**
      * @todo Remove this when we get traits
      */
-    private function getDirSeparator(string! directory) -> string
+    private function getDirSeparator( string directory) -> string
     {
         return rtrim(directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }

--- a/phalcon/Mvc/ViewBaseInterface.zep
+++ b/phalcon/Mvc/ViewBaseInterface.zep
@@ -35,26 +35,26 @@ interface ViewBaseInterface
     /**
      * Renders a partial view
      */
-    public function partial(string! partialPath, var params = null);
+    public function partial( string partialPath, var params = null);
 
     /**
      * Externally sets the view content
      */
-    public function setContent(string! content);
+    public function setContent( string content);
 
     /**
      * Adds parameters to views (alias of setVar)
      */
-    public function setParamToView(string! key, var value);
+    public function setParamToView( string key, var value);
 
     /**
      * Adds parameters to views
      */
-    public function setVar(string! key, var value);
+    public function setVar( string key, var value);
 
     /**
      * Sets views directory. Depending of your platform, always add a trailing
      * slash or backslash
      */
-    public function setViewsDir(string! viewsDir);
+    public function setViewsDir( string viewsDir);
 }

--- a/phalcon/Mvc/ViewInterface.zep
+++ b/phalcon/Mvc/ViewInterface.zep
@@ -88,17 +88,17 @@ interface ViewInterface extends ViewBaseInterface
     /**
      * Choose a view different to render than last-controller/last-action
      */
-    public function pick(string! renderView);
+    public function pick( string renderView);
 
     /**
      * Register templating engines
      */
-    public function registerEngines(array! engines);
+    public function registerEngines( array engines);
 
     /**
      * Executes render process from dispatching data
      */
-    public function render(string! controllerName, string! actionName, array params = []) -> <ViewInterface> | bool;
+    public function render( string controllerName,  string actionName, array params = []) -> <ViewInterface> | bool;
 
     /**
      * Resets the view component to its factory default values
@@ -109,33 +109,33 @@ interface ViewInterface extends ViewBaseInterface
      * Sets base path. Depending of your platform, always add a trailing slash
      * or backslash
      */
-    public function setBasePath(string! basePath);
+    public function setBasePath( string basePath);
 
     /**
      * Change the layout to be used instead of using the name of the latest
      * controller name
      */
-    public function setLayout(string! layout);
+    public function setLayout( string layout);
 
     /**
      * Sets the layouts sub-directory. Must be a directory under the views
      * directory. Depending of your platform, always add a trailing slash or
      * backslash
      */
-    public function setLayoutsDir(string! layoutsDir);
+    public function setLayoutsDir( string layoutsDir);
 
     /**
      * Sets default view name. Must be a file without extension in the views
      * directory
      */
-    public function setMainView(string! viewPath);
+    public function setMainView( string viewPath);
 
     /**
      * Sets a partials sub-directory. Must be a directory under the views
      * directory. Depending of your platform, always add a trailing slash or
      * backslash
      */
-    public function setPartialsDir(string! partialsDir);
+    public function setPartialsDir( string partialsDir);
 
     /**
      * Sets the render level for the view

--- a/phalcon/Paginator/Adapter/AbstractAdapter.zep
+++ b/phalcon/Paginator/Adapter/AbstractAdapter.zep
@@ -54,7 +54,7 @@ abstract class AbstractAdapter implements AdapterInterface
      *
      * @param array $config
      */
-    public function __construct(array! config)
+    public function __construct( array config)
     {
         let this->config = config;
 

--- a/phalcon/Paginator/Adapter/Model.zep
+++ b/phalcon/Paginator/Adapter/Model.zep
@@ -94,7 +94,7 @@ class Model extends AbstractAdapter
      *     'page'   => 1
      * ]
      */
-    public function __construct(array! config)
+    public function __construct( array config)
     {
         if unlikely !isset config["model"] {
             throw new MissingRequiredParameter("model");

--- a/phalcon/Paginator/PaginatorFactory.zep
+++ b/phalcon/Paginator/PaginatorFactory.zep
@@ -18,7 +18,7 @@ class PaginatorFactory extends AbstractFactory
     /**
      * AdapterFactory constructor.
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -71,7 +71,7 @@ class PaginatorFactory extends AbstractFactory
     /**
      * Create a new instance of the adapter
      */
-    public function newInstance(string! name, array! options = []) -> <AdapterInterface>
+    public function newInstance( string name,  array options = []) -> <AdapterInterface>
     {
         var definition;
 

--- a/phalcon/Queue/AdapterFactory.zep
+++ b/phalcon/Queue/AdapterFactory.zep
@@ -31,7 +31,7 @@ class AdapterFactory extends AbstractFactory
     /**
      * AdapterFactory constructor.
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -39,7 +39,7 @@ class AdapterFactory extends AbstractFactory
     /**
      * Creates a new ConnectionFactory for the named adapter.
      */
-    public function newInstance(string! name, array! options = []) -> <ConnectionFactoryInterface>
+    public function newInstance( string name,  array options = []) -> <ConnectionFactoryInterface>
     {
         var definition;
 

--- a/phalcon/Queue/QueueFactory.zep
+++ b/phalcon/Queue/QueueFactory.zep
@@ -72,7 +72,7 @@ class QueueFactory extends AbstractConfigFactory
     /**
      * Builds a Context for the named adapter.
      */
-    public function newInstance(string! name, array! options = []) -> <ContextInterface>
+    public function newInstance( string name,  array options = []) -> <ContextInterface>
     {
         var connectionFactory;
 

--- a/phalcon/Session/Adapter/AbstractAdapter.zep
+++ b/phalcon/Session/Adapter/AbstractAdapter.zep
@@ -99,7 +99,7 @@ abstract class AbstractAdapter implements SessionHandlerInterface, SessionUpdate
      * @todo Remove this when we get traits
      */
     protected function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Session/Adapter/Libmemcached.zep
+++ b/phalcon/Session/Adapter/Libmemcached.zep
@@ -37,7 +37,7 @@ class Libmemcached extends AbstractAdapter
      *     'stripPrefix' => false
      * ]
      */
-    public function __construct(<AdapterFactory> factory, array! options = [])
+    public function __construct(<AdapterFactory> factory,  array options = [])
     {
         /**
          * Session ids are externally generated and never carry the storage

--- a/phalcon/Session/Adapter/Redis.zep
+++ b/phalcon/Session/Adapter/Redis.zep
@@ -83,7 +83,7 @@ use Phalcon\Storage\AdapterFactory;
      *                                'lockWaitTime'   => 50000,
      * ]
      */
-    public function __construct(<AdapterFactory> factory, array! options = [])
+    public function __construct(<AdapterFactory> factory,  array options = [])
     {
         /**
          * Session ids are externally generated and never carry the storage

--- a/phalcon/Session/Adapter/Stream.zep
+++ b/phalcon/Session/Adapter/Stream.zep
@@ -67,7 +67,7 @@ class Stream extends Noop
      *     'savePath' => ''
      * ]
      */
-    public function __construct(array! options = [])
+    public function __construct( array options = [])
     {
         var path;
 
@@ -211,10 +211,10 @@ class Stream extends Noop
      * @todo Remove this when we get traits
      */
     protected function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null,
-        string! cast = null
+         string cast = null
     ) -> var {
         var value;
 
@@ -229,7 +229,7 @@ class Stream extends Noop
         return value;
     }
 
-    private function getDirSeparator(string! directory) -> string
+    private function getDirSeparator( string directory) -> string
     {
         return rtrim(directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }

--- a/phalcon/Session/Bag.zep
+++ b/phalcon/Session/Bag.zep
@@ -101,7 +101,7 @@ class Bag extends Collection implements BagInterface, InjectionAwareInterface
     /**
      * Initialize internal array
      */
-    public function init(array! data = []) -> void
+    public function init( array data = []) -> void
     {
         parent::init(data);
 
@@ -111,7 +111,7 @@ class Bag extends Collection implements BagInterface, InjectionAwareInterface
     /**
      * Removes a property from the internal bag
      */
-    public function remove(string! element) -> void
+    public function remove( string element) -> void
     {
         parent::remove(element);
 
@@ -121,7 +121,7 @@ class Bag extends Collection implements BagInterface, InjectionAwareInterface
     /**
      * Sets a value in the session bag
      */
-    public function set(string! element, var value) -> void
+    public function set( string element, var value) -> void
     {
         parent::set(element, value);
 

--- a/phalcon/Session/BagInterface.zep
+++ b/phalcon/Session/BagInterface.zep
@@ -26,7 +26,7 @@ interface BagInterface
 
     public function init(array data = []) -> void;
 
-    public function get(string element, var defaultValue = null, string! cast = null) -> var;
+    public function get(string element, var defaultValue = null,  string cast = null) -> var;
 
     public function set(string element, var value) -> void;
 

--- a/phalcon/Session/Manager.zep
+++ b/phalcon/Session/Manager.zep
@@ -408,7 +408,7 @@ class Manager extends AbstractInjectionAware implements ManagerInterface
      * @todo Remove this when we get traits
      */
     private function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null
     ) -> var {

--- a/phalcon/Storage/Adapter/AbstractAdapter.zep
+++ b/phalcon/Storage/Adapter/AbstractAdapter.zep
@@ -150,7 +150,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return int | bool
      */
-    public function decrement(string! key, int value = 1) -> int | bool
+    public function decrement( string key, int value = 1) -> int | bool
     {
         var result;
 
@@ -172,7 +172,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return bool
      */
-    public function delete(string! key) -> bool
+    public function delete( string key) -> bool
     {
         var result;
 
@@ -321,7 +321,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return bool
      */
-    public function has(string! key) -> bool
+    public function has( string key) -> bool
     {
         var result;
 
@@ -344,7 +344,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return int | bool
      */
-    public function increment(string! key, int value = 1) -> int | bool
+    public function increment( string key, int value = 1) -> int | bool
     {
         var result;
 
@@ -372,7 +372,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return bool
      */
-    public function set(string! key, var value, var ttl = null) -> bool
+    public function set( string key, var value, var ttl = null) -> bool
     {
         var result;
 
@@ -431,7 +431,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return int | bool
      */
-    abstract protected function doDecrement(string! key, int value = 1) -> int | bool;
+    abstract protected function doDecrement( string key, int value = 1) -> int | bool;
 
     /**
      * Deletes data from the adapter
@@ -440,7 +440,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return bool
      */
-    abstract protected function doDelete(string! key) -> bool;
+    abstract protected function doDelete( string key) -> bool;
 
     /**
      * Checks if an element exists in the cache
@@ -449,7 +449,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return bool
      */
-    abstract protected function doHas(string! key) -> bool;
+    abstract protected function doHas( string key) -> bool;
 
     /**
      * Increments a stored number
@@ -459,7 +459,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return int | bool
      */
-    abstract protected function doIncrement(string! key, int value = 1) -> int | bool;
+    abstract protected function doIncrement( string key, int value = 1) -> int | bool;
 
     /**
      * Stores data in the adapter. If the TTL is `null` (default) or not defined
@@ -474,7 +474,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return bool
      */
-    abstract protected function doSet(string! key, var value, var ttl = null) -> bool;
+    abstract protected function doSet( string key, var value, var ttl = null) -> bool;
 
     /**
      * Filters the keys array based on global and passed prefix
@@ -484,7 +484,7 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      *
      * @return array
      */
-    protected function getFilteredKeys(var keys, string! prefix) -> array
+    protected function getFilteredKeys(var keys,  string prefix) -> array
     {
         var key, pattern;
         array results;
@@ -626,10 +626,10 @@ abstract class AbstractAdapter implements AdapterInterface, EventsAwareInterface
      * @todo Remove this wrapper when we get traits
      */
     protected function getArrVal(
-        array! collection,
+         array collection,
         var index,
         var defaultValue = null,
-        string! cast = null
+         string cast = null
     ) -> var {
         return (new Get())->__invoke(collection, index, defaultValue, cast);
     }

--- a/phalcon/Storage/Adapter/AdapterInterface.zep
+++ b/phalcon/Storage/Adapter/AdapterInterface.zep
@@ -25,12 +25,12 @@ interface AdapterInterface
     /**
      * Decrements a stored number
      */
-    public function decrement(string! key, int value = 1) -> int | bool;
+    public function decrement( string key, int value = 1) -> int | bool;
 
     /**
      * Deletes data from the adapter
      */
-    public function delete(string! key) -> bool;
+    public function delete( string key) -> bool;
 
     /**
      * Deletes multiple data from the adapter
@@ -45,7 +45,7 @@ interface AdapterInterface
      *
      * @return mixed
      */
-    public function get(string! key, var defaultValue = null) -> var;
+    public function get( string key, var defaultValue = null) -> var;
 
     /**
      * Returns the already connected adapter or connects to the backend
@@ -56,7 +56,7 @@ interface AdapterInterface
     /**
      * Returns all the keys stored
      */
-    public function getKeys(string! prefix = "") -> array;
+    public function getKeys( string prefix = "") -> array;
 
     /**
      * Returns the prefix for the keys
@@ -66,12 +66,12 @@ interface AdapterInterface
     /**
      * Checks if an element exists in the cache
      */
-    public function has(string! key) -> bool;
+    public function has( string key) -> bool;
 
     /**
      * Increments a stored number
      */
-    public function increment(string! key, int value = 1) -> int | bool;
+    public function increment( string key, int value = 1) -> int | bool;
 
     /**
      * Stores data in the adapter. If the TTL is `null` (default) or not defined
@@ -86,7 +86,7 @@ interface AdapterInterface
      *
      * @return bool
      */
-    public function set(string! key, var value, var ttl = null) -> bool;
+    public function set( string key, var value, var ttl = null) -> bool;
 
     /**
      * Stores data in the adapter forever. The key needs to manually deleted

--- a/phalcon/Storage/Adapter/Apcu.zep
+++ b/phalcon/Storage/Adapter/Apcu.zep
@@ -40,7 +40,7 @@ class Apcu extends AbstractAdapter
      *
      * @throws SupportException
      */
-    public function __construct(<SerializerFactory> factory, array! options = [])
+    public function __construct(<SerializerFactory> factory,  array options = [])
     {
         parent::__construct(factory, options);
 
@@ -79,7 +79,7 @@ class Apcu extends AbstractAdapter
      *
      * @return array
      */
-    public function getKeys(string! prefix = "") -> array
+    public function getKeys( string prefix = "") -> array
     {
         var item, pattern, apc = null;
         array results;
@@ -108,7 +108,7 @@ class Apcu extends AbstractAdapter
      *
      * @return bool
      */
-    public function setForever(string! key, var value) -> bool
+    public function setForever( string key, var value) -> bool
     {
         var result;
 
@@ -128,7 +128,7 @@ class Apcu extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doDecrement(string! key, int value = 1) -> int | bool
+    protected function doDecrement( string key, int value = 1) -> int | bool
     {
         return this->phpApcuDec(this->getPrefixedKey(key), value);
     }
@@ -140,7 +140,7 @@ class Apcu extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doDelete(string! key) -> bool
+    protected function doDelete( string key) -> bool
     {
         return (bool) this->phpApcuDelete(this->getPrefixedKey(key));
     }
@@ -182,7 +182,7 @@ class Apcu extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doHas(string! key) -> bool
+    protected function doHas( string key) -> bool
     {
         var result;
 
@@ -199,7 +199,7 @@ class Apcu extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doIncrement(string! key, int value = 1) -> int | bool
+    protected function doIncrement( string key, int value = 1) -> int | bool
     {
         return this->phpApcuInc(this->getPrefixedKey(key), value);
     }
@@ -218,7 +218,7 @@ class Apcu extends AbstractAdapter
      * @return bool
      * @throws Exception
      */
-    protected function doSet(string! key, var value, var ttl = null) -> bool
+    protected function doSet( string key, var value, var ttl = null) -> bool
     {
         var result;
 

--- a/phalcon/Storage/Adapter/Libmemcached.zep
+++ b/phalcon/Storage/Adapter/Libmemcached.zep
@@ -127,7 +127,7 @@ class Libmemcached extends AbstractAdapter
      * @return array
      * @throws StorageException
      */
-    public function getKeys(string! prefix = "") -> array
+    public function getKeys( string prefix = "") -> array
     {
         return this->getFilteredKeys(
             this->getAdapter()->getAllKeys(),
@@ -165,7 +165,7 @@ class Libmemcached extends AbstractAdapter
      * @return bool|int
      * @throws StorageException
      */
-    protected function doDecrement(string! key, int value = 1) -> int | bool
+    protected function doDecrement( string key, int value = 1) -> int | bool
     {
         return this->getAdapter()->decrement(key, value);
     }
@@ -178,7 +178,7 @@ class Libmemcached extends AbstractAdapter
      * @return bool
      * @throws StorageException
      */
-    protected function doDelete(string! key) -> bool
+    protected function doDelete( string key) -> bool
     {
         return this->getAdapter()->delete(key, 0);
     }
@@ -222,7 +222,7 @@ class Libmemcached extends AbstractAdapter
      * @return bool
      * @throws StorageException
      */
-    protected function doHas(string! key) -> bool
+    protected function doHas( string key) -> bool
     {
         var connection, code;
 
@@ -242,7 +242,7 @@ class Libmemcached extends AbstractAdapter
      * @return bool|int
      * @throws StorageException
      */
-    protected function doIncrement(string! key, int value = 1) -> int | bool
+    protected function doIncrement( string key, int value = 1) -> int | bool
     {
         return this->getAdapter()->increment(key, value);
     }

--- a/phalcon/Storage/Adapter/Memory.zep
+++ b/phalcon/Storage/Adapter/Memory.zep
@@ -51,7 +51,7 @@ class Memory extends AbstractAdapter
      *
      * @throws SupportException
      */
-    public function __construct(<SerializerFactory> factory, array! options = [])
+    public function __construct(<SerializerFactory> factory,  array options = [])
     {
         parent::__construct(factory, options);
 
@@ -110,7 +110,7 @@ class Memory extends AbstractAdapter
      *
      * @return bool
      */
-    public function setForever(string! key, var value) -> bool
+    public function setForever( string key, var value) -> bool
     {
         return this->set(key, value);
     }
@@ -123,7 +123,7 @@ class Memory extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doDecrement(string! key, int value = 1) -> int | bool
+    protected function doDecrement( string key, int value = 1) -> int | bool
     {
         var current, newValue, prefixedKey, result;
 
@@ -148,7 +148,7 @@ class Memory extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doDelete(string! key) -> bool
+    protected function doDelete( string key) -> bool
     {
         var exists, prefixedKey;
 
@@ -177,7 +177,7 @@ class Memory extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doHas(string! key) -> bool
+    protected function doHas( string key) -> bool
     {
         return array_key_exists(this->getPrefixedKey(key), this->data);
     }
@@ -190,7 +190,7 @@ class Memory extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doIncrement(string! key, int value = 1) -> int | bool
+    protected function doIncrement( string key, int value = 1) -> int | bool
     {
         var current, newValue, prefixedKey, result;
 
@@ -222,7 +222,7 @@ class Memory extends AbstractAdapter
      * @return bool
      * @throws BaseException
      */
-    protected function doSet(string! key, var value, var ttl = null) -> bool
+    protected function doSet( string key, var value, var ttl = null) -> bool
     {
         var content, firstKey, prefixedKey;
 

--- a/phalcon/Storage/Adapter/Redis.zep
+++ b/phalcon/Storage/Adapter/Redis.zep
@@ -58,7 +58,7 @@ class Redis extends AbstractAdapter
      *
      * @throws SupportException
      */
-    public function __construct(<SerializerFactory> factory, array! options = [])
+    public function __construct(<SerializerFactory> factory,  array options = [])
     {
         /**
          * Lets set some defaults and options here
@@ -146,7 +146,7 @@ class Redis extends AbstractAdapter
      * @return array
      * @throws StorageException
      */
-    public function getKeys(string! prefix = "") -> array
+    public function getKeys( string prefix = "") -> array
     {
         var adapter, cursor, keys, pattern, result, scanKeys;
 
@@ -204,7 +204,7 @@ class Redis extends AbstractAdapter
      *
      * @return bool
      */
-    public function setForever(string! key, var value) -> bool
+    public function setForever( string key, var value) -> bool
     {
         var result;
 
@@ -225,7 +225,7 @@ class Redis extends AbstractAdapter
      * @return bool|false|int
      * @throws StorageException
      */
-    protected function doDecrement(string! key, int value = 1) -> int | bool
+    protected function doDecrement( string key, int value = 1) -> int | bool
     {
         return this->getAdapter()->decrBy(key, value);
     }
@@ -238,7 +238,7 @@ class Redis extends AbstractAdapter
      * @return bool
      * @throws StorageException
      */
-    protected function doDelete(string! key) -> bool
+    protected function doDelete( string key) -> bool
     {
         return (bool) this->getAdapter()->unlink(key);
     }
@@ -267,7 +267,7 @@ class Redis extends AbstractAdapter
      * @return bool
      * @throws StorageException
      */
-    protected function doHas(string! key) -> bool
+    protected function doHas( string key) -> bool
     {
         return (bool) this->getAdapter()->exists(key);
     }
@@ -281,7 +281,7 @@ class Redis extends AbstractAdapter
      * @return bool|false|int
      * @throws StorageException
      */
-    protected function doIncrement(string! key, int value = 1) -> int | bool
+    protected function doIncrement( string key, int value = 1) -> int | bool
     {
         return this->getAdapter()->incrBy(key, value);
     }
@@ -300,7 +300,7 @@ class Redis extends AbstractAdapter
      * @return bool
      * @throws BaseException
      */
-    protected function doSet(string! key, var value, var ttl = null) -> bool
+    protected function doSet( string key, var value, var ttl = null) -> bool
     {
         var result;
 

--- a/phalcon/Storage/Adapter/RedisCluster.zep
+++ b/phalcon/Storage/Adapter/RedisCluster.zep
@@ -74,7 +74,7 @@ class RedisCluster extends Redis
      *
      * @throws \Phalcon\Support\Exception
      */
-    public function __construct(<SerializerFactory> factory, array! options = [])
+    public function __construct(<SerializerFactory> factory,  array options = [])
     {
         let options["name"]        = this->getArrVal(options, "name", null),
             options["hosts"]       = this->getArrVal(options, "hosts", ["127.0.0.1:6379"]),
@@ -156,7 +156,7 @@ class RedisCluster extends Redis
      *
      * @return array
      */
-    public function getKeys(string! prefix = "") -> array
+    public function getKeys( string prefix = "") -> array
     {
         return this->getFilteredKeys(
             this->getAdapter()->keys("*"),

--- a/phalcon/Storage/Adapter/Stream.zep
+++ b/phalcon/Storage/Adapter/Stream.zep
@@ -55,7 +55,7 @@ class Stream extends AbstractAdapter
      *
      * @throws InvalidConfiguration
      */
-    public function __construct(<SerializerFactory> factory, array! options = [])
+    public function __construct(<SerializerFactory> factory,  array options = [])
     {
         var storageDir;
 
@@ -107,7 +107,7 @@ class Stream extends AbstractAdapter
      *
      * @return array
      */
-    public function getKeys(string! prefix = "") -> array
+    public function getKeys( string prefix = "") -> array
     {
         var directory, file, iterator;
         array files;
@@ -139,7 +139,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool
      */
-    public function setForever(string! key, var value) -> bool
+    public function setForever( string key, var value) -> bool
     {
         array payload;
 
@@ -160,7 +160,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doDecrement(string! key, int value = 1) -> int | bool
+    protected function doDecrement( string key, int value = 1) -> int | bool
     {
         var data, result;
 
@@ -186,7 +186,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doDelete(string! key) -> bool
+    protected function doDelete( string key) -> bool
     {
         var filepath;
 
@@ -207,7 +207,7 @@ class Stream extends AbstractAdapter
      *
      * @return mixed|null
      */
-    protected function doGet(string! key, var defaultValue = null) -> var
+    protected function doGet( string key, var defaultValue = null) -> var
     {
         var content, filepath, payload;
 
@@ -235,7 +235,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doHas(string! key) -> bool
+    protected function doHas( string key) -> bool
     {
         var payload, filepath;
 
@@ -262,7 +262,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doIncrement(string! key, int value = 1) -> int | bool
+    protected function doIncrement( string key, int value = 1) -> int | bool
     {
         var data, result;
 
@@ -294,7 +294,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doSet(string! key, var value, var ttl = null) -> bool
+    protected function doSet( string key, var value, var ttl = null) -> bool
     {
         array payload;
 
@@ -318,7 +318,7 @@ class Stream extends AbstractAdapter
      *
      * @return string
      */
-    private function getDir(string! key = "") -> string
+    private function getDir( string key = "") -> string
     {
         var dirFromFile, dirPrefix;
 
@@ -347,7 +347,7 @@ class Stream extends AbstractAdapter
      *
      * @return Iterator
      */
-    private function getIterator(string! dir) -> <Iterator>
+    private function getIterator( string dir) -> <Iterator>
     {
         return new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(
@@ -419,7 +419,7 @@ class Stream extends AbstractAdapter
      *
      * @return bool
      */
-    private function isExpired(array! payload) -> bool
+    private function isExpired( array payload) -> bool
     {
         var created, ttl;
 
@@ -490,7 +490,7 @@ class Stream extends AbstractAdapter
         return unlink(filename);
     }
 
-    private function getDirFromFile(string! file) -> string
+    private function getDirFromFile( string file) -> string
     {
         var name, start;
 
@@ -508,7 +508,7 @@ class Stream extends AbstractAdapter
         return implode("/", str_split(start, 2)) . "/";
     }
 
-    private function getDirSeparator(string! directory) -> string
+    private function getDirSeparator( string directory) -> string
     {
         return rtrim(directory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
     }

--- a/phalcon/Storage/Adapter/Weak.zep
+++ b/phalcon/Storage/Adapter/Weak.zep
@@ -53,7 +53,7 @@ class Weak extends AbstractAdapter
      * @param array options = []
      * @throws SupportException
      */
-    public function __construct(<SerializerFactory> factory, array! options = [])
+    public function __construct(<SerializerFactory> factory,  array options = [])
     {
         let this->defaultSerializer = "none",
             this->lifetime           = this->getArrVal(options, "lifetime", 3600),
@@ -123,7 +123,7 @@ class Weak extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doDecrement(string! key, int value = 1) -> int | bool
+    protected function doDecrement( string key, int value = 1) -> int | bool
     {
         return false;
     }
@@ -135,7 +135,7 @@ class Weak extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doDelete(string! key) -> bool
+    protected function doDelete( string key) -> bool
     {
         var exists;
 
@@ -157,7 +157,7 @@ class Weak extends AbstractAdapter
      *
      * @return mixed
      */
-    protected function doGet(string! key, var defaultValue = null) -> var
+    protected function doGet( string key, var defaultValue = null) -> var
     {
         var value, wr;
 
@@ -196,7 +196,7 @@ class Weak extends AbstractAdapter
      *
      * @return bool
      */
-    protected function doHas(string! key) -> bool
+    protected function doHas( string key) -> bool
     {
         return isset this->weakList[key];
     }
@@ -209,7 +209,7 @@ class Weak extends AbstractAdapter
      *
      * @return bool|int
      */
-    protected function doIncrement(string! key, int value = 1) -> int | bool
+    protected function doIncrement( string key, int value = 1) -> int | bool
     {
         return false;
     }
@@ -228,7 +228,7 @@ class Weak extends AbstractAdapter
      * @return bool
      * @throws BaseException
      */
-    protected function doSet(string! key, var value, var ttl = null) -> bool
+    protected function doSet( string key, var value, var ttl = null) -> bool
     {
         if typeof value !== "object" {
             return false;

--- a/phalcon/Storage/AdapterFactory.zep
+++ b/phalcon/Storage/AdapterFactory.zep
@@ -23,7 +23,7 @@ class AdapterFactory extends AbstractFactory
     /**
      * AdapterFactory constructor.
      */
-    public function __construct(<SerializerFactory> factory, array! services = [])
+    public function __construct(<SerializerFactory> factory,  array services = [])
     {
         let this->serializerFactory = factory;
 
@@ -57,7 +57,7 @@ class AdapterFactory extends AbstractFactory
      * @return AdapterInterface
      * @throws Exception
      */
-    public function newInstance(string! name, array! options = []) -> <AdapterInterface>
+    public function newInstance( string name,  array options = []) -> <AdapterInterface>
     {
         var definition;
 

--- a/phalcon/Storage/SerializerFactory.zep
+++ b/phalcon/Storage/SerializerFactory.zep
@@ -20,7 +20,7 @@ class SerializerFactory extends AbstractFactory
      *
      * @param array services
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -31,7 +31,7 @@ class SerializerFactory extends AbstractFactory
      * @return SerializerInterface
      * @throws Exception
      */
-    public function newInstance(string! name) -> <SerializerInterface>
+    public function newInstance( string name) -> <SerializerInterface>
     {
         var definition;
 

--- a/phalcon/Support/Collection.zep
+++ b/phalcon/Support/Collection.zep
@@ -94,7 +94,7 @@ class Collection implements
      *
      * @return mixed|null
      */
-    public function __get(string! element) -> mixed
+    public function __get( string element) -> mixed
     {
         return this->get(element);
     }

--- a/phalcon/Support/Debug.zep
+++ b/phalcon/Support/Debug.zep
@@ -362,7 +362,7 @@ class Debug
      *
      * @param string $uri
      */
-    public function setUri(string! uri) -> <static>
+    public function setUri( string uri) -> <static>
     {
         let this->uri = uri;
 

--- a/phalcon/Support/Debug/Dump.zep
+++ b/phalcon/Support/Debug/Dump.zep
@@ -71,7 +71,7 @@ class Dump implements TemplateAware
     /**
      * Phalcon\Debug\Dump constructor
      */
-    public function __construct(array! styles = [], bool detailed = false)
+    public function __construct( array styles = [], bool detailed = false)
     {
         let this->encode = new Encode();
 
@@ -134,7 +134,7 @@ class Dump implements TemplateAware
     /**
      * Set styles for vars type
      */
-    public function setStyles(array! styles = []) -> array
+    public function setStyles( array styles = []) -> array
     {
         var defaultStyles;
 
@@ -279,7 +279,7 @@ class Dump implements TemplateAware
     /**
      * Get style for type
      */
-    protected function getStyle(string! type) -> string
+    protected function getStyle( string type) -> string
     {
         var style;
 

--- a/phalcon/Support/Helper/Str/Friendly.zep
+++ b/phalcon/Support/Helper/Str/Friendly.zep
@@ -29,8 +29,8 @@ class Friendly extends AbstractStr
      * @throws InvalidReplaceFormat
      */
     public function __invoke(
-        string! text,
-        string! separator = "-",
+         string text,
+         string separator = "-",
         bool lowercase = true,
         var replace = null
     ) -> string {

--- a/phalcon/Support/HelperFactory.zep
+++ b/phalcon/Support/HelperFactory.zep
@@ -82,7 +82,7 @@ class HelperFactory extends AbstractFactory
      *
      * @param array $services
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }

--- a/phalcon/Support/Registry.zep
+++ b/phalcon/Support/Registry.zep
@@ -66,7 +66,7 @@ final class Registry extends Collection
     /**
      * Constructor
      */
-    final public function __construct(array! data = [])
+    final public function __construct( array data = [])
     {
         parent::__construct(data);
     }
@@ -125,9 +125,9 @@ final class Registry extends Collection
      * Get the element from the collection
      */
     final public function get(
-        string! element,
+         string element,
         var defaultValue = null,
-        string! cast = null
+         string cast = null
     ) -> mixed {
         return parent::get(element, defaultValue, cast);
     }
@@ -143,7 +143,7 @@ final class Registry extends Collection
     /**
      * Determines whether an element is present in the collection.
      */
-    final public function has(string! element) -> bool
+    final public function has( string element) -> bool
     {
         return parent::has(element);
     }
@@ -151,7 +151,7 @@ final class Registry extends Collection
     /**
      * Initialize internal array
      */
-    final public function init(array! data = []) -> void
+    final public function init( array data = []) -> void
     {
         parent::init(data);
     }
@@ -209,7 +209,7 @@ final class Registry extends Collection
     /**
      * Delete the element from the collection
      */
-    final public function remove(string! element) -> void
+    final public function remove( string element) -> void
     {
         parent::remove(element);
     }
@@ -227,7 +227,7 @@ final class Registry extends Collection
     /**
      * Set an element in the collection
      */
-    final public function set(string! element, var value) -> void
+    final public function set( string element, var value) -> void
     {
         parent::set(element, value);
     }

--- a/phalcon/Tag.zep
+++ b/phalcon/Tag.zep
@@ -224,7 +224,7 @@ class Tag
     /**
      * Alias of Phalcon\Tag::setDefault()
      */
-    public static function displayTo(string! id, value) -> void
+    public static function displayTo( string id, value) -> void
     {
         self::setDefault(id, value);
     }
@@ -387,7 +387,7 @@ class Tag
     /**
      * Obtains the 'escaper' service if required
      */
-    public static function getEscaper(array! params) -> <EscaperInterface> | null
+    public static function getEscaper( array params) -> <EscaperInterface> | null
     {
         var autoescape;
 
@@ -940,7 +940,7 @@ class Tag
      *     'class' => null
      * ]
      */
-    public static function renderAttributes(string! code, array! attributes) -> string
+    public static function renderAttributes( string code,  array attributes) -> string
     {
         var order, escaper, attrs, attribute, value, escaped, key;
         array attrParts;
@@ -1087,7 +1087,7 @@ class Tag
     /**
      * Assigns default values to generated tags by helpers
      */
-    public static function setDefault(string! id, value) -> void
+    public static function setDefault( string id, value) -> void
     {
         if value !== null {
             if unlikely (typeof value == "array" || typeof value == "object") {
@@ -1103,7 +1103,7 @@ class Tag
     /**
      * Assigns default values to generated tags by helpers
      */
-    public static function setDefaults(array! values, bool merge = false) -> void
+    public static function setDefaults( array values, bool merge = false) -> void
     {
         if merge && typeof self::displayValues == "array" {
             let self::displayValues = array_merge(self::displayValues, values);

--- a/phalcon/Translate/Adapter/AbstractAdapter.zep
+++ b/phalcon/Translate/Adapter/AbstractAdapter.zep
@@ -78,7 +78,7 @@ abstract class AbstractAdapter implements AdapterInterface, ArrayAccess
      *
      * @return string
      */
-    public function _(string! translateKey, array placeholders = []) -> string
+    public function _( string translateKey, array placeholders = []) -> string
     {
         return this->query(translateKey, placeholders);
     }
@@ -91,7 +91,7 @@ abstract class AbstractAdapter implements AdapterInterface, ArrayAccess
      * @return string
      * @throws Exception
      */
-    public function notFound(string! index) -> string
+    public function notFound( string index) -> string
     {
         if unlikely (true === this->triggerError) {
             throw new KeyNotFound(index);
@@ -158,7 +158,7 @@ abstract class AbstractAdapter implements AdapterInterface, ArrayAccess
      *
      * @return string
      */
-    public function t(string! translateKey, array placeholders = []) -> string
+    public function t( string translateKey, array placeholders = []) -> string
     {
         return this->query(translateKey, placeholders);
     }
@@ -171,7 +171,7 @@ abstract class AbstractAdapter implements AdapterInterface, ArrayAccess
      * @return string
      */
     protected function replacePlaceholders(
-        string! translation,
+         string translation,
         array placeholders = []
     ) -> string {
         if null === this->interpolator {

--- a/phalcon/Translate/Adapter/AdapterInterface.zep
+++ b/phalcon/Translate/Adapter/AdapterInterface.zep
@@ -53,5 +53,5 @@ interface AdapterInterface
      *
      * @return string
      */
-    public function t(string! translateKey, array placeholders = []) -> string;
+    public function t( string translateKey, array placeholders = []) -> string;
 }

--- a/phalcon/Translate/Adapter/Csv.zep
+++ b/phalcon/Translate/Adapter/Csv.zep
@@ -78,7 +78,7 @@ class Csv extends AbstractAdapter
      * @return bool
      * @deprecated
      */
-    public function exists(string! index) -> bool
+    public function exists( string index) -> bool
     {
         return this->has(index);
     }
@@ -90,7 +90,7 @@ class Csv extends AbstractAdapter
      *
      * @return bool
      */
-    public function has(string! index) -> bool
+    public function has( string index) -> bool
     {
         return isset this->translate[index];
     }
@@ -103,7 +103,7 @@ class Csv extends AbstractAdapter
      * @return string
      * @throws Exception
      */
-    public function query(string! translateKey, array placeholders = []) -> string
+    public function query( string translateKey, array placeholders = []) -> string
     {
         var translation;
 

--- a/phalcon/Translate/Adapter/Gettext.zep
+++ b/phalcon/Translate/Adapter/Gettext.zep
@@ -72,7 +72,7 @@ class Gettext extends AbstractAdapter
      * @throws MissingGettextExtension
      * @throws MissingRequiredParameter
      */
-    public function __construct(<InterpolatorFactory> interpolator, array! options)
+    public function __construct(<InterpolatorFactory> interpolator,  array options)
     {
         if unlikely !this->phpFunctionExists("gettext") {
             throw new MissingGettextExtension();
@@ -91,7 +91,7 @@ class Gettext extends AbstractAdapter
      * @return bool
      * @deprecated
      */
-    public function exists(string! index) -> bool
+    public function exists( string index) -> bool
     {
         return this->has(index);
     }
@@ -135,7 +135,7 @@ class Gettext extends AbstractAdapter
      *
      * @return bool
      */
-    public function has(string! index) -> bool
+    public function has( string index) -> bool
     {
         return gettext(index) !== index;
     }
@@ -150,11 +150,11 @@ class Gettext extends AbstractAdapter
      * @return string
      */
     public function nquery(
-        string! msgid1,
-        string! msgid2,
-        int! count,
+         string msgid1,
+         string msgid2,
+         int count,
         array placeholders = [],
-        string! domain = null
+         string domain = null
     ) -> string {
         var translation;
 
@@ -179,7 +179,7 @@ class Gettext extends AbstractAdapter
      * @return string
      * @throws Exception
      */
-    public function query(string! translateKey, array placeholders = []) -> string
+    public function query( string translateKey, array placeholders = []) -> string
     {
         var translation;
 
@@ -207,7 +207,7 @@ class Gettext extends AbstractAdapter
      *
      * @param string $domain
      */
-    public function setDefaultDomain(string! domain) -> void
+    public function setDefaultDomain( string domain) -> void
     {
         let this->defaultDomain = domain;
     }
@@ -286,7 +286,7 @@ class Gettext extends AbstractAdapter
      *
      * @return false|string
      */
-    public function setLocale(int! category, array localeArray = []) -> string | bool
+    public function setLocale( int category, array localeArray = []) -> string | bool
     {
         let this->locale   = setlocale(category, localeArray),
             this->category = category;
@@ -322,7 +322,7 @@ class Gettext extends AbstractAdapter
      * @return void
      * @throws MissingRequiredParameter
      */
-    protected function prepareOptions(array! options) -> void
+    protected function prepareOptions( array options) -> void
     {
         if unlikely !isset options["locale"] {
             throw new MissingRequiredParameter("locale");

--- a/phalcon/Translate/Adapter/NativeArray.zep
+++ b/phalcon/Translate/Adapter/NativeArray.zep
@@ -38,7 +38,7 @@ class NativeArray extends AbstractAdapter
      *
      * @throws Exception
      */
-    public function __construct(<InterpolatorFactory> interpolator, array! options)
+    public function __construct(<InterpolatorFactory> interpolator,  array options)
     {
         var data;
 
@@ -63,7 +63,7 @@ class NativeArray extends AbstractAdapter
      * @return bool
      * @deprecated
      */
-    public function exists(string! index) -> bool
+    public function exists( string index) -> bool
     {
         return this->has(index);
     }
@@ -75,7 +75,7 @@ class NativeArray extends AbstractAdapter
      *
      * @return bool
      */
-    public function has(string! index) -> bool
+    public function has( string index) -> bool
     {
         return isset this->translate[index];
     }
@@ -88,7 +88,7 @@ class NativeArray extends AbstractAdapter
      * @return string
      * @throws Exception
      */
-    public function query(string! translateKey, array placeholders = []) -> string
+    public function query( string translateKey, array placeholders = []) -> string
     {
         var translation;
 

--- a/phalcon/Translate/Interpolator/AssociativeArray.zep
+++ b/phalcon/Translate/Interpolator/AssociativeArray.zep
@@ -30,7 +30,7 @@ class AssociativeArray implements InterpolatorInterface
      * @return string
      */
     public function replacePlaceholders(
-        string! translation,
+         string translation,
         array placeholders = []
     ) -> string {
         if null === this->interpolate {

--- a/phalcon/Translate/Interpolator/IndexedArray.zep
+++ b/phalcon/Translate/Interpolator/IndexedArray.zep
@@ -20,7 +20,7 @@ class IndexedArray implements InterpolatorInterface
      * @return string
      */
     public function replacePlaceholders(
-        string! translation,
+         string translation,
         array placeholders = []
     ) -> string {
         if true !== empty(placeholders) {

--- a/phalcon/Translate/Interpolator/InterpolatorInterface.zep
+++ b/phalcon/Translate/Interpolator/InterpolatorInterface.zep
@@ -25,7 +25,7 @@ interface InterpolatorInterface
      * @return string
      */
     public function replacePlaceholders(
-        string! translation,
+         string translation,
         array placeholders = []
     ) -> string;
 }

--- a/phalcon/Translate/InterpolatorFactory.zep
+++ b/phalcon/Translate/InterpolatorFactory.zep
@@ -18,7 +18,7 @@ class InterpolatorFactory extends AbstractFactory
     /**
      * @phpstan-param array<string, string> $services
      */
-    public function __construct(array! services = [])
+    public function __construct( array services = [])
     {
         this->init(services);
     }
@@ -31,7 +31,7 @@ class InterpolatorFactory extends AbstractFactory
      * @return InterpolatorInterface
      * @throws Exception
      */
-    public function newInstance(string! name) -> <InterpolatorInterface>
+    public function newInstance( string name) -> <InterpolatorInterface>
     {
         var definition;
 

--- a/phalcon/Translate/TranslateFactory.zep
+++ b/phalcon/Translate/TranslateFactory.zep
@@ -43,7 +43,7 @@ class TranslateFactory extends AbstractFactory
      */
     public function __construct(
         <InterpolatorFactory> interpolator,
-        array! services = []
+         array services = []
     ) {
         let this->interpolator = interpolator;
 
@@ -80,7 +80,7 @@ class TranslateFactory extends AbstractFactory
      *
      * @return AdapterInterface
      */
-    public function newInstance(string! name, array! options = []) -> <AdapterInterface>
+    public function newInstance( string name,  array options = []) -> <AdapterInterface>
     {
         var definition;
 

--- a/tests/unit/Assets/Manager/ManagerOutputTest.php
+++ b/tests/unit/Assets/Manager/ManagerOutputTest.php
@@ -149,7 +149,7 @@ final class ManagerOutputTest extends AbstractUnitTestCase
     /**
      * Characterization test: in a *filtered* collection the non-join branch
      * renders the COLLECTION's attributes, discarding the per-asset attributes
-     * — unlike the unfiltered branch, which uses the asset's own attributes.
+     * - unlike the unfiltered branch, which uses the asset's own attributes.
      * Pins the current attribute divergence ahead of the v7 fix.
      *
      * @author Phalcon Team <team@phalcon.io>

--- a/tests/unit/Forms/Element/RenderTest.php
+++ b/tests/unit/Forms/Element/RenderTest.php
@@ -171,6 +171,55 @@ final class RenderTest extends AbstractUnitTestCase
     }
 
     /**
+     * Numeric defaults set via setDefault() must be cast to string when the
+     * element is rendered, instead of throwing a TypeError in the underlying
+     * input helper.
+     *
+     * @see    https://github.com/phalcon/cphalcon/issues/17232
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-06-28
+     */
+    public function testFormsElementRenderNumericValue(): void
+    {
+        $name    = uniqid();
+        $factory = new TagFactory(new Escaper());
+        $doctype = $factory->newInstance('doctype');
+        $doctype(Doctype::XHTML5);
+
+        $element = new Numeric($name);
+        $element->setTagFactory($factory);
+
+        /**
+         * Integer default
+         */
+        $element->setDefault(10);
+
+        $expected = sprintf(
+            '<input type="number" id="%s" name="%s" value="10" />',
+            $name,
+            $name
+        );
+        $actual = $element->render();
+
+        $this->assertSame($expected, $actual);
+
+        /**
+         * Float default
+         */
+        $element->setDefault(10.5);
+
+        $expected = sprintf(
+            '<input type="number" id="%s" name="%s" value="10.5" />',
+            $name,
+            $name
+        );
+        $actual = $element->render();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2024-01-01
      */


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17232 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Forms\Element\AbstractElement::render()` to cast a non-`null` element value to `string` before passing it to the input helper, so a numeric default set via `setDefault()` (e.g. `setDefault(10)` or `setDefault(10.5)` on a `Phalcon\Forms\Element\Numeric`) renders as `value="10"` instead of raising a `TypeError` for passing an `int`/`float` to the helper's `string` `$value` parameter.

Removed `!` from parameters.

Thanks

