### PR TITLE
CP-17307 traits openssl

### DIFF
--- a/phalcon/Encryption/Crypt.zep
+++ b/phalcon/Encryption/Crypt.zep
@@ -27,6 +27,7 @@ use Phalcon\Encryption\Crypt\Exception\RandomBytesGenerationFailed;
 use Phalcon\Encryption\Crypt\Exception\UnsupportedAlgorithm;
 use Phalcon\Encryption\Crypt\PadFactory;
 use Phalcon\Traits\Php\InfoTrait;
+use Phalcon\Traits\Php\OpensslTrait;
 
 /**
  * Provides encryption capabilities to Phalcon applications.
@@ -50,6 +51,7 @@ use Phalcon\Traits\Php\InfoTrait;
 class Crypt implements CryptInterface
 {
     use InfoTrait;
+    use OpensslTrait;
 
     /**
      * @var string
@@ -1029,15 +1031,5 @@ class Crypt implements CryptInterface
         return mb_strtolower(
             substr(this->cipher, position - strlen(this->cipher) + 1)
         );
-    }
-
-    protected function phpOpensslCipherIvLength(string cipher) -> int|bool
-    {
-        return openssl_cipher_iv_length(cipher);
-    }
-
-    protected function phpOpensslRandomPseudoBytes(int length)
-    {
-        return openssl_random_pseudo_bytes(length);
     }
 }

--- a/phalcon/Traits/Php/ApcuTrait.zep
+++ b/phalcon/Traits/Php/ApcuTrait.zep
@@ -80,7 +80,7 @@ trait ApcuTrait
     /**
      * @param string $pattern
      *
-     * @return APCUIterator|bool
+     * @return \APCUIterator|bool
      *
      * @link https://php.net/manual/en/class.apcuiterator.php
      */


### PR DESCRIPTION
Hello!

* Type: new feature
* Link to issue: #17307 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Added `Phalcon\Traits\Php\OpensslTrait`, exposing two protected `static` wrappers around PHP's OpenSSL functions - `phpOpensslCipherIvLength()` (`openssl_cipher_iv_length()`) and `phpOpensslRandomPseudoBytes()` (`openssl_random_pseudo_bytes()`) - so those calls can be substituted in tests. `Phalcon\Encryption\Crypt` now `use`s the trait, removing its two inline wrapper copies. 

Thanks

