### PR TITLE
CP-17389 augment adr application

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -10,6 +10,7 @@ All notable changes are documented here. The format is based on [Keep a Changelo
  
 ### Changed
 
+- Changed `Phalcon\ADR\Application` into a self-contained composition root: it owns (or accepts) a `Phalcon\Container\Container` and exposes a small registration surface - `bind()`, `define()`, `factory()`, `set()`, `extend()` and `getContainer()` - plus `setBaseNamespace()` and `secureWith()` for convention-router and namespace-prefix guard configuration. `Phalcon\ADR\Front\AbstractHttpFront` gained a protected `getApplication()` hook returning `Phalcon\Contracts\ADR\Application`, so a front controller can configure the application or wire a different implementation. [#17389](https://github.com/phalcon/cphalcon/issues/17389) [[doc]](https://docs.phalcon.io/5.18/adr/)
 - Replaced fully-qualified class-name strings with `::class` references (and `use` imports) across factories, service providers and DI containers [#17380](https://github.com/phalcon/cphalcon/issues/17380)
 
 ### Added

--- a/ext/phalcon/12__closure.zep.c
+++ b/ext/phalcon/12__closure.zep.c
@@ -45,7 +45,7 @@ PHP_METHOD(phalcon_12__closure, __invoke)
 		zephir_check_call_status();
 	}
 
-	ZEPHIR_RETURN_CALL_METHOD(&_0, "newinstance", NULL, 245);
+	ZEPHIR_RETURN_CALL_METHOD(&_0, "newinstance", NULL, 246);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/13__closure.zep.c
+++ b/ext/phalcon/13__closure.zep.c
@@ -38,7 +38,7 @@ PHP_METHOD(phalcon_13__closure, __invoke)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &container);
 	object_init_ex(return_value, phalcon_auth_access_accesslocator_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 405, container);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 407, container);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/14__closure.zep.c
+++ b/ext/phalcon/14__closure.zep.c
@@ -45,7 +45,7 @@ PHP_METHOD(phalcon_14__closure, __invoke)
 		zephir_check_call_status();
 	}
 
-	ZEPHIR_RETURN_CALL_METHOD(&_0, "newinstance", NULL, 245);
+	ZEPHIR_RETURN_CALL_METHOD(&_0, "newinstance", NULL, 246);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/15__closure.zep.c
+++ b/ext/phalcon/15__closure.zep.c
@@ -38,7 +38,7 @@ PHP_METHOD(phalcon_15__closure, __invoke)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &container);
 	object_init_ex(return_value, phalcon_auth_access_accesslocator_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 405, container);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 407, container);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/16__closure.zep.c
+++ b/ext/phalcon/16__closure.zep.c
@@ -43,7 +43,7 @@ PHP_METHOD(phalcon_16__closure, __invoke)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_read_static_property_ce(&ioc, phalcon_16__closure_ce, SL("ioc"), PH_NOISY_CC);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1368, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1367, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolveargument", NULL, 0, &ioc, &_0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&ioc, "get", NULL, 0, &id);

--- a/ext/phalcon/17__closure.zep.c
+++ b/ext/phalcon/17__closure.zep.c
@@ -43,7 +43,7 @@ PHP_METHOD(phalcon_17__closure, __invoke)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_read_static_property_ce(&ioc, phalcon_17__closure_ce, SL("ioc"), PH_NOISY_CC);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1369, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1368, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolveargument", NULL, 0, &ioc, &_0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&ioc, "new", NULL, 0, &id);

--- a/ext/phalcon/acl/adapter/memory.zep.c
+++ b/ext/phalcon/acl/adapter/memory.zep.c
@@ -309,10 +309,10 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addComponent)
 	} else {
 		ZEPHIR_INIT_NVAR(&componentObject);
 		object_init_ex(&componentObject, phalcon_acl_component_ce);
-		ZEPHIR_CALL_METHOD(NULL, &componentObject, "__construct", NULL, 219, componentValue);
+		ZEPHIR_CALL_METHOD(NULL, &componentObject, "__construct", NULL, 220, componentValue);
 		zephir_check_call_status();
 	}
-	ZEPHIR_CALL_METHOD(&componentName, &componentObject, "getname", NULL, 220);
+	ZEPHIR_CALL_METHOD(&componentName, &componentObject, "getname", NULL, 221);
 	zephir_check_call_status();
 	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 246, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_1, &componentName))) {
@@ -372,7 +372,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addComponentAccess)
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 246, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "Component");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 221, &_0, &componentName_zv, &_1);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 222, &_0, &componentName_zv, &_1);
 	zephir_check_call_status();
 	_2 = Z_TYPE_P(accessList) != IS_ARRAY;
 	if (_2) {
@@ -381,7 +381,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addComponentAccess)
 	if (UNEXPECTED(_2)) {
 		ZEPHIR_INIT_VAR(&_3$$3);
 		object_init_ex(&_3$$3, phalcon_acl_exceptions_invalidaccesslist_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 222);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 223);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$3, "phalcon/Acl/Adapter/Memory.zep", 255);
 		ZEPHIR_MM_RESTORE();
@@ -395,7 +395,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addComponentAccess)
 			{
 				ZEPHIR_INIT_NVAR(&accessName);
 				ZVAL_COPY(&accessName, _4$$4);
-				ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 223, &componentName_zv, &accessName);
+				ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 224, &componentName_zv, &accessName);
 				zephir_check_call_status();
 				zephir_read_property_cached(&_6$$5, this_ptr, _zephir_prop_1, 250, PH_NOISY_CC | PH_READONLY);
 				if (!(zephir_array_isset_value(&_6$$5, &accessKey))) {
@@ -422,7 +422,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addComponentAccess)
 				}
 				ZEPHIR_CALL_METHOD(&accessName, accessList, "current", NULL, 0);
 				zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 223, &componentName_zv, &accessName);
+					ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 224, &componentName_zv, &accessName);
 					zephir_check_call_status();
 					zephir_read_property_cached(&_10$$7, this_ptr, _zephir_prop_1, 250, PH_NOISY_CC | PH_READONLY);
 					if (!(zephir_array_isset_value(&_10$$7, &accessKey))) {
@@ -434,7 +434,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addComponentAccess)
 		}
 		ZEPHIR_INIT_NVAR(&accessName);
 	} else {
-		ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 223, &componentName_zv, accessList);
+		ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 224, &componentName_zv, accessList);
 		zephir_check_call_status();
 		zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 250, PH_NOISY_CC | PH_READONLY);
 		if (!(zephir_array_isset_value(&_12$$9, &accessKey))) {
@@ -530,7 +530,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 	ZVAL_STRING(&_1, "Role");
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "role list");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 221, &_0, &roleName_zv, &_1, &_2);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 222, &_0, &roleName_zv, &_1, &_2);
 	zephir_check_call_status();
 	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 248, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_3, &roleName_zv))) {
@@ -570,7 +570,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 			if (UNEXPECTED(!(zephir_array_isset_value(&_9$$6, &roleInheritName)))) {
 				ZEPHIR_INIT_NVAR(&_10$$10);
 				object_init_ex(&_10$$10, phalcon_acl_exceptions_rolenotfoundexception_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_10$$10, "__construct", &_11, 224, &roleInheritName);
+				ZEPHIR_CALL_METHOD(NULL, &_10$$10, "__construct", &_11, 225, &roleInheritName);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_10$$10, "phalcon/Acl/Adapter/Memory.zep", 330);
 				ZEPHIR_MM_RESTORE();
@@ -592,7 +592,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 						ZEPHIR_INIT_NVAR(&usedRoleToInherit);
 						ZVAL_COPY(&usedRoleToInherit, _15$$12);
 						ZEPHIR_MAKE_REF(&checkRoleToInherits);
-						ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+						ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 						ZEPHIR_UNREF(&checkRoleToInherits);
 						zephir_check_call_status();
 					} ZEND_HASH_FOREACH_END();
@@ -615,7 +615,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 						ZEPHIR_CALL_METHOD(&usedRoleToInherit, &_14$$12, "current", NULL, 0);
 						zephir_check_call_status();
 							ZEPHIR_MAKE_REF(&checkRoleToInherits);
-							ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+							ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 							ZEPHIR_UNREF(&checkRoleToInherits);
 							zephir_check_call_status();
 					}
@@ -638,7 +638,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 					if (UNEXPECTED(ZEPHIR_IS_EQUAL(&roleName_zv, &checkRoleToInherit))) {
 						ZEPHIR_INIT_NVAR(&_19$$17);
 						object_init_ex(&_19$$17, phalcon_acl_exceptions_circularinheritanceerror_ce);
-						ZEPHIR_CALL_METHOD(NULL, &_19$$17, "__construct", &_20, 226, &roleInheritName);
+						ZEPHIR_CALL_METHOD(NULL, &_19$$17, "__construct", &_20, 227, &roleInheritName);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_19$$17, "phalcon/Acl/Adapter/Memory.zep", 368);
 						ZEPHIR_MM_RESTORE();
@@ -655,7 +655,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 								ZEPHIR_INIT_NVAR(&usedRoleToInherit);
 								ZVAL_COPY(&usedRoleToInherit, _24$$18);
 								ZEPHIR_MAKE_REF(&checkRoleToInherits);
-								ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+								ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 								ZEPHIR_UNREF(&checkRoleToInherits);
 								zephir_check_call_status();
 							} ZEND_HASH_FOREACH_END();
@@ -678,7 +678,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 								ZEPHIR_CALL_METHOD(&usedRoleToInherit, &_23$$18, "current", NULL, 0);
 								zephir_check_call_status();
 									ZEPHIR_MAKE_REF(&checkRoleToInherits);
-									ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+									ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 									ZEPHIR_UNREF(&checkRoleToInherits);
 									zephir_check_call_status();
 							}
@@ -726,7 +726,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 				if (UNEXPECTED(!(zephir_array_isset_value(&_32$$21, &roleInheritName)))) {
 					ZEPHIR_INIT_NVAR(&_33$$25);
 					object_init_ex(&_33$$25, phalcon_acl_exceptions_rolenotfoundexception_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_33$$25, "__construct", &_11, 224, &roleInheritName);
+					ZEPHIR_CALL_METHOD(NULL, &_33$$25, "__construct", &_11, 225, &roleInheritName);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_33$$25, "phalcon/Acl/Adapter/Memory.zep", 330);
 					ZEPHIR_MM_RESTORE();
@@ -748,7 +748,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 							ZEPHIR_INIT_NVAR(&usedRoleToInherit);
 							ZVAL_COPY(&usedRoleToInherit, _37$$27);
 							ZEPHIR_MAKE_REF(&checkRoleToInherits);
-							ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+							ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 							ZEPHIR_UNREF(&checkRoleToInherits);
 							zephir_check_call_status();
 						} ZEND_HASH_FOREACH_END();
@@ -771,7 +771,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 							ZEPHIR_CALL_METHOD(&usedRoleToInherit, &_36$$27, "current", NULL, 0);
 							zephir_check_call_status();
 								ZEPHIR_MAKE_REF(&checkRoleToInherits);
-								ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+								ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 								ZEPHIR_UNREF(&checkRoleToInherits);
 								zephir_check_call_status();
 						}
@@ -794,7 +794,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 						if (UNEXPECTED(ZEPHIR_IS_EQUAL(&roleName_zv, &checkRoleToInherit))) {
 							ZEPHIR_INIT_NVAR(&_40$$32);
 							object_init_ex(&_40$$32, phalcon_acl_exceptions_circularinheritanceerror_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_40$$32, "__construct", &_20, 226, &roleInheritName);
+							ZEPHIR_CALL_METHOD(NULL, &_40$$32, "__construct", &_20, 227, &roleInheritName);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_40$$32, "phalcon/Acl/Adapter/Memory.zep", 368);
 							ZEPHIR_MM_RESTORE();
@@ -811,7 +811,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 									ZEPHIR_INIT_NVAR(&usedRoleToInherit);
 									ZVAL_COPY(&usedRoleToInherit, _44$$33);
 									ZEPHIR_MAKE_REF(&checkRoleToInherits);
-									ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+									ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 									ZEPHIR_UNREF(&checkRoleToInherits);
 									zephir_check_call_status();
 								} ZEND_HASH_FOREACH_END();
@@ -834,7 +834,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addInherit)
 									ZEPHIR_CALL_METHOD(&usedRoleToInherit, &_43$$33, "current", NULL, 0);
 									zephir_check_call_status();
 										ZEPHIR_MAKE_REF(&checkRoleToInherits);
-										ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 225, &checkRoleToInherits, &usedRoleToInherit);
+										ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_16, 226, &checkRoleToInherits, &usedRoleToInherit);
 										ZEPHIR_UNREF(&checkRoleToInherits);
 										zephir_check_call_status();
 								}
@@ -909,18 +909,18 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, addRole)
 	} else if (Z_TYPE_P(role) == IS_STRING) {
 		ZEPHIR_INIT_NVAR(&roleObject);
 		object_init_ex(&roleObject, phalcon_acl_role_ce);
-		ZEPHIR_CALL_METHOD(NULL, &roleObject, "__construct", NULL, 227, role);
+		ZEPHIR_CALL_METHOD(NULL, &roleObject, "__construct", NULL, 228, role);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_INIT_VAR(&_1$$5);
 		object_init_ex(&_1$$5, phalcon_acl_exceptions_invalidroletype_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", NULL, 228);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", NULL, 229);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$5, "phalcon/Acl/Adapter/Memory.zep", 414);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	ZEPHIR_CALL_METHOD(&roleName, &roleObject, "getname", NULL, 220);
+	ZEPHIR_CALL_METHOD(&roleName, &roleObject, "getname", NULL, 221);
 	zephir_check_call_status();
 	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 249, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_2, &roleName)) {
@@ -1017,7 +1017,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allow)
 		ZEPHIR_INIT_NVAR(&role);
 		ZVAL_COPY(&role, _2);
 		ZVAL_LONG(&_3$$4, 1);
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "allowordeny", &_4, 229, &role, &componentName_zv, access, &_3$$4, func);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "allowordeny", &_4, 230, &role, &componentName_zv, access, &_3$$4, func);
 		zephir_check_call_status();
 	} ZEND_HASH_FOREACH_END();
 	ZEPHIR_INIT_NVAR(&role);
@@ -1106,7 +1106,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, deny)
 		ZEPHIR_INIT_NVAR(&role);
 		ZVAL_COPY(&role, _2);
 		ZVAL_LONG(&_3$$4, 0);
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "allowordeny", &_4, 229, &role, &componentName_zv, access, &_3$$4, func);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "allowordeny", &_4, 230, &role, &componentName_zv, access, &_3$$4, func);
 		zephir_check_call_status();
 	} ZEND_HASH_FOREACH_END();
 	ZEPHIR_INIT_NVAR(&role);
@@ -1163,7 +1163,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, dropComponentAccess)
 	{
 		ZEPHIR_INIT_NVAR(&accessName);
 		ZVAL_COPY(&accessName, _1);
-		ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_2, 223, &componentName_zv, &accessName);
+		ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_2, 224, &componentName_zv, &accessName);
 		zephir_check_call_status();
 		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_0, 250, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_3$$5, &accessKey)) {
@@ -1420,10 +1420,10 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, isAllowed)
 	if (_1) {
 		ZEPHIR_CPY_WRT(&componentObject, componentName);
 	}
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "torolename", NULL, 230, roleName);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "torolename", NULL, 231, roleName);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(roleName, &_2);
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "tocomponentname", NULL, 231, componentName);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "tocomponentname", NULL, 232, componentName);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(componentName, &_2);
 	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 251, roleName);
@@ -1455,7 +1455,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, isAllowed)
 		zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_9, 257, PH_NOISY_CC | PH_READONLY);
 		RETURN_MM_BOOL((ZEPHIR_IS_LONG(&_6$$6, 1)));
 	}
-	ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "canaccess", NULL, 232, roleName, componentName, &access_zv);
+	ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "canaccess", NULL, 233, roleName, componentName, &access_zv);
 	zephir_check_call_status();
 	_7 = Z_TYPE_P(&accessKey) != IS_NULL;
 	if (_7) {
@@ -1490,14 +1490,14 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, isAllowed)
 	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 254, &accessKey);
 	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 255, &funcAccess);
 	if (Z_TYPE_P(&haveAccess) == IS_NULL) {
-		ZEPHIR_CALL_METHOD(&_11$$8, this_ptr, "buildkey", NULL, 233, roleName, componentName, &access_zv);
+		ZEPHIR_CALL_METHOD(&_11$$8, this_ptr, "buildkey", NULL, 234, roleName, componentName, &access_zv);
 		zephir_check_call_status();
 		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 254, &_11$$8);
 		zephir_read_property_cached(&_12$$8, this_ptr, _zephir_prop_9, 257, PH_NOISY_CC | PH_READONLY);
 		RETURN_MM_BOOL(ZEPHIR_IS_LONG(&_12$$8, 1));
 	}
 	if (zephir_is_callable(&funcAccess)) {
-		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "invokerule", NULL, 234, &funcAccess, &haveAccess, &parameters, &roleObject, &componentObject, roleName, componentName, &access_zv);
+		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "invokerule", NULL, 235, &funcAccess, &haveAccess, &parameters, &roleObject, &componentObject, roleName, componentName, &access_zv);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -1649,12 +1649,12 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allowOrDeny)
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 249, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "Role");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 221, &_0, &roleName_zv, &_1);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 222, &_0, &roleName_zv, &_1);
 	zephir_check_call_status();
 	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 246, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "Component");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 221, &_2, &componentName_zv, &_1);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkexists", NULL, 222, &_2, &componentName_zv, &_1);
 	zephir_check_call_status();
 	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 250, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&accessList, &_3);
@@ -1665,12 +1665,12 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allowOrDeny)
 			{
 				ZEPHIR_INIT_NVAR(&accessName);
 				ZVAL_COPY(&accessName, _4$$3);
-				ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 223, &componentName_zv, &accessName);
+				ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 224, &componentName_zv, &accessName);
 				zephir_check_call_status();
 				if (UNEXPECTED(!(zephir_array_isset_value(&accessList, &accessKey)))) {
 					ZEPHIR_INIT_NVAR(&_6$$5);
 					object_init_ex(&_6$$5, phalcon_acl_exceptions_accessrulenotfound_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_6$$5, "__construct", &_7, 235, &accessName, &componentName_zv);
+					ZEPHIR_CALL_METHOD(NULL, &_6$$5, "__construct", &_7, 236, &accessName, &componentName_zv);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_6$$5, "phalcon/Acl/Adapter/Memory.zep", 767);
 					ZEPHIR_MM_RESTORE();
@@ -1695,12 +1695,12 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allowOrDeny)
 				}
 				ZEPHIR_CALL_METHOD(&accessName, access, "current", NULL, 0);
 				zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 223, &componentName_zv, &accessName);
+					ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 224, &componentName_zv, &accessName);
 					zephir_check_call_status();
 					if (UNEXPECTED(!(zephir_array_isset_value(&accessList, &accessKey)))) {
 						ZEPHIR_INIT_NVAR(&_10$$7);
 						object_init_ex(&_10$$7, phalcon_acl_exceptions_accessrulenotfound_ce);
-						ZEPHIR_CALL_METHOD(NULL, &_10$$7, "__construct", &_7, 235, &accessName, &componentName_zv);
+						ZEPHIR_CALL_METHOD(NULL, &_10$$7, "__construct", &_7, 236, &accessName, &componentName_zv);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_10$$7, "phalcon/Acl/Adapter/Memory.zep", 767);
 						ZEPHIR_MM_RESTORE();
@@ -1715,7 +1715,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allowOrDeny)
 			{
 				ZEPHIR_INIT_NVAR(&accessName);
 				ZVAL_COPY(&accessName, _11$$3);
-				ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildkey", &_12, 233, &roleName_zv, &componentName_zv, &accessName);
+				ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildkey", &_12, 234, &roleName_zv, &componentName_zv, &accessName);
 				zephir_check_call_status();
 				zephir_update_property_array(this_ptr, SL("access"), &accessKey, action);
 				if (Z_TYPE_P(func) != IS_NULL) {
@@ -1740,7 +1740,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allowOrDeny)
 				}
 				ZEPHIR_CALL_METHOD(&accessName, access, "current", NULL, 0);
 				zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildkey", &_12, 233, &roleName_zv, &componentName_zv, &accessName);
+					ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildkey", &_12, 234, &roleName_zv, &componentName_zv, &accessName);
 					zephir_check_call_status();
 					zephir_update_property_array(this_ptr, SL("access"), &accessKey, action);
 					if (Z_TYPE_P(func) != IS_NULL) {
@@ -1751,19 +1751,19 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, allowOrDeny)
 		ZEPHIR_INIT_NVAR(&accessName);
 	} else {
 		if (!ZEPHIR_IS_STRING(access, "*")) {
-			ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 223, &componentName_zv, access);
+			ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildaccesskey", &_5, 224, &componentName_zv, access);
 			zephir_check_call_status();
 			if (UNEXPECTED(!(zephir_array_isset_value(&accessList, &accessKey)))) {
 				ZEPHIR_INIT_VAR(&_15$$14);
 				object_init_ex(&_15$$14, phalcon_acl_exceptions_accessrulenotfound_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_15$$14, "__construct", &_7, 235, access, &componentName_zv);
+				ZEPHIR_CALL_METHOD(NULL, &_15$$14, "__construct", &_7, 236, access, &componentName_zv);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_15$$14, "phalcon/Acl/Adapter/Memory.zep", 784);
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
 		}
-		ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildkey", &_12, 233, &roleName_zv, &componentName_zv, access);
+		ZEPHIR_CALL_METHOD(&accessKey, this_ptr, "buildkey", &_12, 234, &roleName_zv, &componentName_zv, access);
 		zephir_check_call_status();
 		zephir_update_property_array(this_ptr, SL("access"), &accessKey, action);
 		if (Z_TYPE_P(func) != IS_NULL) {
@@ -1907,7 +1907,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, canAccess)
 				ZEPHIR_INIT_NVAR(&usedRoleToInherit);
 				ZVAL_COPY(&usedRoleToInherit, _3$$6);
 				ZEPHIR_MAKE_REF(&checkRoleToInherits);
-				ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 225, &checkRoleToInherits, &usedRoleToInherit);
+				ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 226, &checkRoleToInherits, &usedRoleToInherit);
 				ZEPHIR_UNREF(&checkRoleToInherits);
 				zephir_check_call_status();
 			} ZEND_HASH_FOREACH_END();
@@ -1930,7 +1930,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, canAccess)
 				ZEPHIR_CALL_METHOD(&usedRoleToInherit, &_2$$6, "current", NULL, 0);
 				zephir_check_call_status();
 					ZEPHIR_MAKE_REF(&checkRoleToInherits);
-					ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 225, &checkRoleToInherits, &usedRoleToInherit);
+					ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 226, &checkRoleToInherits, &usedRoleToInherit);
 					ZEPHIR_UNREF(&checkRoleToInherits);
 					zephir_check_call_status();
 			}
@@ -1980,7 +1980,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, canAccess)
 						ZEPHIR_INIT_NVAR(&usedRoleToInherit);
 						ZVAL_COPY(&usedRoleToInherit, _12$$14);
 						ZEPHIR_MAKE_REF(&checkRoleToInherits);
-						ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 225, &checkRoleToInherits, &usedRoleToInherit);
+						ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 226, &checkRoleToInherits, &usedRoleToInherit);
 						ZEPHIR_UNREF(&checkRoleToInherits);
 						zephir_check_call_status();
 					} ZEND_HASH_FOREACH_END();
@@ -2003,7 +2003,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, canAccess)
 						ZEPHIR_CALL_METHOD(&usedRoleToInherit, &_11$$14, "current", NULL, 0);
 						zephir_check_call_status();
 							ZEPHIR_MAKE_REF(&checkRoleToInherits);
-							ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 225, &checkRoleToInherits, &usedRoleToInherit);
+							ZEPHIR_CALL_FUNCTION(NULL, "array_push", &_4, 226, &checkRoleToInherits, &usedRoleToInherit);
 							ZEPHIR_UNREF(&checkRoleToInherits);
 							zephir_check_call_status();
 					}
@@ -2176,9 +2176,9 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 	hasRole = 0;
 	ZEPHIR_INIT_VAR(&reflectionFunction);
 	object_init_ex(&reflectionFunction, zephir_get_internal_ce(SL("reflectionfunction")));
-	ZEPHIR_CALL_METHOD(NULL, &reflectionFunction, "__construct", NULL, 236, funcAccess);
+	ZEPHIR_CALL_METHOD(NULL, &reflectionFunction, "__construct", NULL, 237, funcAccess);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&reflectionParameters, &reflectionFunction, "getparameters", NULL, 237);
+	ZEPHIR_CALL_METHOD(&reflectionParameters, &reflectionFunction, "getparameters", NULL, 238);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&parameterNumber);
 	ZVAL_LONG(&parameterNumber, zephir_fast_count_int(&reflectionParameters));
@@ -2194,7 +2194,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 	}
 	ZEPHIR_INIT_VAR(&parametersForFunction);
 	array_init(&parametersForFunction);
-	ZEPHIR_CALL_METHOD(&numberOfRequiredParameters, &reflectionFunction, "getnumberofrequiredparameters", NULL, 238);
+	ZEPHIR_CALL_METHOD(&numberOfRequiredParameters, &reflectionFunction, "getnumberofrequiredparameters", NULL, 239);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&userParametersSizeShouldBe, &parameterNumber);
 	zephir_is_iterable(&reflectionParameters, 0, "phalcon/Acl/Adapter/Memory.zep", 1055);
@@ -2216,11 +2216,11 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&reflectionClass);
 				object_init_ex(&reflectionClass, zephir_get_internal_ce(SL("reflectionclass")));
-				ZEPHIR_CALL_METHOD(NULL, &reflectionClass, "__construct", &_4, 239, &className);
+				ZEPHIR_CALL_METHOD(NULL, &reflectionClass, "__construct", &_4, 240, &className);
 				zephir_check_call_status();
 				_5$$5 = Z_TYPE_P(roleObject) != IS_NULL;
 				if (_5$$5) {
-					ZEPHIR_CALL_METHOD(&_6$$5, &reflectionClass, "isinstance", &_7, 240, roleObject);
+					ZEPHIR_CALL_METHOD(&_6$$5, &reflectionClass, "isinstance", &_7, 241, roleObject);
 					zephir_check_call_status();
 					_5$$5 = zephir_is_true(&_6$$5);
 				}
@@ -2237,7 +2237,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 				}
 				_9$$5 = Z_TYPE_P(componentObject) != IS_NULL;
 				if (_9$$5) {
-					ZEPHIR_CALL_METHOD(&_10$$5, &reflectionClass, "isinstance", &_7, 240, componentObject);
+					ZEPHIR_CALL_METHOD(&_10$$5, &reflectionClass, "isinstance", &_7, 241, componentObject);
 					zephir_check_call_status();
 					_9$$5 = zephir_is_true(&_10$$5);
 				}
@@ -2260,7 +2260,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 				_14$$5 = _12$$5;
 				if (_14$$5) {
 					zephir_array_fetch(&_16$$5, parameters, &parameterToCheck, PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Memory.zep", 1032);
-					ZEPHIR_CALL_METHOD(&_15$$5, &reflectionClass, "isinstance", &_7, 240, &_16$$5);
+					ZEPHIR_CALL_METHOD(&_15$$5, &reflectionClass, "isinstance", &_7, 241, &_16$$5);
 					zephir_check_call_status();
 					_14$$5 = !zephir_is_true(&_15$$5);
 				}
@@ -2270,7 +2270,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 					ZEPHIR_INIT_NVAR(&_18$$8);
 					zephir_array_fetch(&_19$$8, parameters, &parameterToCheck, PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Memory.zep", 1039);
 					zephir_get_class(&_18$$8, &_19$$8, 0);
-					ZEPHIR_CALL_METHOD(&_20$$8, &reflectionClass, "getname", &_21, 241);
+					ZEPHIR_CALL_METHOD(&_20$$8, &reflectionClass, "getname", &_21, 242);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&_22$$8);
 					ZEPHIR_CONCAT_SSSVSVSVSVSVS(&_22$$8, "Your passed parameter does not have the ", "same class as the parameter in defined function ", "when checking if ", &roleName_zv, " can ", &access_zv, " ", &componentName_zv, ". Class passed: ", &_18$$8, " , Class in defined function: ", &_20$$8, ".");
@@ -2317,11 +2317,11 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&reflectionClass);
 					object_init_ex(&reflectionClass, zephir_get_internal_ce(SL("reflectionclass")));
-					ZEPHIR_CALL_METHOD(NULL, &reflectionClass, "__construct", &_4, 239, &className);
+					ZEPHIR_CALL_METHOD(NULL, &reflectionClass, "__construct", &_4, 240, &className);
 					zephir_check_call_status();
 					_28$$11 = Z_TYPE_P(roleObject) != IS_NULL;
 					if (_28$$11) {
-						ZEPHIR_CALL_METHOD(&_29$$11, &reflectionClass, "isinstance", &_7, 240, roleObject);
+						ZEPHIR_CALL_METHOD(&_29$$11, &reflectionClass, "isinstance", &_7, 241, roleObject);
 						zephir_check_call_status();
 						_28$$11 = zephir_is_true(&_29$$11);
 					}
@@ -2338,7 +2338,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 					}
 					_31$$11 = Z_TYPE_P(componentObject) != IS_NULL;
 					if (_31$$11) {
-						ZEPHIR_CALL_METHOD(&_32$$11, &reflectionClass, "isinstance", &_7, 240, componentObject);
+						ZEPHIR_CALL_METHOD(&_32$$11, &reflectionClass, "isinstance", &_7, 241, componentObject);
 						zephir_check_call_status();
 						_31$$11 = zephir_is_true(&_32$$11);
 					}
@@ -2361,7 +2361,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 					_36$$11 = _34$$11;
 					if (_36$$11) {
 						zephir_array_fetch(&_38$$11, parameters, &parameterToCheck, PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Memory.zep", 1032);
-						ZEPHIR_CALL_METHOD(&_37$$11, &reflectionClass, "isinstance", &_7, 240, &_38$$11);
+						ZEPHIR_CALL_METHOD(&_37$$11, &reflectionClass, "isinstance", &_7, 241, &_38$$11);
 						zephir_check_call_status();
 						_36$$11 = !zephir_is_true(&_37$$11);
 					}
@@ -2371,7 +2371,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, invokeRule)
 						ZEPHIR_INIT_NVAR(&_40$$14);
 						zephir_array_fetch(&_41$$14, parameters, &parameterToCheck, PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Memory.zep", 1039);
 						zephir_get_class(&_40$$14, &_41$$14, 0);
-						ZEPHIR_CALL_METHOD(&_42$$14, &reflectionClass, "getname", &_21, 241);
+						ZEPHIR_CALL_METHOD(&_42$$14, &reflectionClass, "getname", &_21, 242);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&_43$$14);
 						ZEPHIR_CONCAT_SSSVSVSVSVSVS(&_43$$14, "Your passed parameter does not have the ", "same class as the parameter in defined function ", "when checking if ", &roleName_zv, " can ", &access_zv, " ", &componentName_zv, ". Class passed: ", &_40$$14, " , Class in defined function: ", &_42$$14, ".");
@@ -2470,7 +2470,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, toComponentName)
 		}
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_acl_exceptions_invalidcomponentimplementation_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 242);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 243);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Acl/Adapter/Memory.zep", 1113);
 		ZEPHIR_MM_RESTORE();
@@ -2510,7 +2510,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Memory, toRoleName)
 		}
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_acl_exceptions_invalidroleimplementation_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 243);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 244);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Acl/Adapter/Memory.zep", 1133);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/acl/adapter/storage.zep.c
+++ b/ext/phalcon/acl/adapter/storage.zep.c
@@ -103,8 +103,8 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, __construct)
 		zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 367, storage);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 368, &key_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 366, storage);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 367, &key_zv);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_acl_adapter_storage_ce, getThis(), "__construct", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "load", NULL, 0);
@@ -204,12 +204,12 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 367, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 368, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 366, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 367, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&data, &_0, "get", NULL, 0, &_1);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&data) == IS_OBJECT) {
-		ZEPHIR_CALL_METHOD(&_2$$3, this_ptr, "normalizetoarray", NULL, 334, &data);
+		ZEPHIR_CALL_METHOD(&_2$$3, this_ptr, "normalizetoarray", NULL, 336, &data);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&data, &_2$$3);
 	}
@@ -287,7 +287,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 			ZVAL_COPY(&description, _18);
 			ZEPHIR_INIT_NVAR(&_21$$8);
 			object_init_ex(&_21$$8, phalcon_acl_role_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_21$$8, "__construct", &_22, 227, &name, &description);
+			ZEPHIR_CALL_METHOD(NULL, &_21$$8, "__construct", &_22, 228, &name, &description);
 			zephir_check_call_status();
 			zephir_array_update_zval(&rebuiltRoles, &name, &_21$$8, PH_COPY | PH_SEPARATE);
 		} ZEND_HASH_FOREACH_END();
@@ -313,7 +313,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 			zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_25$$9);
 				object_init_ex(&_25$$9, phalcon_acl_role_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_25$$9, "__construct", &_22, 227, &name, &description);
+				ZEPHIR_CALL_METHOD(NULL, &_25$$9, "__construct", &_22, 228, &name, &description);
 				zephir_check_call_status();
 				zephir_array_update_zval(&rebuiltRoles, &name, &_25$$9, PH_COPY | PH_SEPARATE);
 		}
@@ -337,7 +337,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 			ZVAL_COPY(&description, _27);
 			ZEPHIR_INIT_NVAR(&_30$$10);
 			object_init_ex(&_30$$10, phalcon_acl_component_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_30$$10, "__construct", &_31, 219, &name, &description);
+			ZEPHIR_CALL_METHOD(NULL, &_30$$10, "__construct", &_31, 220, &name, &description);
 			zephir_check_call_status();
 			zephir_array_update_zval(&rebuiltComponents, &name, &_30$$10, PH_COPY | PH_SEPARATE);
 		} ZEND_HASH_FOREACH_END();
@@ -363,7 +363,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 			zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_34$$11);
 				object_init_ex(&_34$$11, phalcon_acl_component_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_34$$11, "__construct", &_31, 219, &name, &description);
+				ZEPHIR_CALL_METHOD(NULL, &_34$$11, "__construct", &_31, 220, &name, &description);
 				zephir_check_call_status();
 				zephir_array_update_zval(&rebuiltComponents, &name, &_34$$11, PH_COPY | PH_SEPARATE);
 		}
@@ -371,15 +371,15 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 	ZEPHIR_INIT_NVAR(&description);
 	ZEPHIR_INIT_NVAR(&name);
 	zephir_array_fetch_string(&_35, &data, SL("access"), PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Storage.zep", 119);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 369, &_35);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 368, &_35);
 	zephir_array_fetch_string(&_36, &data, SL("accessList"), PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Storage.zep", 120);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 370, &_36);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 371, &rebuiltComponents);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 369, &_36);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 370, &rebuiltComponents);
 	zephir_array_fetch_string(&_37, &data, SL("componentsNames"), PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Storage.zep", 122);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 372, &_37);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 373, &rebuiltRoles);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 371, &_37);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 372, &rebuiltRoles);
 	zephir_array_fetch_string(&_38, &data, SL("roleInherits"), PH_NOISY | PH_READONLY, "phalcon/Acl/Adapter/Storage.zep", 124);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 374, &_38);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 373, &_38);
 	ZEPHIR_INIT_VAR(&_39);
 	if (zephir_array_isset_value_string(&data, SL("defaultAccess"))) {
 		ZEPHIR_OBS_NVAR(&_39);
@@ -388,7 +388,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 		ZEPHIR_INIT_NVAR(&_39);
 		ZVAL_LONG(&_39, 0);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 375, &_39);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 374, &_39);
 	ZEPHIR_INIT_VAR(&_40);
 	if (zephir_array_isset_value_string(&data, SL("noArgumentsDefaultAction"))) {
 		ZEPHIR_OBS_NVAR(&_40);
@@ -397,7 +397,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, load)
 		ZEPHIR_INIT_NVAR(&_40);
 		ZVAL_LONG(&_40, 0);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 376, &_40);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 375, &_40);
 	RETURN_MM_BOOL(1);
 }
 
@@ -487,10 +487,10 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, save)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 369, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 368, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&access, &_0);
 	ZEPHIR_INIT_VAR(&_1);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 377, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 376, PH_NOISY_CC | PH_READONLY);
 	zephir_array_keys(&_1, &_0);
 	zephir_is_iterable(&_1, 0, "phalcon/Acl/Adapter/Storage.zep", 146);
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_1), _2)
@@ -504,7 +504,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, save)
 	ZEPHIR_INIT_NVAR(&accessKey);
 	ZEPHIR_INIT_VAR(&components);
 	array_init(&components);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 371, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 370, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_4, 0, "phalcon/Acl/Adapter/Storage.zep", 151);
 	if (Z_TYPE_P(&_4) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_4), _6, _7, _5)
@@ -550,7 +550,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, save)
 	ZEPHIR_INIT_NVAR(&componentName);
 	ZEPHIR_INIT_VAR(&roles);
 	array_init(&roles);
-	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_3, 373, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_3, 372, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_12, 0, "phalcon/Acl/Adapter/Storage.zep", 156);
 	if (Z_TYPE_P(&_12) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_12), _14, _15, _13)
@@ -594,28 +594,28 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, save)
 	}
 	ZEPHIR_INIT_NVAR(&roleObject);
 	ZEPHIR_INIT_NVAR(&roleName);
-	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_4, 367, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_21, this_ptr, _zephir_prop_5, 368, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_4, 366, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_21, this_ptr, _zephir_prop_5, 367, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_22);
 	zephir_create_array(&_22, 9, 0);
 	add_assoc_long_ex(&_22, SL("version"), 1);
 	zephir_array_update_string(&_22, SL("access"), &access, PH_COPY | PH_SEPARATE);
 	zephir_memory_observe(&_23);
-	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_6, 370, PH_NOISY_CC);
+	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_6, 369, PH_NOISY_CC);
 	zephir_array_update_string(&_22, SL("accessList"), &_23, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_22, SL("components"), &components, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_23);
-	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_7, 372, PH_NOISY_CC);
+	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_7, 371, PH_NOISY_CC);
 	zephir_array_update_string(&_22, SL("componentsNames"), &_23, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_22, SL("roles"), &roles, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_23);
-	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_8, 374, PH_NOISY_CC);
+	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_8, 373, PH_NOISY_CC);
 	zephir_array_update_string(&_22, SL("roleInherits"), &_23, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_23);
-	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_9, 375, PH_NOISY_CC);
+	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_9, 374, PH_NOISY_CC);
 	zephir_array_update_string(&_22, SL("defaultAccess"), &_23, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_23);
-	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_10, 376, PH_NOISY_CC);
+	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_10, 375, PH_NOISY_CC);
 	zephir_array_update_string(&_22, SL("noArgumentsDefaultAction"), &_23, PH_COPY | PH_SEPARATE);
 	ZEPHIR_RETURN_CALL_METHOD(&_20, "set", NULL, 0, &_21, &_22);
 	zephir_check_call_status();
@@ -654,7 +654,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, normalizeToArray)
 	zephir_fetch_params(1, 1, 0, &value);
 	ZEPHIR_SEPARATE_PARAM(value);
 	if (Z_TYPE_P(value) == IS_OBJECT) {
-		ZEPHIR_CALL_FUNCTION(&_0$$3, "get_object_vars", NULL, 335, value);
+		ZEPHIR_CALL_FUNCTION(&_0$$3, "get_object_vars", NULL, 337, value);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(value, &_0$$3);
 	}
@@ -676,7 +676,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, normalizeToArray)
 			}
 			ZEPHIR_INIT_NVAR(&item);
 			ZVAL_COPY(&item, _1);
-			ZEPHIR_CALL_METHOD(&_4$$5, this_ptr, "normalizetoarray", &_5, 334, &item);
+			ZEPHIR_CALL_METHOD(&_4$$5, this_ptr, "normalizetoarray", &_5, 336, &item);
 			zephir_check_call_status();
 			zephir_array_update_zval(&result, &key, &_4$$5, PH_COPY | PH_SEPARATE);
 		} ZEND_HASH_FOREACH_END();
@@ -700,7 +700,7 @@ PHP_METHOD(Phalcon_Acl_Adapter_Storage, normalizeToArray)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&item, value, "current", NULL, 0);
 			zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&_8$$6, this_ptr, "normalizetoarray", &_5, 334, &item);
+				ZEPHIR_CALL_METHOD(&_8$$6, this_ptr, "normalizetoarray", &_5, 336, &item);
 				zephir_check_call_status();
 				zephir_array_update_zval(&result, &key, &_8$$6, PH_COPY | PH_SEPARATE);
 		}

--- a/ext/phalcon/acl/component.zep.c
+++ b/ext/phalcon/acl/component.zep.c
@@ -78,8 +78,8 @@ PHP_METHOD(Phalcon_Acl_Component, __construct)
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_acl_exceptions_forbiddenwildcard_ce, "component", "phalcon/Acl/Component.zep", 26);
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 378, &name_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 379, &description_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 377, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 378, &description_zv);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/acl/role.zep.c
+++ b/ext/phalcon/acl/role.zep.c
@@ -78,8 +78,8 @@ PHP_METHOD(Phalcon_Acl_Role, __construct)
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_acl_exceptions_forbiddenwildcard_ce, "role", "phalcon/Acl/Role.zep", 26);
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 380, &name_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 381, &description_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 379, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 380, &description_zv);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/adr/application.zep.c
+++ b/ext/phalcon/adr/application.zep.c
@@ -12,11 +12,13 @@
 #include <Zend/zend_interfaces.h>
 
 #include "kernel/main.h"
-#include "kernel/object.h"
+#include "kernel/operators.h"
 #include "kernel/memory.h"
 #include "kernel/fcall.h"
-#include "kernel/operators.h"
+#include "kernel/object.h"
+#include "Zend/zend_closures.h"
 #include "kernel/exception.h"
+#include "kernel/array.h"
 
 
 /**
@@ -31,86 +33,319 @@
  * @link    https://pmjones.io/adr/
  */
 /**
- * Routes the request, writes the matched attributes onto it, dispatches the
- * Action and returns the response. A single try/catch routes any error through
- * the error responder; if that itself fails, a bare 500 is returned so nothing
- * escapes uncaught.
+ * ADR composition root. Owns (or accepts) a container, exposes a small
+ * registration surface that hides the container's definition API, configures
+ * the convention router, and handles the request through the ADR flow.
+ *
+ * When no container is supplied one is created with the ADR defaults
+ * (`AdrProvider`) registered. Type-hinted dependencies autowire; only scalar
+ * parameters need to be declared via `define()`.
  */
 ZEPHIR_INIT_CLASS(Phalcon_ADR_Application)
 {
 	ZEPHIR_REGISTER_CLASS(Phalcon\\ADR, Application, phalcon, adr_application, phalcon_adr_application_method_entry, ZEND_ACC_FINAL_CLASS);
 
 	/**
-	 * @var DispatcherInterface
+	 * @var string
 	 */
-	zend_declare_property_null(phalcon_adr_application_ce, SL("dispatcher"), ZEND_ACC_PROTECTED);
+	zend_declare_property_string(phalcon_adr_application_ce, SL("baseNamespace"), "", ZEND_ACC_PROTECTED);
 	/**
-	 * @var ErrorResponder
+	 * @var Container
 	 */
-	zend_declare_property_null(phalcon_adr_application_ce, SL("errorResponder"), ZEND_ACC_PROTECTED);
+	zend_declare_property_null(phalcon_adr_application_ce, SL("container"), ZEND_ACC_PROTECTED);
 	/**
-	 * @var Manager
+	 * @var array<string, string[]>
 	 */
-	zend_declare_property_null(phalcon_adr_application_ce, SL("events"), ZEND_ACC_PROTECTED);
-	/**
-	 * @var RouterInterface
-	 */
-	zend_declare_property_null(phalcon_adr_application_ce, SL("router"), ZEND_ACC_PROTECTED);
+	zend_declare_property_null(phalcon_adr_application_ce, SL("middlewareMap"), ZEND_ACC_PROTECTED);
+	phalcon_adr_application_ce->create_object = zephir_init_properties_Phalcon_ADR_Application;
+
 	zend_class_implements(phalcon_adr_application_ce, 1, phalcon_contracts_adr_application_ce);
 	return SUCCESS;
 }
 
 PHP_METHOD(Phalcon_ADR_Application, __construct)
 {
-	zval *router, router_sub, *dispatcher, dispatcher_sub, *errorResponder, errorResponder_sub, *events, events_sub;
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval *container = NULL, container_sub, __$null, _0$$3, _1$$3, _2$$3;
 	zval *this_ptr = getThis();
 
-	ZVAL_UNDEF(&router_sub);
-	ZVAL_UNDEF(&dispatcher_sub);
-	ZVAL_UNDEF(&errorResponder_sub);
-	ZVAL_UNDEF(&events_sub);
+	ZVAL_UNDEF(&container_sub);
+	ZVAL_NULL(&__$null);
+	ZVAL_UNDEF(&_0$$3);
+	ZVAL_UNDEF(&_1$$3);
+	ZVAL_UNDEF(&_2$$3);
 	static zend_string *_zephir_prop_0 = NULL;
-	static zend_string *_zephir_prop_1 = NULL;
-	static zend_string *_zephir_prop_2 = NULL;
-	static zend_string *_zephir_prop_3 = NULL;
 	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("router", 6, 1);
-	}
-	if (UNEXPECTED(!_zephir_prop_1)) {
-		_zephir_prop_1 = zend_string_init("dispatcher", 10, 1);
-	}
-	if (UNEXPECTED(!_zephir_prop_2)) {
-		_zephir_prop_2 = zend_string_init("errorResponder", 14, 1);
-	}
-	if (UNEXPECTED(!_zephir_prop_3)) {
-		_zephir_prop_3 = zend_string_init("events", 6, 1);
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
 	}
 
-	ZEND_PARSE_PARAMETERS_START(4, 4)
-		Z_PARAM_OBJECT_OF_CLASS(router, phalcon_contracts_adr_router_router_ce)
-		Z_PARAM_OBJECT_OF_CLASS(dispatcher, phalcon_contracts_adr_dispatcher_ce)
-		Z_PARAM_OBJECT_OF_CLASS(errorResponder, phalcon_adr_errorresponder_ce)
-		Z_PARAM_OBJECT_OF_CLASS(events, phalcon_contracts_events_manager_ce)
+	bool is_null_true = 1;
+	ZEND_PARSE_PARAMETERS_START(0, 1)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_OBJECT_OF_CLASS_OR_NULL(container, phalcon_container_container_ce)
 	ZEND_PARSE_PARAMETERS_END();
-	zephir_fetch_params_without_memory_grow(4, 0, &router, &dispatcher, &errorResponder, &events);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 329, router);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 330, dispatcher);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 331, errorResponder);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 332, events);
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	zephir_fetch_params(1, 0, 1, &container);
+	if (!container) {
+		container = &container_sub;
+		ZEPHIR_CPY_WRT(container, &__$null);
+	} else {
+		ZEPHIR_SEPARATE_PARAM(container);
+	}
+	if (Z_TYPE_P(container) == IS_NULL) {
+		ZEPHIR_INIT_VAR(&_0$$3);
+		object_init_ex(&_0$$3, phalcon_container_containerfactory_ce);
+		if (zephir_has_constructor(&_0$$3)) {
+			ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 0);
+			zephir_check_call_status();
+		}
+
+		ZEPHIR_INIT_VAR(&_2$$3);
+		object_init_ex(&_2$$3, phalcon_adr_container_adrprovider_ce);
+		if (zephir_has_constructor(&_2$$3)) {
+			ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 0);
+			zephir_check_call_status();
+		}
+
+		ZEPHIR_CALL_METHOD(&_1$$3, &_0$$3, "addprovider", NULL, 301, &_2$$3);
+		zephir_check_call_status();
+		ZEPHIR_CALL_METHOD(container, &_1$$3, "newcontainer", NULL, 0);
+		zephir_check_call_status();
+	}
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 329, container);
+	ZEPHIR_MM_RESTORE();
 }
 
+/**
+ * Bind an interface to a concrete class.
+ */
+PHP_METHOD(Phalcon_ADR_Application, bind)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval interfaceName_zv, concrete_zv, _0;
+	zend_string *interfaceName = NULL, *concrete = NULL;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&interfaceName_zv);
+	ZVAL_UNDEF(&concrete_zv);
+	ZVAL_UNDEF(&_0);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(interfaceName)
+		Z_PARAM_STR(concrete)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	zephir_memory_observe(&interfaceName_zv);
+	ZVAL_STR_COPY(&interfaceName_zv, interfaceName);
+	zephir_memory_observe(&concrete_zv);
+	ZVAL_STR_COPY(&concrete_zv, concrete);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "bind", NULL, 0, &interfaceName_zv, &concrete_zv);
+	zephir_check_call_status();
+	RETURN_THIS();
+}
+
+/**
+ * Register a class together with explicit values for its constructor
+ * parameters. Type-hinted dependencies autowire; only the supplied
+ * (usually scalar) parameters are declared. Lazy values (e.g.
+ * `new Phalcon\Container\Resolver\Lazy\Env(...)`) may be passed as values.
+ */
+PHP_METHOD(Phalcon_ADR_Application, define)
+{
+	zend_bool _6;
+	zend_ulong _2;
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zephir_fcall_cache_entry *_4 = NULL, *_7 = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval parameters;
+	zval className_zv, *parameters_param = NULL, definition, param, value, _0, *_1, _5;
+	zend_string *className = NULL, *_3;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&className_zv);
+	ZVAL_UNDEF(&definition);
+	ZVAL_UNDEF(&param);
+	ZVAL_UNDEF(&value);
+	ZVAL_UNDEF(&_0);
+	ZVAL_UNDEF(&_5);
+	ZVAL_UNDEF(&parameters);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(1, 2)
+		Z_PARAM_STR(className)
+		Z_PARAM_OPTIONAL
+		ZEPHIR_Z_PARAM_ARRAY(parameters, parameters_param)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	if (ZEND_NUM_ARGS() > 1) {
+		parameters_param = ZEND_CALL_ARG(execute_data, 2);
+	}
+	zephir_memory_observe(&className_zv);
+	ZVAL_STR_COPY(&className_zv, className);
+	if (!parameters_param) {
+		ZEPHIR_INIT_VAR(&parameters);
+		array_init(&parameters);
+	} else {
+		zephir_get_arrval(&parameters, parameters_param);
+	}
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(&definition, &_0, "set", NULL, 0, &className_zv, &className_zv);
+	zephir_check_call_status();
+	zephir_is_iterable(&parameters, 0, "phalcon/ADR/Application.zep", 94);
+	if (Z_TYPE_P(&parameters) == IS_ARRAY) {
+		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&parameters), _2, _3, _1)
+		{
+			ZEPHIR_INIT_NVAR(&param);
+			if (_3 != NULL) { 
+				ZVAL_STR_COPY(&param, _3);
+			} else {
+				ZVAL_LONG(&param, _2);
+			}
+			ZEPHIR_INIT_NVAR(&value);
+			ZVAL_COPY(&value, _1);
+			ZEPHIR_CALL_METHOD(NULL, &definition, "setargument", &_4, 0, &param, &value);
+			zephir_check_call_status();
+		} ZEND_HASH_FOREACH_END();
+	} else {
+		ZEPHIR_CALL_METHOD(NULL, &parameters, "rewind", NULL, 0);
+		zephir_check_call_status();
+		_6 = 1;
+		while (1) {
+			if (_6) {
+				_6 = 0;
+			} else {
+				ZEPHIR_CALL_METHOD(NULL, &parameters, "next", NULL, 0);
+				zephir_check_call_status();
+			}
+			ZEPHIR_CALL_METHOD(&_5, &parameters, "valid", NULL, 0);
+			zephir_check_call_status();
+			if (!zend_is_true(&_5)) {
+				break;
+			}
+			ZEPHIR_CALL_METHOD(&param, &parameters, "key", NULL, 0);
+			zephir_check_call_status();
+			ZEPHIR_CALL_METHOD(&value, &parameters, "current", NULL, 0);
+			zephir_check_call_status();
+				ZEPHIR_CALL_METHOD(NULL, &definition, "setargument", &_7, 0, &param, &value);
+				zephir_check_call_status();
+		}
+	}
+	ZEPHIR_INIT_NVAR(&value);
+	ZEPHIR_INIT_NVAR(&param);
+	RETURN_THIS();
+}
+
+/**
+ * Register a post-build extender (decorator) for a service.
+ */
+PHP_METHOD(Phalcon_ADR_Application, extend)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval name_zv, *extender, extender_sub, _0;
+	zend_string *name = NULL;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&name_zv);
+	ZVAL_UNDEF(&extender_sub);
+	ZVAL_UNDEF(&_0);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_OBJECT_OF_CLASS(extender, zend_ce_closure)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	extender = ZEND_CALL_ARG(execute_data, 2);
+	zephir_memory_observe(&name_zv);
+	ZVAL_STR_COPY(&name_zv, name);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "extend", NULL, 0, &name_zv, extender);
+	zephir_check_call_status();
+	RETURN_THIS();
+}
+
+/**
+ * Register a factory closure for a service.
+ */
+PHP_METHOD(Phalcon_ADR_Application, factory)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval name_zv, *factory, factory_sub, _0;
+	zend_string *name = NULL;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&name_zv);
+	ZVAL_UNDEF(&factory_sub);
+	ZVAL_UNDEF(&_0);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_OBJECT_OF_CLASS(factory, zend_ce_closure)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	factory = ZEND_CALL_ARG(execute_data, 2);
+	zephir_memory_observe(&name_zv);
+	ZVAL_STR_COPY(&name_zv, name);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &name_zv, factory);
+	zephir_check_call_status();
+	RETURN_THIS();
+}
+
+/**
+ * Returns the underlying container for definition-level access.
+ */
+PHP_METHOD(Phalcon_ADR_Application, getContainer)
+{
+
+	RETURN_MEMBER(getThis(), "container");
+}
+
+/**
+ * Routes the request, writes the matched attributes onto it, dispatches
+ * the Action and returns the response. A single try/catch routes any error
+ * through the error responder; if that itself fails, a bare 500 is returned
+ * so nothing escapes uncaught.
+ */
 PHP_METHOD(Phalcon_ADR_Application, handle)
 {
-	zend_bool _12$$3;
-	zend_string *_7$$3;
-	zend_ulong _6$$3;
+	zend_bool _17$$5;
+	zend_string *_12$$5;
+	zend_ulong _11$$5;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-	zephir_fcall_cache_entry *_9 = NULL, *_10 = NULL, *_14 = NULL;
+	zephir_fcall_cache_entry *_14 = NULL, *_15 = NULL, *_19 = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *request, request_sub, match, response, key, value, exception, _0, _1, _25, _26, _2$$3, _4$$3, *_5$$3, _11$$3, _15$$3, _16$$3, _17$$3, _3$$4, _8$$5, _13$$6, _18$$8, _19$$8, _20$$7, _21$$7, _22$$9, _23$$9, _24$$9;
+	zval *request, request_sub, router, dispatcher, events, match, response, key, value, exception, _0, _1, _2, _3, _4, _6, _30, _5$$3, _7$$4, _8$$6, _9$$5, *_10$$5, _16$$5, _20$$5, _21$$5, _13$$7, _18$$8, _22$$10, _23$$10, _24$$10, _25$$9, _26$$9, _27$$11, _28$$11, _29$$11;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&request_sub);
+	ZVAL_UNDEF(&router);
+	ZVAL_UNDEF(&dispatcher);
+	ZVAL_UNDEF(&events);
 	ZVAL_UNDEF(&match);
 	ZVAL_UNDEF(&response);
 	ZVAL_UNDEF(&key);
@@ -118,39 +353,39 @@ PHP_METHOD(Phalcon_ADR_Application, handle)
 	ZVAL_UNDEF(&exception);
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_1);
-	ZVAL_UNDEF(&_25);
-	ZVAL_UNDEF(&_26);
-	ZVAL_UNDEF(&_2$$3);
-	ZVAL_UNDEF(&_4$$3);
-	ZVAL_UNDEF(&_11$$3);
-	ZVAL_UNDEF(&_15$$3);
-	ZVAL_UNDEF(&_16$$3);
-	ZVAL_UNDEF(&_17$$3);
-	ZVAL_UNDEF(&_3$$4);
-	ZVAL_UNDEF(&_8$$5);
-	ZVAL_UNDEF(&_13$$6);
+	ZVAL_UNDEF(&_2);
+	ZVAL_UNDEF(&_3);
+	ZVAL_UNDEF(&_4);
+	ZVAL_UNDEF(&_6);
+	ZVAL_UNDEF(&_30);
+	ZVAL_UNDEF(&_5$$3);
+	ZVAL_UNDEF(&_7$$4);
+	ZVAL_UNDEF(&_8$$6);
+	ZVAL_UNDEF(&_9$$5);
+	ZVAL_UNDEF(&_16$$5);
+	ZVAL_UNDEF(&_20$$5);
+	ZVAL_UNDEF(&_21$$5);
+	ZVAL_UNDEF(&_13$$7);
 	ZVAL_UNDEF(&_18$$8);
-	ZVAL_UNDEF(&_19$$8);
-	ZVAL_UNDEF(&_20$$7);
-	ZVAL_UNDEF(&_21$$7);
-	ZVAL_UNDEF(&_22$$9);
-	ZVAL_UNDEF(&_23$$9);
-	ZVAL_UNDEF(&_24$$9);
+	ZVAL_UNDEF(&_22$$10);
+	ZVAL_UNDEF(&_23$$10);
+	ZVAL_UNDEF(&_24$$10);
+	ZVAL_UNDEF(&_25$$9);
+	ZVAL_UNDEF(&_26$$9);
+	ZVAL_UNDEF(&_27$$11);
+	ZVAL_UNDEF(&_28$$11);
+	ZVAL_UNDEF(&_29$$11);
 	static zend_string *_zephir_prop_0 = NULL;
 	static zend_string *_zephir_prop_1 = NULL;
 	static zend_string *_zephir_prop_2 = NULL;
-	static zend_string *_zephir_prop_3 = NULL;
 	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("events", 6, 1);
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
 	}
 	if (UNEXPECTED(!_zephir_prop_1)) {
-		_zephir_prop_1 = zend_string_init("router", 6, 1);
+		_zephir_prop_1 = zend_string_init("baseNamespace", 13, 1);
 	}
 	if (UNEXPECTED(!_zephir_prop_2)) {
-		_zephir_prop_2 = zend_string_init("dispatcher", 10, 1);
-	}
-	if (UNEXPECTED(!_zephir_prop_3)) {
-		_zephir_prop_3 = zend_string_init("errorResponder", 14, 1);
+		_zephir_prop_2 = zend_string_init("middlewareMap", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -159,79 +394,103 @@ PHP_METHOD(Phalcon_ADR_Application, handle)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &request);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 332, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
+	ZVAL_STRING(&_1, "Phalcon\\Contracts\\ADR\\Router\\Router");
+	ZEPHIR_CALL_METHOD(&router, &_0, "get", NULL, 0, &_1);
+	zephir_check_call_status();
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_INIT_NVAR(&_1);
+	ZVAL_STRING(&_1, "Phalcon\\Contracts\\ADR\\Dispatcher");
+	ZEPHIR_CALL_METHOD(&dispatcher, &_2, "get", NULL, 0, &_1);
+	zephir_check_call_status();
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_INIT_NVAR(&_1);
+	ZVAL_STRING(&_1, "Phalcon\\Contracts\\Events\\Manager");
+	ZEPHIR_CALL_METHOD(&events, &_3, "get", NULL, 0, &_1);
+	zephir_check_call_status();
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 330, PH_NOISY_CC | PH_READONLY);
+	if (!ZEPHIR_IS_STRING_IDENTICAL(&_4, "")) {
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 330, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(NULL, &router, "setbasenamespace", NULL, 0, &_5$$3);
+		zephir_check_call_status();
+	}
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_2, 331, PH_NOISY_CC | PH_READONLY);
+	if (zephir_fast_count_int(&_6)) {
+		zephir_read_property_cached(&_7$$4, this_ptr, _zephir_prop_2, 331, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(NULL, &router, "setmiddlewaremap", NULL, 0, &_7$$4);
+		zephir_check_call_status();
+	}
+	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "application:beforeHandle");
-	ZEPHIR_CALL_METHOD(NULL, &_0, "fire", NULL, 0, &_1, this_ptr, request);
+	ZEPHIR_CALL_METHOD(NULL, &events, "fire", NULL, 0, &_1, this_ptr, request);
 	zephir_check_call_status();
 
 	/* try_start_1: */
 
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 329, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(&match, &_2$$3, "match", NULL, 0, request);
+		ZEPHIR_CALL_METHOD(&match, &router, "match", NULL, 0, request);
 		zephir_check_call_status_or_jump(try_end_1);
 		if (Z_TYPE_P(&match) == IS_NULL) {
-			ZEPHIR_INIT_VAR(&_3$$4);
-			object_init_ex(&_3$$4, phalcon_adr_exceptions_routenotfound_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", NULL, 300);
+			ZEPHIR_INIT_VAR(&_8$$6);
+			object_init_ex(&_8$$6, phalcon_adr_exceptions_routenotfound_ce);
+			ZEPHIR_CALL_METHOD(NULL, &_8$$6, "__construct", NULL, 302);
 			zephir_check_call_status_or_jump(try_end_1);
-			zephir_throw_exception_debug(&_3$$4, "phalcon/ADR/Application.zep", 76);
+			zephir_throw_exception_debug(&_8$$6, "phalcon/ADR/Application.zep", 152);
 			goto try_end_1;
 
 		}
-		ZEPHIR_CALL_METHOD(&_4$$3, &match, "getattributes", NULL, 0);
+		ZEPHIR_CALL_METHOD(&_9$$5, &match, "getattributes", NULL, 0);
 		zephir_check_call_status_or_jump(try_end_1);
-		zephir_is_iterable(&_4$$3, 0, "phalcon/ADR/Application.zep", 83);
-		if (Z_TYPE_P(&_4$$3) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_4$$3), _6$$3, _7$$3, _5$$3)
+		zephir_is_iterable(&_9$$5, 0, "phalcon/ADR/Application.zep", 159);
+		if (Z_TYPE_P(&_9$$5) == IS_ARRAY) {
+			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_9$$5), _11$$5, _12$$5, _10$$5)
 			{
 				ZEPHIR_INIT_NVAR(&key);
-				if (_7$$3 != NULL) { 
-					ZVAL_STR_COPY(&key, _7$$3);
+				if (_12$$5 != NULL) { 
+					ZVAL_STR_COPY(&key, _12$$5);
 				} else {
-					ZVAL_LONG(&key, _6$$3);
+					ZVAL_LONG(&key, _11$$5);
 				}
 				ZEPHIR_INIT_NVAR(&value);
-				ZVAL_COPY(&value, _5$$3);
-				ZEPHIR_CALL_METHOD(&_8$$5, request, "getattributes", &_9, 0);
+				ZVAL_COPY(&value, _10$$5);
+				ZEPHIR_CALL_METHOD(&_13$$7, request, "getattributes", &_14, 0);
 				zephir_check_call_status_or_jump(try_end_1);
-				ZEPHIR_CALL_METHOD(NULL, &_8$$5, "set", &_10, 0, &key, &value);
+				ZEPHIR_CALL_METHOD(NULL, &_13$$7, "set", &_15, 0, &key, &value);
 				zephir_check_call_status_or_jump(try_end_1);
 			} ZEND_HASH_FOREACH_END();
 		} else {
-			ZEPHIR_CALL_METHOD(NULL, &_4$$3, "rewind", NULL, 0);
+			ZEPHIR_CALL_METHOD(NULL, &_9$$5, "rewind", NULL, 0);
 			zephir_check_call_status();
-			_12$$3 = 1;
+			_17$$5 = 1;
 			while (1) {
-				if (_12$$3) {
-					_12$$3 = 0;
+				if (_17$$5) {
+					_17$$5 = 0;
 				} else {
-					ZEPHIR_CALL_METHOD(NULL, &_4$$3, "next", NULL, 0);
+					ZEPHIR_CALL_METHOD(NULL, &_9$$5, "next", NULL, 0);
 					zephir_check_call_status();
 				}
-				ZEPHIR_CALL_METHOD(&_11$$3, &_4$$3, "valid", NULL, 0);
+				ZEPHIR_CALL_METHOD(&_16$$5, &_9$$5, "valid", NULL, 0);
 				zephir_check_call_status();
-				if (!zend_is_true(&_11$$3)) {
+				if (!zend_is_true(&_16$$5)) {
 					break;
 				}
-				ZEPHIR_CALL_METHOD(&key, &_4$$3, "key", NULL, 0);
+				ZEPHIR_CALL_METHOD(&key, &_9$$5, "key", NULL, 0);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&value, &_4$$3, "current", NULL, 0);
+				ZEPHIR_CALL_METHOD(&value, &_9$$5, "current", NULL, 0);
 				zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&_13$$6, request, "getattributes", &_14, 0);
+					ZEPHIR_CALL_METHOD(&_18$$8, request, "getattributes", &_19, 0);
 					zephir_check_call_status_or_jump(try_end_1);
-					ZEPHIR_CALL_METHOD(NULL, &_13$$6, "set", &_10, 0, &key, &value);
+					ZEPHIR_CALL_METHOD(NULL, &_18$$8, "set", &_15, 0, &key, &value);
 					zephir_check_call_status_or_jump(try_end_1);
 			}
 		}
 		ZEPHIR_INIT_NVAR(&value);
 		ZEPHIR_INIT_NVAR(&key);
-		zephir_read_property_cached(&_15$$3, this_ptr, _zephir_prop_2, 330, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(&_16$$3, &match, "getaction", NULL, 0);
+		ZEPHIR_CALL_METHOD(&_20$$5, &match, "getaction", NULL, 0);
 		zephir_check_call_status_or_jump(try_end_1);
-		ZEPHIR_CALL_METHOD(&_17$$3, &match, "getmiddleware", NULL, 0);
+		ZEPHIR_CALL_METHOD(&_21$$5, &match, "getmiddleware", NULL, 0);
 		zephir_check_call_status_or_jump(try_end_1);
-		ZEPHIR_CALL_METHOD(&response, &_15$$3, "dispatch", NULL, 0, &_16$$3, request, &_17$$3);
+		ZEPHIR_CALL_METHOD(&response, &dispatcher, "dispatch", NULL, 0, &_20$$5, request, &_21$$5);
 		zephir_check_call_status_or_jump(try_end_1);
 
 	try_end_1:
@@ -246,44 +505,172 @@ PHP_METHOD(Phalcon_ADR_Application, handle)
 
 			/* try_start_2: */
 
-				zephir_read_property_cached(&_18$$8, this_ptr, _zephir_prop_3, 331, PH_NOISY_CC | PH_READONLY);
-				ZEPHIR_INIT_VAR(&_19$$8);
-				object_init_ex(&_19$$8, phalcon_http_response_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_19$$8, "__construct", NULL, 301);
+				zephir_read_property_cached(&_22$$10, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+				ZEPHIR_INIT_VAR(&_24$$10);
+				ZVAL_STRING(&_24$$10, "Phalcon\\ADR\\ErrorResponder");
+				ZEPHIR_CALL_METHOD(&_23$$10, &_22$$10, "get", NULL, 0, &_24$$10);
 				zephir_check_call_status_or_jump(try_end_2);
-				ZEPHIR_CALL_METHOD(&response, &_18$$8, "handle", NULL, 0, request, &_19$$8, &exception);
+				ZEPHIR_INIT_NVAR(&_24$$10);
+				object_init_ex(&_24$$10, phalcon_http_response_ce);
+				ZEPHIR_CALL_METHOD(NULL, &_24$$10, "__construct", NULL, 303);
+				zephir_check_call_status_or_jump(try_end_2);
+				ZEPHIR_CALL_METHOD(&response, &_23$$10, "handle", NULL, 0, request, &_24$$10, &exception);
 				zephir_check_call_status_or_jump(try_end_2);
 
 			try_end_2:
 
 			if (EG(exception)) {
-				ZEPHIR_INIT_VAR(&_20$$7);
-				ZVAL_OBJ(&_20$$7, EG(exception));
-				Z_ADDREF_P(&_20$$7);
-				ZEPHIR_INIT_VAR(&_21$$7);
-				if (zephir_is_instance_of(&_20$$7, SL("Throwable"))) {
+				ZEPHIR_INIT_VAR(&_25$$9);
+				ZVAL_OBJ(&_25$$9, EG(exception));
+				Z_ADDREF_P(&_25$$9);
+				ZEPHIR_INIT_VAR(&_26$$9);
+				if (zephir_is_instance_of(&_25$$9, SL("Throwable"))) {
 					zend_clear_exception();
-					ZEPHIR_CPY_WRT(&_21$$7, &_20$$7);
+					ZEPHIR_CPY_WRT(&_26$$9, &_25$$9);
 					ZEPHIR_INIT_NVAR(&response);
 					object_init_ex(&response, phalcon_http_response_ce);
-					ZEPHIR_CALL_METHOD(NULL, &response, "__construct", NULL, 301);
+					ZEPHIR_CALL_METHOD(NULL, &response, "__construct", NULL, 303);
 					zephir_check_call_status();
-					ZVAL_LONG(&_23$$9, 500);
-					ZEPHIR_CALL_METHOD(&_22$$9, &response, "setstatuscode", NULL, 302, &_23$$9);
+					ZVAL_LONG(&_28$$11, 500);
+					ZEPHIR_CALL_METHOD(&_27$$11, &response, "setstatuscode", NULL, 304, &_28$$11);
 					zephir_check_call_status();
-					ZEPHIR_INIT_VAR(&_24$$9);
-					ZVAL_STRING(&_24$$9, "Internal Server Error");
-					ZEPHIR_CALL_METHOD(NULL, &_22$$9, "setcontent", NULL, 0, &_24$$9);
+					ZEPHIR_INIT_VAR(&_29$$11);
+					ZVAL_STRING(&_29$$11, "Internal Server Error");
+					ZEPHIR_CALL_METHOD(NULL, &_27$$11, "setcontent", NULL, 0, &_29$$11);
 					zephir_check_call_status();
 				}
 			}
 		}
 	}
-	zephir_read_property_cached(&_25, this_ptr, _zephir_prop_0, 332, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_INIT_VAR(&_26);
-	ZVAL_STRING(&_26, "application:afterHandle");
-	ZEPHIR_CALL_METHOD(NULL, &_25, "fire", NULL, 0, &_26, this_ptr, &response);
+	ZEPHIR_INIT_VAR(&_30);
+	ZVAL_STRING(&_30, "application:afterHandle");
+	ZEPHIR_CALL_METHOD(NULL, &events, "fire", NULL, 0, &_30, this_ptr, &response);
 	zephir_check_call_status();
 	RETURN_CCTOR(&response);
+}
+
+/**
+ * Attach a guard (middleware) to every Action under a namespace prefix.
+ */
+PHP_METHOD(Phalcon_ADR_Application, secureWith)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zval guard_zv, prefix_zv, list, _0, _1$$3;
+	zend_string *guard = NULL, *prefix = NULL;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&guard_zv);
+	ZVAL_UNDEF(&prefix_zv);
+	ZVAL_UNDEF(&list);
+	ZVAL_UNDEF(&_0);
+	ZVAL_UNDEF(&_1$$3);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("middlewareMap", 13, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(guard)
+		Z_PARAM_STR(prefix)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	zephir_memory_observe(&guard_zv);
+	ZVAL_STR_COPY(&guard_zv, guard);
+	zephir_memory_observe(&prefix_zv);
+	ZVAL_STR_COPY(&prefix_zv, prefix);
+	ZEPHIR_INIT_VAR(&list);
+	array_init(&list);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 331, PH_NOISY_CC | PH_READONLY);
+	if (zephir_array_isset_value(&_0, &prefix_zv)) {
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 331, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_OBS_NVAR(&list);
+		zephir_array_fetch(&list, &_1$$3, &prefix_zv, PH_NOISY, "phalcon/ADR/Application.zep", 193);
+	}
+	zephir_array_append(&list, &guard_zv, PH_SEPARATE, "phalcon/ADR/Application.zep", 196);
+	zephir_update_property_array(this_ptr, SL("middlewareMap"), &prefix_zv, &list);
+	RETURN_THIS();
+}
+
+/**
+ * Register a service with a raw definition (class-string, closure or value).
+ */
+PHP_METHOD(Phalcon_ADR_Application, set)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval name_zv, *definition, definition_sub, _0;
+	zend_string *name = NULL;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&name_zv);
+	ZVAL_UNDEF(&definition_sub);
+	ZVAL_UNDEF(&_0);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("container", 9, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_STR(name)
+		Z_PARAM_ZVAL(definition)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	definition = ZEND_CALL_ARG(execute_data, 2);
+	zephir_memory_observe(&name_zv);
+	ZVAL_STR_COPY(&name_zv, name);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 329, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &name_zv, definition);
+	zephir_check_call_status();
+	RETURN_THIS();
+}
+
+/**
+ * Set the base namespace the convention router derives Actions from.
+ */
+PHP_METHOD(Phalcon_ADR_Application, setBaseNamespace)
+{
+	zval baseNamespace_zv;
+	zend_string *baseNamespace = NULL;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&baseNamespace_zv);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("baseNamespace", 13, 1);
+	}
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(baseNamespace)
+	ZEND_PARSE_PARAMETERS_END();
+	ZVAL_STR(&baseNamespace_zv, baseNamespace);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 330, &baseNamespace_zv);
+	RETURN_THISW();
+}
+
+zend_object *zephir_init_properties_Phalcon_ADR_Application(zend_class_entry *class_type)
+{
+		zval _0, _1$$3;
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+		ZVAL_UNDEF(&_0);
+	ZVAL_UNDEF(&_1$$3);
+	
+
+		ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+		zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	
+	{
+		zval local_this_ptr, *this_ptr = &local_this_ptr;
+		ZEPHIR_CREATE_OBJECT(this_ptr, class_type);
+		zephir_read_property_ex(&_0, this_ptr, ZEND_STRL("middlewareMap"), PH_NOISY_CC | PH_READONLY);
+		if (Z_TYPE_P(&_0) == IS_NULL) {
+			ZEPHIR_INIT_VAR(&_1$$3);
+			array_init(&_1$$3);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("middlewareMap"), &_1$$3);
+		}
+		ZEPHIR_MM_RESTORE();
+		return Z_OBJ_P(this_ptr);
+	}
 }
 

--- a/ext/phalcon/adr/application.zep.h
+++ b/ext/phalcon/adr/application.zep.h
@@ -4,21 +4,75 @@ extern zend_class_entry *phalcon_adr_application_ce;
 ZEPHIR_INIT_CLASS(Phalcon_ADR_Application);
 
 PHP_METHOD(Phalcon_ADR_Application, __construct);
+PHP_METHOD(Phalcon_ADR_Application, bind);
+PHP_METHOD(Phalcon_ADR_Application, define);
+PHP_METHOD(Phalcon_ADR_Application, extend);
+PHP_METHOD(Phalcon_ADR_Application, factory);
+PHP_METHOD(Phalcon_ADR_Application, getContainer);
 PHP_METHOD(Phalcon_ADR_Application, handle);
+PHP_METHOD(Phalcon_ADR_Application, secureWith);
+PHP_METHOD(Phalcon_ADR_Application, set);
+PHP_METHOD(Phalcon_ADR_Application, setBaseNamespace);
+zend_object *zephir_init_properties_Phalcon_ADR_Application(zend_class_entry *class_type);
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_adr_application___construct, 0, 0, 4)
-	ZEND_ARG_OBJ_INFO(0, router, Phalcon\\Contracts\\ADR\\Router\\Router, 0)
-	ZEND_ARG_OBJ_INFO(0, dispatcher, Phalcon\\Contracts\\ADR\\Dispatcher, 0)
-	ZEND_ARG_OBJ_INFO(0, errorResponder, Phalcon\\ADR\\ErrorResponder, 0)
-	ZEND_ARG_OBJ_INFO(0, events, Phalcon\\Contracts\\Events\\Manager, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_adr_application___construct, 0, 0, 0)
+	ZEND_ARG_OBJ_TYPE_MASK(0, container, Phalcon\\Container\\Container, MAY_BE_NULL, "null")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_bind, 0, 2, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, interfaceName, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, concrete, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_define, 0, 1, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
+ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, parameters, IS_ARRAY, 0, "[]")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_extend, 0, 2, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, extender, Closure, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_factory, 0, 2, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, factory, Closure, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_adr_application_getcontainer, 0, 0, Phalcon\\Container\\Container, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_adr_application_handle, 0, 1, Phalcon\\Http\\ResponseInterface, 0)
 	ZEND_ARG_OBJ_INFO(0, request, Phalcon\\Contracts\\Http\\AttributeRequest, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_securewith, 0, 2, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, guard, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_set, 0, 2, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+	ZEND_ARG_INFO(0, definition)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_phalcon_adr_application_setbasenamespace, 0, 1, MAY_BE_STATIC)
+	ZEND_ARG_TYPE_INFO(0, baseNamespace, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_phalcon_adr_application_zephir_init_properties_phalcon_adr_application, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 ZEPHIR_INIT_FUNCS(phalcon_adr_application_method_entry) {
 	PHP_ME(Phalcon_ADR_Application, __construct, arginfo_phalcon_adr_application___construct, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
+	PHP_ME(Phalcon_ADR_Application, bind, arginfo_phalcon_adr_application_bind, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, define, arginfo_phalcon_adr_application_define, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, extend, arginfo_phalcon_adr_application_extend, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, factory, arginfo_phalcon_adr_application_factory, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, getContainer, arginfo_phalcon_adr_application_getcontainer, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_ADR_Application, handle, arginfo_phalcon_adr_application_handle, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, secureWith, arginfo_phalcon_adr_application_securewith, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, set, arginfo_phalcon_adr_application_set, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_ADR_Application, setBaseNamespace, arginfo_phalcon_adr_application_setbasenamespace, ZEND_ACC_PUBLIC)
 	PHP_FE_END
 };

--- a/ext/phalcon/adr/dispatcher.zep.c
+++ b/ext/phalcon/adr/dispatcher.zep.c
@@ -102,9 +102,9 @@ PHP_METHOD(Phalcon_ADR_Dispatcher, __construct)
 	} else {
 		zephir_get_arrval(&globalMiddleware, globalMiddleware_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 333, container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 334, events);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 335, &globalMiddleware);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 332, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 333, events);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 334, &globalMiddleware);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -162,41 +162,41 @@ PHP_METHOD(Phalcon_ADR_Dispatcher, dispatch)
 	} else {
 		zephir_get_arrval(&routeMiddleware, routeMiddleware_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 333, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 332, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&action, &_0, "getservice", NULL, 0, &actionClass_zv);
 	zephir_check_call_status();
 	if (!(zephir_instance_of_ev(&action, phalcon_contracts_adr_action_ce))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_adr_exceptions_notanaction_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 303, &actionClass_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 305, &actionClass_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/ADR/Dispatcher.zep", 75);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "resolveglobal", NULL, 304);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "resolveglobal", NULL, 306);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_3, this_ptr, "resolveall", NULL, 305, &routeMiddleware);
+	ZEPHIR_CALL_METHOD(&_3, this_ptr, "resolveall", NULL, 307, &routeMiddleware);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&middleware);
 	zephir_fast_array_merge(&middleware, &_2, &_3);
 	ZEPHIR_INIT_VAR(&terminal);
 	object_init_ex(&terminal, phalcon_adr_eventfulhandler_ce);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 334, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_METHOD(NULL, &terminal, "__construct", NULL, 306, &action, &_4);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 333, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, &terminal, "__construct", NULL, 308, &action, &_4);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&pipeline);
 	object_init_ex(&pipeline, phalcon_adr_pipeline_ce);
-	ZEPHIR_CALL_METHOD(NULL, &pipeline, "__construct", NULL, 307, &middleware, &terminal);
+	ZEPHIR_CALL_METHOD(NULL, &pipeline, "__construct", NULL, 309, &middleware, &terminal);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 334, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 333, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_6);
 	ZVAL_STRING(&_6, "pipeline:beforeDispatch");
 	ZEPHIR_CALL_METHOD(NULL, &_5, "fire", NULL, 0, &_6, this_ptr, request);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&response, &pipeline, "__invoke", NULL, 308, request);
+	ZEPHIR_CALL_METHOD(&response, &pipeline, "__invoke", NULL, 310, request);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_1, 334, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_1, 333, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_6);
 	ZVAL_STRING(&_6, "pipeline:afterDispatch");
 	ZEPHIR_CALL_METHOD(NULL, &_7, "fire", NULL, 0, &_6, this_ptr, &response);
@@ -241,7 +241,7 @@ PHP_METHOD(Phalcon_ADR_Dispatcher, resolveAll)
 		{
 			ZEPHIR_INIT_NVAR(&className);
 			ZVAL_COPY(&className, _0);
-			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 333, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 332, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_2$$3, &_1$$3, "getservice", NULL, 0, &className);
 			zephir_check_call_status();
 			zephir_array_append(&result, &_2$$3, PH_SEPARATE, "phalcon/ADR/Dispatcher.zep", 97);
@@ -264,7 +264,7 @@ PHP_METHOD(Phalcon_ADR_Dispatcher, resolveAll)
 			}
 			ZEPHIR_CALL_METHOD(&className, &classes, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_0, 333, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_0, 332, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&_6$$4, &_5$$4, "getservice", NULL, 0, &className);
 				zephir_check_call_status();
 				zephir_array_append(&result, &_6$$4, PH_SEPARATE, "phalcon/ADR/Dispatcher.zep", 97);
@@ -295,12 +295,12 @@ PHP_METHOD(Phalcon_ADR_Dispatcher, resolveGlobal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 336, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 335, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 335, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "resolveall", NULL, 305, &_2$$3);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 334, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "resolveall", NULL, 307, &_2$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 336, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 335, &_1$$3);
 	}
 	RETURN_MM_MEMBER_TYPED(getThis(), "resolvedGlobal", IS_ARRAY);
 }

--- a/ext/phalcon/adr/emitter/sapiemitter.zep.c
+++ b/ext/phalcon/adr/emitter/sapiemitter.zep.c
@@ -57,12 +57,12 @@ PHP_METHOD(Phalcon_ADR_Emitter_SapiEmitter, emit)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &response);
-	ZEPHIR_CALL_FUNCTION(&_0, "headers_sent", NULL, 215);
+	ZEPHIR_CALL_FUNCTION(&_0, "headers_sent", NULL, 216);
 	zephir_check_call_status();
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_adr_exceptions_headersalreadysent_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 309);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 311);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/ADR/Emitter/SapiEmitter.zep", 29);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/adr/errorresponder.zep.c
+++ b/ext/phalcon/adr/errorresponder.zep.c
@@ -115,18 +115,18 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, __construct)
 	} else {
 		zephir_get_arrval(&exceptionMap, exceptionMap_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 337, chain);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 338, logger);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 336, chain);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 337, logger);
 	if (debug) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 339, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 338, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 339, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 338, &__$false);
 	}
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "defaultmap", NULL, 310);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "defaultmap", NULL, 312);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_add_function(&_1, &exceptionMap, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 340, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 339, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -172,9 +172,9 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, handle)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &request, &response, &exception);
-	ZEPHIR_CALL_METHOD(&ref, this_ptr, "correlationid", NULL, 311, request);
+	ZEPHIR_CALL_METHOD(&ref, this_ptr, "correlationid", NULL, 313, request);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 338, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 337, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, exception, 0);
 	ZEPHIR_CALL_METHOD(&_2, exception, "getmessage", NULL, 0);
@@ -193,7 +193,7 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, handle)
 	zephir_array_update_string(&_7, SL("ref"), &ref, PH_COPY | PH_SEPARATE);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "error", NULL, 0, &_6, &_7);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&status, this_ptr, "resolvestatus", NULL, 312, exception);
+	ZEPHIR_CALL_METHOD(&status, this_ptr, "resolvestatus", NULL, 314, exception);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(&_5);
 	object_init_ex(&_5, phalcon_adr_payload_payload_ce);
@@ -202,13 +202,13 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, handle)
 		zephir_check_call_status();
 	}
 
-	ZEPHIR_CALL_METHOD(&_8, &_5, "withstatus", NULL, 313, &status);
+	ZEPHIR_CALL_METHOD(&_8, &_5, "withstatus", NULL, 315, &status);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_9, this_ptr, "details", NULL, 314, exception, &ref, &status);
+	ZEPHIR_CALL_METHOD(&_9, this_ptr, "details", NULL, 316, exception, &ref, &status);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&payload, &_8, "withresult", NULL, 0, &_9);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_1, 337, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_1, 336, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_10, "__invoke", NULL, 0, request, response, &payload);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -239,9 +239,9 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, correlationId)
 	zephir_check_call_status();
 	if (ZEPHIR_IS_EMPTY(&id)) {
 		ZVAL_LONG(&_1$$3, 8);
-		ZEPHIR_CALL_FUNCTION(&_2$$3, "random_bytes", NULL, 315, &_1$$3);
+		ZEPHIR_CALL_FUNCTION(&_2$$3, "random_bytes", NULL, 317, &_1$$3);
 		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(&id, "bin2hex", NULL, 316, &_2$$3);
+		ZEPHIR_CALL_FUNCTION(&id, "bin2hex", NULL, 318, &_2$$3);
 		zephir_check_call_status();
 	}
 	zephir_cast_to_string(&_3, &id);
@@ -297,7 +297,7 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, details)
 	} else {
 		zephir_get_strval(&status, status_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 339, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 338, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		zephir_create_array(return_value, 3, 0);
 		ZEPHIR_CALL_METHOD(&_1$$3, exception, "getmessage", NULL, 0);
@@ -310,7 +310,7 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, details)
 		RETURN_MM();
 	}
 	zephir_create_array(return_value, 2, 0);
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "reason", NULL, 317, &status);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "reason", NULL, 319, &status);
 	zephir_check_call_status();
 	zephir_array_update_string(return_value, SL("message"), &_2, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(return_value, SL("ref"), &ref_zv, PH_COPY | PH_SEPARATE);
@@ -394,17 +394,17 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, resolveStatus)
 	zephir_fetch_params(1, 1, 0, &exception);
 	ZEPHIR_INIT_VAR(&className);
 	zephir_get_class(&className, exception, 0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 340, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 339, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, &className)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 340, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 339, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, &className, PH_NOISY | PH_READONLY, "phalcon/ADR/ErrorResponder.zep", 169);
 		RETURN_CTOR(&_2$$3);
 	}
-	ZEPHIR_CALL_FUNCTION(&_3, "class_parents", NULL, 318, exception);
+	ZEPHIR_CALL_FUNCTION(&_3, "class_parents", NULL, 320, exception);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_4, "array_values", NULL, 27, &_3);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_5, "class_implements", NULL, 319, exception);
+	ZEPHIR_CALL_FUNCTION(&_5, "class_implements", NULL, 321, exception);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_6, "array_values", NULL, 27, &_5);
 	zephir_check_call_status();
@@ -415,9 +415,9 @@ PHP_METHOD(Phalcon_ADR_ErrorResponder, resolveStatus)
 	{
 		ZEPHIR_INIT_NVAR(&ancestor);
 		ZVAL_COPY(&ancestor, _7);
-		zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_0, 340, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_0, 339, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_8$$4, &ancestor)) {
-			zephir_read_property_cached(&_9$$5, this_ptr, _zephir_prop_0, 340, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$5, this_ptr, _zephir_prop_0, 339, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch(&_10$$5, &_9$$5, &ancestor, PH_NOISY | PH_READONLY, "phalcon/ADR/ErrorResponder.zep", 179);
 			RETURN_CTOR(&_10$$5);
 		}

--- a/ext/phalcon/adr/eventfulhandler.zep.c
+++ b/ext/phalcon/adr/eventfulhandler.zep.c
@@ -69,8 +69,8 @@ PHP_METHOD(Phalcon_ADR_EventfulHandler, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(events, phalcon_contracts_events_manager_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(2, 0, &action, &events);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 341, action);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 342, events);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 340, action);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 341, events);
 }
 
 PHP_METHOD(Phalcon_ADR_EventfulHandler, __invoke)
@@ -103,17 +103,17 @@ PHP_METHOD(Phalcon_ADR_EventfulHandler, __invoke)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &request);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 342, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 341, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 341, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 340, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "adr:beforeExecuteAction");
 	ZEPHIR_CALL_METHOD(NULL, &_0, "fire", NULL, 0, &_2, &_1, request);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 341, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 340, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&response, &_3, "__invoke", NULL, 0, request);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 342, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 341, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 341, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 340, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "adr:afterExecuteAction");
 	ZEPHIR_CALL_METHOD(NULL, &_4, "fire", NULL, 0, &_2, &_5, &response);

--- a/ext/phalcon/adr/front/abstracthttpfront.zep.c
+++ b/ext/phalcon/adr/front/abstracthttpfront.zep.c
@@ -30,10 +30,10 @@
  * @link    https://pmjones.io/adr/
  */
 /**
- * Boots a container, resolves the Application, handles the request and emits the
- * response. Userland front controllers override `loadEnvironment()` /
- * `registerProviders()`; 
- * bootstrap is `exit((new AppFront(dirname(__DIR__)))->run());`.
+ * Boots a container, builds the Application, handles the request and emits the
+ * response. Userland front controllers override `loadEnvironment()`,
+ * `registerProviders()` and optionally `getApplication()`; bootstrap is
+ * `exit((new AppFront(dirname(__DIR__)))->run());`.
  */
 ZEPHIR_INIT_CLASS(Phalcon_ADR_Front_AbstractHttpFront)
 {
@@ -98,9 +98,7 @@ PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, run)
 		ZVAL_STRING(&_0$$3, "Phalcon\\Contracts\\Http\\AttributeRequest");
 		ZEPHIR_CALL_METHOD(&request, &container, "get", NULL, 0, &_0$$3);
 		zephir_check_call_status_or_jump(try_end_1);
-		ZEPHIR_INIT_NVAR(&_0$$3);
-		ZVAL_STRING(&_0$$3, "Phalcon\\ADR\\Application");
-		ZEPHIR_CALL_METHOD(&application, &container, "get", NULL, 0, &_0$$3);
+		ZEPHIR_CALL_METHOD(&application, this_ptr, "getapplication", NULL, 0, &container);
 		zephir_check_call_status_or_jump(try_end_1);
 		ZEPHIR_CALL_METHOD(&response, &application, "handle", NULL, 0, &request);
 		zephir_check_call_status_or_jump(try_end_1);
@@ -142,6 +140,30 @@ PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, buildContainer)
 	RETURN_MM();
 }
 
+/**
+ * Builds the Application the front will hand the request to. Override to
+ * configure it (`setBaseNamespace()`/`secureWith()`) or to wire a different
+ * `Phalcon\Contracts\ADR\Application` implementation.
+ */
+PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, getApplication)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zval *container, container_sub;
+
+	ZVAL_UNDEF(&container_sub);
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_container_container_ce)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	zephir_fetch_params(1, 1, 0, &container);
+	object_init_ex(return_value, phalcon_adr_application_ce);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 214, container);
+	zephir_check_call_status();
+	RETURN_MM();
+}
+
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, handleBootError)
 {
 	zval _0;
@@ -161,17 +183,17 @@ PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, handleBootError)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &exception);
 	zephir_cast_to_string(&_0, exception);
-	ZEPHIR_CALL_FUNCTION(NULL, "error_log", NULL, 214, &_0);
+	ZEPHIR_CALL_FUNCTION(NULL, "error_log", NULL, 215, &_0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_1, "headers_sent", NULL, 215);
+	ZEPHIR_CALL_FUNCTION(&_1, "headers_sent", NULL, 216);
 	zephir_check_call_status();
 	if (!(zephir_is_true(&_1))) {
 		ZVAL_LONG(&_2$$3, 500);
-		ZEPHIR_CALL_FUNCTION(NULL, "http_response_code", NULL, 216, &_2$$3);
+		ZEPHIR_CALL_FUNCTION(NULL, "http_response_code", NULL, 217, &_2$$3);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZVAL_STRING(&_3$$3, "Content-Type: text/plain; charset=utf-8");
-		ZEPHIR_CALL_FUNCTION(NULL, "header", NULL, 217, &_3$$3);
+		ZEPHIR_CALL_FUNCTION(NULL, "header", NULL, 218, &_3$$3);
 		zephir_check_call_status();
 		php_printf("%s", "Internal Server Error\n");
 	}
@@ -210,7 +232,7 @@ PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, registerProviders)
 		zephir_check_call_status();
 	}
 
-	ZEPHIR_CALL_METHOD(NULL, &_0, "provide", NULL, 218, container);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "provide", NULL, 219, container);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/adr/front/abstracthttpfront.zep.h
+++ b/ext/phalcon/adr/front/abstracthttpfront.zep.h
@@ -6,6 +6,7 @@ ZEPHIR_INIT_CLASS(Phalcon_ADR_Front_AbstractHttpFront);
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, __construct);
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, run);
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, buildContainer);
+PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, getApplication);
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, handleBootError);
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, loadEnvironment);
 PHP_METHOD(Phalcon_ADR_Front_AbstractHttpFront, registerProviders);
@@ -18,6 +19,10 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_adr_front_abstracthttpfr
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_adr_front_abstracthttpfront_buildcontainer, 0, 0, Phalcon\\Container\\Container, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_phalcon_adr_front_abstracthttpfront_getapplication, 0, 1, Phalcon\\Contracts\\ADR\\Application, 0)
+	ZEND_ARG_OBJ_INFO(0, container, Phalcon\\Container\\Container, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_adr_front_abstracthttpfront_handlebooterror, 0, 1, IS_LONG, 0)
@@ -38,6 +43,7 @@ ZEPHIR_INIT_FUNCS(phalcon_adr_front_abstracthttpfront_method_entry) {
 	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, __construct, arginfo_phalcon_adr_front_abstracthttpfront___construct, ZEND_ACC_PUBLIC|ZEND_ACC_CTOR)
 	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, run, arginfo_phalcon_adr_front_abstracthttpfront_run, ZEND_ACC_FINAL|ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, buildContainer, arginfo_phalcon_adr_front_abstracthttpfront_buildcontainer, ZEND_ACC_PROTECTED)
+	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, getApplication, arginfo_phalcon_adr_front_abstracthttpfront_getapplication, ZEND_ACC_PROTECTED)
 	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, handleBootError, arginfo_phalcon_adr_front_abstracthttpfront_handlebooterror, ZEND_ACC_PROTECTED)
 	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, loadEnvironment, arginfo_phalcon_adr_front_abstracthttpfront_loadenvironment, ZEND_ACC_PROTECTED)
 	PHP_ME(Phalcon_ADR_Front_AbstractHttpFront, registerProviders, arginfo_phalcon_adr_front_abstracthttpfront_registerproviders, ZEND_ACC_PROTECTED)

--- a/ext/phalcon/adr/input/input.zep.c
+++ b/ext/phalcon/adr/input/input.zep.c
@@ -77,7 +77,7 @@ PHP_METHOD(Phalcon_ADR_Input_Input, __construct)
 	} else {
 		zephir_get_arrval(&data, data_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 343, &data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 342, &data);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -97,7 +97,7 @@ PHP_METHOD(Phalcon_ADR_Input_Input, fromArray)
 	zephir_fetch_params(1, 1, 0, &data_param);
 	zephir_get_arrval(&data, data_param);
 	object_init_ex(return_value, zend_get_called_scope(execute_data));
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 320, &data);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 322, &data);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -135,7 +135,7 @@ PHP_METHOD(Phalcon_ADR_Input_Input, fromRequest)
 	zephir_cast_to_string(&_1, &_0);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "json");
-	ZEPHIR_CALL_FUNCTION(&_3, "str_contains", NULL, 321, &_1, &_2);
+	ZEPHIR_CALL_FUNCTION(&_3, "str_contains", NULL, 323, &_1, &_2);
 	zephir_check_call_status();
 	if (zephir_is_true(&_3)) {
 		ZVAL_BOOL(&_4$$3, 1);
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_ADR_Input_Input, fromRequest)
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_9, "array_merge", NULL, 195, &_5, &_6, &json, &_8);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 320, &_9);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 322, &_9);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -197,9 +197,9 @@ PHP_METHOD(Phalcon_ADR_Input_Input, get)
 		defaultValue = &__$null;
 	}
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 343, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 342, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_1, &key_zv)) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 343, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 342, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_OBS_NVAR(&_0);
 		zephir_array_fetch(&_0, &_2, &key_zv, PH_NOISY, "phalcon/ADR/Input/Input.zep", 74);
 	} else {
@@ -225,7 +225,7 @@ PHP_METHOD(Phalcon_ADR_Input_Input, has)
 		Z_PARAM_STR(key)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&key_zv, key);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 343, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 342, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &key_zv));
 }
 

--- a/ext/phalcon/adr/middleware/corsmiddleware.zep.c
+++ b/ext/phalcon/adr/middleware/corsmiddleware.zep.c
@@ -125,7 +125,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, __construct)
 	ZVAL_STRING(&_2, "origins");
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getarrval", NULL, 0, &config, &_2, &_1);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 344, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 343, &_0);
 	ZEPHIR_INIT_VAR(&_4);
 	zephir_create_array(&_4, 6, 0);
 	ZEPHIR_INIT_NVAR(&_2);
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, __construct)
 	ZVAL_STRING(&_2, "methods");
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "getarrval", NULL, 0, &config, &_2, &_4);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 345, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 344, &_3);
 	ZEPHIR_INIT_VAR(&_6);
 	zephir_create_array(&_6, 2, 0);
 	ZEPHIR_INIT_NVAR(&_2);
@@ -163,7 +163,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, __construct)
 	ZVAL_STRING(&_2, "headers");
 	ZEPHIR_CALL_METHOD(&_5, this_ptr, "getarrval", NULL, 0, &config, &_2, &_6);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 346, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 345, &_5);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "credentials");
 	ZVAL_BOOL(&_8, 0);
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, __construct)
 	ZVAL_STRING(&_9, "bool");
 	ZEPHIR_CALL_METHOD(&_7, this_ptr, "getarrval", NULL, 0, &config, &_2, &_8, &_9);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 347, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 346, &_7);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "maxAge");
 	ZVAL_LONG(&_8, 0);
@@ -179,7 +179,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, __construct)
 	ZVAL_STRING(&_9, "int");
 	ZEPHIR_CALL_METHOD(&_10, this_ptr, "getarrval", NULL, 0, &config, &_2, &_8, &_9);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 348, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 347, &_10);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -251,35 +251,35 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, __invoke)
 	if (ZEPHIR_IS_IDENTICAL(&_4, &_3)) {
 		ZEPHIR_INIT_VAR(&response);
 		object_init_ex(&response, phalcon_http_response_ce);
-		ZEPHIR_CALL_METHOD(NULL, &response, "__construct", NULL, 301);
+		ZEPHIR_CALL_METHOD(NULL, &response, "__construct", NULL, 303);
 		zephir_check_call_status();
 		ZVAL_LONG(&_5$$4, 204);
-		ZEPHIR_CALL_METHOD(NULL, &response, "setstatuscode", NULL, 302, &_5$$4);
+		ZEPHIR_CALL_METHOD(NULL, &response, "setstatuscode", NULL, 304, &_5$$4);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "applyheaders", NULL, 0, &response, &origin);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_6$$4);
-		zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_0, 345, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_0, 344, PH_NOISY_CC | PH_READONLY);
 		zephir_fast_join_str(&_6$$4, SL(", "), &_5$$4);
 		ZEPHIR_INIT_VAR(&_7$$4);
 		ZVAL_STRING(&_7$$4, "Access-Control-Allow-Methods");
-		ZEPHIR_CALL_METHOD(NULL, &response, "setheader", NULL, 322, &_7$$4, &_6$$4);
+		ZEPHIR_CALL_METHOD(NULL, &response, "setheader", NULL, 324, &_7$$4, &_6$$4);
 		zephir_check_call_status();
 		ZEPHIR_INIT_NVAR(&_7$$4);
-		zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_1, 346, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_1, 345, PH_NOISY_CC | PH_READONLY);
 		zephir_fast_join_str(&_7$$4, SL(", "), &_8$$4);
 		ZEPHIR_INIT_VAR(&_9$$4);
 		ZVAL_STRING(&_9$$4, "Access-Control-Allow-Headers");
-		ZEPHIR_CALL_METHOD(NULL, &response, "setheader", NULL, 322, &_9$$4, &_7$$4);
+		ZEPHIR_CALL_METHOD(NULL, &response, "setheader", NULL, 324, &_9$$4, &_7$$4);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_10$$4, this_ptr, _zephir_prop_2, 348, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$4, this_ptr, _zephir_prop_2, 347, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_GT_LONG(&_10$$4, 0)) {
 			zephir_memory_observe(&_11$$5);
-			zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_2, 348, PH_NOISY_CC);
+			zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_2, 347, PH_NOISY_CC);
 			zephir_cast_to_string(&_12$$5, &_11$$5);
 			ZEPHIR_INIT_VAR(&_13$$5);
 			ZVAL_STRING(&_13$$5, "Access-Control-Max-Age");
-			ZEPHIR_CALL_METHOD(NULL, &response, "setheader", NULL, 322, &_13$$5, &_12$$5);
+			ZEPHIR_CALL_METHOD(NULL, &response, "setheader", NULL, 324, &_13$$5, &_12$$5);
 			zephir_check_call_status();
 		}
 		RETURN_CCTOR(&response);
@@ -323,7 +323,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, applyHeaders)
 	ZVAL_STRING(&_0, "Access-Control-Allow-Origin");
 	ZEPHIR_CALL_METHOD(NULL, response, "setheader", NULL, 0, &_0, &origin_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 347, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 346, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_1)) {
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "Access-Control-Allow-Credentials");
@@ -361,7 +361,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, isAllowed)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&origin_zv);
 	ZVAL_STR_COPY(&origin_zv, origin);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 344, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 343, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "*");
 	ZEPHIR_CALL_FUNCTION(&_2, "in_array", NULL, 87, &_1, &_0, &__$true);
@@ -369,7 +369,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_CorsMiddleware, isAllowed)
 	if (zephir_is_true(&_2)) {
 		RETURN_MM_BOOL(1);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 344, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 343, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_FUNCTION("in_array", NULL, 87, &origin_zv, &_3, &__$true);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/adr/middleware/methodoverridemiddleware.zep.c
+++ b/ext/phalcon/adr/middleware/methodoverridemiddleware.zep.c
@@ -98,7 +98,7 @@ PHP_METHOD(Phalcon_ADR_Middleware_MethodOverrideMiddleware, __invoke)
 		zephir_cast_to_string(&_4$$3, &_2$$3);
 		ZEPHIR_INIT_VAR(&spoofed);
 		zephir_fast_strtoupper(&spoofed, &_4$$3);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 349, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 348, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_6$$3, "in_array", NULL, 87, &spoofed, &_5$$3, &__$true);
 		zephir_check_call_status();
 		if (zephir_is_true(&_6$$3)) {

--- a/ext/phalcon/adr/middleware/requestidmiddleware.zep.c
+++ b/ext/phalcon/adr/middleware/requestidmiddleware.zep.c
@@ -68,9 +68,9 @@ PHP_METHOD(Phalcon_ADR_Middleware_RequestIdMiddleware, __invoke)
 	zephir_check_call_status();
 	if (ZEPHIR_IS_EMPTY(&id)) {
 		ZVAL_LONG(&_1$$3, 16);
-		ZEPHIR_CALL_FUNCTION(&_2$$3, "random_bytes", NULL, 315, &_1$$3);
+		ZEPHIR_CALL_FUNCTION(&_2$$3, "random_bytes", NULL, 317, &_1$$3);
 		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(&id, "bin2hex", NULL, 316, &_2$$3);
+		ZEPHIR_CALL_FUNCTION(&id, "bin2hex", NULL, 318, &_2$$3);
 		zephir_check_call_status();
 	}
 	ZEPHIR_CALL_METHOD(&_3, request, "getattributes", NULL, 0);

--- a/ext/phalcon/adr/payload/payload.zep.c
+++ b/ext/phalcon/adr/payload/payload.zep.c
@@ -110,7 +110,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, accepted)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "ACCEPTED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -152,7 +152,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, authenticated)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "AUTHENTICATED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -194,7 +194,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, authorized)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "AUTHORIZED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -236,7 +236,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, created)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "CREATED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -278,7 +278,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, deleted)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "DELETED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -320,7 +320,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, error)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "ERROR");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -363,7 +363,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, forbidden)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_AUTHORIZED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -405,7 +405,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, found)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "FOUND");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -501,7 +501,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, invalid)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_VALID");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -543,7 +543,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, notAccepted)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_ACCEPTED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -585,7 +585,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, notCreated)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_CREATED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -627,7 +627,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, notDeleted)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_DELETED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -669,7 +669,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, notFound)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_FOUND");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -711,7 +711,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, notUpdated)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_UPDATED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -753,7 +753,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, processing)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "PROCESSING");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -795,7 +795,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, success)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "SUCCESS");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -838,7 +838,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, unauthenticated)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "NOT_AUTHENTICATED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withmessages", NULL, 0, messages);
 	zephir_check_call_status();
@@ -880,7 +880,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, updated)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "UPDATED");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();
@@ -922,7 +922,7 @@ PHP_METHOD(Phalcon_ADR_Payload_Payload, valid)
 
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "VALID");
-	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 313, &_2);
+	ZEPHIR_CALL_METHOD(&_1, &_0, "withstatus", NULL, 315, &_2);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "withresult", NULL, 0, result);
 	zephir_check_call_status();

--- a/ext/phalcon/adr/pipeline.zep.c
+++ b/ext/phalcon/adr/pipeline.zep.c
@@ -95,11 +95,11 @@ PHP_METHOD(Phalcon_ADR_Pipeline, __construct)
 		index = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 350, &middleware);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 351, terminal);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 349, &middleware);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 350, terminal);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, index);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 352, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 351, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -141,26 +141,26 @@ PHP_METHOD(Phalcon_ADR_Pipeline, __invoke)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &request);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 352, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 350, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 351, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 349, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_GE_LONG(&_0, zephir_fast_count_int(&_1))) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 351, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 350, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_RETURN_CALL_METHOD(&_2$$3, "__invoke", NULL, 0, request);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 350, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 349, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&mw);
 	zephir_memory_observe(&_4);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 352, PH_NOISY_CC);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 351, PH_NOISY_CC);
 	zephir_array_fetch(&mw, &_3, &_4, PH_NOISY, "phalcon/ADR/Pipeline.zep", 59);
 	ZEPHIR_INIT_VAR(&next);
 	object_init_ex(&next, phalcon_adr_pipeline_ce);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 350, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_2, 351, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 352, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 349, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_2, 350, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 351, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_8, (zephir_get_numberval(&_7) + 1));
-	ZEPHIR_CALL_METHOD(NULL, &next, "__construct", NULL, 307, &_5, &_6, &_8);
+	ZEPHIR_CALL_METHOD(NULL, &next, "__construct", NULL, 309, &_5, &_6, &_8);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&mw, "__invoke", NULL, 0, request, &next);
 	zephir_check_call_status();

--- a/ext/phalcon/adr/responder/formatresponder.zep.c
+++ b/ext/phalcon/adr/responder/formatresponder.zep.c
@@ -75,7 +75,7 @@ PHP_METHOD(Phalcon_ADR_Responder_FormatResponder, __construct)
 	} else {
 		zephir_get_arrval(&formatters, formatters_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 353, &formatters);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 352, &formatters);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -119,7 +119,7 @@ PHP_METHOD(Phalcon_ADR_Responder_FormatResponder, __invoke)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &request, &response, &payload);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 353, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 352, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		RETVAL_ZVAL(response, 1, 0);
 		RETURN_MM();
@@ -132,7 +132,7 @@ PHP_METHOD(Phalcon_ADR_Responder_FormatResponder, __invoke)
 	ZEPHIR_CPY_WRT(&accept, &_3);
 	ZEPHIR_INIT_VAR(&chosen);
 	ZVAL_NULL(&chosen);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 353, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 352, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_4, 0, "phalcon/ADR/Responder/FormatResponder.zep", 61);
 	if (Z_TYPE_P(&_4) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_4), _5)
@@ -174,7 +174,7 @@ PHP_METHOD(Phalcon_ADR_Responder_FormatResponder, __invoke)
 	}
 	ZEPHIR_INIT_NVAR(&formatter);
 	if (Z_TYPE_P(&chosen) == IS_NULL) {
-		zephir_read_property_cached(&_10$$8, this_ptr, _zephir_prop_0, 353, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$8, this_ptr, _zephir_prop_0, 352, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_OBS_NVAR(&chosen);
 		zephir_array_fetch_long(&chosen, &_10$$8, 0, PH_NOISY, "phalcon/ADR/Responder/FormatResponder.zep", 62);
 	}

--- a/ext/phalcon/adr/responder/redirect.zep.c
+++ b/ext/phalcon/adr/responder/redirect.zep.c
@@ -79,10 +79,10 @@ PHP_METHOD(Phalcon_ADR_Responder_Redirect, __construct)
 		status = 302;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 354, &url_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 353, &url_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, status);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 355, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 354, &_0);
 }
 
 PHP_METHOD(Phalcon_ADR_Responder_Redirect, permanent)
@@ -103,7 +103,7 @@ PHP_METHOD(Phalcon_ADR_Responder_Redirect, permanent)
 	ZVAL_STR_COPY(&url_zv, url);
 	object_init_ex(return_value, phalcon_adr_responder_redirect_ce);
 	ZVAL_LONG(&_0, 301);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 323, &url_zv, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 325, &url_zv, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -126,7 +126,7 @@ PHP_METHOD(Phalcon_ADR_Responder_Redirect, seeOther)
 	ZVAL_STR_COPY(&url_zv, url);
 	object_init_ex(return_value, phalcon_adr_responder_redirect_ce);
 	ZVAL_LONG(&_0, 303);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 323, &url_zv, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 325, &url_zv, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -155,7 +155,7 @@ PHP_METHOD(Phalcon_ADR_Responder_Redirect, temporary)
 	ZVAL_STR_COPY(&url_zv, url);
 	object_init_ex(return_value, phalcon_adr_responder_redirect_ce);
 	ZVAL_LONG(&_0, 302);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 323, &url_zv, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 325, &url_zv, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/adr/responder/statusmapper.zep.c
+++ b/ext/phalcon/adr/responder/statusmapper.zep.c
@@ -100,7 +100,7 @@ PHP_METHOD(Phalcon_ADR_Responder_StatusMapper, __construct)
 	add_assoc_long_ex(&_0, SL("VALID"), 200);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_add_function(&_1, &overrides, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 356, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 355, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -133,9 +133,9 @@ PHP_METHOD(Phalcon_ADR_Responder_StatusMapper, toHttpCode)
 	zephir_memory_observe(&status_zv);
 	ZVAL_STR_COPY(&status_zv, status);
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 356, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 355, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_1, &status_zv)) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 356, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 355, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_OBS_NVAR(&_0);
 		zephir_array_fetch(&_0, &_2, &status_zv, PH_NOISY, "phalcon/ADR/Responder/StatusMapper.zep", 66);
 	} else {

--- a/ext/phalcon/adr/responder/statusresponder.zep.c
+++ b/ext/phalcon/adr/responder/statusresponder.zep.c
@@ -74,11 +74,11 @@ PHP_METHOD(Phalcon_ADR_Responder_StatusResponder, __construct)
 	if (Z_TYPE_P(mapper) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_adr_responder_statusmapper_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 324);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 326);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 357, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 356, &_0$$3);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 357, mapper);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 356, mapper);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -114,7 +114,7 @@ PHP_METHOD(Phalcon_ADR_Responder_StatusResponder, __invoke)
 	ZEPHIR_CALL_METHOD(&status, payload, "getstatus", NULL, 0);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&status) != IS_NULL) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 357, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 356, PH_NOISY_CC | PH_READONLY);
 		zephir_cast_to_string(&_2$$3, &status);
 		ZEPHIR_CALL_METHOD(&_1$$3, &_0$$3, "tohttpcode", NULL, 0, &_2$$3);
 		zephir_check_call_status();

--- a/ext/phalcon/adr/responder/viewresponder.zep.c
+++ b/ext/phalcon/adr/responder/viewresponder.zep.c
@@ -99,9 +99,9 @@ PHP_METHOD(Phalcon_ADR_Responder_ViewResponder, __construct)
 		zephir_memory_observe(&template_zv);
 	ZVAL_STR_COPY(&template_zv, template);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 358, renderer);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 359, statusMapper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 360, &template_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 357, renderer);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 358, statusMapper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 359, &template_zv);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -148,13 +148,13 @@ PHP_METHOD(Phalcon_ADR_Responder_ViewResponder, __invoke)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &request, &response, &payload);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 358, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 360, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "viewdata", NULL, 325, payload);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 357, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 359, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "viewdata", NULL, 327, payload);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&html, &_0, "render", NULL, 0, &_1, &_2);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 359, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 358, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_6, payload, "getstatus", NULL, 0);
 	zephir_check_call_status();
 	zephir_cast_to_string(&_7, &_6);

--- a/ext/phalcon/adr/router/router.zep.c
+++ b/ext/phalcon/adr/router/router.zep.c
@@ -121,31 +121,31 @@ PHP_METHOD(Phalcon_ADR_Router_Router, match)
 		zephir_fast_explode_str(&segments, SL("/"), &uri, LONG_MAX);
 	}
 	if (ZEPHIR_IS_EMPTY(&segments)) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 361, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 360, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&className);
 		ZEPHIR_CONCAT_VSV(&className, &_5$$3, "\\", &verb);
 		if (zephir_class_exists(&className, 1)) {
 			object_init_ex(return_value, phalcon_adr_router_routermatch_ce);
 			ZEPHIR_INIT_VAR(&_6$$4);
 			array_init(&_6$$4);
-			ZEPHIR_CALL_METHOD(&_7$$4, this_ptr, "middlewarefor", NULL, 326, &className);
+			ZEPHIR_CALL_METHOD(&_7$$4, this_ptr, "middlewarefor", NULL, 328, &className);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 327, &className, &_6$$4, &_7$$4);
+			ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 329, &className, &_6$$4, &_7$$4);
 			zephir_check_call_status();
 			RETURN_MM();
 		}
 		RETURN_MM_NULL();
 	}
-	ZEPHIR_CALL_METHOD(&located, this_ptr, "locate", NULL, 328, &segments, &verb);
+	ZEPHIR_CALL_METHOD(&located, this_ptr, "locate", NULL, 330, &segments, &verb);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&located) == IS_ARRAY) {
 		object_init_ex(return_value, phalcon_adr_router_routermatch_ce);
 		zephir_array_fetch_long(&_8$$5, &located, 0, PH_NOISY | PH_READONLY, "phalcon/ADR/Router/Router.zep", 64);
 		zephir_array_fetch_long(&_9$$5, &located, 1, PH_NOISY | PH_READONLY, "phalcon/ADR/Router/Router.zep", 65);
 		zephir_array_fetch_long(&_11$$5, &located, 0, PH_NOISY | PH_READONLY, "phalcon/ADR/Router/Router.zep", 66);
-		ZEPHIR_CALL_METHOD(&_10$$5, this_ptr, "middlewarefor", NULL, 326, &_11$$5);
+		ZEPHIR_CALL_METHOD(&_10$$5, this_ptr, "middlewarefor", NULL, 328, &_11$$5);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 327, &_8$$5, &_9$$5, &_10$$5);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 329, &_8$$5, &_9$$5, &_10$$5);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -173,14 +173,14 @@ PHP_METHOD(Phalcon_ADR_Router_Router, match)
 		ZVAL_COPY(&other, _13);
 		_14$$6 = !ZEPHIR_IS_IDENTICAL(&other, &verb);
 		if (_14$$6) {
-			ZEPHIR_CALL_METHOD(&_15$$6, this_ptr, "locate", NULL, 328, &segments, &other);
+			ZEPHIR_CALL_METHOD(&_15$$6, this_ptr, "locate", NULL, 330, &segments, &other);
 			zephir_check_call_status();
 			_14$$6 = Z_TYPE_P(&_15$$6) == IS_ARRAY;
 		}
 		if (_14$$6) {
 			ZEPHIR_INIT_NVAR(&_16$$7);
 			object_init_ex(&_16$$7, phalcon_adr_exceptions_methodnotallowed_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_16$$7, "__construct", &_17, 329);
+			ZEPHIR_CALL_METHOD(NULL, &_16$$7, "__construct", &_17, 331);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_16$$7, "phalcon/ADR/Router/Router.zep", 73);
 			ZEPHIR_MM_RESTORE();
@@ -217,7 +217,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, setBaseNamespace)
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "\\");
 	zephir_fast_trim(&_0, &baseNamespace_zv, &_1, ZEPHIR_TRIM_RIGHT);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 361, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 360, &_0);
 	RETURN_THIS();
 }
 
@@ -241,7 +241,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, setMiddlewareMap)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &middlewareMap_param);
 	zephir_get_arrval(&middlewareMap, middlewareMap_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 362, &middlewareMap);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 361, &middlewareMap);
 	RETURN_THIS();
 }
 
@@ -280,7 +280,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, camelize)
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, " ");
 	zephir_fast_str_replace(&_0, &_1, &_2, &segment_zv);
-	ZEPHIR_CALL_FUNCTION(&_3, "ucwords", NULL, 330, &_0);
+	ZEPHIR_CALL_FUNCTION(&_3, "ucwords", NULL, 332, &_0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, " ");
@@ -345,7 +345,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, locate)
 		ZEPHIR_INIT_NVAR(&last);
 		ZVAL_LONG(&last, (zephir_get_numberval(&index) - 1));
 		ZVAL_LONG(&_0$$3, 0);
-		ZEPHIR_CALL_FUNCTION(&head, "array_slice", &_1, 270, &segments, &_0$$3, &index);
+		ZEPHIR_CALL_FUNCTION(&head, "array_slice", &_1, 271, &segments, &_0$$3, &index);
 		zephir_check_call_status();
 		if (ZEPHIR_GE_LONG(&index, 2)) {
 			ZEPHIR_INIT_NVAR(&prev);
@@ -354,22 +354,22 @@ PHP_METHOD(Phalcon_ADR_Router_Router, locate)
 			zephir_array_fetch(&resourceName, &head, &prev, PH_NOISY, "phalcon/ADR/Router/Router.zep", 111);
 			ZEPHIR_OBS_NVAR(&operation);
 			zephir_array_fetch(&operation, &head, &last, PH_NOISY, "phalcon/ADR/Router/Router.zep", 112);
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 361, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 360, PH_NOISY_CC | PH_READONLY);
 			ZVAL_LONG(&_4$$4, 0);
-			ZEPHIR_CALL_FUNCTION(&_5$$4, "array_slice", &_1, 270, &head, &_4$$4, &last);
+			ZEPHIR_CALL_FUNCTION(&_5$$4, "array_slice", &_1, 271, &head, &_4$$4, &last);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "tonamespace", &_6, 331, &_5$$4);
+			ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "tonamespace", &_6, 333, &_5$$4);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_7$$4, this_ptr, "camelize", &_8, 332, &resourceName);
+			ZEPHIR_CALL_METHOD(&_7$$4, this_ptr, "camelize", &_8, 334, &resourceName);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_9$$4, this_ptr, "camelize", &_8, 332, &operation);
+			ZEPHIR_CALL_METHOD(&_9$$4, this_ptr, "camelize", &_8, 334, &operation);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(&className);
 			ZEPHIR_CONCAT_VVSVVV(&className, &_2$$4, &_3$$4, "\\", &verb_zv, &_7$$4, &_9$$4);
 			if (zephir_class_exists(&className, 1)) {
 				zephir_create_array(return_value, 2, 0);
 				zephir_array_fast_append(return_value, &className);
-				ZEPHIR_CALL_FUNCTION(&_10$$5, "array_slice", &_1, 270, &segments, &index);
+				ZEPHIR_CALL_FUNCTION(&_10$$5, "array_slice", &_1, 271, &segments, &index);
 				zephir_check_call_status();
 				zephir_array_fast_append(return_value, &_10$$5);
 				RETURN_MM();
@@ -377,17 +377,17 @@ PHP_METHOD(Phalcon_ADR_Router_Router, locate)
 		}
 		ZEPHIR_OBS_NVAR(&resourceName);
 		zephir_array_fetch(&resourceName, &head, &last, PH_NOISY, "phalcon/ADR/Router/Router.zep", 122);
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 361, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(&_11$$3, this_ptr, "tonamespace", &_6, 331, &head);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 360, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(&_11$$3, this_ptr, "tonamespace", &_6, 333, &head);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_12$$3, this_ptr, "camelize", &_8, 332, &resourceName);
+		ZEPHIR_CALL_METHOD(&_12$$3, this_ptr, "camelize", &_8, 334, &resourceName);
 		zephir_check_call_status();
 		ZEPHIR_INIT_NVAR(&className);
 		ZEPHIR_CONCAT_VVSVV(&className, &_0$$3, &_11$$3, "\\", &verb_zv, &_12$$3);
 		if (zephir_class_exists(&className, 1)) {
 			zephir_create_array(return_value, 2, 0);
 			zephir_array_fast_append(return_value, &className);
-			ZEPHIR_CALL_FUNCTION(&_13$$6, "array_slice", &_1, 270, &segments, &index);
+			ZEPHIR_CALL_FUNCTION(&_13$$6, "array_slice", &_1, 271, &segments, &index);
 			zephir_check_call_status();
 			zephir_array_fast_append(return_value, &_13$$6);
 			RETURN_MM();
@@ -443,7 +443,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, middlewareFor)
 	ZVAL_STR_COPY(&className_zv, className);
 	ZEPHIR_INIT_VAR(&stacked);
 	array_init(&stacked);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 362, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 361, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/ADR/Router/Router.zep", 150);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_0), _2, _3, _1)
@@ -456,11 +456,11 @@ PHP_METHOD(Phalcon_ADR_Router_Router, middlewareFor)
 			}
 			ZEPHIR_INIT_NVAR(&list);
 			ZVAL_COPY(&list, _1);
-			zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 361, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 360, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_NVAR(&full);
 			ZEPHIR_CONCAT_VV(&full, &_4$$3, &prefix);
 			ZVAL_LONG(&_5$$3, zephir_fast_strlen_ev(&full));
-			ZEPHIR_CALL_FUNCTION(&_6$$3, "strncmp", &_7, 333, &className_zv, &full, &_5$$3);
+			ZEPHIR_CALL_FUNCTION(&_6$$3, "strncmp", &_7, 335, &className_zv, &full, &_5$$3);
 			zephir_check_call_status();
 			if (ZEPHIR_IS_LONG_IDENTICAL(&_6$$3, 0)) {
 				ZEPHIR_INIT_NVAR(&_8$$4);
@@ -488,11 +488,11 @@ PHP_METHOD(Phalcon_ADR_Router_Router, middlewareFor)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&list, &_0, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_1, 361, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_1, 360, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_NVAR(&full);
 				ZEPHIR_CONCAT_VV(&full, &_11$$5, &prefix);
 				ZVAL_LONG(&_12$$5, zephir_fast_strlen_ev(&full));
-				ZEPHIR_CALL_FUNCTION(&_13$$5, "strncmp", &_7, 333, &className_zv, &full, &_12$$5);
+				ZEPHIR_CALL_FUNCTION(&_13$$5, "strncmp", &_7, 335, &className_zv, &full, &_12$$5);
 				zephir_check_call_status();
 				if (ZEPHIR_IS_LONG_IDENTICAL(&_13$$5, 0)) {
 					ZEPHIR_INIT_NVAR(&_14$$6);
@@ -538,7 +538,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, toNamespace)
 		{
 			ZEPHIR_INIT_NVAR(&segment);
 			ZVAL_COPY(&segment, _0);
-			ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "camelize", &_2, 332, &segment);
+			ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "camelize", &_2, 334, &segment);
 			zephir_check_call_status();
 			zephir_array_append(&parts, &_1$$3, PH_SEPARATE, "phalcon/ADR/Router/Router.zep", 159);
 		} ZEND_HASH_FOREACH_END();
@@ -560,7 +560,7 @@ PHP_METHOD(Phalcon_ADR_Router_Router, toNamespace)
 			}
 			ZEPHIR_CALL_METHOD(&segment, &segments, "current", NULL, 0);
 			zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&_5$$4, this_ptr, "camelize", &_2, 332, &segment);
+				ZEPHIR_CALL_METHOD(&_5$$4, this_ptr, "camelize", &_2, 334, &segment);
 				zephir_check_call_status();
 				zephir_array_append(&parts, &_5$$4, PH_SEPARATE, "phalcon/ADR/Router/Router.zep", 159);
 		}

--- a/ext/phalcon/adr/router/routermatch.zep.c
+++ b/ext/phalcon/adr/router/routermatch.zep.c
@@ -120,10 +120,10 @@ PHP_METHOD(Phalcon_ADR_Router_RouterMatch, __construct)
 		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 363, &action_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 364, &attributes);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 365, &middleware);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 366, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 362, &action_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 363, &attributes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 364, &middleware);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 365, &name_zv);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/annotations/adapter/apcu.zep.c
+++ b/ext/phalcon/annotations/adapter/apcu.zep.c
@@ -95,11 +95,11 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Apcu, __construct)
 	}
 	zephir_memory_observe(&prefix);
 	if (zephir_array_isset_string_fetch(&prefix, &options, SL("prefix"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 382, &prefix);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 381, &prefix);
 	}
 	zephir_memory_observe(&ttl);
 	if (zephir_array_isset_string_fetch(&ttl, &options, SL("lifetime"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 383, &ttl);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 382, &ttl);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -132,11 +132,11 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Apcu, read)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 382, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 381, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZEPHIR_CONCAT_SVV(&_2, "_PHAN", &_1, &key_zv);
 	zephir_fast_strtolower(&_0, &_2);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_fetch", NULL, 274, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_fetch", NULL, 275, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -177,12 +177,12 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Apcu, write)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 382, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 381, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZEPHIR_CONCAT_SVV(&_2, "_PHAN", &_1, &key_zv);
 	zephir_fast_strtolower(&_0, &_2);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 383, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_store", NULL, 276, &_0, data, &_3);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 382, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_store", NULL, 277, &_0, data, &_3);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/annotations/adapter/memory.zep.c
+++ b/ext/phalcon/annotations/adapter/memory.zep.c
@@ -91,7 +91,7 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Memory, read)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&data);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 384, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 383, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_fast_strtolower(&_1, &key_zv);
 	if (!(zephir_array_isset_fetch(&data, &_0, &_1, 0))) {

--- a/ext/phalcon/annotations/adapter/stream.zep.c
+++ b/ext/phalcon/annotations/adapter/stream.zep.c
@@ -90,7 +90,7 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Stream, __construct)
 	}
 	zephir_memory_observe(&annotationsDir);
 	if (zephir_array_isset_string_fetch(&annotationsDir, &options, SL("annotationsDir"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 385, &annotationsDir);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 384, &annotationsDir);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -132,7 +132,7 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Stream, read)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 385, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 384, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "_");
@@ -155,17 +155,17 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Stream, read)
 	ZEPHIR_INIT_NVAR(&_5);
 	zephir_create_closure_ex(&_5, NULL, phalcon_6__closure_ce, SL("__invoke"));
 	ZVAL_LONG(&_6, 2);
-	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 292, &_5, &_6);
+	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 293, &_5, &_6);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_7, "unserialize", NULL, 26, &contents);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&contents, &_7);
-	ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 293);
+	ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 294);
 	zephir_check_call_status();
 	if (UNEXPECTED(ZEPHIR_GLOBAL(warning).enable)) {
 		ZEPHIR_INIT_VAR(&_8$$5);
 		object_init_ex(&_8$$5, phalcon_annotations_exceptions_cannotreadannotationdata_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_8$$5, "__construct", NULL, 336);
+		ZEPHIR_CALL_METHOD(NULL, &_8$$5, "__construct", NULL, 338);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_8$$5, "phalcon/Annotations/Adapter/Stream.zep", 94);
 		ZEPHIR_MM_RESTORE();
@@ -210,7 +210,7 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Stream, write)
 	data = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 385, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 384, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "_");
@@ -225,7 +225,7 @@ PHP_METHOD(Phalcon_Annotations_Adapter_Stream, write)
 	if (UNEXPECTED(ZEPHIR_IS_FALSE_IDENTICAL(&_4))) {
 		ZEPHIR_INIT_VAR(&_5$$3);
 		object_init_ex(&_5$$3, phalcon_annotations_exceptions_annotationsdirectorynotwritable_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_5$$3, "__construct", NULL, 337);
+		ZEPHIR_CALL_METHOD(NULL, &_5$$3, "__construct", NULL, 339);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_5$$3, "phalcon/Annotations/Adapter/Stream.zep", 115);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/annotations/annotation.zep.c
+++ b/ext/phalcon/annotations/annotation.zep.c
@@ -104,7 +104,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, __construct)
 	zephir_memory_observe(&name);
 	if (zephir_array_isset_string_fetch(&name, &reflectionData, SL("name"), 0)) {
 		zephir_array_fetch_string(&_0$$3, &reflectionData, SL("name"), PH_NOISY | PH_READONLY, "phalcon/Annotations/Annotation.zep", 50);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 386, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 385, &_0$$3);
 	}
 	zephir_memory_observe(&exprArguments);
 	if (zephir_array_isset_string_fetch(&exprArguments, &reflectionData, SL("arguments"), 0)) {
@@ -156,8 +156,8 @@ PHP_METHOD(Phalcon_Annotations_Annotation, __construct)
 			}
 		}
 		ZEPHIR_INIT_NVAR(&argument);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 387, &arguments);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 388, &exprArguments);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 386, &arguments);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 387, &exprArguments);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -186,7 +186,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, getArgument)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &position);
 	zephir_memory_observe(&argument);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 387, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 386, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&argument, &_0, position, 0)) {
 		RETURN_CCTOR(&argument);
 	}
@@ -277,7 +277,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, getExpression)
 					ZEPHIR_INIT_NVAR(&item);
 					ZVAL_COPY(&item, _1$$7);
 					zephir_array_fetch_string(&_2$$8, &item, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Annotations/Annotation.zep", 141);
-					ZEPHIR_CALL_METHOD(&resolvedItem, this_ptr, "getexpression", &_3, 338, &_2$$8);
+					ZEPHIR_CALL_METHOD(&resolvedItem, this_ptr, "getexpression", &_3, 340, &_2$$8);
 					zephir_check_call_status();
 					ZEPHIR_OBS_NVAR(&name);
 					if (zephir_array_isset_string_fetch(&name, &item, SL("name"), 0)) {
@@ -305,7 +305,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, getExpression)
 					ZEPHIR_CALL_METHOD(&item, &_0$$7, "current", NULL, 0);
 					zephir_check_call_status();
 						zephir_array_fetch_string(&_6$$11, &item, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Annotations/Annotation.zep", 141);
-						ZEPHIR_CALL_METHOD(&resolvedItem, this_ptr, "getexpression", &_3, 338, &_6$$11);
+						ZEPHIR_CALL_METHOD(&resolvedItem, this_ptr, "getexpression", &_3, 340, &_6$$11);
 						zephir_check_call_status();
 						ZEPHIR_OBS_NVAR(&name);
 						if (zephir_array_isset_string_fetch(&name, &item, SL("name"), 0)) {
@@ -320,13 +320,13 @@ PHP_METHOD(Phalcon_Annotations_Annotation, getExpression)
 		}
 		if (ZEPHIR_IS_LONG(&type, 300)) {
 			object_init_ex(return_value, phalcon_annotations_annotation_ce);
-			ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 339, &expr);
+			ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 341, &expr);
 			zephir_check_call_status();
 			RETURN_MM();
 		}
 		ZEPHIR_INIT_VAR(&_7$$15);
 		object_init_ex(&_7$$15, phalcon_annotations_exceptions_unknownannotationexpression_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_7$$15, "__construct", NULL, 340, &type);
+		ZEPHIR_CALL_METHOD(NULL, &_7$$15, "__construct", NULL, 342, &type);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_7$$15, "phalcon/Annotations/Annotation.zep", 156);
 		ZEPHIR_MM_RESTORE();
@@ -371,7 +371,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, getNamedArgument)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&argument);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 387, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 386, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&argument, &_0, &name_zv, 0)) {
 		RETURN_CCTOR(&argument);
 	}
@@ -421,7 +421,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, hasArgument)
 		Z_PARAM_ZVAL(position)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &position);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 387, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 386, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, position));
 }
 
@@ -438,7 +438,7 @@ PHP_METHOD(Phalcon_Annotations_Annotation, numberArguments)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("arguments", 9, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 387, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 386, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 

--- a/ext/phalcon/annotations/collection.zep.c
+++ b/ext/phalcon/annotations/collection.zep.c
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, __construct)
 			ZVAL_COPY(&annotationData, _0);
 			ZEPHIR_INIT_NVAR(&_1$$3);
 			object_init_ex(&_1$$3, phalcon_annotations_annotation_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", &_2, 339, &annotationData);
+			ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", &_2, 341, &annotationData);
 			zephir_check_call_status();
 			zephir_array_append(&annotations, &_1$$3, PH_SEPARATE, "phalcon/Annotations/Collection.zep", 56);
 		} ZEND_HASH_FOREACH_END();
@@ -133,13 +133,13 @@ PHP_METHOD(Phalcon_Annotations_Collection, __construct)
 			zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_5$$4);
 				object_init_ex(&_5$$4, phalcon_annotations_annotation_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_5$$4, "__construct", &_2, 339, &annotationData);
+				ZEPHIR_CALL_METHOD(NULL, &_5$$4, "__construct", &_2, 341, &annotationData);
 				zephir_check_call_status();
 				zephir_array_append(&annotations, &_5$$4, PH_SEPARATE, "phalcon/Annotations/Collection.zep", 56);
 		}
 	}
 	ZEPHIR_INIT_NVAR(&annotationData);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 389, &annotations);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 388, &annotations);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, count)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("annotations", 11, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 389, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 388, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 
@@ -184,8 +184,8 @@ PHP_METHOD(Phalcon_Annotations_Collection, current)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&annotation);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 389, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 390, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 388, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 389, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&annotation, &_0, &_1, 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -224,7 +224,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, get)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 389, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 388, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&annotations, &_0);
 	zephir_is_iterable(&annotations, 0, "phalcon/Annotations/Collection.zep", 99);
 	if (Z_TYPE_P(&annotations) == IS_ARRAY) {
@@ -266,7 +266,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, get)
 	ZEPHIR_INIT_NVAR(&annotation);
 	ZEPHIR_INIT_VAR(&_6);
 	object_init_ex(&_6, phalcon_annotations_exceptions_annotationnotfound_ce);
-	ZEPHIR_CALL_METHOD(NULL, &_6, "__construct", NULL, 341, &name_zv);
+	ZEPHIR_CALL_METHOD(NULL, &_6, "__construct", NULL, 343, &name_zv);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(&_6, "phalcon/Annotations/Collection.zep", 99);
 	ZEPHIR_MM_RESTORE();
@@ -308,7 +308,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, getAll)
 	ZVAL_STR_COPY(&name_zv, name);
 	ZEPHIR_INIT_VAR(&found);
 	array_init(&found);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 389, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 388, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&annotations, &_0);
 	zephir_is_iterable(&annotations, 0, "phalcon/Annotations/Collection.zep", 119);
 	if (Z_TYPE_P(&annotations) == IS_ARRAY) {
@@ -391,7 +391,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, has)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 389, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 388, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&annotations, &_0);
 	zephir_is_iterable(&annotations, 0, "phalcon/Annotations/Collection.zep", 145);
 	if (Z_TYPE_P(&annotations) == IS_ARRAY) {
@@ -467,7 +467,7 @@ PHP_METHOD(Phalcon_Annotations_Collection, rewind)
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 390, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 389, &_0);
 }
 
 /**
@@ -488,8 +488,8 @@ PHP_METHOD(Phalcon_Annotations_Collection, valid)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("position", 8, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 389, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 390, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 388, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 389, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &_1));
 }
 

--- a/ext/phalcon/annotations/reader.zep.c
+++ b/ext/phalcon/annotations/reader.zep.c
@@ -106,15 +106,15 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 	array_init(&annotations);
 	ZEPHIR_INIT_VAR(&reflection);
 	object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionclass")));
-	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 239, &className_zv);
+	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 240, &className_zv);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&comment, &reflection, "getdoccomment", NULL, 342);
+	ZEPHIR_CALL_METHOD(&comment, &reflection, "getdoccomment", NULL, 344);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&comment)) {
 		ZEPHIR_INIT_VAR(&classAnnotations);
-		ZEPHIR_CALL_METHOD(&_0$$3, &reflection, "getfilename", NULL, 343);
+		ZEPHIR_CALL_METHOD(&_0$$3, &reflection, "getfilename", NULL, 345);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_1$$3, &reflection, "getstartline", NULL, 344);
+		ZEPHIR_CALL_METHOD(&_1$$3, &reflection, "getstartline", NULL, 346);
 		zephir_check_call_status();
 		ZEPHIR_LAST_CALL_STATUS = phannot_parse_annotations(&classAnnotations, &comment, &_0$$3, &_1$$3);
 		zephir_check_call_status();
@@ -122,7 +122,7 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 			zephir_array_update_string(&annotations, SL("class"), &classAnnotations, PH_COPY | PH_SEPARATE);
 		}
 	}
-	ZEPHIR_CALL_METHOD(&constants, &reflection, "getconstants", NULL, 345);
+	ZEPHIR_CALL_METHOD(&constants, &reflection, "getconstants", NULL, 347);
 	zephir_check_call_status();
 	if (zephir_fast_count_int(&constants)) {
 		line = 1;
@@ -135,13 +135,13 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 		{
 			ZEPHIR_INIT_NVAR(&constant);
 			ZVAL_COPY(&constant, _2$$5);
-			ZEPHIR_CALL_METHOD(&constantReflection, &reflection, "getreflectionconstant", &_3, 346, &constant);
+			ZEPHIR_CALL_METHOD(&constantReflection, &reflection, "getreflectionconstant", &_3, 348, &constant);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&comment, &constantReflection, "getdoccomment", NULL, 0);
 			zephir_check_call_status();
 			if (!ZEPHIR_IS_FALSE_IDENTICAL(&comment)) {
 				ZEPHIR_INIT_NVAR(&constantAnnotations);
-				ZEPHIR_CALL_METHOD(&_4$$7, &reflection, "getfilename", NULL, 343);
+				ZEPHIR_CALL_METHOD(&_4$$7, &reflection, "getfilename", NULL, 345);
 				zephir_check_call_status();
 				ZVAL_LONG(&_5$$7, line);
 				ZEPHIR_LAST_CALL_STATUS = phannot_parse_annotations(&constantAnnotations, &comment, &_4$$7, &_5$$7);
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 			zephir_array_update_string(&annotations, SL("constants"), &anotationsConstants, PH_COPY | PH_SEPARATE);
 		}
 	}
-	ZEPHIR_CALL_METHOD(&properties, &reflection, "getproperties", NULL, 347);
+	ZEPHIR_CALL_METHOD(&properties, &reflection, "getproperties", NULL, 349);
 	zephir_check_call_status();
 	if (zephir_fast_count_int(&properties)) {
 		line = 1;
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 				zephir_check_call_status();
 				if (!ZEPHIR_IS_FALSE_IDENTICAL(&comment)) {
 					ZEPHIR_INIT_NVAR(&propertyAnnotations);
-					ZEPHIR_CALL_METHOD(&_7$$12, &reflection, "getfilename", NULL, 343);
+					ZEPHIR_CALL_METHOD(&_7$$12, &reflection, "getfilename", NULL, 345);
 					zephir_check_call_status();
 					ZVAL_LONG(&_8$$12, line);
 					ZEPHIR_LAST_CALL_STATUS = phannot_parse_annotations(&propertyAnnotations, &comment, &_7$$12, &_8$$12);
@@ -206,7 +206,7 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 					zephir_check_call_status();
 					if (!ZEPHIR_IS_FALSE_IDENTICAL(&comment)) {
 						ZEPHIR_INIT_NVAR(&propertyAnnotations);
-						ZEPHIR_CALL_METHOD(&_12$$15, &reflection, "getfilename", NULL, 343);
+						ZEPHIR_CALL_METHOD(&_12$$15, &reflection, "getfilename", NULL, 345);
 						zephir_check_call_status();
 						ZVAL_LONG(&_13$$15, line);
 						ZEPHIR_LAST_CALL_STATUS = phannot_parse_annotations(&propertyAnnotations, &comment, &_12$$15, &_13$$15);
@@ -224,7 +224,7 @@ PHP_METHOD(Phalcon_Annotations_Reader, parse)
 			zephir_array_update_string(&annotations, SL("properties"), &annotationsProperties, PH_COPY | PH_SEPARATE);
 		}
 	}
-	ZEPHIR_CALL_METHOD(&methods, &reflection, "getmethods", NULL, 348);
+	ZEPHIR_CALL_METHOD(&methods, &reflection, "getmethods", NULL, 350);
 	zephir_check_call_status();
 	if (0 == ZEPHIR_IS_EMPTY(&methods)) {
 		ZEPHIR_INIT_VAR(&annotationsMethods);

--- a/ext/phalcon/annotations/reflection.zep.c
+++ b/ext/phalcon/annotations/reflection.zep.c
@@ -100,7 +100,7 @@ PHP_METHOD(Phalcon_Annotations_Reflection, __construct)
 	} else {
 		zephir_get_arrval(&reflectionData, reflectionData_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 391, &reflectionData);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 390, &reflectionData);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -131,16 +131,16 @@ PHP_METHOD(Phalcon_Annotations_Reflection, getClassAnnotations)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 392, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 391, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		zephir_memory_observe(&reflectionClass);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 391, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 390, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_string_fetch(&reflectionClass, &_1$$3, SL("class"), 0)) {
 			ZEPHIR_INIT_VAR(&_2$$4);
 			object_init_ex(&_2$$4, phalcon_annotations_collection_ce);
 			ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 84, &reflectionClass);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 392, &_2$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 391, &_2$$4);
 		}
 	}
 	RETURN_MM_MEMBER(getThis(), "classAnnotations");
@@ -177,7 +177,7 @@ PHP_METHOD(Phalcon_Annotations_Reflection, getConstantsAnnotations)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&reflectionConstants);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 391, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 390, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&reflectionConstants, &_0, SL("constants"), 0)) {
 		_1$$3 = Z_TYPE_P(&reflectionConstants) == IS_ARRAY;
 		if (_1$$3) {
@@ -267,7 +267,7 @@ PHP_METHOD(Phalcon_Annotations_Reflection, getPropertiesAnnotations)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&reflectionProperties);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 391, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 390, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&reflectionProperties, &_0, SL("properties"), 0)) {
 		_1$$3 = Z_TYPE_P(&reflectionProperties) == IS_ARRAY;
 		if (_1$$3) {
@@ -357,7 +357,7 @@ PHP_METHOD(Phalcon_Annotations_Reflection, getMethodsAnnotations)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&reflectionMethods);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 391, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 390, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&reflectionMethods, &_0, SL("methods"), 0)) {
 		_1$$3 = Z_TYPE_P(&reflectionMethods) == IS_ARRAY;
 		if (_1$$3) {

--- a/ext/phalcon/assets/collection.zep.c
+++ b/ext/phalcon/assets/collection.zep.c
@@ -117,7 +117,7 @@ PHP_METHOD(Phalcon_Assets_Collection, add)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &asset);
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "addasset", NULL, 349, asset);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "addasset", NULL, 351, asset);
 	zephir_check_call_status();
 	RETURN_THIS();
 }
@@ -212,7 +212,7 @@ PHP_METHOD(Phalcon_Assets_Collection, addCss)
 	} else {
 		ZVAL_BOOL(&_2, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processadd", NULL, 350, &_0, &path_zv, isLocal, &_1, &attributes, &version_zv, &_2);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processadd", NULL, 352, &_0, &path_zv, isLocal, &_1, &attributes, &version_zv, &_2);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -255,7 +255,7 @@ PHP_METHOD(Phalcon_Assets_Collection, addInline)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &code);
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "addasset", NULL, 349, code);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "addasset", NULL, 351, code);
 	zephir_check_call_status();
 	RETURN_THIS();
 }
@@ -314,7 +314,7 @@ PHP_METHOD(Phalcon_Assets_Collection, addInlineCss)
 	} else {
 		ZVAL_BOOL(&_1, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processaddinline", NULL, 351, &_0, &content_zv, &_1, &attributes);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processaddinline", NULL, 353, &_0, &content_zv, &_1, &attributes);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -373,7 +373,7 @@ PHP_METHOD(Phalcon_Assets_Collection, addInlineJs)
 	} else {
 		ZVAL_BOOL(&_1, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processaddinline", NULL, 351, &_0, &content_zv, &_1, &attributes);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processaddinline", NULL, 353, &_0, &content_zv, &_1, &attributes);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -468,7 +468,7 @@ PHP_METHOD(Phalcon_Assets_Collection, addJs)
 	} else {
 		ZVAL_BOOL(&_2, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processadd", NULL, 350, &_0, &path_zv, isLocal, &_1, &attributes, &version_zv, &_2);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processadd", NULL, 352, &_0, &path_zv, isLocal, &_1, &attributes, &version_zv, &_2);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -490,7 +490,7 @@ PHP_METHOD(Phalcon_Assets_Collection, count)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("assets", 6, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 393, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 392, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 
@@ -542,7 +542,7 @@ PHP_METHOD(Phalcon_Assets_Collection, getIterator)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, spl_ce_ArrayIterator);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 393, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 392, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 18, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -598,7 +598,7 @@ PHP_METHOD(Phalcon_Assets_Collection, getRealTargetPath)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&basePath_zv);
 	ZVAL_STR_COPY(&basePath_zv, basePath);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 394, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 393, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&completePath);
 	ZEPHIR_CONCAT_VV(&completePath, &basePath_zv, &_0);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "phpfileexists", NULL, 0, &completePath);
@@ -671,7 +671,7 @@ PHP_METHOD(Phalcon_Assets_Collection, has)
 	zephir_fetch_params(1, 1, 0, &asset);
 	ZEPHIR_CALL_METHOD(&key, asset, "getassetkey", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 393, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 392, PH_NOISY_CC | PH_READONLY);
 	RETURN_MM_BOOL(zephir_array_isset_value(&_0, &key));
 }
 
@@ -712,9 +712,9 @@ PHP_METHOD(Phalcon_Assets_Collection, join)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 395, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 394, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 395, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 394, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -744,7 +744,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setAttributes)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
 	zephir_get_arrval(&attributes, attributes_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 396, &attributes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 395, &attributes);
 	RETURN_THIS();
 }
 
@@ -769,9 +769,9 @@ PHP_METHOD(Phalcon_Assets_Collection, setAutoVersion)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 397, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 396, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 397, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 396, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -801,7 +801,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setFilters)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &filters_param);
 	zephir_get_arrval(&filters, filters_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 398, &filters);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 397, &filters);
 	RETURN_THIS();
 }
 
@@ -826,7 +826,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setPrefix)
 		Z_PARAM_STR(prefix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&prefix_zv, prefix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 399, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 398, &prefix_zv);
 	RETURN_THISW();
 }
 
@@ -853,9 +853,9 @@ PHP_METHOD(Phalcon_Assets_Collection, setTargetIsLocal)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 400, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 399, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 400, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 399, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -881,7 +881,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setVersion)
 		Z_PARAM_STR(version)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&version_zv, version);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 401, &version_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 400, &version_zv);
 	RETURN_THISW();
 }
 
@@ -1014,8 +1014,8 @@ PHP_METHOD(Phalcon_Assets_Collection, processAdd)
 	ZEPHIR_CONCAT_SV(&_0, "Phalcon\\Assets\\Asset\\", &className_zv);
 	ZEPHIR_CPY_WRT(&name, &_0);
 	zephir_memory_observe(&flag);
-	zephir_read_property_cached(&flag, this_ptr, _zephir_prop_0, 402, PH_NOISY_CC);
-	ZEPHIR_CALL_METHOD(&attrs, this_ptr, "processattributes", NULL, 352, &attributes);
+	zephir_read_property_cached(&flag, this_ptr, _zephir_prop_0, 401, PH_NOISY_CC);
+	ZEPHIR_CALL_METHOD(&attrs, this_ptr, "processattributes", NULL, 354, &attributes);
 	zephir_check_call_status();
 	if (Z_TYPE_P(isLocal) != IS_NULL) {
 		ZEPHIR_INIT_NVAR(&flag);
@@ -1107,7 +1107,7 @@ PHP_METHOD(Phalcon_Assets_Collection, processAddInline)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_SV(&_0, "Phalcon\\Assets\\Inline\\", &className_zv);
 	ZEPHIR_CPY_WRT(&name, &_0);
-	ZEPHIR_CALL_METHOD(&attrs, this_ptr, "processattributes", NULL, 352, &attributes);
+	ZEPHIR_CALL_METHOD(&attrs, this_ptr, "processattributes", NULL, 354, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&asset);
 	zephir_fetch_safe_class(&_1, &name);
@@ -1167,7 +1167,7 @@ PHP_METHOD(Phalcon_Assets_Collection, processAttributes)
 		ZEPHIR_CPY_WRT(&_0, &attributes);
 	} else {
 		zephir_memory_observe(&_1);
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 396, PH_NOISY_CC);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 395, PH_NOISY_CC);
 		zephir_get_arrval(&_2, &_1);
 		ZEPHIR_CPY_WRT(&_0, &_2);
 	}
@@ -1196,7 +1196,7 @@ PHP_METHOD(Phalcon_Assets_Collection, getAttributes)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 396, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 395, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -1704,9 +1704,9 @@ PHP_METHOD(Phalcon_Assets_Collection, setIsLocal)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 402, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 401, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 402, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 401, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1734,7 +1734,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setSourcePath)
 		Z_PARAM_STR(sourcePath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&sourcePath_zv, sourcePath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 403, &sourcePath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 402, &sourcePath_zv);
 	RETURN_THISW();
 }
 
@@ -1761,7 +1761,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setTargetPath)
 		Z_PARAM_STR(targetPath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&targetPath_zv, targetPath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 394, &targetPath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 393, &targetPath_zv);
 	RETURN_THISW();
 }
 
@@ -1788,7 +1788,7 @@ PHP_METHOD(Phalcon_Assets_Collection, setTargetUri)
 		Z_PARAM_STR(targetUri)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&targetUri_zv, targetUri);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 404, &targetUri_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 403, &targetUri_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/assets/manager.zep.c
+++ b/ext/phalcon/assets/manager.zep.c
@@ -97,8 +97,8 @@ PHP_METHOD(Phalcon_Assets_Manager, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 405, tagFactory);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 406, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 404, tagFactory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 405, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -155,7 +155,7 @@ PHP_METHOD(Phalcon_Assets_Manager, addAssetByType)
 	asset = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&type_zv);
 	ZVAL_STR_COPY(&type_zv, type);
-	ZEPHIR_CALL_METHOD(&collection, this_ptr, "checkandcreatecollection", NULL, 353, &type_zv);
+	ZEPHIR_CALL_METHOD(&collection, this_ptr, "checkandcreatecollection", NULL, 355, &type_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &collection, "add", NULL, 0, asset);
 	zephir_check_call_status();
@@ -257,7 +257,7 @@ PHP_METHOD(Phalcon_Assets_Manager, addCss)
 	} else {
 		ZVAL_BOOL(&_3, 0);
 	}
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 354, &path_zv, &_1, &_2, &attributes, &version_zv, &_3);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 356, &path_zv, &_1, &_2, &attributes, &version_zv, &_3);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, "css");
@@ -319,7 +319,7 @@ PHP_METHOD(Phalcon_Assets_Manager, addInlineCodeByType)
 	code = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&type_zv);
 	ZVAL_STR_COPY(&type_zv, type);
-	ZEPHIR_CALL_METHOD(&collection, this_ptr, "checkandcreatecollection", NULL, 353, &type_zv);
+	ZEPHIR_CALL_METHOD(&collection, this_ptr, "checkandcreatecollection", NULL, 355, &type_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &collection, "addinline", NULL, 0, code);
 	zephir_check_call_status();
@@ -381,7 +381,7 @@ PHP_METHOD(Phalcon_Assets_Manager, addInlineCss)
 	} else {
 		ZVAL_BOOL(&_1, 0);
 	}
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 355, &content_zv, &_1, &attributes);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 357, &content_zv, &_1, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "css");
@@ -445,7 +445,7 @@ PHP_METHOD(Phalcon_Assets_Manager, addInlineJs)
 	} else {
 		ZVAL_BOOL(&_1, 0);
 	}
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 356, &content_zv, &_1, &attributes);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 358, &content_zv, &_1, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "js");
@@ -554,7 +554,7 @@ PHP_METHOD(Phalcon_Assets_Manager, addJs)
 	} else {
 		ZVAL_BOOL(&_3, 0);
 	}
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 357, &path_zv, &_1, &_2, &attributes, &version_zv, &_3);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 359, &path_zv, &_1, &_2, &attributes, &version_zv, &_3);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, "js");
@@ -584,7 +584,7 @@ PHP_METHOD(Phalcon_Assets_Manager, collection)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "checkandcreatecollection", NULL, 353, &name_zv);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "checkandcreatecollection", NULL, 355, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -743,17 +743,17 @@ PHP_METHOD(Phalcon_Assets_Manager, get)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 407, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 406, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(1 != zephir_array_isset_value(&_0, &name_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_assets_exceptions_collectionnotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 358, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 360, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Assets/Manager.zep", 299);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 407, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 406, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Assets/Manager.zep", 302);
 	RETURN_CTOR(&_3);
 }
@@ -787,7 +787,7 @@ PHP_METHOD(Phalcon_Assets_Manager, getCss)
 
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "css");
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "checkandcreatecollection", NULL, 353, &_0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "checkandcreatecollection", NULL, 355, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -810,7 +810,7 @@ PHP_METHOD(Phalcon_Assets_Manager, getJs)
 
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "js");
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "checkandcreatecollection", NULL, 353, &_0);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "checkandcreatecollection", NULL, 355, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -853,7 +853,7 @@ PHP_METHOD(Phalcon_Assets_Manager, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 407, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 406, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &name_zv));
 }
 
@@ -985,7 +985,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 	ZVAL_STRING(&output, "");
 	ZEPHIR_INIT_VAR(&outputParts);
 	array_init(&outputParts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 406, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 405, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "css");
@@ -1039,18 +1039,18 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 			if (1 == ZEPHIR_IS_EMPTY(&completeTargetPath)) {
 				ZEPHIR_INIT_VAR(&_3$$9);
 				object_init_ex(&_3$$9, phalcon_assets_exceptions_invalidtargetpath_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_3$$9, "__construct", NULL, 359, &completeTargetPath);
+				ZEPHIR_CALL_METHOD(NULL, &_3$$9, "__construct", NULL, 361, &completeTargetPath);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_3$$9, "phalcon/Assets/Manager.zep", 467);
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			ZEPHIR_CALL_FUNCTION(&_4$$8, "is_dir", NULL, 294, &completeTargetPath);
+			ZEPHIR_CALL_FUNCTION(&_4$$8, "is_dir", NULL, 295, &completeTargetPath);
 			zephir_check_call_status();
 			if (ZEPHIR_IS_TRUE_IDENTICAL(&_4$$8)) {
 				ZEPHIR_INIT_VAR(&_5$$10);
 				object_init_ex(&_5$$10, phalcon_assets_exceptions_targetpathisdirectory_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_5$$10, "__construct", NULL, 360, &completeTargetPath);
+				ZEPHIR_CALL_METHOD(NULL, &_5$$10, "__construct", NULL, 362, &completeTargetPath);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_5$$10, "phalcon/Assets/Manager.zep", 471);
 				ZEPHIR_MM_RESTORE();
@@ -1079,7 +1079,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&_8$$14);
 						object_init_ex(&_8$$14, phalcon_assets_exceptions_invalidassetsourcepath_ce);
-						ZEPHIR_CALL_METHOD(NULL, &_8$$14, "__construct", &_9, 361, &sourcePath);
+						ZEPHIR_CALL_METHOD(NULL, &_8$$14, "__construct", &_9, 363, &sourcePath);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_8$$14, "phalcon/Assets/Manager.zep", 499);
 						ZEPHIR_MM_RESTORE();
@@ -1093,7 +1093,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 					object_init_ex(&_10$$15, phalcon_assets_exceptions_invalidassettargetpath_ce);
 					ZEPHIR_CALL_METHOD(&_11$$15, &asset, "getpath", NULL, 0);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(NULL, &_10$$15, "__construct", &_12, 362, &_11$$15);
+					ZEPHIR_CALL_METHOD(NULL, &_10$$15, "__construct", &_12, 364, &_11$$15);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_10$$15, "phalcon/Assets/Manager.zep", 513);
 					ZEPHIR_MM_RESTORE();
@@ -1105,7 +1105,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 					if (ZEPHIR_IS_IDENTICAL(&targetPath, &sourcePath)) {
 						ZEPHIR_INIT_NVAR(&_14$$17);
 						object_init_ex(&_14$$17, phalcon_assets_exceptions_assetsourcetargetcollision_ce);
-						ZEPHIR_CALL_METHOD(NULL, &_14$$17, "__construct", &_15, 363, &targetPath);
+						ZEPHIR_CALL_METHOD(NULL, &_14$$17, "__construct", &_15, 365, &targetPath);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_14$$17, "phalcon/Assets/Manager.zep", 521);
 						ZEPHIR_MM_RESTORE();
@@ -1130,15 +1130,15 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&_21$$21, &asset, "getrealsourcepath", NULL, 0);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 364, collection, &_20$$21, &_21$$21);
+				ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 366, collection, &_20$$21, &_21$$21);
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&_23$$21, &asset, "getattributes", NULL, 0);
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&_24$$21, &asset, "islocal", NULL, 0);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 365, &callback, &_23$$21, &prefixedPath, &_24$$21);
+				ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 367, &callback, &_23$$21, &prefixedPath, &_24$$21);
 				zephir_check_call_status();
-				zephir_read_property_cached(&_26$$21, this_ptr, _zephir_prop_1, 408, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_26$$21, this_ptr, _zephir_prop_1, 407, PH_NOISY_CC | PH_READONLY);
 				if (ZEPHIR_IS_TRUE_IDENTICAL(&_26$$21)) {
 					zend_print_zval(&html, 0);
 				} else {
@@ -1151,7 +1151,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&mustFilter, &asset, "getfilter", NULL, 0);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&filteredContent, this_ptr, "applyfilters", &_27, 366, &content, &filters, &mustFilter);
+				ZEPHIR_CALL_METHOD(&filteredContent, this_ptr, "applyfilters", &_27, 368, &content, &filters, &mustFilter);
 				zephir_check_call_status();
 				if (zephir_is_true(&join)) {
 					zephir_concat_self(&filteredJoinedContent, &filteredContent);
@@ -1175,14 +1175,14 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&_32$$28, &asset, "getrealsourcepath", NULL, 0);
 				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 364, collection, &_31$$28, &_32$$28);
+				ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 366, collection, &_31$$28, &_32$$28);
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&_33$$28, collection, "getattributes", &_34, 0);
 				zephir_check_call_status();
 				ZVAL_BOOL(&_35$$28, 1);
-				ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 365, &callback, &_33$$28, &prefixedPath, &_35$$28);
+				ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 367, &callback, &_33$$28, &prefixedPath, &_35$$28);
 				zephir_check_call_status();
-				zephir_read_property_cached(&_35$$28, this_ptr, _zephir_prop_1, 408, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_35$$28, this_ptr, _zephir_prop_1, 407, PH_NOISY_CC | PH_READONLY);
 				if (ZEPHIR_IS_TRUE_IDENTICAL(&_35$$28)) {
 					zend_print_zval(&html, 0);
 				} else {
@@ -1223,7 +1223,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 							zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_39$$34);
 							object_init_ex(&_39$$34, phalcon_assets_exceptions_invalidassetsourcepath_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_39$$34, "__construct", &_9, 361, &sourcePath);
+							ZEPHIR_CALL_METHOD(NULL, &_39$$34, "__construct", &_9, 363, &sourcePath);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_39$$34, "phalcon/Assets/Manager.zep", 499);
 							ZEPHIR_MM_RESTORE();
@@ -1237,7 +1237,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 						object_init_ex(&_40$$35, phalcon_assets_exceptions_invalidassettargetpath_ce);
 						ZEPHIR_CALL_METHOD(&_41$$35, &asset, "getpath", NULL, 0);
 						zephir_check_call_status();
-						ZEPHIR_CALL_METHOD(NULL, &_40$$35, "__construct", &_12, 362, &_41$$35);
+						ZEPHIR_CALL_METHOD(NULL, &_40$$35, "__construct", &_12, 364, &_41$$35);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_40$$35, "phalcon/Assets/Manager.zep", 513);
 						ZEPHIR_MM_RESTORE();
@@ -1249,7 +1249,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 						if (ZEPHIR_IS_IDENTICAL(&targetPath, &sourcePath)) {
 							ZEPHIR_INIT_NVAR(&_43$$37);
 							object_init_ex(&_43$$37, phalcon_assets_exceptions_assetsourcetargetcollision_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_43$$37, "__construct", &_15, 363, &targetPath);
+							ZEPHIR_CALL_METHOD(NULL, &_43$$37, "__construct", &_15, 365, &targetPath);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_43$$37, "phalcon/Assets/Manager.zep", 521);
 							ZEPHIR_MM_RESTORE();
@@ -1274,15 +1274,15 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_48$$41, &asset, "getrealsourcepath", NULL, 0);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 364, collection, &_47$$41, &_48$$41);
+					ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 366, collection, &_47$$41, &_48$$41);
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_49$$41, &asset, "getattributes", NULL, 0);
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_50$$41, &asset, "islocal", NULL, 0);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 365, &callback, &_49$$41, &prefixedPath, &_50$$41);
+					ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 367, &callback, &_49$$41, &prefixedPath, &_50$$41);
 					zephir_check_call_status();
-					zephir_read_property_cached(&_51$$41, this_ptr, _zephir_prop_1, 408, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_51$$41, this_ptr, _zephir_prop_1, 407, PH_NOISY_CC | PH_READONLY);
 					if (ZEPHIR_IS_TRUE_IDENTICAL(&_51$$41)) {
 						zend_print_zval(&html, 0);
 					} else {
@@ -1295,7 +1295,7 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&mustFilter, &asset, "getfilter", NULL, 0);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&filteredContent, this_ptr, "applyfilters", &_27, 366, &content, &filters, &mustFilter);
+					ZEPHIR_CALL_METHOD(&filteredContent, this_ptr, "applyfilters", &_27, 368, &content, &filters, &mustFilter);
 					zephir_check_call_status();
 					if (zephir_is_true(&join)) {
 						zephir_concat_self(&filteredJoinedContent, &filteredContent);
@@ -1319,14 +1319,14 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_55$$48, &asset, "getrealsourcepath", NULL, 0);
 					zephir_check_call_status();
-					ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 364, collection, &_54$$48, &_55$$48);
+					ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 366, collection, &_54$$48, &_55$$48);
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_56$$48, collection, "getattributes", &_34, 0);
 					zephir_check_call_status();
 					ZVAL_BOOL(&_57$$48, 1);
-					ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 365, &callback, &_56$$48, &prefixedPath, &_57$$48);
+					ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 367, &callback, &_56$$48, &prefixedPath, &_57$$48);
 					zephir_check_call_status();
-					zephir_read_property_cached(&_57$$48, this_ptr, _zephir_prop_1, 408, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_57$$48, this_ptr, _zephir_prop_1, 407, PH_NOISY_CC | PH_READONLY);
 					if (ZEPHIR_IS_TRUE_IDENTICAL(&_57$$48)) {
 						zend_print_zval(&html, 0);
 					} else {
@@ -1345,15 +1345,15 @@ PHP_METHOD(Phalcon_Assets_Manager, output)
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&_59$$51, collection, "gettargeturi", NULL, 0);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 364, collection, &_59$$51, &completeTargetPath);
+		ZEPHIR_CALL_METHOD(&prefixedPath, this_ptr, "calculateprefixedpath", &_22, 366, collection, &_59$$51, &completeTargetPath);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&_60$$51, collection, "getattributes", &_34, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&_61$$51, collection, "gettargetislocal", NULL, 0);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 365, &callback, &_60$$51, &prefixedPath, &_61$$51);
+		ZEPHIR_CALL_METHOD(&html, this_ptr, "docallback", &_25, 367, &callback, &_60$$51, &prefixedPath, &_61$$51);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_62$$51, this_ptr, _zephir_prop_1, 408, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_62$$51, this_ptr, _zephir_prop_1, 407, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_IS_TRUE_IDENTICAL(&_62$$51)) {
 			zend_print_zval(&html, 0);
 		} else {
@@ -1501,13 +1501,13 @@ PHP_METHOD(Phalcon_Assets_Manager, outputInline)
 				ZEPHIR_CALL_METHOD(&content, &code, "getcontent", NULL, 0);
 				zephir_check_call_status();
 				ZVAL_BOOL(&_2$$4, 1);
-				ZEPHIR_CALL_METHOD(&_1$$4, this_ptr, "applyfilters", &_3, 366, &content, &filters, &_2$$4);
+				ZEPHIR_CALL_METHOD(&_1$$4, this_ptr, "applyfilters", &_3, 368, &content, &filters, &_2$$4);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&content, &_1$$4);
 				if (ZEPHIR_IS_TRUE_IDENTICAL(&join)) {
 					zephir_concat_self(&joinedContent, &content);
 				} else {
-					zephir_read_property_cached(&_4$$6, this_ptr, _zephir_prop_0, 405, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_4$$6, this_ptr, _zephir_prop_0, 404, PH_NOISY_CC | PH_READONLY);
 					ZVAL_BOOL(&_6$$6, 1);
 					ZEPHIR_CALL_METHOD(&_5$$6, &_4$$6, "element", NULL, 0, type, &content, &attributes, &_6$$6);
 					zephir_check_call_status();
@@ -1541,13 +1541,13 @@ PHP_METHOD(Phalcon_Assets_Manager, outputInline)
 					ZEPHIR_CALL_METHOD(&content, &code, "getcontent", NULL, 0);
 					zephir_check_call_status();
 					ZVAL_BOOL(&_12$$7, 1);
-					ZEPHIR_CALL_METHOD(&_11$$7, this_ptr, "applyfilters", &_3, 366, &content, &filters, &_12$$7);
+					ZEPHIR_CALL_METHOD(&_11$$7, this_ptr, "applyfilters", &_3, 368, &content, &filters, &_12$$7);
 					zephir_check_call_status();
 					ZEPHIR_CPY_WRT(&content, &_11$$7);
 					if (ZEPHIR_IS_TRUE_IDENTICAL(&join)) {
 						zephir_concat_self(&joinedContent, &content);
 					} else {
-						zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_0, 405, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_0, 404, PH_NOISY_CC | PH_READONLY);
 						ZVAL_BOOL(&_15$$9, 1);
 						ZEPHIR_CALL_METHOD(&_14$$9, &_13$$9, "element", NULL, 0, type, &content, &attributes, &_15$$9);
 						zephir_check_call_status();
@@ -1561,7 +1561,7 @@ PHP_METHOD(Phalcon_Assets_Manager, outputInline)
 		}
 		ZEPHIR_INIT_NVAR(&code);
 		if (ZEPHIR_IS_TRUE_IDENTICAL(&join)) {
-			zephir_read_property_cached(&_18$$10, this_ptr, _zephir_prop_0, 405, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_18$$10, this_ptr, _zephir_prop_0, 404, PH_NOISY_CC | PH_READONLY);
 			ZVAL_BOOL(&_20$$10, 1);
 			ZEPHIR_CALL_METHOD(&_19$$10, &_18$$10, "element", NULL, 0, type, &joinedContent, &attributes, &_20$$10);
 			zephir_check_call_status();
@@ -1571,7 +1571,7 @@ PHP_METHOD(Phalcon_Assets_Manager, outputInline)
 			ZEPHIR_CONCAT_VV(&_22$$10, &_19$$10, &_21$$10);
 			zephir_concat_self(&html, &_22$$10);
 		}
-		zephir_read_property_cached(&_23$$3, this_ptr, _zephir_prop_1, 408, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_23$$3, this_ptr, _zephir_prop_1, 407, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_IS_TRUE_IDENTICAL(&_23$$3)) {
 			zend_print_zval(&html, 0);
 		} else {
@@ -1767,7 +1767,7 @@ PHP_METHOD(Phalcon_Assets_Manager, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 406, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 405, &options);
 	RETURN_THIS();
 }
 
@@ -1794,9 +1794,9 @@ PHP_METHOD(Phalcon_Assets_Manager, useImplicitOutput)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &implicitOutput_param);
 	if (implicitOutput) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 408, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 407, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 408, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 407, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1862,7 +1862,7 @@ PHP_METHOD(Phalcon_Assets_Manager, applyFilters)
 			if (UNEXPECTED(_1$$4)) {
 				ZEPHIR_INIT_NVAR(&_2$$5);
 				object_init_ex(&_2$$5, phalcon_assets_exceptions_invalidfilter_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_2$$5, "__construct", &_3, 367);
+				ZEPHIR_CALL_METHOD(NULL, &_2$$5, "__construct", &_3, 369);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_2$$5, "phalcon/Assets/Manager.zep", 880);
 				ZEPHIR_MM_RESTORE();
@@ -1897,7 +1897,7 @@ PHP_METHOD(Phalcon_Assets_Manager, applyFilters)
 				if (UNEXPECTED(_7$$6)) {
 					ZEPHIR_INIT_NVAR(&_8$$7);
 					object_init_ex(&_8$$7, phalcon_assets_exceptions_invalidfilter_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_8$$7, "__construct", &_3, 367);
+					ZEPHIR_CALL_METHOD(NULL, &_8$$7, "__construct", &_3, 369);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_8$$7, "phalcon/Assets/Manager.zep", 880);
 					ZEPHIR_MM_RESTORE();
@@ -2014,7 +2014,7 @@ PHP_METHOD(Phalcon_Assets_Manager, checkAndCreateCollection)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&type_zv);
 	ZVAL_STR_COPY(&type_zv, type);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 407, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 406, PH_NOISY_CC | PH_READONLY);
 	if (1 != zephir_array_isset_value(&_0, &type_zv)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_assets_collection_ce);
@@ -2025,7 +2025,7 @@ PHP_METHOD(Phalcon_Assets_Manager, checkAndCreateCollection)
 
 		zephir_update_property_array(this_ptr, SL("collections"), &type_zv, &_1$$3);
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 407, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 406, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, &type_zv, PH_NOISY | PH_READONLY, "phalcon/Assets/Manager.zep", 936);
 	RETURN_CTOR(&_3);
 }
@@ -2080,7 +2080,7 @@ PHP_METHOD(Phalcon_Assets_Manager, cssLink)
 	ZVAL_STRING(&_2, "text/css");
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "href");
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processparameters", NULL, 368, parameters, &_0, &_1, &_2, &_3);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processparameters", NULL, 370, parameters, &_0, &_1, &_2, &_3);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -2189,7 +2189,7 @@ PHP_METHOD(Phalcon_Assets_Manager, jsLink)
 	ZVAL_STRING(&_2, "application/javascript");
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "src");
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processparameters", NULL, 368, parameters, &_0, &_1, &_2, &_3);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "processparameters", NULL, 370, parameters, &_0, &_1, &_2, &_3);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -2310,10 +2310,10 @@ PHP_METHOD(Phalcon_Assets_Manager, processParameters)
 	zephir_array_fetch(&tag, &params, &name_zv, PH_NOISY, "phalcon/Assets/Manager.zep", 1057);
 	zephir_array_unset(&params, &name_zv, PH_SEPARATE);
 	if (local) {
-		zephir_read_property_cached(&_8$$11, this_ptr, _zephir_prop_0, 409, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$11, this_ptr, _zephir_prop_0, 408, PH_NOISY_CC | PH_READONLY);
 		_9$$11 = Z_TYPE_P(&_8$$11) != IS_NULL;
 		if (_9$$11) {
-			zephir_read_property_cached(&_10$$11, this_ptr, _zephir_prop_0, 409, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$11, this_ptr, _zephir_prop_0, 408, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_12$$11);
 			ZVAL_STRING(&_12$$11, "url");
 			ZEPHIR_CALL_METHOD(&_11$$11, &_10$$11, "has", NULL, 0, &_12$$11);
@@ -2321,7 +2321,7 @@ PHP_METHOD(Phalcon_Assets_Manager, processParameters)
 			_9$$11 = zephir_is_true(&_11$$11);
 		}
 		if (_9$$11) {
-			zephir_read_property_cached(&_13$$12, this_ptr, _zephir_prop_0, 409, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_13$$12, this_ptr, _zephir_prop_0, 408, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_15$$12);
 			ZVAL_STRING(&_15$$12, "url");
 			ZEPHIR_CALL_METHOD(&_14$$12, &_13$$12, "get", NULL, 0, &_15$$12);
@@ -2339,7 +2339,7 @@ PHP_METHOD(Phalcon_Assets_Manager, processParameters)
 			ZEPHIR_CPY_WRT(&tag, &_19$$13);
 		}
 	}
-	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_1, 405, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_1, 404, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&helper, &_20, "newinstance", NULL, 0, &helperClass_zv);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_21);

--- a/ext/phalcon/assets/traits/attributestrait.zep.c
+++ b/ext/phalcon/assets/traits/attributestrait.zep.c
@@ -65,7 +65,7 @@ PHP_METHOD(Phalcon_Assets_Traits_AttributesTrait, getAttributes)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 410, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 409, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }

--- a/ext/phalcon/assets/traits/sourcetargettrait.zep.c
+++ b/ext/phalcon/assets/traits/sourcetargettrait.zep.c
@@ -115,9 +115,9 @@ PHP_METHOD(Phalcon_Assets_Traits_SourceTargetTrait, setIsLocal)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 411, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 410, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 411, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 410, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -145,7 +145,7 @@ PHP_METHOD(Phalcon_Assets_Traits_SourceTargetTrait, setSourcePath)
 		Z_PARAM_STR(sourcePath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&sourcePath_zv, sourcePath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 412, &sourcePath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 411, &sourcePath_zv);
 	RETURN_THISW();
 }
 
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Assets_Traits_SourceTargetTrait, setTargetPath)
 		Z_PARAM_STR(targetPath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&targetPath_zv, targetPath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 413, &targetPath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 412, &targetPath_zv);
 	RETURN_THISW();
 }
 
@@ -199,7 +199,7 @@ PHP_METHOD(Phalcon_Assets_Traits_SourceTargetTrait, setTargetUri)
 		Z_PARAM_STR(targetUri)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&targetUri_zv, targetUri);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 414, &targetUri_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 413, &targetUri_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/auth/access/accesslocator.zep.c
+++ b/ext/phalcon/auth/access/accesslocator.zep.c
@@ -81,7 +81,7 @@ PHP_METHOD(Phalcon_Auth_Access_AccessLocator, newInstance)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 415, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 414, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "getservice", NULL, 0, &name_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_CE_STATIC(&_0, phalcon_auth_internal_containerresolver_ce, "resolvefresh", NULL, 0, &_1, &_2);

--- a/ext/phalcon/auth/access/acl.zep.c
+++ b/ext/phalcon/auth/access/acl.zep.c
@@ -108,16 +108,16 @@ PHP_METHOD(Phalcon_Auth_Access_Acl, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 416, acl);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 415, acl);
 	zephir_memory_observe(&value);
 	if (zephir_array_isset_string_fetch(&value, &options, SL("guestRole"), 0)) {
 		zephir_cast_to_string(&_0$$3, &value);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 417, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 416, &_0$$3);
 	}
 	ZEPHIR_OBS_NVAR(&value);
 	if (zephir_array_isset_string_fetch(&value, &options, SL("moduleSeparator"), 0)) {
 		zephir_cast_to_string(&_1$$4, &value);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 418, &_1$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 417, &_1$$4);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -191,17 +191,17 @@ PHP_METHOD(Phalcon_Auth_Access_Acl, isAllowed)
 	} else {
 		zephir_get_arrval(&context, context_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 419, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 418, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&_1, "in_array", NULL, 87, &actionName_zv, &_0, &__$true);
 	zephir_check_call_status();
 	if (zephir_is_true(&_1)) {
 		RETURN_MM_BOOL(1);
 	}
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 420, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 419, PH_NOISY_CC);
 	_3 = !(ZEPHIR_IS_EMPTY(&_2));
 	if (_3) {
-		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 420, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 419, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_5, "in_array", NULL, 87, &actionName_zv, &_4, &__$true);
 		zephir_check_call_status();
 		_3 = !zephir_is_true(&_5);
@@ -218,7 +218,7 @@ PHP_METHOD(Phalcon_Auth_Access_Acl, isAllowed)
 	if (_6) {
 		ZEPHIR_INIT_VAR(&_7$$5);
 		object_init_ex(&_7$$5, phalcon_auth_exceptions_missinghandlercontext_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_7$$5, "__construct", NULL, 369);
+		ZEPHIR_CALL_METHOD(NULL, &_7$$5, "__construct", NULL, 371);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_7$$5, "phalcon/Auth/Access/Acl.zep", 93);
 		ZEPHIR_MM_RESTORE();
@@ -232,7 +232,7 @@ PHP_METHOD(Phalcon_Auth_Access_Acl, isAllowed)
 		_8 = !ZEPHIR_IS_STRING_IDENTICAL(&module, "");
 	}
 	if (_8) {
-		zephir_read_property_cached(&_9$$6, this_ptr, _zephir_prop_2, 418, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_9$$6, this_ptr, _zephir_prop_2, 417, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&component);
 		ZEPHIR_CONCAT_VVV(&component, &module, &_9$$6, &handler);
 	}
@@ -244,7 +244,7 @@ PHP_METHOD(Phalcon_Auth_Access_Acl, isAllowed)
 		ZEPHIR_INIT_NVAR(&params);
 		ZVAL_NULL(&params);
 	}
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_3, 416, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_3, 415, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_11, this_ptr, "resolverole", NULL, 0, guard);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_10, "isallowed", NULL, 0, &_11, &component, &actionName_zv, &params);
@@ -304,7 +304,7 @@ PHP_METHOD(Phalcon_Auth_Access_Acl, resolveRole)
 	ZVAL_STRING(&_1, "Authenticated user");
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "Phalcon\\Acl\\RoleAwareInterface");
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 370, &_1, &_2);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 372, &_1, &_2);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(&_0, "phalcon/Auth/Access/Acl.zep", 147);
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/adapter/config/memoryadapterconfig.zep.c
+++ b/ext/phalcon/auth/adapter/config/memoryadapterconfig.zep.c
@@ -87,7 +87,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Config_MemoryAdapterConfig, __construct)
 		zephir_memory_observe(&model_zv);
 	ZVAL_STR_COPY(&model_zv, model);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 421, &users);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 420, &users);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_auth_adapter_config_memoryadapterconfig_ce, getThis(), "__construct", NULL, 0, &model_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/adapter/config/modeladapterconfig.zep.c
+++ b/ext/phalcon/auth/adapter/config/modeladapterconfig.zep.c
@@ -92,7 +92,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Config_ModelAdapterConfig, __construct)
 		ZVAL_STRING(&_2$$3, "model");
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZVAL_STRING(&_3$$3, " class name");
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 371, &_1$$3, &_2$$3, &_3$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 373, &_1$$3, &_2$$3, &_3$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Auth/Adapter/Config/ModelAdapterConfig.zep", 36);
 		ZEPHIR_MM_RESTORE();
@@ -105,13 +105,13 @@ PHP_METHOD(Phalcon_Auth_Adapter_Config_ModelAdapterConfig, __construct)
 		ZVAL_STRING(&_5$$4, "Model adapter");
 		ZEPHIR_INIT_VAR(&_6$$4);
 		ZVAL_STRING(&_6$$4, "idColumn");
-		ZEPHIR_CALL_METHOD(NULL, &_4$$4, "__construct", NULL, 371, &_5$$4, &_6$$4);
+		ZEPHIR_CALL_METHOD(NULL, &_4$$4, "__construct", NULL, 373, &_5$$4, &_6$$4);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_4$$4, "phalcon/Auth/Adapter/Config/ModelAdapterConfig.zep", 43);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 422, &idColumn_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 421, &idColumn_zv);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_auth_adapter_config_modeladapterconfig_ce, getThis(), "__construct", NULL, 0, &model_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/adapter/config/streamadapterconfig.zep.c
+++ b/ext/phalcon/auth/adapter/config/streamadapterconfig.zep.c
@@ -88,13 +88,13 @@ PHP_METHOD(Phalcon_Auth_Adapter_Config_StreamAdapterConfig, __construct)
 		ZVAL_STRING(&_2$$3, "file");
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZVAL_STRING(&_3$$3, " path");
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 371, &_1$$3, &_2$$3, &_3$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 373, &_1$$3, &_2$$3, &_3$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Auth/Adapter/Config/StreamAdapterConfig.zep", 36);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 423, &file_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 422, &file_zv);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_auth_adapter_config_streamadapterconfig_ce, getThis(), "__construct", NULL, 0, &model_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/adapter/memory.zep.c
+++ b/ext/phalcon/auth/adapter/memory.zep.c
@@ -156,9 +156,9 @@ PHP_METHOD(Phalcon_Auth_Adapter_Memory, fromOptions)
 	ZVAL_STRING(&_3, "model");
 	ZEPHIR_CALL_CE_STATIC(&_4, phalcon_auth_internal_options_ce, "stringornull", NULL, 0, &options, &_3);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 372, &_1, &_4);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 374, &_1, &_4);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 373, hasher, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 375, hasher, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -197,11 +197,11 @@ PHP_METHOD(Phalcon_Auth_Adapter_Memory, retrieveById)
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(zend_ce_type_error, "The parameter must be 'int' or 'string'", "phalcon/Auth/Adapter/Memory.zep", 68);
 		return;
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 424, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 423, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_1, id))) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 424, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 423, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, id, PH_NOISY | PH_READONLY, "phalcon/Auth/Adapter/Memory.zep", 75);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "hydrate", NULL, 0, &_3);
 	zephir_check_call_status();
@@ -226,7 +226,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Memory, loadUsers)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 425, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 424, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getusers", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/auth/adapter/model.zep.c
+++ b/ext/phalcon/auth/adapter/model.zep.c
@@ -111,9 +111,9 @@ PHP_METHOD(Phalcon_Auth_Adapter_Model, fromOptions)
 		ZEPHIR_INIT_NVAR(&_4);
 		ZVAL_STRING(&_4, "id");
 	}
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 374, &_1, &_4);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 376, &_1, &_4);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 375, hasher, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 377, hasher, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -151,9 +151,9 @@ PHP_METHOD(Phalcon_Auth_Adapter_Model, createRememberToken)
 	ZEPHIR_CALL_CE_STATIC(NULL, phalcon_auth_exceptions_doesnotimplement_ce, "assert", NULL, 0, user, &_0, &_1, &_2);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 30);
-	ZEPHIR_CALL_FUNCTION(&_4, "random_bytes", NULL, 315, &_3);
+	ZEPHIR_CALL_FUNCTION(&_4, "random_bytes", NULL, 317, &_3);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_5, "bin2hex", NULL, 316, &_4);
+	ZEPHIR_CALL_FUNCTION(&_5, "bin2hex", NULL, 318, &_4);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(user, "createremembertoken", NULL, 0, &_5);
 	zephir_check_call_status();
@@ -258,7 +258,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Model, retrieveByCredentials)
 	zephir_fast_join_str(&_8, SL(" AND "), &conditions);
 	zephir_array_update_string(&_7, SL("conditions"), &_8, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_7, SL("bind"), &bind, PH_COPY | PH_SEPARATE);
-	ZEPHIR_CALL_METHOD(&found, this_ptr, "findfirstasauthuser", NULL, 376, &_7);
+	ZEPHIR_CALL_METHOD(&found, this_ptr, "findfirstasauthuser", NULL, 378, &_7);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&found) == IS_NULL) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "burnhash", NULL, 0);
@@ -303,7 +303,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Model, retrieveById)
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_create_array(&_1, 2, 0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 426, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 425, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, &_2, "getidcolumn", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_4);
@@ -313,7 +313,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Model, retrieveById)
 	zephir_create_array(&_5, 1, 0);
 	zephir_array_update_string(&_5, SL("id"), id, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_1, SL("bind"), &_5, PH_COPY | PH_SEPARATE);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "findfirstasauthuser", NULL, 376, &_1);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "findfirstasauthuser", NULL, 378, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -416,7 +416,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Model, findFirstAsAuthUser)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &parameters_param);
 	zephir_get_arrval(&parameters, parameters_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 426, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 425, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&modelClass, &_0, "getmodel", NULL, 0);
 	zephir_check_call_status();
 	_1 = zephir_fetch_class(&modelClass);

--- a/ext/phalcon/auth/adapter/stream.zep.c
+++ b/ext/phalcon/auth/adapter/stream.zep.c
@@ -104,9 +104,9 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, fromOptions)
 	ZVAL_STRING(&_2, "model");
 	ZEPHIR_CALL_CE_STATIC(&_4, phalcon_auth_internal_options_ce, "stringornull", NULL, 0, &options, &_2);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 377, &_1, &_4);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 379, &_1, &_4);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 378, hasher, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 380, hasher, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -147,7 +147,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, loadUsers)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 427, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 426, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&path, &_0, "getfile", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "phpfileexists", NULL, 0, &path);
@@ -155,7 +155,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, loadUsers)
 	if (!zephir_is_true(&_1)) {
 		ZEPHIR_INIT_VAR(&_2$$3);
 		object_init_ex(&_2$$3, phalcon_auth_exceptions_filedoesnotexist_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 379, &path);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 381, &path);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$3, "phalcon/Auth/Adapter/Stream.zep", 73);
 		ZEPHIR_MM_RESTORE();
@@ -166,7 +166,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, loadUsers)
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&contents)) {
 		ZEPHIR_INIT_VAR(&_3$$4);
 		object_init_ex(&_3$$4, phalcon_auth_exceptions_filecannotread_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", NULL, 380, &path);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", NULL, 382, &path);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$4, "phalcon/Auth/Adapter/Stream.zep", 79);
 		ZEPHIR_MM_RESTORE();
@@ -183,7 +183,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, loadUsers)
 		}
 
 		ZVAL_BOOL(&_5$$5, 1);
-		ZEPHIR_CALL_METHOD(&data, &_4$$5, "__invoke", NULL, 381, &contents, &_5$$5);
+		ZEPHIR_CALL_METHOD(&data, &_4$$5, "__invoke", NULL, 383, &contents, &_5$$5);
 		zephir_check_call_status_or_jump(try_end_1);
 
 	try_end_1:
@@ -197,7 +197,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, loadUsers)
 			ZEPHIR_CPY_WRT(&ex, &_6);
 			ZEPHIR_INIT_VAR(&_7$$6);
 			object_init_ex(&_7$$6, phalcon_auth_exceptions_filenotvalidjson_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_7$$6, "__construct", NULL, 382, &path, &ex);
+			ZEPHIR_CALL_METHOD(NULL, &_7$$6, "__construct", NULL, 384, &path, &ex);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_7$$6, "phalcon/Auth/Adapter/Stream.zep", 85);
 			ZEPHIR_MM_RESTORE();
@@ -207,7 +207,7 @@ PHP_METHOD(Phalcon_Auth_Adapter_Stream, loadUsers)
 	if (Z_TYPE_P(&data) != IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_8$$7);
 		object_init_ex(&_8$$7, phalcon_auth_exceptions_filedoesnotcontainjson_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_8$$7, "__construct", NULL, 383, &path);
+		ZEPHIR_CALL_METHOD(NULL, &_8$$7, "__construct", NULL, 385, &path);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_8$$7, "phalcon/Auth/Adapter/Stream.zep", 89);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/authuser.zep.c
+++ b/ext/phalcon/auth/authuser.zep.c
@@ -93,13 +93,13 @@ PHP_METHOD(Phalcon_Auth_AuthUser, __construct)
 	if (_0) {
 		ZEPHIR_INIT_VAR(&_4$$3);
 		object_init_ex(&_4$$3, phalcon_auth_exceptions_datamustcontainidkey_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_4$$3, "__construct", NULL, 384);
+		ZEPHIR_CALL_METHOD(NULL, &_4$$3, "__construct", NULL, 386);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_4$$3, "phalcon/Auth/AuthUser.zep", 39);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 428, &data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 427, &data);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -118,7 +118,7 @@ PHP_METHOD(Phalcon_Auth_AuthUser, getAuthIdentifier)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 428, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 427, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&id);
 	zephir_array_fetch_string(&id, &_0, SL("id"), PH_NOISY, "phalcon/Auth/AuthUser.zep", 50);
 	RETURN_CCTOR(&id);
@@ -141,7 +141,7 @@ PHP_METHOD(Phalcon_Auth_AuthUser, getAuthPassword)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&password);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 428, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 427, PH_NOISY_CC | PH_READONLY);
 	zephir_array_isset_string_fetch(&password, &_0, SL("password"), 0);
 	ZEPHIR_INIT_VAR(&_1);
 	if (Z_TYPE_P(&password) == IS_STRING) {

--- a/ext/phalcon/auth/exceptions/configrequiresnonemptyvalue.zep.c
+++ b/ext/phalcon/auth/exceptions/configrequiresnonemptyvalue.zep.c
@@ -125,7 +125,7 @@ PHP_METHOD(Phalcon_Auth_Exceptions_ConfigRequiresNonEmptyValue, assert)
 	if (ZEPHIR_IS_STRING_IDENTICAL(value, "")) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_auth_exceptions_configrequiresnonemptyvalue_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 371, &configName_zv, &configKey_zv, &suffix_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 373, &configName_zv, &configKey_zv, &suffix_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Auth/Exceptions/ConfigRequiresNonEmptyValue.zep", 49);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/exceptions/doesnotimplement.zep.c
+++ b/ext/phalcon/auth/exceptions/doesnotimplement.zep.c
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Auth_Exceptions_DoesNotImplement, assert)
 	if (_0) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_auth_exceptions_doesnotimplement_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 370, &type_zv, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 372, &type_zv, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Auth/Exceptions/DoesNotImplement.zep", 40);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/guard/config/sessionguardconfig.zep.c
+++ b/ext/phalcon/auth/guard/config/sessionguardconfig.zep.c
@@ -138,15 +138,15 @@ PHP_METHOD(Phalcon_Auth_Guard_Config_SessionGuardConfig, __construct)
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "suffix");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "validatenonempty", NULL, 385, &_0, &suffix_zv);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "validatenonempty", NULL, 387, &_0, &suffix_zv);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "name");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "validatenonempty", NULL, 385, &_0, &name_zv);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "validatenonempty", NULL, 387, &_0, &name_zv);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "rememberName");
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "validatenonempty", NULL, 385, &_0, &rememberName_zv);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "validatenonempty", NULL, 387, &_0, &rememberName_zv);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_1);
 	if (Z_TYPE_P(&name_zv) != IS_NULL) {
@@ -154,20 +154,20 @@ PHP_METHOD(Phalcon_Auth_Guard_Config_SessionGuardConfig, __construct)
 	} else {
 		ZEPHIR_INIT_NVAR(&_0);
 		ZVAL_STRING(&_0, "auth");
-		ZEPHIR_CALL_METHOD(&_1, this_ptr, "derive", NULL, 386, &_0, &suffix_zv);
+		ZEPHIR_CALL_METHOD(&_1, this_ptr, "derive", NULL, 388, &_0, &suffix_zv);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 429, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 428, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	if (Z_TYPE_P(&rememberName_zv) != IS_NULL) {
 		ZEPHIR_CPY_WRT(&_2, &rememberName_zv);
 	} else {
 		ZEPHIR_INIT_NVAR(&_0);
 		ZVAL_STRING(&_0, "remember");
-		ZEPHIR_CALL_METHOD(&_2, this_ptr, "derive", NULL, 386, &_0, &suffix_zv);
+		ZEPHIR_CALL_METHOD(&_2, this_ptr, "derive", NULL, 388, &_0, &suffix_zv);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 430, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 429, &_2);
 	ZEPHIR_INIT_VAR(&_3);
 	if (Z_TYPE_P(rememberTtl) != IS_NULL) {
 		ZEPHIR_INIT_NVAR(&_3);
@@ -176,13 +176,13 @@ PHP_METHOD(Phalcon_Auth_Guard_Config_SessionGuardConfig, __construct)
 		ZEPHIR_INIT_NVAR(&_3);
 		ZVAL_LONG(&_3, 31536000);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 431, &_3);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 429, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 430, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 430, &_3);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 428, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 429, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_IDENTICAL(&_4, &_5)) {
 		ZEPHIR_INIT_VAR(&_6$$3);
 		object_init_ex(&_6$$3, phalcon_auth_exceptions_sessionnamesmustdiffer_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_6$$3, "__construct", NULL, 387);
+		ZEPHIR_CALL_METHOD(NULL, &_6$$3, "__construct", NULL, 389);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_6$$3, "phalcon/Auth/Guard/Config/SessionGuardConfig.zep", 68);
 		ZEPHIR_MM_RESTORE();
@@ -285,7 +285,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Config_SessionGuardConfig, validateNonEmpty)
 		object_init_ex(&_0$$4, phalcon_auth_exceptions_configrequiresnonemptyvalue_ce);
 		ZEPHIR_INIT_VAR(&_1$$4);
 		ZVAL_STRING(&_1$$4, "Session guard");
-		ZEPHIR_CALL_METHOD(NULL, &_0$$4, "__construct", NULL, 371, &_1$$4, &param_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$4, "__construct", NULL, 373, &_1$$4, &param_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$4, "phalcon/Auth/Guard/Config/SessionGuardConfig.zep", 102);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/guard/config/tokenguardconfig.zep.c
+++ b/ext/phalcon/auth/guard/config/tokenguardconfig.zep.c
@@ -90,7 +90,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Config_TokenGuardConfig, __construct)
 		ZVAL_STRING(&_1$$3, "Token guard");
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "inputKey");
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 371, &_1$$3, &_2$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 373, &_1$$3, &_2$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Auth/Guard/Config/TokenGuardConfig.zep", 38);
 		ZEPHIR_MM_RESTORE();
@@ -103,14 +103,14 @@ PHP_METHOD(Phalcon_Auth_Guard_Config_TokenGuardConfig, __construct)
 		ZVAL_STRING(&_4$$4, "Token guard");
 		ZEPHIR_INIT_VAR(&_5$$4);
 		ZVAL_STRING(&_5$$4, "storageKey");
-		ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", NULL, 371, &_4$$4, &_5$$4);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", NULL, 373, &_4$$4, &_5$$4);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$4, "phalcon/Auth/Guard/Config/TokenGuardConfig.zep", 45);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 432, &inputKey_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 433, &storageKey_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 431, &inputKey_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 432, &storageKey_zv);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/auth/guard/session.zep.c
+++ b/ext/phalcon/auth/guard/session.zep.c
@@ -121,20 +121,20 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, __construct)
 	} else {
 		ZEPHIR_SEPARATE_PARAM(clock);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 434, request);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 435, cookies);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 436, session);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 433, request);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 434, cookies);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 435, session);
 	if (Z_TYPE_P(config) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(config);
 		object_init_ex(config, phalcon_auth_guard_config_sessionguardconfig_ce);
-		ZEPHIR_CALL_METHOD(NULL, config, "__construct", NULL, 388);
+		ZEPHIR_CALL_METHOD(NULL, config, "__construct", NULL, 390);
 		zephir_check_call_status();
 	}
 	if (Z_TYPE_P(clock) == IS_NULL) {
 		ZEPHIR_CALL_CE_STATIC(clock, phalcon_time_clock_systemclock_ce, "fromutc", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 437, clock);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 436, clock);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_auth_guard_session_ce, getThis(), "__construct", NULL, 0, adapter, config);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -193,7 +193,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, fromOptions)
 		ZEPHIR_INIT_NVAR(&_4);
 		ZVAL_NULL(&_4);
 	}
-	ZEPHIR_CALL_METHOD(NULL, &config, "__construct", NULL, 388, &_0, &_2, &_3, &_4);
+	ZEPHIR_CALL_METHOD(NULL, &config, "__construct", NULL, 390, &_0, &_2, &_3, &_4);
 	zephir_check_call_status();
 	object_init_ex(return_value, zend_get_called_scope(execute_data));
 	ZEPHIR_INIT_NVAR(&_1);
@@ -226,7 +226,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, fromOptions)
 	ZVAL_STRING(&_8, "Session guard");
 	ZEPHIR_CALL_CE_STATIC(&_10, phalcon_auth_internal_containerresolver_ce, "resolvecandidate", NULL, 0, container, &options, &_1, &_6, &_7, &_8);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 389, adapter, &_5, &_9, &_10, &config);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 391, adapter, &_5, &_9, &_10, &config);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -277,7 +277,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, attempt)
 	if (!zephir_is_true(&_0)) {
 		RETURN_MM_BOOL(0);
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 438, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 437, PH_NOISY_CC | PH_READONLY);
 	if (remember) {
 		ZVAL_BOOL(&_2, 1);
 	} else {
@@ -354,7 +354,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, getName)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 438, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getname", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -375,7 +375,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, getRememberName)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 438, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getremembername", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -430,7 +430,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, login)
 	ZVAL_BOOL(&_2, 0);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", NULL, 0, &_0, &_1, &_2);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 436, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 435, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "getname", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_4, user, "getauthidentifier", NULL, 0);
@@ -438,7 +438,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, login)
 	ZEPHIR_CALL_METHOD(NULL, &_1, "set", NULL, 0, &_3, &_4);
 	zephir_check_call_status();
 	if (remember) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 440, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 439, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_6$$3);
 		ZVAL_STRING(&_6$$3, "Phalcon\\Contracts\\Auth\\Adapter\\RememberAdapter");
 		ZEPHIR_INIT_VAR(&_7$$3);
@@ -501,7 +501,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, loginById)
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(zend_ce_type_error, "The parameter must be 'int' or 'string'", "phalcon/Auth/Guard/Session.zep", 203);
 		return;
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&resolved, &_1, "retrievebyid", NULL, 0, id);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&resolved) == IS_NULL) {
@@ -574,7 +574,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, logout)
 		_3 = zephir_instance_of_ev(&current, phalcon_contracts_auth_authremember_ce);
 	}
 	if (_3) {
-		ZEPHIR_CALL_METHOD(&token, &recaller, "gettoken", NULL, 390);
+		ZEPHIR_CALL_METHOD(&token, &recaller, "gettoken", NULL, 392);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&tokenRow, &current, "getremembertoken", NULL, 0, &token);
 		zephir_check_call_status();
@@ -582,20 +582,20 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, logout)
 			ZEPHIR_CALL_METHOD(NULL, &tokenRow, "delete", NULL, 0);
 			zephir_check_call_status();
 		}
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 435, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 434, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_6$$3, this_ptr, "getremembername", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&_5$$3, &_4$$3, "has", NULL, 0, &_6$$3);
 		zephir_check_call_status();
 		if (zephir_is_true(&_5$$3)) {
-			zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_0, 435, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_0, 434, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_8$$5, this_ptr, "getremembername", NULL, 0);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(NULL, &_7$$5, "delete", NULL, 0, &_8$$5);
 			zephir_check_call_status();
 		}
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 436, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 435, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_9, this_ptr, "getname", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_2, "remove", NULL, 0, &_9);
@@ -608,7 +608,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, logout)
 	ZVAL_BOOL(&_11, 0);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", NULL, 0, &_1, &_10, &_11);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 441, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 440, &__$null);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -659,7 +659,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, once)
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "validate", NULL, 0, &credentials);
 	zephir_check_call_status();
 	if (zephir_is_true(&_3)) {
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 438, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 437, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setuser", NULL, 0, &_4$$3);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_5$$3);
@@ -731,7 +731,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, onceBasic)
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "once", NULL, 0, &_1);
 	zephir_check_call_status();
 	if (zephir_is_true(&_0)) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 441, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&user, &_2$$4);
 		RETURN_CCTOR(&user);
 	}
@@ -773,11 +773,11 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, user)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 441, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
 		RETURN_MM_MEMBER(getThis(), "user");
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 436, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 435, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "getname", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&id, &_1, "get", NULL, 0, &_2);
@@ -787,14 +787,14 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, user)
 		_3 = Z_TYPE_P(&id) == IS_STRING;
 	}
 	if (_3) {
-		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_2, 440, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_2, 439, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_5$$4, &_4$$4, "retrievebyid", NULL, 0, &id);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 441, &_5$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 440, &_5$$4);
 	}
 	ZEPHIR_CALL_METHOD(&recaller, this_ptr, "recaller", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 441, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
 	_7 = Z_TYPE_P(&_6) == IS_NULL;
 	if (_7) {
 		_7 = Z_TYPE_P(&recaller) != IS_NULL;
@@ -803,8 +803,8 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, user)
 		ZEPHIR_CALL_METHOD(&fromRecaller, this_ptr, "userfromrecaller", NULL, 0, &recaller);
 		zephir_check_call_status();
 		if (Z_TYPE_P(&fromRecaller) != IS_NULL) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 441, &fromRecaller);
-			zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_1, 436, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 440, &fromRecaller);
+			zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_1, 435, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_9$$6, this_ptr, "getname", NULL, 0);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&_10$$6, &fromRecaller, "getauthidentifier", NULL, 0);
@@ -854,10 +854,10 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, validate)
 	} else {
 		zephir_get_arrval(&credentials, credentials_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&resolved, &_0, "retrievebycredentials", NULL, 0, &credentials);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 438, &resolved);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 437, &resolved);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "hasvalidcredentials", NULL, 0, &resolved, &credentials);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -944,7 +944,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, basicCredentials)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&field_zv);
 	ZVAL_STR_COPY(&field_zv, field);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 434, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 433, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&basic, &_0, "getbasicauth", NULL, 0);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&basic) == IS_NULL) {
@@ -981,7 +981,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, createRememberToken)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &user);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&adapter, &_0);
 	ZEPHIR_RETURN_CALL_METHOD(&adapter, "createremembertoken", NULL, 0, user);
 	zephir_check_call_status();
@@ -1009,7 +1009,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, recaller)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 435, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 434, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "getremembername", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, &_0, "has", NULL, 0, &_2);
@@ -1017,7 +1017,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, recaller)
 	if (!zephir_is_true(&_1)) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 435, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 434, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, this_ptr, "getremembername", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_4, &_3, "get", NULL, 0, &_5);
@@ -1029,7 +1029,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, recaller)
 	}
 	if (Z_TYPE_P(&raw) == IS_STRING) {
 		object_init_ex(return_value, phalcon_auth_guard_userremember_ce);
-		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 391, &raw);
+		ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 393, &raw);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -1037,7 +1037,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, recaller)
 		RETURN_MM_NULL();
 	}
 	object_init_ex(return_value, phalcon_auth_guard_userremember_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 391, &raw);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 393, &raw);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -1093,7 +1093,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, rememberUser)
 	zephir_fetch_params(1, 1, 0, &user);
 	ZEPHIR_CALL_METHOD(&token, this_ptr, "createremembertoken", NULL, 0, user);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 434, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 433, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getuseragent", NULL, 0);
 	zephir_check_call_status();
 	zephir_cast_to_string(&_2, &_1);
@@ -1117,15 +1117,15 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, rememberUser)
 	ZVAL_LONG(&_6, 4194304);
 	ZEPHIR_CALL_METHOD(&payload, &_3, "__invoke", NULL, 25, &_4, &_6);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 435, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 434, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, this_ptr, "getremembername", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 437, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 436, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_8, &_7, "now", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_9, &_8, "gettimestamp", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_3, 439, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_3, 438, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_11, &_10, "getrememberttl", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_12);
@@ -1167,26 +1167,26 @@ PHP_METHOD(Phalcon_Auth_Guard_Session, userFromRecaller)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &recaller);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC);
 	if (!(zephir_instance_of_ev(&_0, phalcon_contracts_auth_adapter_rememberadapter_ce))) {
 		RETURN_MM_NULL();
 	}
-	ZEPHIR_CALL_METHOD(&id, recaller, "getid", NULL, 392);
+	ZEPHIR_CALL_METHOD(&id, recaller, "getid", NULL, 394);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&id) == IS_NULL) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 440, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_METHOD(&_2, recaller, "gettoken", NULL, 390);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 439, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(&_2, recaller, "gettoken", NULL, 392);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_3, recaller, "getuseragent", NULL, 393);
+	ZEPHIR_CALL_METHOD(&_3, recaller, "getuseragent", NULL, 395);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&resolved, &_1, "retrievebytoken", NULL, 0, &id, &_2, &_3);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&resolved) != IS_NULL) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 442, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 441, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 442, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 441, &__$false);
 	}
 	RETURN_CCTOR(&resolved);
 }

--- a/ext/phalcon/auth/guard/token.zep.c
+++ b/ext/phalcon/auth/guard/token.zep.c
@@ -70,7 +70,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &adapter, &request, &config);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 443, request);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 442, request);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_auth_guard_token_ce, getThis(), "__construct", NULL, 0, adapter, config);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -127,9 +127,9 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, fromOptions)
 	ZVAL_STRING(&_3, "token guard");
 	ZEPHIR_CALL_CE_STATIC(&_6, phalcon_auth_internal_options_ce, "requirestring", NULL, 0, &options, &_2, &_3);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 394, &_5, &_6);
+	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 396, &_5, &_6);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 395, adapter, &_0, &_1);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 397, adapter, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -168,8 +168,8 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, getTokenForRequest)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 443, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 444, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 442, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 443, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "getinputkey", NULL, 0);
 	zephir_check_call_status();
 	ZVAL_NULL(&_3);
@@ -183,7 +183,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, getTokenForRequest)
 	if (_5) {
 		RETURN_CCTOR(&token);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 443, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 442, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_7);
 	ZVAL_STRING(&_7, "Authorization");
 	ZEPHIR_CALL_METHOD(&_6, &_3, "getheader", NULL, 0, &_7);
@@ -198,7 +198,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, getTokenForRequest)
 		ZVAL_LONG(&_10$$4, 7);
 		ZEPHIR_INIT_VAR(&_11$$4);
 		ZVAL_STRING(&_11$$4, "UTF-8");
-		ZEPHIR_CALL_FUNCTION(&bearer, "mb_substr", NULL, 296, &header, &_10$$4, &__$null, &_11$$4);
+		ZEPHIR_CALL_FUNCTION(&bearer, "mb_substr", NULL, 297, &header, &_10$$4, &__$null, &_11$$4);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_STRING_IDENTICAL(&bearer, "")) {
 			RETURN_CCTOR(&bearer);
@@ -222,7 +222,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, setRequest)
 		Z_PARAM_OBJECT_OF_CLASS(request, phalcon_http_requestinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &request);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 443, request);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 442, request);
 	RETURN_THISW();
 }
 
@@ -256,7 +256,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, user)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 445, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 444, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
 		RETURN_MM_MEMBER(getThis(), "user");
 	}
@@ -265,17 +265,17 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, user)
 	if (Z_TYPE_P(&token) == IS_NULL) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 446, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 445, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 1, 0);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 444, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 443, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_4, &_3, "getstoragekey", NULL, 0);
 	zephir_check_call_status();
 	zephir_array_update_zval(&_2, &_4, &token, PH_COPY);
 	ZEPHIR_CALL_METHOD(&found, &_1, "retrievebycredentials", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&found) != IS_NULL) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 445, &found);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 444, &found);
 	}
 	RETURN_MM_MEMBER(getThis(), "user");
 }
@@ -322,7 +322,7 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, validate)
 	} else {
 		zephir_get_arrval(&credentials, credentials_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 444, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 443, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&inputKey, &_0, "getinputkey", NULL, 0);
 	zephir_check_call_status();
 	if (!(zephir_array_isset_value(&credentials, &inputKey))) {
@@ -330,10 +330,10 @@ PHP_METHOD(Phalcon_Auth_Guard_Token, validate)
 	}
 	zephir_memory_observe(&token);
 	zephir_array_fetch(&token, &credentials, &inputKey, PH_NOISY, "phalcon/Auth/Guard/Token.zep", 134);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 446, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 445, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_3);
 	zephir_create_array(&_3, 1, 0);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 444, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 443, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_4, "getstoragekey", NULL, 0);
 	zephir_check_call_status();
 	zephir_array_update_zval(&_3, &_5, &token, PH_COPY);

--- a/ext/phalcon/auth/guard/userremember.zep.c
+++ b/ext/phalcon/auth/guard/userremember.zep.c
@@ -125,7 +125,7 @@ PHP_METHOD(Phalcon_Auth_Guard_UserRemember, __construct)
 			}
 
 			ZVAL_BOOL(&_2$$4, 1);
-			ZEPHIR_CALL_METHOD(&data, &_1$$4, "__invoke", NULL, 381, payload, &_2$$4);
+			ZEPHIR_CALL_METHOD(&data, &_1$$4, "__invoke", NULL, 383, payload, &_2$$4);
 			zephir_check_call_status_or_jump(try_end_1);
 		} else {
 			ZEPHIR_CPY_WRT(&data, payload);
@@ -167,7 +167,7 @@ PHP_METHOD(Phalcon_Auth_Guard_UserRemember, __construct)
 		ZEPHIR_INIT_NVAR(&_5);
 		ZVAL_NULL(&_5);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 447, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 446, &_5);
 	ZEPHIR_INIT_VAR(&_7);
 	if (zephir_array_isset_value_string(&data, SL("token"))) {
 		zephir_memory_observe(&_8);
@@ -178,7 +178,7 @@ PHP_METHOD(Phalcon_Auth_Guard_UserRemember, __construct)
 		ZEPHIR_INIT_NVAR(&_7);
 		ZVAL_STRING(&_7, "");
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 448, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 447, &_7);
 	ZEPHIR_INIT_VAR(&_10);
 	if (zephir_array_isset_value_string(&data, SL("user_agent"))) {
 		zephir_memory_observe(&_11);
@@ -189,7 +189,7 @@ PHP_METHOD(Phalcon_Auth_Guard_UserRemember, __construct)
 		ZEPHIR_INIT_NVAR(&_10);
 		ZVAL_STRING(&_10, "");
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 449, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 448, &_10);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/auth/internal/containerresolver.zep.c
+++ b/ext/phalcon/auth/internal/containerresolver.zep.c
@@ -234,7 +234,7 @@ PHP_METHOD(Phalcon_Auth_Internal_ContainerResolver, requireService)
 			ZEPHIR_CALL_METHOD(&_1$$3, container, "has", NULL, 0, &name);
 			zephir_check_call_status();
 			if (zephir_is_true(&_1$$3)) {
-				ZEPHIR_RETURN_CALL_SELF("resolveshared", &_2, 396, container, &name);
+				ZEPHIR_RETURN_CALL_SELF("resolveshared", &_2, 398, container, &name);
 				zephir_check_call_status();
 				RETURN_MM();
 			}
@@ -260,7 +260,7 @@ PHP_METHOD(Phalcon_Auth_Internal_ContainerResolver, requireService)
 				ZEPHIR_CALL_METHOD(&_5$$5, container, "has", NULL, 0, &name);
 				zephir_check_call_status();
 				if (zephir_is_true(&_5$$5)) {
-					ZEPHIR_RETURN_CALL_SELF("resolveshared", &_2, 396, container, &name);
+					ZEPHIR_RETURN_CALL_SELF("resolveshared", &_2, 398, container, &name);
 					zephir_check_call_status();
 					RETURN_MM();
 				}

--- a/ext/phalcon/auth/internal/options.zep.c
+++ b/ext/phalcon/auth/internal/options.zep.c
@@ -129,7 +129,7 @@ PHP_METHOD(Phalcon_Auth_Internal_Options, requireArray)
 	if (_0) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_auth_exceptions_optionrequiresarray_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 397, &context_zv, &key_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 399, &context_zv, &key_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Auth/Internal/Options.zep", 59);
 		ZEPHIR_MM_RESTORE();
@@ -179,7 +179,7 @@ PHP_METHOD(Phalcon_Auth_Internal_Options, requireString)
 	if (_0) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_auth_exceptions_optionrequiresstring_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 398, &context_zv, &key_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 400, &context_zv, &key_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Auth/Internal/Options.zep", 77);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/manager.zep.c
+++ b/ext/phalcon/auth/manager.zep.c
@@ -81,7 +81,7 @@ PHP_METHOD(Phalcon_Auth_Manager, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(accessFactory, phalcon_auth_access_accesslocator_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &accessFactory);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 450, accessFactory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 449, accessFactory);
 }
 
 /**
@@ -117,22 +117,22 @@ PHP_METHOD(Phalcon_Auth_Manager, access)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&accessName_zv);
 	ZVAL_STR_COPY(&accessName_zv, accessName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 450, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 449, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "has", NULL, 0, &accessName_zv);
 	zephir_check_call_status();
 	if (!zephir_is_true(&_1)) {
 		ZEPHIR_INIT_VAR(&_2$$3);
 		object_init_ex(&_2$$3, phalcon_auth_exceptions_accessnotregistered_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 399, &accessName_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 401, &accessName_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$3, "phalcon/Auth/Manager.zep", 68);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 450, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 449, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_4, &_3, "newinstance", NULL, 0, &accessName_zv);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 451, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 450, &_4);
 	RETURN_THIS();
 }
 
@@ -180,7 +180,7 @@ PHP_METHOD(Phalcon_Auth_Manager, addAccessList)
 			}
 			ZEPHIR_INIT_NVAR(&className);
 			ZVAL_COPY(&className, _0);
-			zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 450, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 449, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_3$$3, "register", NULL, 0, &name, &className);
 			zephir_check_call_status();
 		} ZEND_HASH_FOREACH_END();
@@ -204,7 +204,7 @@ PHP_METHOD(Phalcon_Auth_Manager, addAccessList)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&className, &accessList, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_0, 450, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_0, 449, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &_6$$4, "register", NULL, 0, &name, &className);
 				zephir_check_call_status();
 		}
@@ -245,7 +245,7 @@ PHP_METHOD(Phalcon_Auth_Manager, addGuard)
 		}
 	zephir_update_property_array(this_ptr, SL("guards"), &nameGuard_zv, guard);
 	if (isDefault) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 452, guard);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 451, guard);
 	}
 	RETURN_THISW();
 }
@@ -285,7 +285,7 @@ PHP_METHOD(Phalcon_Auth_Manager, attempt)
 		remember = 0;
 	} else {
 		}
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requirestatefulguard", NULL, 400);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requirestatefulguard", NULL, 402);
 	zephir_check_call_status();
 	if (remember) {
 		ZVAL_BOOL(&_1, 1);
@@ -334,7 +334,7 @@ PHP_METHOD(Phalcon_Auth_Manager, except)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	ZEPHIR_INIT_VAR(&actions);
 	zephir_get_args_from(&actions, 0);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requireactiveaccess", NULL, 401);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requireactiveaccess", NULL, 403);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_1, "array_values", NULL, 27, &actions);
 	zephir_check_call_status();
@@ -367,7 +367,7 @@ PHP_METHOD(Phalcon_Auth_Manager, getAccessList)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 450, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 449, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getall", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -429,11 +429,11 @@ PHP_METHOD(Phalcon_Auth_Manager, guard)
 	ZVAL_STR_COPY(&name_zv, name);
 	}
 	if (ZEPHIR_IS_NULL(&name_zv)) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 452, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 451, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_0$$3) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_1$$4);
 			object_init_ex(&_1$$4, phalcon_auth_exceptions_defaultguardnotregistered_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 402);
+			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 404);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_1$$4, "phalcon/Auth/Manager.zep", 162);
 			ZEPHIR_MM_RESTORE();
@@ -441,17 +441,17 @@ PHP_METHOD(Phalcon_Auth_Manager, guard)
 		}
 		RETURN_MM_MEMBER(getThis(), "defaultGuard");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 453, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 452, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_2, &name_zv))) {
 		ZEPHIR_INIT_VAR(&_3$$5);
 		object_init_ex(&_3$$5, phalcon_auth_exceptions_guardnotdefined_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_3$$5, "__construct", NULL, 403, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$5, "__construct", NULL, 405, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$5, "phalcon/Auth/Manager.zep", 169);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 453, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 452, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_5, &_4, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Auth/Manager.zep", 172);
 	RETURN_CTOR(&_5);
 }
@@ -485,7 +485,7 @@ PHP_METHOD(Phalcon_Auth_Manager, logout)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requirestatefulguard", NULL, 400);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requirestatefulguard", NULL, 402);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_0, "logout", NULL, 0);
 	zephir_check_call_status();
@@ -511,7 +511,7 @@ PHP_METHOD(Phalcon_Auth_Manager, only)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	ZEPHIR_INIT_VAR(&actions);
 	zephir_get_args_from(&actions, 0);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requireactiveaccess", NULL, 401);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "requireactiveaccess", NULL, 403);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_1, "array_values", NULL, 27, &actions);
 	zephir_check_call_status();
@@ -535,7 +535,7 @@ PHP_METHOD(Phalcon_Auth_Manager, setAccess)
 		Z_PARAM_OBJECT_OF_CLASS(access, phalcon_contracts_auth_access_access_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &access);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 451, access);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 450, access);
 	RETURN_THISW();
 }
 
@@ -554,7 +554,7 @@ PHP_METHOD(Phalcon_Auth_Manager, setDefaultGuard)
 		Z_PARAM_OBJECT_OF_CLASS(guard, phalcon_contracts_auth_guard_guard_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &guard);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 452, guard);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 451, guard);
 	RETURN_THISW();
 }
 
@@ -628,11 +628,11 @@ PHP_METHOD(Phalcon_Auth_Manager, requireActiveAccess)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 451, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 450, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_auth_exceptions_activeaccessrequired_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 404);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 406);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Auth/Manager.zep", 228);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/auth/managerfactory.zep.c
+++ b/ext/phalcon/auth/managerfactory.zep.c
@@ -174,38 +174,38 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, __construct)
 	}
 	ZEPHIR_CALL_CE_STATIC(NULL, phalcon_auth_internal_containerresolver_ce, "ensurecontainer", NULL, 0, container);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 454, container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 455, hasher);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 453, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 454, hasher);
 	ZEPHIR_INIT_VAR(&_0);
 	if (Z_TYPE_P(adapterLocator) != IS_NULL) {
 		ZEPHIR_CPY_WRT(&_0, adapterLocator);
 	} else {
 		ZEPHIR_INIT_NVAR(&_0);
 		object_init_ex(&_0, phalcon_auth_adapter_adapterlocator_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 405, container);
+		ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 407, container);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 456, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 455, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	if (Z_TYPE_P(guardLocator) != IS_NULL) {
 		ZEPHIR_CPY_WRT(&_1, guardLocator);
 	} else {
 		ZEPHIR_INIT_NVAR(&_1);
 		object_init_ex(&_1, phalcon_auth_guard_guardlocator_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 405, container);
+		ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 407, container);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 457, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 456, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	if (Z_TYPE_P(accessLocator) != IS_NULL) {
 		ZEPHIR_CPY_WRT(&_2, accessLocator);
 	} else {
 		ZEPHIR_INIT_NVAR(&_2);
 		object_init_ex(&_2, phalcon_auth_access_accesslocator_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2, "__construct", NULL, 405, container);
+		ZEPHIR_CALL_METHOD(NULL, &_2, "__construct", NULL, 407, container);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 458, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 457, &_2);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -298,8 +298,8 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 	}
 	ZEPHIR_INIT_VAR(&manager);
 	object_init_ex(&manager, phalcon_auth_manager_ce);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 458, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_METHOD(NULL, &manager, "__construct", NULL, 406, &_3);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 457, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, &manager, "__construct", NULL, 408, &_3);
 	zephir_check_call_status();
 	if (zephir_array_isset_value_string(config, SL("guards"))) {
 		zephir_memory_observe(&guards);
@@ -320,7 +320,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 			}
 			ZEPHIR_INIT_NVAR(&gconf);
 			ZVAL_COPY(&gconf, _4);
-			zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_1, 456, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_1, 455, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_NVAR(&_10$$5);
 			ZEPHIR_CONCAT_SVS(&_10$$5, "guard '", &name, "'");
 			ZEPHIR_INIT_NVAR(&_11$$5);
@@ -329,7 +329,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&adapter, this_ptr, "buildadapter", &_12, 0, &_7$$5, &_8$$5);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_13$$5, this_ptr, _zephir_prop_2, 457, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_13$$5, this_ptr, _zephir_prop_2, 456, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_NVAR(&_16$$5);
 			ZEPHIR_CONCAT_SVS(&_16$$5, "guard '", &name, "'");
 			ZEPHIR_INIT_NVAR(&_11$$5);
@@ -356,7 +356,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 				ZVAL_BOOL(&_20$$5, 0);
 			}
 			ZVAL_BOOL(&_21$$5, zephir_get_boolval(&_20$$5));
-			ZEPHIR_CALL_METHOD(NULL, &manager, "addguard", &_22, 407, &_19$$5, &guard, &_21$$5);
+			ZEPHIR_CALL_METHOD(NULL, &manager, "addguard", &_22, 409, &_19$$5, &guard, &_21$$5);
 			zephir_check_call_status();
 		} ZEND_HASH_FOREACH_END();
 	} else {
@@ -379,7 +379,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&gconf, &guards, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_25$$6, this_ptr, _zephir_prop_1, 456, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_25$$6, this_ptr, _zephir_prop_1, 455, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_NVAR(&_27$$6);
 				ZEPHIR_CONCAT_SVS(&_27$$6, "guard '", &name, "'");
 				ZEPHIR_INIT_NVAR(&_28$$6);
@@ -388,7 +388,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&adapter, this_ptr, "buildadapter", &_12, 0, &_25$$6, &_26$$6);
 				zephir_check_call_status();
-				zephir_read_property_cached(&_29$$6, this_ptr, _zephir_prop_2, 457, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_29$$6, this_ptr, _zephir_prop_2, 456, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_NVAR(&_31$$6);
 				ZEPHIR_CONCAT_SVS(&_31$$6, "guard '", &name, "'");
 				ZEPHIR_INIT_NVAR(&_28$$6);
@@ -415,7 +415,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 					ZVAL_BOOL(&_34$$6, 0);
 				}
 				ZVAL_BOOL(&_35$$6, zephir_get_boolval(&_34$$6));
-				ZEPHIR_CALL_METHOD(NULL, &manager, "addguard", &_22, 407, &_33$$6, &guard, &_35$$6);
+				ZEPHIR_CALL_METHOD(NULL, &manager, "addguard", &_22, 409, &_33$$6, &guard, &_35$$6);
 				zephir_check_call_status();
 		}
 	}
@@ -429,7 +429,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, load)
 		array_init(&accessList);
 	}
 	if (!(ZEPHIR_IS_EMPTY(&accessList))) {
-		ZEPHIR_CALL_METHOD(NULL, &manager, "addaccesslist", NULL, 408, &accessList);
+		ZEPHIR_CALL_METHOD(NULL, &manager, "addaccesslist", NULL, 410, &accessList);
 		zephir_check_call_status();
 	}
 	RETURN_CCTOR(&manager);
@@ -483,7 +483,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, buildAdapter)
 	if (!zephir_is_true(&_2)) {
 		ZEPHIR_INIT_VAR(&_3$$3);
 		object_init_ex(&_3$$3, phalcon_auth_exceptions_unknownadapter_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 409, &name);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 411, &name);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$3, "phalcon/Auth/ManagerFactory.zep", 184);
 		ZEPHIR_MM_RESTORE();
@@ -491,7 +491,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, buildAdapter)
 	}
 	ZEPHIR_CALL_METHOD(&className, locator, "getclass", NULL, 0, &name);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 455, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 454, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_5);
 	if (zephir_array_isset_value_string(&cfg, SL("options"))) {
 		ZEPHIR_OBS_NVAR(&_5);
@@ -553,7 +553,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, buildGuard)
 	if (!zephir_is_true(&_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_auth_exceptions_unknownguard_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 410, &type_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 412, &type_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Auth/ManagerFactory.zep", 209);
 		ZEPHIR_MM_RESTORE();
@@ -561,7 +561,7 @@ PHP_METHOD(Phalcon_Auth_ManagerFactory, buildGuard)
 	}
 	ZEPHIR_CALL_METHOD(&className, locator, "getclass", NULL, 0, &type_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 454, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 453, PH_NOISY_CC | PH_READONLY);
 	_3 = zephir_fetch_class(&className);
 	ZEPHIR_RETURN_CALL_CE_STATIC(_3, "fromoptions", NULL, 0, adapter, &_2, &options);
 	zephir_check_call_status();

--- a/ext/phalcon/auth/micro/authmicrolistener.zep.c
+++ b/ext/phalcon/auth/micro/authmicrolistener.zep.c
@@ -85,7 +85,7 @@ PHP_METHOD(Phalcon_Auth_Micro_AuthMicroListener, __construct)
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_auth_micro_authmicrolistener_ce, getThis(), "__construct", NULL, 0, manager);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 459, &componentName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 458, &componentName_zv);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -144,7 +144,7 @@ PHP_METHOD(Phalcon_Auth_Micro_AuthMicroListener, beforeExecuteRoute)
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 2, 0);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 459, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 458, PH_NOISY_CC);
 	zephir_array_update_string(&_2, SL("handler"), &_3, PH_COPY | PH_SEPARATE);
 	ZEPHIR_CALL_METHOD(&_4, &router, "getparams", NULL, 0);
 	zephir_check_call_status();

--- a/ext/phalcon/autoload/loader.zep.c
+++ b/ext/phalcon/autoload/loader.zep.c
@@ -129,9 +129,9 @@ PHP_METHOD(Phalcon_Autoload_Loader, __construct)
 	ZVAL_STRING(&_1, "php");
 	zephir_update_property_array(this_ptr, SL("extensions"), &_0, &_1);
 	if (isDebug) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 460, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 459, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 460, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 459, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -294,10 +294,10 @@ PHP_METHOD(Phalcon_Autoload_Loader, addNamespace)
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_CONCAT_VV(&_1, &_0, &nsSeparator);
 	ZEPHIR_CPY_WRT(&nsName, &_1);
-	ZEPHIR_CALL_METHOD(&_2, this_ptr, "checkdirectories", NULL, 411, directories, &dirSeparator, &name_zv);
+	ZEPHIR_CALL_METHOD(&_2, this_ptr, "checkdirectories", NULL, 413, directories, &dirSeparator, &name_zv);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(directories, &_2);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 460, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_3, &nsName))) {
 		ZEPHIR_INIT_VAR(&_4$$3);
 		array_init(&_4$$3);
@@ -306,12 +306,12 @@ PHP_METHOD(Phalcon_Autoload_Loader, addNamespace)
 	if (prepend) {
 		ZEPHIR_CPY_WRT(&source, directories);
 	} else {
-		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 460, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_OBS_NVAR(&source);
 		zephir_array_fetch(&source, &_5, &nsName, PH_NOISY, "phalcon/Autoload/Loader.zep", 176);
 	}
 	if (prepend) {
-		zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 460, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&target);
 		zephir_array_fetch(&target, &_6, &nsName, PH_NOISY, "phalcon/Autoload/Loader.zep", 177);
 	} else {
@@ -319,7 +319,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, addNamespace)
 	}
 	ZEPHIR_INIT_VAR(&_7);
 	zephir_fast_array_merge(&_7, &source, &target);
-	ZEPHIR_CALL_FUNCTION(&_2, "array_unique", NULL, 412, &_7);
+	ZEPHIR_CALL_FUNCTION(&_2, "array_unique", NULL, 414, &_7);
 	zephir_check_call_status();
 	zephir_update_property_array(this_ptr, SL("namespaces"), &nsName, &_2);
 	RETURN_THIS();
@@ -379,47 +379,47 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoload)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&className_zv);
 	ZVAL_STR_COPY(&className_zv, className);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 462, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_LONG_IDENTICAL(&_0, 0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		array_init(&_1$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 463, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 462, &_1$$3);
 	}
 	result = 1;
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 462, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
 	ZVAL_UNDEF(&_3);
 	ZVAL_LONG(&_3, (zephir_get_numberval(&_2) + 1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 462, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 461, &_3);
 	ZEPHIR_INIT_VAR(&_4);
 	ZEPHIR_CONCAT_SV(&_4, "Loading: ", &className_zv);
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_4);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_4);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_5);
 	ZVAL_STRING(&_5, "loader:beforeCheckClass");
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", NULL, 0, &_5, &className_zv);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_6, this_ptr, "autoloadcheckclasses", NULL, 414, &className_zv);
+	ZEPHIR_CALL_METHOD(&_6, this_ptr, "autoloadcheckclasses", NULL, 416, &className_zv);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_6)) {
 		ZEPHIR_INIT_VAR(&_7$$4);
 		ZEPHIR_CONCAT_SV(&_7$$4, "Class: 404: ", &className_zv);
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_7$$4);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_7$$4);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_8$$4, this_ptr, "autoloadchecknamespaces", NULL, 415, &className_zv);
+		ZEPHIR_CALL_METHOD(&_8$$4, this_ptr, "autoloadchecknamespaces", NULL, 417, &className_zv);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_8$$4)) {
 			ZEPHIR_INIT_VAR(&_9$$5);
 			ZEPHIR_CONCAT_SV(&_9$$5, "Namespace: 404: ", &className_zv);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_9$$5);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_9$$5);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_2, 464, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_2, 463, PH_NOISY_CC | PH_READONLY);
 			ZVAL_BOOL(&_12$$5, 1);
-			ZEPHIR_CALL_METHOD(&_10$$5, this_ptr, "autoloadcheckdirectories", NULL, 416, &_11$$5, &className_zv, &_12$$5);
+			ZEPHIR_CALL_METHOD(&_10$$5, this_ptr, "autoloadcheckdirectories", NULL, 418, &_11$$5, &className_zv, &_12$$5);
 			zephir_check_call_status();
 			if (!ZEPHIR_IS_TRUE_IDENTICAL(&_10$$5)) {
 				ZEPHIR_INIT_VAR(&_13$$6);
 				ZEPHIR_CONCAT_SV(&_13$$6, "Directories: 404: ", &className_zv);
-				ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_13$$6);
+				ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_13$$6);
 				zephir_check_call_status();
 				ZEPHIR_INIT_VAR(&_14$$6);
 				ZVAL_STRING(&_14$$6, "loader:afterCheckClass");
@@ -429,10 +429,10 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoload)
 			}
 		}
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 462, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
 	ZVAL_UNDEF(&_15);
 	ZVAL_LONG(&_15, (zephir_get_numberval(&_3) - 1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 462, &_15);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 461, &_15);
 	RETURN_MM_BOOL(result);
 }
 
@@ -549,7 +549,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, loadFiles)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 465, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 464, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&files, &_0);
 	zephir_is_iterable(&files, 0, "phalcon/Autoload/Loader.zep", 336);
 	if (Z_TYPE_P(&files) == IS_ARRAY) {
@@ -628,7 +628,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, register)
 		prepend = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 466, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 465, PH_NOISY_CC | PH_READONLY);
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "loadfiles", NULL, 0);
 		zephir_check_call_status();
@@ -639,12 +639,12 @@ PHP_METHOD(Phalcon_Autoload_Loader, register)
 		ZVAL_STRING(&_2$$3, "autoload");
 		zephir_array_fast_append(&_1$$3, &_2$$3);
 		ZVAL_BOOL(&_3$$3, (prepend ? 1 : 0));
-		ZEPHIR_CALL_FUNCTION(NULL, "spl_autoload_register", NULL, 417, &_1$$3, &__$true, &_3$$3);
+		ZEPHIR_CALL_FUNCTION(NULL, "spl_autoload_register", NULL, 419, &_1$$3, &__$true, &_3$$3);
 		zephir_check_call_status();
 		if (1) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 466, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 465, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 466, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 465, &__$false);
 		}
 	}
 	RETURN_THIS();
@@ -696,7 +696,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, setClasses)
 	if (!merge) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		array_init(&_0$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 467, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 466, &_0$$3);
 	}
 	zephir_is_iterable(&classes, 0, "phalcon/Autoload/Loader.zep", 378);
 	if (Z_TYPE_P(&classes) == IS_ARRAY) {
@@ -785,7 +785,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, setDirectories)
 	} else {
 		ZVAL_BOOL(&_2, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "addtocollection", NULL, 418, &directories, &_0, &_1, &_2);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "addtocollection", NULL, 420, &directories, &_0, &_1, &_2);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -836,7 +836,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, setExtensions)
 	if (!merge) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		array_init(&_0$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 468, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 467, &_0$$3);
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "php");
 		ZEPHIR_INIT_VAR(&_2$$3);
@@ -927,16 +927,16 @@ PHP_METHOD(Phalcon_Autoload_Loader, setFileCheckingCallback)
 		method = &__$null;
 	}
 	if (1 == zephir_is_callable(method)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 469, method);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 468, method);
 	} else if (Z_TYPE_P(method) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_0$$4);
 		ZEPHIR_INIT_NVAR(&_0$$4);
 		zephir_create_closure_ex(&_0$$4, NULL, phalcon_8__closure_ce, SL("__invoke"));
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 469, &_0$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 468, &_0$$4);
 	} else {
 		ZEPHIR_INIT_VAR(&_1$$5);
 		object_init_ex(&_1$$5, phalcon_autoload_exceptions_loadermethodnotcallable_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", NULL, 419);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", NULL, 421);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$5, "phalcon/Autoload/Loader.zep", 453);
 		ZEPHIR_MM_RESTORE();
@@ -989,7 +989,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, setFiles)
 	} else {
 		ZVAL_BOOL(&_2, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "addtocollection", NULL, 418, &files, &_0, &_1, &_2);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "addtocollection", NULL, 420, &files, &_0, &_1, &_2);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -1040,7 +1040,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, setNamespaces)
 	if (!merge) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		array_init(&_0$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 461, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 460, &_0$$3);
 	}
 	zephir_is_iterable(&namespaces, 0, "phalcon/Autoload/Loader.zep", 498);
 	if (Z_TYPE_P(&namespaces) == IS_ARRAY) {
@@ -1122,7 +1122,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, unregister)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 466, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 465, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		zephir_create_array(&_1$$3, 2, 0);
@@ -1130,12 +1130,12 @@ PHP_METHOD(Phalcon_Autoload_Loader, unregister)
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "autoload");
 		zephir_array_fast_append(&_1$$3, &_2$$3);
-		ZEPHIR_CALL_FUNCTION(NULL, "spl_autoload_unregister", NULL, 420, &_1$$3);
+		ZEPHIR_CALL_FUNCTION(NULL, "spl_autoload_unregister", NULL, 422, &_1$$3);
 		zephir_check_call_status();
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 466, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 465, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 466, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 465, &__$false);
 		}
 	}
 	RETURN_THIS();
@@ -1179,18 +1179,18 @@ PHP_METHOD(Phalcon_Autoload_Loader, requireFile)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&file_zv);
 	ZVAL_STR_COPY(&file_zv, file);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 469, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 468, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&_1, "call_user_func", NULL, 80, &_0, &file_zv);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&_1)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 470, &file_zv);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 469, &file_zv);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "loader:pathFound");
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", NULL, 0, &_2$$3, &file_zv);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZEPHIR_CONCAT_SV(&_3$$3, "Require: ", &file_zv);
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_3$$3);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_3$$3);
 		zephir_check_call_status();
 		if (zephir_require_once_zval(&file_zv) == FAILURE) {
 			RETURN_MM_NULL();
@@ -1199,7 +1199,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, requireFile)
 	}
 	ZEPHIR_INIT_VAR(&_4);
 	ZEPHIR_CONCAT_SV(&_4, "Require: 404: ", &file_zv);
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_4);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_4);
 	zephir_check_call_status();
 	RETURN_MM_BOOL(0);
 }
@@ -1226,7 +1226,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, addDebug)
 		Z_PARAM_STR(message)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&message_zv, message);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 460, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 459, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		zephir_update_property_array_append(this_ptr, SL("debug"), &message_zv);
 	}
@@ -1356,9 +1356,9 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckClasses)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&className_zv);
 	ZVAL_STR_COPY(&className_zv, className);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 467, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 466, PH_NOISY_CC | PH_READONLY);
 	if (1 == zephir_array_isset_value(&_0, &className_zv)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 467, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 466, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&filePath);
 		zephir_array_fetch(&filePath, &_1$$3, &className_zv, PH_NOISY, "phalcon/Autoload/Loader.zep", 621);
 		ZEPHIR_INIT_VAR(&_2$$3);
@@ -1370,7 +1370,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckClasses)
 		if (ZEPHIR_IS_TRUE_IDENTICAL(&_3$$3)) {
 			ZEPHIR_INIT_VAR(&_4$$4);
 			ZEPHIR_CONCAT_SV(&_4$$4, "Class: load: ", &filePath);
-			ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 413, &_4$$4);
+			ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", NULL, 415, &_4$$4);
 			zephir_check_call_status();
 			RETURN_MM_BOOL(1);
 		}
@@ -1461,7 +1461,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 	ZVAL_STRING(&nsSeparator, "\\");
 	ZEPHIR_INIT_VAR(&localClassName);
 	zephir_fast_str_replace(&localClassName, &nsSeparator, &dirSeparator, &className_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 468, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 467, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extensions, &_0);
 	zephir_is_iterable(&directories, 0, "phalcon/Autoload/Loader.zep", 682);
 	if (Z_TYPE_P(&directories) == IS_ARRAY) {
@@ -1481,7 +1481,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 					ZVAL_COPY(&extension, _3$$3);
 					ZEPHIR_INIT_NVAR(&filePath);
 					ZEPHIR_CONCAT_VVSV(&filePath, &fixedDirectory, &localClassName, ".", &extension);
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 471, &filePath);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 470, &filePath);
 					ZEPHIR_INIT_NVAR(&_4$$4);
 					ZVAL_STRING(&_4$$4, "loader:beforeCheckPath");
 					ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", &_5, 0, &_4$$4, &filePath);
@@ -1492,7 +1492,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 						if (isDirectory) {
 							ZEPHIR_INIT_NVAR(&_8$$6);
 							ZEPHIR_CONCAT_SV(&_8$$6, "Directories: ", &filePath);
-							ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 413, &_8$$6);
+							ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 415, &_8$$6);
 							zephir_check_call_status();
 						}
 						RETURN_MM_BOOL(1);
@@ -1518,7 +1518,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 					zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&filePath);
 						ZEPHIR_CONCAT_VVSV(&filePath, &fixedDirectory, &localClassName, ".", &extension);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 471, &filePath);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 470, &filePath);
 						ZEPHIR_INIT_NVAR(&_12$$7);
 						ZVAL_STRING(&_12$$7, "loader:beforeCheckPath");
 						ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", &_5, 0, &_12$$7, &filePath);
@@ -1529,7 +1529,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 							if (isDirectory) {
 								ZEPHIR_INIT_NVAR(&_14$$9);
 								ZEPHIR_CONCAT_SV(&_14$$9, "Directories: ", &filePath);
-								ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 413, &_14$$9);
+								ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 415, &_14$$9);
 								zephir_check_call_status();
 							}
 							RETURN_MM_BOOL(1);
@@ -1568,7 +1568,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 						ZVAL_COPY(&extension, _18$$10);
 						ZEPHIR_INIT_NVAR(&filePath);
 						ZEPHIR_CONCAT_VVSV(&filePath, &fixedDirectory, &localClassName, ".", &extension);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 471, &filePath);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 470, &filePath);
 						ZEPHIR_INIT_NVAR(&_19$$11);
 						ZVAL_STRING(&_19$$11, "loader:beforeCheckPath");
 						ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", &_5, 0, &_19$$11, &filePath);
@@ -1579,7 +1579,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 							if (isDirectory) {
 								ZEPHIR_INIT_NVAR(&_21$$13);
 								ZEPHIR_CONCAT_SV(&_21$$13, "Directories: ", &filePath);
-								ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 413, &_21$$13);
+								ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 415, &_21$$13);
 								zephir_check_call_status();
 							}
 							RETURN_MM_BOOL(1);
@@ -1605,7 +1605,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 						zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&filePath);
 							ZEPHIR_CONCAT_VVSV(&filePath, &fixedDirectory, &localClassName, ".", &extension);
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 471, &filePath);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 470, &filePath);
 							ZEPHIR_INIT_NVAR(&_24$$14);
 							ZVAL_STRING(&_24$$14, "loader:beforeCheckPath");
 							ZEPHIR_CALL_METHOD(NULL, this_ptr, "firemanagerevent", &_5, 0, &_24$$14, &filePath);
@@ -1616,7 +1616,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckDirectories)
 								if (isDirectory) {
 									ZEPHIR_INIT_NVAR(&_26$$16);
 									ZEPHIR_CONCAT_SV(&_26$$16, "Directories: ", &filePath);
-									ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 413, &_26$$16);
+									ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 415, &_26$$16);
 									zephir_check_call_status();
 								}
 								RETURN_MM_BOOL(1);
@@ -1680,7 +1680,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckNamespaces)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&className_zv);
 	ZVAL_STR_COPY(&className_zv, className);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 461, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 460, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&namespaces, &_0);
 	zephir_is_iterable(&namespaces, 0, "phalcon/Autoload/Loader.zep", 712);
 	if (Z_TYPE_P(&namespaces) == IS_ARRAY) {
@@ -1700,13 +1700,13 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckNamespaces)
 			ZVAL_LONG(&_4$$3, zephir_fast_strlen_ev(&prefix));
 			ZEPHIR_INIT_NVAR(&fileName);
 			zephir_substr(&fileName, &className_zv, zephir_get_intval(&_4$$3), 0, ZEPHIR_SUBSTR_NO_LENGTH);
-			ZEPHIR_CALL_METHOD(&_5$$3, this_ptr, "autoloadcheckdirectories", &_6, 416, &directories, &fileName);
+			ZEPHIR_CALL_METHOD(&_5$$3, this_ptr, "autoloadcheckdirectories", &_6, 418, &directories, &fileName);
 			zephir_check_call_status();
 			if (ZEPHIR_IS_TRUE_IDENTICAL(&_5$$3)) {
-				zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_1, 471, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_1, 470, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_NVAR(&_8$$5);
 				ZEPHIR_CONCAT_SVSV(&_8$$5, "Namespace: ", &prefix, " - ", &_7$$5);
-				ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 413, &_8$$5);
+				ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 415, &_8$$5);
 				zephir_check_call_status();
 				RETURN_MM_BOOL(1);
 			}
@@ -1737,13 +1737,13 @@ PHP_METHOD(Phalcon_Autoload_Loader, autoloadCheckNamespaces)
 				ZVAL_LONG(&_12$$6, zephir_fast_strlen_ev(&prefix));
 				ZEPHIR_INIT_NVAR(&fileName);
 				zephir_substr(&fileName, &className_zv, zephir_get_intval(&_12$$6), 0, ZEPHIR_SUBSTR_NO_LENGTH);
-				ZEPHIR_CALL_METHOD(&_13$$6, this_ptr, "autoloadcheckdirectories", &_6, 416, &directories, &fileName);
+				ZEPHIR_CALL_METHOD(&_13$$6, this_ptr, "autoloadcheckdirectories", &_6, 418, &directories, &fileName);
 				zephir_check_call_status();
 				if (ZEPHIR_IS_TRUE_IDENTICAL(&_13$$6)) {
-					zephir_read_property_cached(&_14$$8, this_ptr, _zephir_prop_1, 471, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_14$$8, this_ptr, _zephir_prop_1, 470, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_INIT_NVAR(&_15$$8);
 					ZEPHIR_CONCAT_SVSV(&_15$$8, "Namespace: ", &prefix, " - ", &_14$$8);
-					ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 413, &_15$$8);
+					ZEPHIR_CALL_METHOD(NULL, this_ptr, "adddebug", &_9, 415, &_15$$8);
 					zephir_check_call_status();
 					RETURN_MM_BOOL(1);
 				}
@@ -1815,7 +1815,7 @@ PHP_METHOD(Phalcon_Autoload_Loader, checkDirectories)
 	if (_0) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_autoload_exceptions_loaderdirectoriesnotarray_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 421, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 423, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Autoload/Loader.zep", 737);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/cache/abstractcache.zep.c
+++ b/ext/phalcon/cache/abstractcache.zep.c
@@ -613,7 +613,7 @@ PHP_METHOD(Phalcon_Cache_AbstractCache, doGetMultiple)
 		ZEPHIR_CALL_FUNCTION(&_9$$3, "array_map", NULL, 19, &_8$$3, &results);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&results, &_9$$3);
-		ZEPHIR_CALL_FUNCTION(&_9$$3, "array_combine", NULL, 244, &keysArray, &results);
+		ZEPHIR_CALL_FUNCTION(&_9$$3, "array_combine", NULL, 245, &keysArray, &results);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&results, &_9$$3);
 	} else {

--- a/ext/phalcon/cache/adapterfactory.zep.c
+++ b/ext/phalcon/cache/adapterfactory.zep.c
@@ -76,7 +76,7 @@ PHP_METHOD(Phalcon_Cache_AdapterFactory, __construct)
 	} else {
 		zephir_get_arrval(&services, services_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 472, factory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 471, factory);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -152,7 +152,7 @@ PHP_METHOD(Phalcon_Cache_AdapterFactory, newInstance)
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_create_array(&_0, 2, 0);
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 472, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 471, PH_NOISY_CC);
 	zephir_array_fast_append(&_0, &_1);
 	zephir_array_fast_append(&_0, &options);
 	ZEPHIR_LAST_CALL_STATUS = zephir_create_instance_params(return_value, &definition, &_0);

--- a/ext/phalcon/cache/cachefactory.zep.c
+++ b/ext/phalcon/cache/cachefactory.zep.c
@@ -59,7 +59,7 @@ PHP_METHOD(Phalcon_Cache_CacheFactory, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(factory, phalcon_cache_adapterfactory_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &factory);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 473, factory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 472, factory);
 }
 
 /**
@@ -195,11 +195,11 @@ PHP_METHOD(Phalcon_Cache_CacheFactory, newInstance)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 472, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&adapter, &_0, "newinstance", NULL, 0, &name_zv, &options);
 	zephir_check_call_status();
 	object_init_ex(return_value, phalcon_cache_cache_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 422, &adapter);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 424, &adapter);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/cli/console.zep.c
+++ b/ext/phalcon/cli/console.zep.c
@@ -150,19 +150,19 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 	} else {
 		zephir_get_arrval(&arguments, arguments_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_cli_console_exceptions_containerrequired_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 423);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 425);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Cli/Console.zep", 49);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_2) != IS_NULL) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_5$$4);
 		ZVAL_STRING(&_5$$4, "console:boot");
 		ZEPHIR_CALL_METHOD(&_4$$4, &_3$$4, "fire", NULL, 0, &_5$$4, this_ptr);
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 			RETURN_MM_BOOL(0);
 		}
 	}
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_8);
 	ZVAL_STRING(&_8, "router");
 	ZEPHIR_CALL_METHOD(&_7, &_6, "getshared", NULL, 0, &_8);
@@ -179,11 +179,11 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 	ZEPHIR_CPY_WRT(&router, &_7);
 	_9 = !(zephir_fast_count_int(&arguments));
 	if (_9) {
-		zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 476, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 475, PH_NOISY_CC | PH_READONLY);
 		_9 = zephir_is_true(&_10);
 	}
 	if (_9) {
-		zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_2, 476, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_2, 475, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &router, "handle", NULL, 0, &_11$$6);
 		zephir_check_call_status();
 	} else {
@@ -194,12 +194,12 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 	zephir_check_call_status();
 	if (!(zephir_is_true(&moduleName))) {
 		ZEPHIR_OBS_NVAR(&moduleName);
-		zephir_read_property_cached(&moduleName, this_ptr, _zephir_prop_3, 477, PH_NOISY_CC);
+		zephir_read_property_cached(&moduleName, this_ptr, _zephir_prop_3, 476, PH_NOISY_CC);
 	}
 	if (zephir_is_true(&moduleName)) {
-		zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_12$$9) != IS_NULL) {
-			zephir_read_property_cached(&_13$$10, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_13$$10, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_15$$10);
 			ZVAL_STRING(&_15$$10, "console:beforeStartModule");
 			ZEPHIR_CALL_METHOD(&_14$$10, &_13$$10, "fire", NULL, 0, &_15$$10, this_ptr, &moduleName);
@@ -219,7 +219,7 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 			object_init_ex(&_17$$12, phalcon_cli_console_exceptions_invalidmoduledefinition_ce);
 			ZEPHIR_INIT_VAR(&_18$$12);
 			ZVAL_STRING(&_18$$12, "The module definition must be an array or an object");
-			ZEPHIR_CALL_METHOD(NULL, &_17$$12, "__construct", NULL, 424, &moduleName, &_18$$12);
+			ZEPHIR_CALL_METHOD(NULL, &_17$$12, "__construct", NULL, 426, &moduleName, &_18$$12);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_17$$12, "phalcon/Cli/Console.zep", 98);
 			ZEPHIR_MM_RESTORE();
@@ -238,7 +238,7 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 				if (UNEXPECTED(!zephir_is_true(&_19$$15))) {
 					ZEPHIR_INIT_VAR(&_20$$16);
 					object_init_ex(&_20$$16, phalcon_cli_console_exceptions_moduledefinitionpathnotfound_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_20$$16, "__construct", NULL, 425, &path);
+					ZEPHIR_CALL_METHOD(NULL, &_20$$16, "__construct", NULL, 427, &path);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_20$$16, "phalcon/Cli/Console.zep", 118);
 					ZEPHIR_MM_RESTORE();
@@ -250,14 +250,14 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 					}
 				}
 			}
-			zephir_read_property_cached(&_21$$13, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_21$$13, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_22$$13, &_21$$13, "get", NULL, 0, &className);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&moduleObject, &_22$$13);
-			zephir_read_property_cached(&_23$$13, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_23$$13, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &moduleObject, "registerautoloaders", NULL, 0, &_23$$13);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_24$$13, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_24$$13, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &moduleObject, "registerservices", NULL, 0, &_24$$13);
 			zephir_check_call_status();
 		} else {
@@ -266,7 +266,7 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 				object_init_ex(&_25$$19, phalcon_cli_console_exceptions_invalidmoduledefinition_ce);
 				ZEPHIR_INIT_VAR(&_26$$19);
 				ZVAL_STRING(&_26$$19, "The module definition object must be a Closure");
-				ZEPHIR_CALL_METHOD(NULL, &_25$$19, "__construct", NULL, 424, &moduleName, &_26$$19);
+				ZEPHIR_CALL_METHOD(NULL, &_25$$19, "__construct", NULL, 426, &moduleName, &_26$$19);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_25$$19, "phalcon/Cli/Console.zep", 142);
 				ZEPHIR_MM_RESTORE();
@@ -275,15 +275,15 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 			ZEPHIR_INIT_VAR(&_27$$18);
 			zephir_create_array(&_27$$18, 1, 0);
 			zephir_memory_observe(&_28$$18);
-			zephir_read_property_cached(&_28$$18, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC);
+			zephir_read_property_cached(&_28$$18, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC);
 			zephir_array_fast_append(&_27$$18, &_28$$18);
 			ZEPHIR_INIT_NVAR(&moduleObject);
 			ZEPHIR_CALL_USER_FUNC_ARRAY(&moduleObject, &module, &_27$$18);
 			zephir_check_call_status();
 		}
-		zephir_read_property_cached(&_29$$9, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_29$$9, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_29$$9) != IS_NULL) {
-			zephir_read_property_cached(&_30$$20, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_30$$20, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_32$$20);
 			ZVAL_STRING(&_32$$20, "console:afterStartModule");
 			ZEPHIR_CALL_METHOD(&_31$$20, &_30$$20, "fire", NULL, 0, &_32$$20, this_ptr, &moduleObject);
@@ -293,7 +293,7 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 			}
 		}
 	}
-	zephir_read_property_cached(&_33, this_ptr, _zephir_prop_0, 474, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_33, this_ptr, _zephir_prop_0, 473, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_8);
 	ZVAL_STRING(&_8, "dispatcher");
 	ZEPHIR_CALL_METHOD(&_7, &_33, "getshared", NULL, 0, &_8);
@@ -313,12 +313,12 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &dispatcher, "setparams", NULL, 0, &_35);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_36, this_ptr, _zephir_prop_4, 478, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_36, this_ptr, _zephir_prop_4, 477, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &dispatcher, "setoptions", NULL, 0, &_36);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_37, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_37, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_37) != IS_NULL) {
-		zephir_read_property_cached(&_38$$22, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_38$$22, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_40$$22);
 		ZVAL_STRING(&_40$$22, "console:beforeHandleTask");
 		ZEPHIR_CALL_METHOD(&_39$$22, &_38$$22, "fire", NULL, 0, &_40$$22, this_ptr, &dispatcher);
@@ -329,9 +329,9 @@ PHP_METHOD(Phalcon_Cli_Console, handle)
 	}
 	ZEPHIR_CALL_METHOD(&task, &dispatcher, "dispatch", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_41, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_41, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_41) != IS_NULL) {
-		zephir_read_property_cached(&_42$$24, this_ptr, _zephir_prop_1, 475, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_42$$24, this_ptr, _zephir_prop_1, 474, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_43$$24);
 		ZVAL_STRING(&_43$$24, "console:afterHandleTask");
 		ZEPHIR_CALL_METHOD(NULL, &_42$$24, "fire", NULL, 0, &_43$$24, this_ptr, &task);
@@ -462,7 +462,7 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 				ZEPHIR_INIT_NVAR(&_2$$5);
 				ZVAL_STRING(&_2$$5, "--");
 				ZVAL_LONG(&_3$$5, 2);
-				ZEPHIR_CALL_FUNCTION(&_4$$5, "strncmp", &_5, 333, &arg, &_2$$5, &_3$$5);
+				ZEPHIR_CALL_FUNCTION(&_4$$5, "strncmp", &_5, 335, &arg, &_2$$5, &_3$$5);
 				zephir_check_call_status();
 				if (ZEPHIR_IS_LONG(&_4$$5, 0)) {
 					ZEPHIR_INIT_NVAR(&_6$$6);
@@ -494,7 +494,7 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 					ZEPHIR_INIT_NVAR(&_17$$9);
 					ZVAL_STRING(&_17$$9, "-");
 					ZVAL_LONG(&_18$$9, 1);
-					ZEPHIR_CALL_FUNCTION(&_19$$9, "strncmp", &_5, 333, &arg, &_17$$9, &_18$$9);
+					ZEPHIR_CALL_FUNCTION(&_19$$9, "strncmp", &_5, 335, &arg, &_17$$9, &_18$$9);
 					zephir_check_call_status();
 					if (ZEPHIR_IS_LONG(&_19$$9, 0)) {
 						ZVAL_LONG(&_20$$10, 1);
@@ -531,7 +531,7 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 					ZEPHIR_INIT_NVAR(&_24$$14);
 					ZVAL_STRING(&_24$$14, "--");
 					ZVAL_LONG(&_25$$14, 2);
-					ZEPHIR_CALL_FUNCTION(&_26$$14, "strncmp", &_5, 333, &arg, &_24$$14, &_25$$14);
+					ZEPHIR_CALL_FUNCTION(&_26$$14, "strncmp", &_5, 335, &arg, &_24$$14, &_25$$14);
 					zephir_check_call_status();
 					if (ZEPHIR_IS_LONG(&_26$$14, 0)) {
 						ZEPHIR_INIT_NVAR(&_27$$15);
@@ -563,7 +563,7 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 						ZEPHIR_INIT_NVAR(&_38$$18);
 						ZVAL_STRING(&_38$$18, "-");
 						ZVAL_LONG(&_39$$18, 1);
-						ZEPHIR_CALL_FUNCTION(&_40$$18, "strncmp", &_5, 333, &arg, &_38$$18, &_39$$18);
+						ZEPHIR_CALL_FUNCTION(&_40$$18, "strncmp", &_5, 335, &arg, &_38$$18, &_39$$18);
 						zephir_check_call_status();
 						if (ZEPHIR_IS_LONG(&_40$$18, 0)) {
 							ZVAL_LONG(&_41$$19, 1);
@@ -585,7 +585,7 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 		ZEPHIR_CALL_CE_STATIC(&_44$$22, phalcon_cli_router_route_ce, "getdelimiter", NULL, 0);
 		zephir_check_call_status();
 		zephir_fast_join(&_43$$22, &_44$$22, &args);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 476, &_43$$22);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 475, &_43$$22);
 	} else {
 		if (zephir_fast_count_int(&args)) {
 			ZEPHIR_MAKE_REF(&args);
@@ -606,9 +606,9 @@ PHP_METHOD(Phalcon_Cli_Console, setArgument)
 			zephir_fast_array_merge(&_47$$26, &handleArgs, &args);
 			ZEPHIR_CPY_WRT(&handleArgs, &_47$$26);
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 476, &handleArgs);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 475, &handleArgs);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 478, &opts);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 477, &opts);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/cli/dispatcher.zep.c
+++ b/ext/phalcon/cli/dispatcher.zep.c
@@ -127,7 +127,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, callActionMethod)
 	ZEPHIR_CALL_FUNCTION(&localParams, "array_values", NULL, 27, &params);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 479, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 478, PH_NOISY_CC | PH_READONLY);
 	zephir_fast_array_merge(&_0, &localParams, &_1);
 	ZEPHIR_CPY_WRT(&localParams, &_0);
 	ZEPHIR_INIT_VAR(&_2);
@@ -211,7 +211,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, getOption)
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 479, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 478, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	zephir_memory_observe(&optionValue);
 	if (!(zephir_array_isset_fetch(&optionValue, &options, option, 0))) {
@@ -221,7 +221,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, getOption)
 	if (Z_TYPE_P(filters) == IS_NULL) {
 		RETURN_CCTOR(&optionValue);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 480, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 479, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$5);
@@ -286,7 +286,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, hasOption)
 		Z_PARAM_ZVAL(option)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &option);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 479, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 478, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, option));
 }
 
@@ -309,7 +309,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, setDefaultTask)
 		Z_PARAM_STR(taskName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&taskName_zv, taskName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 481, &taskName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 480, &taskName_zv);
 }
 
 /**
@@ -335,7 +335,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 479, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 478, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -358,7 +358,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, setTaskName)
 		Z_PARAM_STR(taskName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&taskName_zv, taskName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 482, &taskName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 481, &taskName_zv);
 }
 
 /**
@@ -380,7 +380,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, setTaskSuffix)
 		Z_PARAM_STR(taskSuffix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&taskSuffix_zv, taskSuffix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 483, &taskSuffix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 482, &taskSuffix_zv);
 }
 
 /**
@@ -409,7 +409,7 @@ PHP_METHOD(Phalcon_Cli_Dispatcher, handleException)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &exception);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 484, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 483, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	if (Z_TYPE_P(&eventsManager) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&_2$$3);

--- a/ext/phalcon/cli/router.zep.c
+++ b/ext/phalcon/cli/router.zep.c
@@ -144,9 +144,9 @@ PHP_METHOD(Phalcon_Cli_Router, __construct)
 		add_assoc_long_ex(&_0$$3, SL("task"), 1);
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "#^(?::delimiter)?([a-zA-Z0-9\\_\\-]+)[:delimiter]{0,1}$#");
-		ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 426, &_1$$3, &_0$$3);
+		ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 428, &_1$$3, &_0$$3);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_2$$3, &route, "getrouteid", NULL, 427);
+		ZEPHIR_CALL_METHOD(&_2$$3, &route, "getrouteid", NULL, 429);
 		zephir_check_call_status();
 		zephir_update_property_array(this_ptr, SL("routes"), &_2$$3, &route);
 		ZEPHIR_INIT_NVAR(&route);
@@ -158,9 +158,9 @@ PHP_METHOD(Phalcon_Cli_Router, __construct)
 		add_assoc_long_ex(&_3$$3, SL("params"), 3);
 		ZEPHIR_INIT_NVAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "#^(?::delimiter)?([a-zA-Z0-9\\_\\-]+):delimiter([a-zA-Z0-9\\.\\_]+)(:delimiter.*)?$#");
-		ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 426, &_1$$3, &_3$$3);
+		ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 428, &_1$$3, &_3$$3);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_4$$3, &route, "getrouteid", NULL, 427);
+		ZEPHIR_CALL_METHOD(&_4$$3, &route, "getrouteid", NULL, 429);
 		zephir_check_call_status();
 		zephir_update_property_array(this_ptr, SL("routes"), &_4$$3, &route);
 	}
@@ -208,9 +208,9 @@ PHP_METHOD(Phalcon_Cli_Router, add)
 	}
 	ZEPHIR_INIT_VAR(&route);
 	object_init_ex(&route, phalcon_cli_router_route_ce);
-	ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 426, &pattern_zv, paths);
+	ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 428, &pattern_zv, paths);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_0, &route, "getrouteid", NULL, 427);
+	ZEPHIR_CALL_METHOD(&_0, &route, "getrouteid", NULL, 429);
 	zephir_check_call_status();
 	zephir_update_property_array(this_ptr, SL("routes"), &_0, &route);
 	RETURN_CCTOR(&route);
@@ -302,9 +302,9 @@ PHP_METHOD(Phalcon_Cli_Router, getRouteById)
 		Z_PARAM_ZVAL(id)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &id);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 485, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 484, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, id)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 485, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 484, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, id, PH_NOISY | PH_READONLY, "phalcon/Cli/Router.zep", 211);
 		RETURN_CTORW(&_2$$3);
 	}
@@ -341,7 +341,7 @@ PHP_METHOD(Phalcon_Cli_Router, getRouteByName)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 485, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 484, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Cli/Router.zep", 230);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)
@@ -546,11 +546,11 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 	ZEPHIR_INIT_VAR(&matches);
 	ZVAL_NULL(&matches);
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 486, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 485, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 486, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 485, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 487, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 486, &__$null);
 	if (Z_TYPE_P(arguments) != IS_ARRAY) {
 		_0$$3 = Z_TYPE_P(arguments) != IS_STRING;
 		if (_0$$3) {
@@ -561,13 +561,13 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 			object_init_ex(&_1$$4, phalcon_cli_router_exceptions_routerargumentsinvalidtype_ce);
 			ZEPHIR_INIT_VAR(&_2$$4);
 			zephir_gettype(&_2$$4, arguments);
-			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 428, &_2$$4);
+			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 430, &_2$$4);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_1$$4, "phalcon/Cli/Router.zep", 269);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 485, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 484, PH_NOISY_CC | PH_READONLY);
 		zephir_is_iterable(&_3$$3, 0, "phalcon/Cli/Router.zep", 373);
 		if (Z_TYPE_P(&_3$$3) == IS_ARRAY) {
 			ZEND_HASH_REVERSE_FOREACH_VAL(Z_ARRVAL_P(&_3$$3), _4$$3)
@@ -592,7 +592,7 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 							object_init_ex(&_5$$10, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
 							ZEPHIR_CALL_METHOD(&_6$$10, &route, "getpattern", NULL, 0);
 							zephir_check_call_status();
-							ZEPHIR_CALL_METHOD(NULL, &_5$$10, "__construct", &_7, 429, &_6$$10);
+							ZEPHIR_CALL_METHOD(NULL, &_5$$10, "__construct", &_7, 431, &_6$$10);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_5$$10, "phalcon/Cli/Router.zep", 295);
 							ZEPHIR_MM_RESTORE();
@@ -704,9 +704,9 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 						}
 						ZEPHIR_INIT_NVAR(&position);
 						ZEPHIR_INIT_NVAR(&part);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 488, &matches);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 487, &matches);
 					}
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 487, &route);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 486, &route);
 					break;
 				}
 			} ZEND_HASH_FOREACH_END();
@@ -746,7 +746,7 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 								object_init_ex(&_24$$30, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
 								ZEPHIR_CALL_METHOD(&_25$$30, &route, "getpattern", NULL, 0);
 								zephir_check_call_status();
-								ZEPHIR_CALL_METHOD(NULL, &_24$$30, "__construct", &_7, 429, &_25$$30);
+								ZEPHIR_CALL_METHOD(NULL, &_24$$30, "__construct", &_7, 431, &_25$$30);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_24$$30, "phalcon/Cli/Router.zep", 295);
 								ZEPHIR_MM_RESTORE();
@@ -858,9 +858,9 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 							}
 							ZEPHIR_INIT_NVAR(&position);
 							ZEPHIR_INIT_NVAR(&part);
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 488, &matches);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 487, &matches);
 						}
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 487, &route);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 486, &route);
 						break;
 					}
 			}
@@ -868,24 +868,24 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 		ZEPHIR_INIT_NVAR(&route);
 		if (zephir_is_true(&routeFound)) {
 			if (1) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 486, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 485, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 486, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 485, &__$false);
 			}
 		} else {
 			if (0) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 486, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 485, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 486, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 485, &__$false);
 			}
-			zephir_read_property_cached(&_40$$46, this_ptr, _zephir_prop_4, 489, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 490, &_40$$46);
-			zephir_read_property_cached(&_41$$46, this_ptr, _zephir_prop_6, 491, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 492, &_41$$46);
-			zephir_read_property_cached(&_42$$46, this_ptr, _zephir_prop_8, 493, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 494, &_42$$46);
-			zephir_read_property_cached(&_43$$46, this_ptr, _zephir_prop_10, 495, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 496, &_43$$46);
+			zephir_read_property_cached(&_40$$46, this_ptr, _zephir_prop_4, 488, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 489, &_40$$46);
+			zephir_read_property_cached(&_41$$46, this_ptr, _zephir_prop_6, 490, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 491, &_41$$46);
+			zephir_read_property_cached(&_42$$46, this_ptr, _zephir_prop_8, 492, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 493, &_42$$46);
+			zephir_read_property_cached(&_43$$46, this_ptr, _zephir_prop_10, 494, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 495, &_43$$46);
 			RETURN_THIS();
 		}
 	} else {
@@ -902,21 +902,21 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 		zephir_array_unset_string(&parts, SL("module"), PH_SEPARATE);
 	} else {
 		ZEPHIR_OBS_NVAR(&moduleName);
-		zephir_read_property_cached(&moduleName, this_ptr, _zephir_prop_4, 489, PH_NOISY_CC);
+		zephir_read_property_cached(&moduleName, this_ptr, _zephir_prop_4, 488, PH_NOISY_CC);
 	}
 	ZEPHIR_OBS_NVAR(&taskName);
 	if (zephir_array_isset_string_fetch(&taskName, &parts, SL("task"), 0)) {
 		zephir_array_unset_string(&parts, SL("task"), PH_SEPARATE);
 	} else {
 		ZEPHIR_OBS_NVAR(&taskName);
-		zephir_read_property_cached(&taskName, this_ptr, _zephir_prop_6, 491, PH_NOISY_CC);
+		zephir_read_property_cached(&taskName, this_ptr, _zephir_prop_6, 490, PH_NOISY_CC);
 	}
 	ZEPHIR_OBS_NVAR(&actionName);
 	if (zephir_array_isset_string_fetch(&actionName, &parts, SL("action"), 0)) {
 		zephir_array_unset_string(&parts, SL("action"), PH_SEPARATE);
 	} else {
 		ZEPHIR_OBS_NVAR(&actionName);
-		zephir_read_property_cached(&actionName, this_ptr, _zephir_prop_8, 493, PH_NOISY_CC);
+		zephir_read_property_cached(&actionName, this_ptr, _zephir_prop_8, 492, PH_NOISY_CC);
 	}
 	ZEPHIR_OBS_NVAR(&params);
 	if (zephir_array_isset_string_fetch(&params, &parts, SL("params"), 0)) {
@@ -944,10 +944,10 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 	} else {
 		ZEPHIR_CPY_WRT(&params, &parts);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 490, &moduleName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 492, &taskName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 494, &actionName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 496, &params);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 489, &moduleName);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 491, &taskName);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 493, &actionName);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 495, &params);
 	RETURN_THIS();
 }
 
@@ -970,7 +970,7 @@ PHP_METHOD(Phalcon_Cli_Router, setDefaultAction)
 		Z_PARAM_STR(actionName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&actionName_zv, actionName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 493, &actionName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 492, &actionName_zv);
 	RETURN_THISW();
 }
 
@@ -993,7 +993,7 @@ PHP_METHOD(Phalcon_Cli_Router, setDefaultModule)
 		Z_PARAM_STR(moduleName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&moduleName_zv, moduleName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 489, &moduleName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 488, &moduleName_zv);
 	RETURN_THISW();
 }
 
@@ -1049,19 +1049,19 @@ PHP_METHOD(Phalcon_Cli_Router, setDefaults)
 	zephir_get_arrval(&defaults, defaults_param);
 	zephir_memory_observe(&module);
 	if (zephir_array_isset_string_fetch(&module, &defaults, SL("module"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 489, &module);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 488, &module);
 	}
 	zephir_memory_observe(&task);
 	if (zephir_array_isset_string_fetch(&task, &defaults, SL("task"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 491, &task);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 490, &task);
 	}
 	zephir_memory_observe(&action);
 	if (zephir_array_isset_string_fetch(&action, &defaults, SL("action"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 493, &action);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 492, &action);
 	}
 	zephir_memory_observe(&params);
 	if (zephir_array_isset_string_fetch(&params, &defaults, SL("params"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 495, &params);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 494, &params);
 	}
 	RETURN_THIS();
 }
@@ -1085,7 +1085,7 @@ PHP_METHOD(Phalcon_Cli_Router, setDefaultTask)
 		Z_PARAM_STR(taskName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&taskName_zv, taskName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 491, &taskName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 490, &taskName_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/cli/router/route.zep.c
+++ b/ext/phalcon/cli/router/route.zep.c
@@ -139,7 +139,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, __construct)
 	}
 	zephir_memory_observe(&_0);
 	zephir_read_static_property_ce(&_0, phalcon_cli_router_route_ce, SL("delimiterPath"), PH_NOISY_CC);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 497, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 496, &_0);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "reconfigure", NULL, 0, &pattern_zv, paths);
 	zephir_check_call_status();
 	zephir_memory_observe(&_1);
@@ -147,7 +147,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, __construct)
 	ZEPHIR_CPY_WRT(&uniqueId, &_1);
 	ZEPHIR_CPY_WRT(&routeId, &uniqueId);
 	zephir_cast_to_string(&_2, &routeId);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 498, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 497, &_2);
 	ZVAL_UNDEF(&_1);
 	ZVAL_LONG(&_1, (zephir_get_numberval(&uniqueId) + 1));
 	zephir_update_static_property_ce(phalcon_cli_router_route_ce, ZEND_STRL("uniqueId"), &_1);
@@ -189,14 +189,14 @@ PHP_METHOD(Phalcon_Cli_Router_Route, beforeMatch)
 	if (UNEXPECTED(!(zephir_is_callable(callback)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 499, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 429, &_1$$3);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 498, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 431, &_1$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Cli/Router/Route.zep", 113);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 500, callback);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 499, callback);
 	RETURN_THIS();
 }
 
@@ -250,41 +250,41 @@ PHP_METHOD(Phalcon_Cli_Router_Route, compilePattern)
 	zephir_fetch_params(1, 1, 0, &pattern_param);
 	zephir_get_strval(&pattern, pattern_param);
 	if (zephir_memnstr_str(&pattern, SL(":"), "phalcon/Cli/Router/Route.zep", 131)) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&idPattern);
 		ZEPHIR_CONCAT_VS(&idPattern, &_0$$3, "([a-zA-Z0-9\\_\\-]+)");
 		ZEPHIR_INIT_VAR(&map);
 		zephir_create_array(&map, 7, 0);
 		zephir_memory_observe(&_1$$3);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC);
 		zephir_array_update_string(&map, SL(":delimiter"), &_1$$3, PH_COPY | PH_SEPARATE);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZEPHIR_CONCAT_VS(&_3$$3, &_2$$3, ":module");
 		zephir_array_update_zval(&map, &_3$$3, &idPattern, PH_COPY);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_5$$3);
 		ZEPHIR_CONCAT_VS(&_5$$3, &_4$$3, ":task");
 		zephir_array_update_zval(&map, &_5$$3, &idPattern, PH_COPY);
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_7$$3);
 		ZEPHIR_CONCAT_VS(&_7$$3, &_6$$3, ":namespace");
 		zephir_array_update_zval(&map, &_7$$3, &idPattern, PH_COPY);
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_9$$3);
 		ZEPHIR_CONCAT_VS(&_9$$3, &_8$$3, ":action");
 		zephir_array_update_zval(&map, &_9$$3, &idPattern, PH_COPY);
-		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_11$$3);
 		ZEPHIR_CONCAT_VS(&_11$$3, &_10$$3, ":params");
-		zephir_read_property_cached(&_12$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_13$$3);
 		ZEPHIR_CONCAT_SVS(&_13$$3, "(", &_12$$3, ".*)?");
 		zephir_array_update_zval(&map, &_11$$3, &_13$$3, PH_COPY);
-		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_13$$3);
 		ZEPHIR_CONCAT_VS(&_13$$3, &_14$$3, ":int");
-		zephir_read_property_cached(&_15$$3, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_15$$3, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_16$$3);
 		ZEPHIR_CONCAT_VS(&_16$$3, &_15$$3, "([0-9]+)");
 		zephir_array_update_zval(&map, &_13$$3, &_16$$3, PH_COPY);
@@ -562,7 +562,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, extractNamedParams)
 								}
 								zephir_array_update_zval(&matches, &variable, &tmp, PH_COPY | PH_SEPARATE);
 							} else {
-								zephir_read_property_cached(&_28$$27, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+								zephir_read_property_cached(&_28$$27, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 								ZEPHIR_INIT_NVAR(&_29$$27);
 								ZEPHIR_CONCAT_SVS(&_29$$27, "([^", &_28$$27, "]*)");
 								zephir_concat_self(&route, &_29$$27);
@@ -693,8 +693,8 @@ PHP_METHOD(Phalcon_Cli_Router_Route, getReversedPaths)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 501, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_RETURN_CALL_FUNCTION("array_flip", NULL, 253, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 500, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_RETURN_CALL_FUNCTION("array_flip", NULL, 254, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -835,7 +835,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, reConfigure)
 				if (UNEXPECTED(_1$$10)) {
 					ZEPHIR_INIT_VAR(&_2$$11);
 					object_init_ex(&_2$$11, phalcon_cli_router_exceptions_invalidroutepaths_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_2$$11, "__construct", NULL, 430, &pattern);
+					ZEPHIR_CALL_METHOD(NULL, &_2$$11, "__construct", NULL, 432, &pattern);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_2$$11, "phalcon/Cli/Router/Route.zep", 466);
 					ZEPHIR_MM_RESTORE();
@@ -860,7 +860,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, reConfigure)
 	if (UNEXPECTED(Z_TYPE_P(&routePaths) != IS_ARRAY)) {
 		ZEPHIR_INIT_VAR(&_4$$16);
 		object_init_ex(&_4$$16, phalcon_cli_router_exceptions_invalidroutepaths_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_4$$16, "__construct", NULL, 430, &pattern);
+		ZEPHIR_CALL_METHOD(NULL, &_4$$16, "__construct", NULL, 432, &pattern);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_4$$16, "phalcon/Cli/Router/Route.zep", 490);
 		ZEPHIR_MM_RESTORE();
@@ -884,7 +884,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, reConfigure)
 	} else {
 		if (zephir_memnstr_str(&pattern, SL(":delimiter"), "phalcon/Cli/Router/Route.zep", 515)) {
 			ZEPHIR_INIT_VAR(&_7$$21);
-			zephir_read_property_cached(&_8$$21, this_ptr, _zephir_prop_0, 497, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$21, this_ptr, _zephir_prop_0, 496, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_9$$21);
 			ZVAL_STRING(&_9$$21, ":delimiter");
 			zephir_fast_str_replace(&_7$$21, &_9$$21, &_8$$21, &pattern);
@@ -892,9 +892,9 @@ PHP_METHOD(Phalcon_Cli_Router_Route, reConfigure)
 		}
 		ZEPHIR_CPY_WRT(&compiledPattern, &pattern);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 499, &pattern);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 502, &compiledPattern);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 501, &routePaths);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 498, &pattern);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 501, &compiledPattern);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 500, &routePaths);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -934,7 +934,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, setDescription)
 		Z_PARAM_STR(description)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&description_zv, description);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 503, &description_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 502, &description_zv);
 	RETURN_THISW();
 }
 
@@ -966,7 +966,7 @@ PHP_METHOD(Phalcon_Cli_Router_Route, setName)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 504, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 503, &name_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/config/adapter/grouped.zep.c
+++ b/ext/phalcon/config/adapter/grouped.zep.c
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 	if (Z_TYPE_P(&configFactory) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(&configFactory);
 		object_init_ex(&configFactory, phalcon_config_configfactory_ce);
-		ZEPHIR_CALL_METHOD(NULL, &configFactory, "__construct", NULL, 431);
+		ZEPHIR_CALL_METHOD(NULL, &configFactory, "__construct", NULL, 433);
 		zephir_check_call_status();
 	}
 	zephir_is_iterable(&arrayConfig, 0, "phalcon/Config/Adapter/Grouped.zep", 135);
@@ -194,7 +194,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 				ZEPHIR_INIT_NVAR(&_4$$6);
 				ZVAL_STRING(&_4$$6, "");
 				if (ZEPHIR_IS_IDENTICAL(&_4$$6, &defaultAdapter_zv)) {
-					ZEPHIR_CALL_METHOD(&_5$$7, &configFactory, "load", &_6, 432, &configName);
+					ZEPHIR_CALL_METHOD(&_5$$7, &configFactory, "load", &_6, 434, &configName);
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(NULL, this_ptr, "merge", &_3, 0, &_5$$7);
 					zephir_check_call_status();
@@ -215,7 +215,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 				if (!(zephir_array_isset_value_string(&configInstance, SL("config")))) {
 					ZEPHIR_INIT_NVAR(&_10$$10);
 					object_init_ex(&_10$$10, phalcon_config_exceptions_groupedadapterrequiresarray_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_10$$10, "__construct", &_11, 433);
+					ZEPHIR_CALL_METHOD(NULL, &_10$$10, "__construct", &_11, 435);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_10$$10, "phalcon/Config/Adapter/Grouped.zep", 124);
 					ZEPHIR_MM_RESTORE();
@@ -225,11 +225,11 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 				zephir_array_fetch_string(&configArray, &configInstance, SL("config"), PH_NOISY, "phalcon/Config/Adapter/Grouped.zep", 127);
 				ZEPHIR_INIT_NVAR(&configInstance);
 				object_init_ex(&configInstance, phalcon_config_config_ce);
-				zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_0, 505, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_0, 504, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &configInstance, "__construct", &_13, 41, &configArray, &_12$$9);
 				zephir_check_call_status();
 			} else {
-				ZEPHIR_CALL_METHOD(&_14$$11, &configFactory, "load", &_6, 432, &configInstance);
+				ZEPHIR_CALL_METHOD(&_14$$11, &configFactory, "load", &_6, 434, &configInstance);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&configInstance, &_14$$11);
 			}
@@ -267,7 +267,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 					ZEPHIR_INIT_NVAR(&_18$$14);
 					ZVAL_STRING(&_18$$14, "");
 					if (ZEPHIR_IS_IDENTICAL(&_18$$14, &defaultAdapter_zv)) {
-						ZEPHIR_CALL_METHOD(&_19$$15, &configFactory, "load", &_6, 432, &configName);
+						ZEPHIR_CALL_METHOD(&_19$$15, &configFactory, "load", &_6, 434, &configName);
 						zephir_check_call_status();
 						ZEPHIR_CALL_METHOD(NULL, this_ptr, "merge", &_3, 0, &_19$$15);
 						zephir_check_call_status();
@@ -288,7 +288,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 					if (!(zephir_array_isset_value_string(&configInstance, SL("config")))) {
 						ZEPHIR_INIT_NVAR(&_23$$18);
 						object_init_ex(&_23$$18, phalcon_config_exceptions_groupedadapterrequiresarray_ce);
-						ZEPHIR_CALL_METHOD(NULL, &_23$$18, "__construct", &_11, 433);
+						ZEPHIR_CALL_METHOD(NULL, &_23$$18, "__construct", &_11, 435);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_23$$18, "phalcon/Config/Adapter/Grouped.zep", 124);
 						ZEPHIR_MM_RESTORE();
@@ -298,11 +298,11 @@ PHP_METHOD(Phalcon_Config_Adapter_Grouped, __construct)
 					zephir_array_fetch_string(&configArray, &configInstance, SL("config"), PH_NOISY, "phalcon/Config/Adapter/Grouped.zep", 127);
 					ZEPHIR_INIT_NVAR(&configInstance);
 					object_init_ex(&configInstance, phalcon_config_config_ce);
-					zephir_read_property_cached(&_24$$17, this_ptr, _zephir_prop_0, 505, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_24$$17, this_ptr, _zephir_prop_0, 504, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &configInstance, "__construct", &_13, 41, &configArray, &_24$$17);
 					zephir_check_call_status();
 				} else {
-					ZEPHIR_CALL_METHOD(&_25$$19, &configFactory, "load", &_6, 432, &configInstance);
+					ZEPHIR_CALL_METHOD(&_25$$19, &configFactory, "load", &_6, 434, &configInstance);
 					zephir_check_call_status();
 					ZEPHIR_CPY_WRT(&configInstance, &_25$$19);
 				}

--- a/ext/phalcon/config/adapter/ini.zep.c
+++ b/ext/phalcon/config/adapter/ini.zep.c
@@ -154,7 +154,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, __construct)
 		object_init_ex(&_2$$3, phalcon_config_exceptions_cannotloadconfigfile_ce);
 		ZEPHIR_INIT_VAR(&_3$$3);
 		zephir_basename(&_3$$3, &filePath_zv);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 434, &_3$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 436, &_3$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$3, "phalcon/Config/Adapter/Ini.zep", 80);
 		ZEPHIR_MM_RESTORE();
@@ -539,7 +539,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, parseIniString)
 	ZEPHIR_INIT_VAR(&_3);
 	zephir_substr(&_3, &path, zephir_get_intval(&_2), 0, ZEPHIR_SUBSTR_NO_LENGTH);
 	zephir_get_strval(&path, &_3);
-	ZEPHIR_CALL_METHOD(&result, this_ptr, "parseinistring", NULL, 435, &path, &castValue);
+	ZEPHIR_CALL_METHOD(&result, this_ptr, "parseinistring", NULL, 437, &path, &castValue);
 	zephir_check_call_status();
 	zephir_create_array(return_value, 1, 0);
 	zephir_array_update_zval(return_value, &key, &result, PH_COPY);
@@ -584,7 +584,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, phpIniGet)
 		zephir_memory_observe(&defaultValue_zv);
 	ZVAL_STR_COPY(&defaultValue_zv, defaultValue);
 	}
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_STR(zend_string_copy(defaultValue));
@@ -631,7 +631,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, phpIniGetBool)
 	} else {
 		}
 	result = 0;
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_BOOL(defaultValue);
@@ -683,7 +683,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, phpIniGetInt)
 		defaultValue = 0;
 	} else {
 		}
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_LONG(defaultValue);
@@ -739,7 +739,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Ini, phpParseIniFile)
 		}
 	ZVAL_BOOL(&_0, (processSections ? 1 : 0));
 	ZVAL_LONG(&_1, scannerMode);
-	ZEPHIR_RETURN_CALL_FUNCTION("parse_ini_file", NULL, 437, &filename_zv, &_0, &_1);
+	ZEPHIR_RETURN_CALL_FUNCTION("parse_ini_file", NULL, 439, &filename_zv, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/config/adapter/json.zep.c
+++ b/ext/phalcon/config/adapter/json.zep.c
@@ -89,7 +89,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Json, __construct)
 		object_init_ex(&_0$$3, phalcon_config_exceptions_cannotloadconfigfile_ce);
 		ZEPHIR_INIT_VAR(&_1$$3);
 		zephir_basename(&_1$$3, &filePath_zv);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 434, &_1$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 436, &_1$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Config/Adapter/Json.zep", 54);
 		ZEPHIR_MM_RESTORE();
@@ -103,7 +103,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Json, __construct)
 	}
 
 	ZVAL_BOOL(&_4, 1);
-	ZEPHIR_CALL_METHOD(&_3, &_2, "__invoke", NULL, 381, &content, &_4);
+	ZEPHIR_CALL_METHOD(&_3, &_2, "__invoke", NULL, 383, &content, &_4);
 	zephir_check_call_status();
 	ZEPHIR_CALL_PARENT(NULL, phalcon_config_adapter_json_ce, getThis(), "__construct", NULL, 0, &_3);
 	zephir_check_call_status();

--- a/ext/phalcon/config/adapter/php.zep.c
+++ b/ext/phalcon/config/adapter/php.zep.c
@@ -95,14 +95,14 @@ PHP_METHOD(Phalcon_Config_Adapter_Php, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&filePath_zv);
 	ZVAL_STR_COPY(&filePath_zv, filePath);
-	ZEPHIR_CALL_FUNCTION(&_0, "is_file", NULL, 438, &filePath_zv);
+	ZEPHIR_CALL_FUNCTION(&_0, "is_file", NULL, 440, &filePath_zv);
 	zephir_check_call_status();
 	if (UNEXPECTED(!ZEPHIR_IS_TRUE_IDENTICAL(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_config_exceptions_cannotloadconfigfile_ce);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		zephir_basename(&_2$$3, &filePath_zv);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 434, &_2$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 436, &_2$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Config/Adapter/Php.zep", 61);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/config/adapter/yaml.zep.c
+++ b/ext/phalcon/config/adapter/yaml.zep.c
@@ -118,7 +118,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Yaml, __construct)
 	if (UNEXPECTED(!zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_2$$3);
 		object_init_ex(&_2$$3, phalcon_config_exceptions_missingyamlextension_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 439);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 441);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$3, "phalcon/Config/Adapter/Yaml.zep", 70);
 		ZEPHIR_MM_RESTORE();
@@ -141,7 +141,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Yaml, __construct)
 		object_init_ex(&_4$$7, phalcon_config_exceptions_cannotloadconfigfile_ce);
 		ZEPHIR_INIT_VAR(&_5$$7);
 		zephir_basename(&_5$$7, &filePath_zv);
-		ZEPHIR_CALL_METHOD(NULL, &_4$$7, "__construct", NULL, 434, &_5$$7);
+		ZEPHIR_CALL_METHOD(NULL, &_4$$7, "__construct", NULL, 436, &_5$$7);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_4$$7, "phalcon/Config/Adapter/Yaml.zep", 84);
 		ZEPHIR_MM_RESTORE();
@@ -176,7 +176,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Yaml, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -256,7 +256,7 @@ PHP_METHOD(Phalcon_Config_Adapter_Yaml, phpYamlParseFile)
 	ZVAL_NULL(&ndocs);
 	ZVAL_LONG(&_0, pos);
 	ZEPHIR_MAKE_REF(&ndocs);
-	ZEPHIR_RETURN_CALL_FUNCTION("yaml_parse_file", NULL, 441, &filename_zv, &_0, &ndocs, &callbacks);
+	ZEPHIR_RETURN_CALL_FUNCTION("yaml_parse_file", NULL, 443, &filename_zv, &_0, &ndocs, &callbacks);
 	ZEPHIR_UNREF(&ndocs);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/config/configfactory.zep.c
+++ b/ext/phalcon/config/configfactory.zep.c
@@ -359,7 +359,7 @@ PHP_METHOD(Phalcon_Config_ConfigFactory, parseConfig)
 		if (1 == ZEPHIR_IS_EMPTY(&extension)) {
 			ZEPHIR_INIT_VAR(&_1$$4);
 			object_init_ex(&_1$$4, phalcon_config_exceptions_missingfileextension_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 442);
+			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 444);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_1$$4, "phalcon/Config/ConfigFactory.zep", 193);
 			ZEPHIR_MM_RESTORE();
@@ -383,13 +383,13 @@ PHP_METHOD(Phalcon_Config_ConfigFactory, parseConfig)
 	if (Z_TYPE_P(config) != IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_5$$6);
 		object_init_ex(&_5$$6, phalcon_config_exceptions_confignotarrayorobject_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_5$$6, "__construct", NULL, 443);
+		ZEPHIR_CALL_METHOD(NULL, &_5$$6, "__construct", NULL, 445);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_5$$6, "phalcon/Config/ConfigFactory.zep", 207);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkconfigarray", NULL, 444, config);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkconfigarray", NULL, 446, config);
 	zephir_check_call_status();
 	RETVAL_ZVAL(config, 1, 0);
 	RETURN_MM();

--- a/ext/phalcon/config/exceptions/cannotloadconfigfile.zep.c
+++ b/ext/phalcon/config/exceptions/cannotloadconfigfile.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Phalcon_Config_Exceptions_CannotLoadConfigFile, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&fileName_zv);
 	ZVAL_STR_COPY(&fileName_zv, fileName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 506, &fileName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 505, &fileName_zv);
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_SVS(&_0, "Configuration file ", &fileName_zv, " cannot be loaded");
 	ZEPHIR_CALL_PARENT(NULL, phalcon_config_exceptions_cannotloadconfigfile_ce, getThis(), "__construct", NULL, 0, &_0);

--- a/ext/phalcon/config/exceptions/missingconfigoption.zep.c
+++ b/ext/phalcon/config/exceptions/missingconfigoption.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Phalcon_Config_Exceptions_MissingConfigOption, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&option_zv);
 	ZVAL_STR_COPY(&option_zv, option);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 507, &option_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 506, &option_zv);
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_SVS(&_0, "You must provide '", &option_zv, "' option in factory config parameter.");
 	ZEPHIR_CALL_PARENT(NULL, phalcon_config_exceptions_missingconfigoption_ce, getThis(), "__construct", NULL, 0, &_0);

--- a/ext/phalcon/container/container.zep.c
+++ b/ext/phalcon/container/container.zep.c
@@ -123,7 +123,7 @@ PHP_METHOD(Phalcon_Container_Container, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 508, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 507, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_create_array(&_1, 3, 0);
 	ZEPHIR_INIT_VAR(&_2);
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_Container_Container, __construct)
 	}
 
 	zephir_array_fast_append(&_1, &_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 509, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 508, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -288,30 +288,30 @@ PHP_METHOD(Phalcon_Container_Container, extend)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &name_param, &callableObject);
 	zephir_get_strval(&name, name_param);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 445, &name);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 447, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 509, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_key_exists(&_1, &name)) {
 		ZEPHIR_INIT_VAR(&_2$$3);
 		object_init_ex(&_2$$3, phalcon_container_exceptions_cannotextendresolved_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 446, &name);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 448, &name);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$3, "phalcon/Container/Container.zep", 165);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_key_exists(&_3, &name))) {
 		ZEPHIR_INIT_VAR(&_4$$4);
 		object_init_ex(&_4$$4, phalcon_container_exceptions_servicenotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_4$$4, "__construct", NULL, 447, &name);
+		ZEPHIR_CALL_METHOD(NULL, &_4$$4, "__construct", NULL, 449, &name);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_4$$4, "phalcon/Container/Container.zep", 169);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_6, &_5, &name, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 172);
 	ZEPHIR_CALL_METHOD(NULL, &_6, "addextender", NULL, 0, callableObject);
 	zephir_check_call_status();
@@ -357,23 +357,23 @@ PHP_METHOD(Phalcon_Container_Container, get)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
 	zephir_get_strval(&name, name_param);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 445, &name);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 447, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_key_exists(&_1, &name)) {
-		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolveparameter", NULL, 448, &name);
+		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolveparameter", NULL, 450, &name);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 509, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_key_exists(&_2, &name)) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 509, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_4$$4, &_3$$4, &name, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 192);
 		RETURN_CTOR(&_4$$4);
 	}
 	ZVAL_BOOL(&_5, 1);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolve", NULL, 449, &name, &_5);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolve", NULL, 451, &name, &_5);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -408,7 +408,7 @@ PHP_METHOD(Phalcon_Container_Container, getAlias)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&alias);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&alias, &_0, &name_zv, 0)) {
 		RETURN_CCTOR(&alias);
 	}
@@ -453,7 +453,7 @@ PHP_METHOD(Phalcon_Container_Container, getByTag)
 	zephir_memory_observe(&tag_zv);
 	ZVAL_STR_COPY(&tag_zv, tag);
 	zephir_memory_observe(&names);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 514, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&names, &_0, &tag_zv, 0))) {
 		ZEPHIR_INIT_NVAR(&names);
 		array_init(&names);
@@ -530,17 +530,17 @@ PHP_METHOD(Phalcon_Container_Container, getDefinition)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_key_exists(&_0, &name_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_container_exceptions_servicenotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 447, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 449, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Container/Container.zep", 251);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 254);
 	RETURN_CTOR(&_3);
 }
@@ -578,17 +578,17 @@ PHP_METHOD(Phalcon_Container_Container, getInstance)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 509, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_key_exists(&_0, &name_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_container_exceptions_instancenotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 450, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 452, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Container/Container.zep", 268);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 509, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 271);
 	RETURN_CTOR(&_3);
 }
@@ -624,17 +624,17 @@ PHP_METHOD(Phalcon_Container_Container, getParameter)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_key_exists(&_0, &name_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_container_exceptions_parameternotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 451, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 453, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Container/Container.zep", 285);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolveparameter", NULL, 448, &name_zv);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolveparameter", NULL, 450, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -682,7 +682,7 @@ PHP_METHOD(Phalcon_Container_Container, getService)
 	if (!(Z_TYPE_P(&result) == IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_container_exceptions_servicenotregistered_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 452, &serviceName_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 454, &serviceName_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Container/Container.zep", 317);
 		ZEPHIR_MM_RESTORE();
@@ -744,27 +744,27 @@ PHP_METHOD(Phalcon_Container_Container, has)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
 	zephir_get_strval(&name, name_param);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 445, &name);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 447, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
 	_2 = zephir_array_key_exists(&_1, &name);
 	if (!(_2)) {
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 509, PH_NOISY_CC | PH_READONLY);
 		_2 = zephir_array_key_exists(&_3, &name);
 	}
 	_4 = _2;
 	if (!(_4)) {
-		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 511, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 510, PH_NOISY_CC | PH_READONLY);
 		_4 = zephir_array_key_exists(&_5, &name);
 	}
 	if (_4) {
 		RETURN_MM_BOOL(1);
 	}
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 515, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 514, PH_NOISY_CC | PH_READONLY);
 	_7 = zephir_is_true(&_6);
 	if (_7) {
-		zephir_read_property_cached(&_8, this_ptr, _zephir_prop_4, 508, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8, this_ptr, _zephir_prop_4, 507, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_9, &_8, "isresolvableclass", NULL, 0, &name);
 		zephir_check_call_status();
 		_7 = zephir_is_true(&_9);
@@ -796,7 +796,7 @@ PHP_METHOD(Phalcon_Container_Container, hasAlias)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_key_exists(&_0, &name_zv));
 }
 
@@ -824,7 +824,7 @@ PHP_METHOD(Phalcon_Container_Container, hasDefinition)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_key_exists(&_0, &name_zv));
 }
 
@@ -852,7 +852,7 @@ PHP_METHOD(Phalcon_Container_Container, hasInstance)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 509, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_key_exists(&_0, &name_zv));
 }
 
@@ -880,7 +880,7 @@ PHP_METHOD(Phalcon_Container_Container, hasParameter)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_key_exists(&_0, &name_zv));
 }
 
@@ -952,11 +952,11 @@ PHP_METHOD(Phalcon_Container_Container, new)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &name_param);
 	zephir_get_strval(&name, name_param);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 445, &name);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvealias", NULL, 447, &name);
 	zephir_check_call_status();
 	zephir_get_strval(&name, &_0);
 	ZVAL_BOOL(&_1, 0);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolve", NULL, 449, &name, &_1);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolve", NULL, 451, &name, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -987,7 +987,7 @@ PHP_METHOD(Phalcon_Container_Container, newDefinition)
 	object_init_ex(return_value, phalcon_container_definition_servicedefinition_ce);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "string");
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 453, &name_zv, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 455, &name_zv, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -1022,7 +1022,7 @@ PHP_METHOD(Phalcon_Container_Container, set)
 	definition = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_CALL_METHOD(&processor, this_ptr, "findprocessor", NULL, 454, definition);
+	ZEPHIR_CALL_METHOD(&processor, this_ptr, "findprocessor", NULL, 456, definition);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&def, &processor, "process", NULL, 0, &name_zv, definition, this_ptr);
 	zephir_check_call_status();
@@ -1061,7 +1061,7 @@ PHP_METHOD(Phalcon_Container_Container, setAlias)
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&alias_zv);
 	ZVAL_STR_COPY(&alias_zv, alias);
-	ZEPHIR_CALL_METHOD(NULL, this_ptr, "detectcircularalias", NULL, 455, &alias_zv, &name_zv);
+	ZEPHIR_CALL_METHOD(NULL, this_ptr, "detectcircularalias", NULL, 457, &alias_zv, &name_zv);
 	zephir_check_call_status();
 	zephir_update_property_array(this_ptr, SL("aliases"), &alias_zv, &name_zv);
 	RETURN_THIS();
@@ -1092,9 +1092,9 @@ PHP_METHOD(Phalcon_Container_Container, setAutowire)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &enabled_param);
 	if (enabled) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 515, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 514, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 515, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 514, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1221,13 +1221,13 @@ PHP_METHOD(Phalcon_Container_Container, setTag)
 	ZVAL_STR_COPY(&tag_zv, tag);
 	zephir_memory_observe(&serviceName_zv);
 	ZVAL_STR_COPY(&serviceName_zv, serviceName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 514, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_key_exists(&_0, &tag_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		array_init(&_1$$3);
 		zephir_update_property_array(this_ptr, SL("tags"), &tag_zv, &_1$$3);
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 514, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, &tag_zv, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 561);
 	ZEPHIR_CALL_FUNCTION(&_4, "in_array", NULL, 87, &serviceName_zv, &_3, &__$true);
 	zephir_check_call_status();
@@ -1262,7 +1262,7 @@ PHP_METHOD(Phalcon_Container_Container, unsetAlias)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("aliases"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 }
 
@@ -1291,7 +1291,7 @@ PHP_METHOD(Phalcon_Container_Container, unsetDefinition)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("services"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 }
 
@@ -1325,10 +1325,10 @@ PHP_METHOD(Phalcon_Container_Container, unsetInstance)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("instances"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 509, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("instanceLifetimes"), &name_zv);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 516, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 515, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_1, &name_zv, PH_SEPARATE);
 }
 
@@ -1374,7 +1374,7 @@ PHP_METHOD(Phalcon_Container_Container, unsetInstances)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&lifetime_zv);
 	ZVAL_STR_COPY(&lifetime_zv, lifetime);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 516, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 515, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Container/Container.zep", 620);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_0), _2, _3, _1)
@@ -1389,10 +1389,10 @@ PHP_METHOD(Phalcon_Container_Container, unsetInstances)
 			ZVAL_COPY(&instanceLifetime, _1);
 			if (ZEPHIR_IS_IDENTICAL(&instanceLifetime, &lifetime_zv)) {
 				zephir_unset_property_array(this_ptr, ZEND_STRL("instances"), &name);
-				zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 509, PH_NOISY_CC | PH_READONLY);
 				zephir_array_unset(&_4$$4, &name, PH_SEPARATE);
 				zephir_unset_property_array(this_ptr, ZEND_STRL("instanceLifetimes"), &name);
-				zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_0, 516, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_0, 515, PH_NOISY_CC | PH_READONLY);
 				zephir_array_unset(&_5$$4, &name, PH_SEPARATE);
 			}
 		} ZEND_HASH_FOREACH_END();
@@ -1418,10 +1418,10 @@ PHP_METHOD(Phalcon_Container_Container, unsetInstances)
 			zephir_check_call_status();
 				if (ZEPHIR_IS_IDENTICAL(&instanceLifetime, &lifetime_zv)) {
 					zephir_unset_property_array(this_ptr, ZEND_STRL("instances"), &name);
-					zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_1, 510, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_1, 509, PH_NOISY_CC | PH_READONLY);
 					zephir_array_unset(&_8$$6, &name, PH_SEPARATE);
 					zephir_unset_property_array(this_ptr, ZEND_STRL("instanceLifetimes"), &name);
-					zephir_read_property_cached(&_9$$6, this_ptr, _zephir_prop_0, 516, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_9$$6, this_ptr, _zephir_prop_0, 515, PH_NOISY_CC | PH_READONLY);
 					zephir_array_unset(&_9$$6, &name, PH_SEPARATE);
 				}
 		}
@@ -1456,7 +1456,7 @@ PHP_METHOD(Phalcon_Container_Container, unsetParameter)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("parameters"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 }
 
@@ -1512,7 +1512,7 @@ PHP_METHOD(Phalcon_Container_Container, detectCircularAlias)
 		if (ZEPHIR_IS_IDENTICAL(&current, &alias_zv)) {
 			ZEPHIR_INIT_NVAR(&_0$$4);
 			object_init_ex(&_0$$4, phalcon_container_exceptions_circularaliasfound_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_0$$4, "__construct", &_1, 456, &alias_zv);
+			ZEPHIR_CALL_METHOD(NULL, &_0$$4, "__construct", &_1, 458, &alias_zv);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_0$$4, "phalcon/Container/Container.zep", 652);
 			ZEPHIR_MM_RESTORE();
@@ -1521,12 +1521,12 @@ PHP_METHOD(Phalcon_Container_Container, detectCircularAlias)
 		if (zephir_array_key_exists(&seen, &current)) {
 			break;
 		}
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 		if (!(zephir_array_key_exists(&_2$$3, &current))) {
 			break;
 		}
 		zephir_array_update_zval(&seen, &current, &__$true, PH_COPY | PH_SEPARATE);
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_4$$3, &_3$$3, &current, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 664);
 		ZEPHIR_CPY_WRT(&current, &_4$$3);
 	}
@@ -1567,7 +1567,7 @@ PHP_METHOD(Phalcon_Container_Container, findProcessor)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &definition);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 509, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 508, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Container/Container.zep", 686);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)
@@ -1608,7 +1608,7 @@ PHP_METHOD(Phalcon_Container_Container, findProcessor)
 	ZEPHIR_INIT_NVAR(&processor);
 	ZEPHIR_INIT_VAR(&_6);
 	object_init_ex(&_6, phalcon_container_exceptions_noprocessorfound_ce);
-	ZEPHIR_CALL_METHOD(NULL, &_6, "__construct", NULL, 457);
+	ZEPHIR_CALL_METHOD(NULL, &_6, "__construct", NULL, 459);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(&_6, "phalcon/Container/Container.zep", 686);
 	ZEPHIR_MM_RESTORE();
@@ -1660,9 +1660,9 @@ PHP_METHOD(Phalcon_Container_Container, resolve)
 	cache_param = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_key_exists(&_0, &name_zv))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 515, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 514, PH_NOISY_CC | PH_READONLY);
 		_2$$3 = zephir_is_true(&_1$$3);
 		if (_2$$3) {
 			_2$$3 = zephir_class_exists(&name_zv, 1);
@@ -1673,14 +1673,14 @@ PHP_METHOD(Phalcon_Container_Container, resolve)
 		} else {
 			ZEPHIR_INIT_VAR(&_3$$5);
 			object_init_ex(&_3$$5, phalcon_container_exceptions_servicenotfound_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_3$$5, "__construct", NULL, 447, &name_zv);
+			ZEPHIR_CALL_METHOD(NULL, &_3$$5, "__construct", NULL, 449, &name_zv);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_3$$5, "phalcon/Container/Container.zep", 707);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 510, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&definition);
 	zephir_array_fetch(&definition, &_4, &name_zv, PH_NOISY, "phalcon/Container/Container.zep", 711);
 	ZEPHIR_CALL_METHOD(NULL, &definition, "freeze", NULL, 0, this_ptr);
@@ -1741,21 +1741,21 @@ PHP_METHOD(Phalcon_Container_Container, resolveAlias)
 	array_init(&seen);
 	ZEPHIR_CPY_WRT(&current, &name_zv);
 	while (1) {
-		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 		if (!(zephir_array_key_exists(&_0, &current))) {
 			break;
 		}
 		if (zephir_array_key_exists(&seen, &current)) {
 			ZEPHIR_INIT_NVAR(&_1$$4);
 			object_init_ex(&_1$$4, phalcon_container_exceptions_circularaliasfound_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", &_2, 456, &name_zv);
+			ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", &_2, 458, &name_zv);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_1$$4, "phalcon/Container/Container.zep", 752);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
 		zephir_array_update_zval(&seen, &current, &__$true, PH_COPY | PH_SEPARATE);
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 513, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_4$$3, &_3$$3, &current, PH_NOISY | PH_READONLY, "phalcon/Container/Container.zep", 756);
 		ZEPHIR_CPY_WRT(&current, &_4$$3);
 	}
@@ -1794,7 +1794,7 @@ PHP_METHOD(Phalcon_Container_Container, resolveParameter)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 512, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 511, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&value);
 	zephir_array_fetch(&value, &_0, &name_zv, PH_NOISY, "phalcon/Container/Container.zep", 773);
 	_1 = Z_TYPE_P(&value) == IS_OBJECT;

--- a/ext/phalcon/container/containerfactory.zep.c
+++ b/ext/phalcon/container/containerfactory.zep.c
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Container_ContainerFactory, newContainer)
 	object_init_ex(&container, phalcon_container_container_ce);
 	ZEPHIR_CALL_METHOD(NULL, &container, "__construct", NULL, 213);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 517, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 516, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Container/ContainerFactory.zep", 72);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/container/definition/processor/closureprocessor.zep.c
+++ b/ext/phalcon/container/definition/processor/closureprocessor.zep.c
@@ -109,9 +109,9 @@ PHP_METHOD(Phalcon_Container_Definition_Processor_ClosureProcessor, process)
 	object_init_ex(&def, phalcon_container_definition_servicedefinition_ce);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "closure");
-	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 453, &name_zv, &_0, definition);
+	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 455, &name_zv, &_0, definition);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, &def, "setfactory", NULL, 458, definition);
+	ZEPHIR_CALL_METHOD(NULL, &def, "setfactory", NULL, 460, definition);
 	zephir_check_call_status();
 	RETURN_CCTOR(&def);
 }

--- a/ext/phalcon/container/definition/processor/objectprocessor.zep.c
+++ b/ext/phalcon/container/definition/processor/objectprocessor.zep.c
@@ -114,13 +114,13 @@ PHP_METHOD(Phalcon_Container_Definition_Processor_ObjectProcessor, process)
 	object_init_ex(&def, phalcon_container_definition_servicedefinition_ce);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "object");
-	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 453, &name_zv, &_0, definition);
+	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 455, &name_zv, &_0, definition);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	zephir_create_closure_ex(&_0, NULL, phalcon_11__closure_ce, SL("__invoke"));
 	zephir_update_static_property_ce(phalcon_11__closure_ce, ZEND_STRL("definition"), definition);
-	ZEPHIR_CALL_METHOD(NULL, &def, "setfactory", NULL, 458, &_0);
+	ZEPHIR_CALL_METHOD(NULL, &def, "setfactory", NULL, 460, &_0);
 	zephir_check_call_status();
 	RETURN_CCTOR(&def);
 }

--- a/ext/phalcon/container/definition/processor/parameterprocessor.zep.c
+++ b/ext/phalcon/container/definition/processor/parameterprocessor.zep.c
@@ -111,7 +111,7 @@ PHP_METHOD(Phalcon_Container_Definition_Processor_ParameterProcessor, process)
 	object_init_ex(&def, phalcon_container_definition_servicedefinition_ce);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "parameter");
-	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 453, &name_zv, &_0, definition);
+	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 455, &name_zv, &_0, definition);
 	zephir_check_call_status();
 	_1 = !((zephir_is_instance_of(definition, SL("Closure"))));
 	if (_1) {
@@ -123,7 +123,7 @@ PHP_METHOD(Phalcon_Container_Definition_Processor_ParameterProcessor, process)
 	} else {
 		ZVAL_BOOL(&_2, 0);
 	}
-	ZEPHIR_CALL_METHOD(NULL, &def, "setiscacheable", NULL, 459, &_2);
+	ZEPHIR_CALL_METHOD(NULL, &def, "setiscacheable", NULL, 461, &_2);
 	zephir_check_call_status();
 	RETURN_CCTOR(&def);
 }

--- a/ext/phalcon/container/definition/processor/stringprocessor.zep.c
+++ b/ext/phalcon/container/definition/processor/stringprocessor.zep.c
@@ -114,12 +114,12 @@ PHP_METHOD(Phalcon_Container_Definition_Processor_StringProcessor, process)
 	object_init_ex(&def, phalcon_container_definition_servicedefinition_ce);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "string");
-	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 453, &name_zv, &_0, definition);
+	ZEPHIR_CALL_METHOD(NULL, &def, "__construct", NULL, 455, &name_zv, &_0, definition);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, &def, "setclass", NULL, 460, definition);
+	ZEPHIR_CALL_METHOD(NULL, &def, "setclass", NULL, 462, definition);
 	zephir_check_call_status();
 	ZVAL_BOOL(&_1, 1);
-	ZEPHIR_CALL_METHOD(NULL, &def, "setiscacheable", NULL, 459, &_1);
+	ZEPHIR_CALL_METHOD(NULL, &def, "setiscacheable", NULL, 461, &_1);
 	zephir_check_call_status();
 	RETURN_CCTOR(&def);
 }

--- a/ext/phalcon/container/definition/servicedefinition.zep.c
+++ b/ext/phalcon/container/definition/servicedefinition.zep.c
@@ -150,9 +150,9 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, __construct)
 		raw = &raw_sub;
 		raw = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 518, &serviceName_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 519, &type_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 520, raw);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 517, &serviceName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 518, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 519, raw);
 }
 
 /**
@@ -230,21 +230,21 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, addTag)
 	ZVAL_STR_COPY(&tag_zv, tag);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 521, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 520, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&_1, "in_array", NULL, 87, &tag_zv, &_0, &__$true);
 	zephir_check_call_status();
 	if (!zephir_is_true(&_1)) {
 		zephir_update_property_array_append(this_ptr, SL("tags"), &tag_zv);
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 522, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 521, PH_NOISY_CC | PH_READONLY);
 	_3 = Z_TYPE_P(&_2) != IS_NULL;
 	if (_3) {
-		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 522, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 521, PH_NOISY_CC | PH_READONLY);
 		_3 = (zephir_method_exists_ex(&_4, ZEND_STRL("settag")) == SUCCESS);
 	}
 	if (_3) {
-		zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_1, 522, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 518, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_1, 521, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 517, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_5$$4, "settag", NULL, 0, &tag_zv, &_6$$4);
 		zephir_check_call_status();
 	}
@@ -313,32 +313,32 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, buildService)
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "hasfactory", NULL, 0);
 	zephir_check_call_status();
 	if (zephir_is_true(&_0)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 523, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 522, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&factory, &_1$$3);
 		ZEPHIR_CALL_ZVAL_FUNCTION(&instance, &factory, NULL, 0, container);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_INIT_VAR(&_2$$4);
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 524, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 523, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_3$$4) != IS_NULL) {
 			ZEPHIR_OBS_NVAR(&_2$$4);
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 524, PH_NOISY_CC);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 523, PH_NOISY_CC);
 		} else {
 			ZEPHIR_OBS_NVAR(&_2$$4);
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_2, 518, PH_NOISY_CC);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_2, 517, PH_NOISY_CC);
 		}
 		ZEPHIR_CPY_WRT(&className, &_2$$4);
-		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_3, 525, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(&args, this_ptr, "resolveargs", NULL, 461, container, &_4$$4);
+		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_3, 524, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(&args, this_ptr, "resolveargs", NULL, 463, container, &_4$$4);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&reflection);
 		object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionclass")));
-		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 239, &className);
+		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 240, &className);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&instance, &reflection, "newinstanceargs", NULL, 462, &args);
+		ZEPHIR_CALL_METHOD(&instance, &reflection, "newinstanceargs", NULL, 464, &args);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_4, 526, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_4, 525, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_5, 0, "phalcon/Container/Definition/ServiceDefinition.zep", 177);
 	if (Z_TYPE_P(&_5) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_5), _6)
@@ -441,11 +441,11 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, freeze)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &container);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 527, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 526, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 519, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 518, PH_NOISY_CC | PH_READONLY);
 	_2 = ZEPHIR_IS_STRING_IDENTICAL(&_1, "string");
 	if (_2) {
 		_2 = (zephir_method_exists_ex(container, ZEND_STRL("isautowireenabled")) == SUCCESS);
@@ -458,20 +458,20 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, freeze)
 	}
 	if (_3) {
 		ZEPHIR_INIT_VAR(&_8$$4);
-		zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_3, 524, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_3, 523, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_9$$4) != IS_NULL) {
 			ZEPHIR_OBS_NVAR(&_8$$4);
-			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_3, 524, PH_NOISY_CC);
+			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_3, 523, PH_NOISY_CC);
 		} else {
 			ZEPHIR_OBS_NVAR(&_8$$4);
-			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_4, 518, PH_NOISY_CC);
+			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_4, 517, PH_NOISY_CC);
 		}
 		ZEPHIR_CPY_WRT(&className, &_8$$4);
 		ZEPHIR_INIT_VAR(&reflection);
 		object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionclass")));
-		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 239, &className);
+		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 240, &className);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&constructor, &reflection, "getconstructor", NULL, 463);
+		ZEPHIR_CALL_METHOD(&constructor, &reflection, "getconstructor", NULL, 465);
 		zephir_check_call_status();
 		if (Z_TYPE_P(&constructor) != IS_NULL) {
 			ZEPHIR_CALL_METHOD(&params, &constructor, "getparameters", NULL, 0);
@@ -483,28 +483,28 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, freeze)
 		if ((zephir_method_exists_ex(container, ZEND_STRL("getresolver")) == SUCCESS)) {
 			ZEPHIR_CALL_METHOD(&_10$$5, container, "getresolver", NULL, 0);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_2, 528, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_2, 527, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_11$$5, &_10$$5, "resolveparameters", NULL, 0, container, &params, &_12$$5);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 525, &_11$$5);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 524, &_11$$5);
 		}
 	} else {
-		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 519, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 518, PH_NOISY_CC | PH_READONLY);
 		_6 = ZEPHIR_IS_STRING_IDENTICAL(&_5, "string");
 		if (_6) {
 			zephir_memory_observe(&_7);
-			zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 528, PH_NOISY_CC);
+			zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 527, PH_NOISY_CC);
 			_6 = !(ZEPHIR_IS_EMPTY(&_7));
 		}
 		if (_6) {
-			zephir_read_property_cached(&_13$$6, this_ptr, _zephir_prop_2, 528, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 525, &_13$$6);
+			zephir_read_property_cached(&_13$$6, this_ptr, _zephir_prop_2, 527, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 524, &_13$$6);
 		}
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 527, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 526, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 527, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 526, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -547,12 +547,12 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, getClass)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 524, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 523, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_container_exceptions_noclassset_ce);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 518, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 464, &_2$$3);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 517, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 466, &_2$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Container/Definition/ServiceDefinition.zep", 239);
 		ZEPHIR_MM_RESTORE();
@@ -610,12 +610,12 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, getFactory)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 523, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 522, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_container_exceptions_nofactoryset_ce);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 518, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 465, &_2$$3);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 517, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 467, &_2$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Container/Definition/ServiceDefinition.zep", 274);
 		ZEPHIR_MM_RESTORE();
@@ -683,7 +683,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, hasClass)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("className", 9, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 524, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 523, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(Z_TYPE_P(&_0) != IS_NULL);
 }
 
@@ -707,7 +707,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, hasExtenders)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 526, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 525, PH_NOISY_CC);
 	RETURN_MM_BOOL(!(ZEPHIR_IS_EMPTY(&_0)));
 }
 
@@ -726,7 +726,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, hasFactory)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("factory", 7, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 523, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 522, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(Z_TYPE_P(&_0) != IS_NULL);
 }
 
@@ -751,10 +751,10 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, isCacheable)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("frozen", 6, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 529, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 528, PH_NOISY_CC | PH_READONLY);
 	_1 = zephir_is_true(&_0);
 	if (_1) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 527, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 526, PH_NOISY_CC | PH_READONLY);
 		_1 = zephir_is_true(&_2);
 	}
 	RETURN_BOOL(_1);
@@ -824,7 +824,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setContainer)
 		Z_PARAM_OBJECT(container)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 522, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 521, container);
 	RETURN_THISW();
 }
 
@@ -859,7 +859,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setClass)
 	ZVAL_STR_COPY(&className_zv, className);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 524, &className_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 523, &className_zv);
 	RETURN_THIS();
 }
 
@@ -928,9 +928,9 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setExtenders)
 			if (!(zephir_is_callable(&extender))) {
 				ZEPHIR_INIT_NVAR(&_3$$4);
 				object_init_ex(&_3$$4, phalcon_container_exceptions_invalidextender_ce);
-				zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 518, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 517, PH_NOISY_CC | PH_READONLY);
 				zephir_cast_to_string(&_5$$4, &key);
-				ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", &_6, 466, &_4$$4, &_5$$4);
+				ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", &_6, 468, &_4$$4, &_5$$4);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_3$$4, "phalcon/Container/Definition/ServiceDefinition.zep", 434);
 				ZEPHIR_MM_RESTORE();
@@ -960,9 +960,9 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setExtenders)
 				if (!(zephir_is_callable(&extender))) {
 					ZEPHIR_INIT_NVAR(&_9$$6);
 					object_init_ex(&_9$$6, phalcon_container_exceptions_invalidextender_ce);
-					zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_0, 518, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_0, 517, PH_NOISY_CC | PH_READONLY);
 					zephir_cast_to_string(&_11$$6, &key);
-					ZEPHIR_CALL_METHOD(NULL, &_9$$6, "__construct", &_6, 466, &_10$$6, &_11$$6);
+					ZEPHIR_CALL_METHOD(NULL, &_9$$6, "__construct", &_6, 468, &_10$$6, &_11$$6);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_9$$6, "phalcon/Container/Definition/ServiceDefinition.zep", 434);
 					ZEPHIR_MM_RESTORE();
@@ -972,7 +972,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setExtenders)
 	}
 	ZEPHIR_INIT_NVAR(&extender);
 	ZEPHIR_INIT_NVAR(&key);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 526, &extenders);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 525, &extenders);
 	RETURN_THIS();
 }
 
@@ -1005,7 +1005,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setFactory)
 	zephir_fetch_params(1, 1, 0, &factory);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 523, factory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 522, factory);
 	RETURN_THIS();
 }
 
@@ -1040,9 +1040,9 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setIsCacheable)
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
 	if (isCacheable) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 529, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 528, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 529, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 528, &__$false);
 	}
 	RETURN_THIS();
 }
@@ -1078,7 +1078,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, setLifetime)
 	ZVAL_STR_COPY(&lifetime_zv, lifetime);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 530, &lifetime_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 529, &lifetime_zv);
 	RETURN_THIS();
 }
 
@@ -1105,7 +1105,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, unsetClass)
 
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 524, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 523, &__$null);
 	RETURN_THIS();
 }
 
@@ -1134,7 +1134,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, unsetExtenders)
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 526, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 525, &_0);
 	RETURN_THIS();
 }
 
@@ -1161,7 +1161,7 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, unsetFactory)
 
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkfrozen", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 523, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 522, &__$null);
 	RETURN_THIS();
 }
 
@@ -1192,12 +1192,12 @@ PHP_METHOD(Phalcon_Container_Definition_ServiceDefinition, checkFrozen)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 527, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 526, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_container_exceptions_frozendefinition_ce);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 518, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 467, &_2$$3);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 517, PH_NOISY_CC | PH_READONLY);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 469, &_2$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Container/Definition/ServiceDefinition.zep", 541);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/container/resolver/lazy/arrayvalues.zep.c
+++ b/ext/phalcon/container/resolver/lazy/arrayvalues.zep.c
@@ -93,7 +93,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, __construct)
 	} else {
 		zephir_get_arrval(&values, values_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 531, &values);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 530, &values);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -107,7 +107,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, count)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("values", 6, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 530, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 
@@ -127,7 +127,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, getIterator)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, spl_ce_ArrayIterator);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 530, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 18, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -225,7 +225,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, offsetExists)
 		Z_PARAM_ZVAL(offset)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &offset);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 530, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_key_exists(&_0, offset));
 }
 
@@ -247,7 +247,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, offsetGet)
 		Z_PARAM_ZVAL(offset)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &offset);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 530, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_1, &_0, offset, PH_NOISY | PH_READONLY, "phalcon/Container/Resolver/Lazy/ArrayValues.zep", 88);
 	RETURN_CTORW(&_1);
 }
@@ -290,7 +290,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, offsetUnset)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &offset);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("values"), offset);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 530, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, offset, PH_SEPARATE);
 }
 
@@ -321,7 +321,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_ArrayValues, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 530, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "resolvevalues", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/container/resolver/lazy/call.zep.c
+++ b/ext/phalcon/container/resolver/lazy/call.zep.c
@@ -74,7 +74,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_Call, __construct)
 		Z_PARAM_ZVAL(callableObject)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &callableObject);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 532, callableObject);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 531, callableObject);
 }
 
 /**
@@ -105,7 +105,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_Call, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 532, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 531, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&callableObject, &_0);
 	ZEPHIR_RETURN_CALL_ZVAL_FUNCTION(&callableObject, NULL, 0, ioc);
 	zephir_check_call_status();

--- a/ext/phalcon/container/resolver/lazy/callableget.zep.c
+++ b/ext/phalcon/container/resolver/lazy/callableget.zep.c
@@ -73,7 +73,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_CallableGet, __construct)
 		Z_PARAM_ZVAL(id)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &id);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 533, id);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 532, id);
 }
 
 /**

--- a/ext/phalcon/container/resolver/lazy/callablenew.zep.c
+++ b/ext/phalcon/container/resolver/lazy/callablenew.zep.c
@@ -73,7 +73,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_CallableNew, __construct)
 		Z_PARAM_ZVAL(id)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &id);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 534, id);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 533, id);
 }
 
 /**

--- a/ext/phalcon/container/resolver/lazy/csenv.zep.c
+++ b/ext/phalcon/container/resolver/lazy/csenv.zep.c
@@ -105,9 +105,9 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_CsEnv, resolve)
 	ZVAL_STRING(&_2, "\"");
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "\\");
-	ZEPHIR_CALL_FUNCTION(&values, "str_getcsv", NULL, 468, &_0, &_1, &_2, &_3);
+	ZEPHIR_CALL_FUNCTION(&values, "str_getcsv", NULL, 470, &_0, &_1, &_2, &_3);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 535, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 534, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_4) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&result);
 		array_init(&result);
@@ -123,7 +123,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_CsEnv, resolve)
 				}
 				ZEPHIR_INIT_NVAR(&value);
 				ZVAL_COPY(&value, _5$$3);
-				zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_0, 535, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_0, 534, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_MAKE_REF(&value);
 				ZEPHIR_CALL_FUNCTION(NULL, "settype", &_9, 16, &value, &_8$$4);
 				ZEPHIR_UNREF(&value);
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_CsEnv, resolve)
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&value, &values, "current", NULL, 0);
 				zephir_check_call_status();
-					zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_0, 535, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_0, 534, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_MAKE_REF(&value);
 					ZEPHIR_CALL_FUNCTION(NULL, "settype", &_9, 16, &value, &_12$$5);
 					ZEPHIR_UNREF(&value);

--- a/ext/phalcon/container/resolver/lazy/envdefault.zep.c
+++ b/ext/phalcon/container/resolver/lazy/envdefault.zep.c
@@ -95,7 +95,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_EnvDefault, __construct)
 		zephir_memory_observe(&vartype_zv);
 	ZVAL_STR_COPY(&vartype_zv, vartype);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 536, defaultValue);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 535, defaultValue);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_container_resolver_lazy_envdefault_ce, getThis(), "__construct", NULL, 0, &varname_zv, &vartype_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/container/resolver/lazy/functioncall.zep.c
+++ b/ext/phalcon/container/resolver/lazy/functioncall.zep.c
@@ -93,8 +93,8 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_FunctionCall, __construct)
 	arguments_param = ZEND_CALL_ARG(execute_data, 2);
 	ZVAL_STR(&functionName_zv, functionName);
 	zephir_get_arrval(&arguments, arguments_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 537, &functionName_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 538, &arguments);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 536, &functionName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 537, &arguments);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -131,10 +131,10 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_FunctionCall, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 538, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 537, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&arguments, this_ptr, "resolvearguments", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 537, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 536, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_USER_FUNC_ARRAY(return_value, &_1, &arguments);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/container/resolver/lazy/get.zep.c
+++ b/ext/phalcon/container/resolver/lazy/get.zep.c
@@ -74,7 +74,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_Get, __construct)
 		Z_PARAM_ZVAL(id)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &id);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 539, id);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 538, id);
 }
 
 /**
@@ -105,7 +105,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_Get, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 539, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 538, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolveargument", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(ioc, "get", NULL, 0, &id);

--- a/ext/phalcon/container/resolver/lazy/getcall.zep.c
+++ b/ext/phalcon/container/resolver/lazy/getcall.zep.c
@@ -106,9 +106,9 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_GetCall, __construct)
 	arguments_param = ZEND_CALL_ARG(execute_data, 3);
 	ZVAL_STR(&method_zv, method);
 	zephir_get_arrval(&arguments, arguments_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 540, id);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 541, &method_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 542, &arguments);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 539, id);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 540, &method_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 541, &arguments);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -154,10 +154,10 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_GetCall, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 540, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 539, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolveargument", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 542, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 541, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&arguments, this_ptr, "resolvearguments", NULL, 0, ioc, &_1);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&service, ioc, "get", NULL, 0, &id);
@@ -166,7 +166,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_GetCall, resolve)
 	zephir_create_array(&_2, 2, 0);
 	zephir_array_fast_append(&_2, &service);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 541, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 540, PH_NOISY_CC);
 	zephir_array_fast_append(&_2, &_3);
 	ZEPHIR_CALL_USER_FUNC_ARRAY(return_value, &_2, &arguments);
 	zephir_check_call_status();

--- a/ext/phalcon/container/resolver/lazy/lazyfactory.zep.c
+++ b/ext/phalcon/container/resolver/lazy/lazyfactory.zep.c
@@ -74,7 +74,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, arrayValues)
 	zephir_fetch_params(1, 1, 0, &values_param);
 	zephir_get_arrval(&values, values_param);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_arrayvalues_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 469, &values);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 471, &values);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -93,7 +93,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, call)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &callableObject);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_call_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 470, callableObject);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 472, callableObject);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -114,7 +114,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, callableGet)
 	zephir_memory_observe(&id_zv);
 	ZVAL_STR_COPY(&id_zv, id);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_callableget_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 471, &id_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 473, &id_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -135,7 +135,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, callableNew)
 	zephir_memory_observe(&id_zv);
 	ZVAL_STR_COPY(&id_zv, id);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_callablenew_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 472, &id_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 474, &id_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -166,7 +166,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, csEnv)
 	ZVAL_STR_COPY(&type_zv, type);
 	}
 	object_init_ex(return_value, phalcon_container_resolver_lazy_csenv_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 473, &name_zv, &type_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 475, &name_zv, &type_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -197,7 +197,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, env)
 	ZVAL_STR_COPY(&type_zv, type);
 	}
 	object_init_ex(return_value, phalcon_container_resolver_lazy_env_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 473, &name_zv, &type_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 475, &name_zv, &type_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -232,7 +232,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, envDefault)
 	ZVAL_STR_COPY(&type_zv, type);
 	}
 	object_init_ex(return_value, phalcon_container_resolver_lazy_envdefault_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 474, &name_zv, defaultValue, &type_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 476, &name_zv, defaultValue, &type_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -264,7 +264,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, functionCall)
 	ZVAL_STR_COPY(&functionName_zv, functionName);
 	zephir_get_arrval(&args, args_param);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_functioncall_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 475, &functionName_zv, &args);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 477, &functionName_zv, &args);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -285,7 +285,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, get)
 	zephir_memory_observe(&id_zv);
 	ZVAL_STR_COPY(&id_zv, id);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_get_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 476, &id_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 478, &id_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -322,7 +322,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, getCall)
 	ZVAL_STR_COPY(&method_zv, method);
 	zephir_get_arrval(&args, args_param);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_getcall_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 477, &id_zv, &method_zv, &args);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 479, &id_zv, &method_zv, &args);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -359,7 +359,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, newCall)
 	ZVAL_STR_COPY(&method_zv, method);
 	zephir_get_arrval(&args, args_param);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_newcall_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 478, &id_zv, &method_zv, &args);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 480, &id_zv, &method_zv, &args);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -380,7 +380,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, newInstance)
 	zephir_memory_observe(&id_zv);
 	ZVAL_STR_COPY(&id_zv, id);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_newinstance_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 479, &id_zv);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 481, &id_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -417,7 +417,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_LazyFactory, staticCall)
 	ZVAL_STR_COPY(&method_zv, method);
 	zephir_get_arrval(&args, args_param);
 	object_init_ex(return_value, phalcon_container_resolver_lazy_staticcall_ce);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 480, &className_zv, &method_zv, &args);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 482, &className_zv, &method_zv, &args);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/container/resolver/lazy/newcall.zep.c
+++ b/ext/phalcon/container/resolver/lazy/newcall.zep.c
@@ -106,9 +106,9 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_NewCall, __construct)
 	arguments_param = ZEND_CALL_ARG(execute_data, 3);
 	ZVAL_STR(&method_zv, method);
 	zephir_get_arrval(&arguments, arguments_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 543, id);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 544, &method_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 545, &arguments);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 542, id);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 543, &method_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 544, &arguments);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -154,10 +154,10 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_NewCall, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 543, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 542, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolveargument", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 545, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 544, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&arguments, this_ptr, "resolvearguments", NULL, 0, ioc, &_1);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&service, ioc, "new", NULL, 0, &id);
@@ -166,7 +166,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_NewCall, resolve)
 	zephir_create_array(&_2, 2, 0);
 	zephir_array_fast_append(&_2, &service);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 544, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 543, PH_NOISY_CC);
 	zephir_array_fast_append(&_2, &_3);
 	ZEPHIR_CALL_USER_FUNC_ARRAY(return_value, &_2, &arguments);
 	zephir_check_call_status();

--- a/ext/phalcon/container/resolver/lazy/newinstance.zep.c
+++ b/ext/phalcon/container/resolver/lazy/newinstance.zep.c
@@ -74,7 +74,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_NewInstance, __construct)
 		Z_PARAM_ZVAL(id)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &id);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 546, id);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 545, id);
 }
 
 /**
@@ -105,7 +105,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_NewInstance, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 546, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 545, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolveargument", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(ioc, "new", NULL, 0, &id);

--- a/ext/phalcon/container/resolver/lazy/staticcall.zep.c
+++ b/ext/phalcon/container/resolver/lazy/staticcall.zep.c
@@ -106,9 +106,9 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_StaticCall, __construct)
 	arguments_param = ZEND_CALL_ARG(execute_data, 3);
 	ZVAL_STR(&method_zv, method);
 	zephir_get_arrval(&arguments, arguments_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 547, className);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 548, &method_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 549, &arguments);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 546, className);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 547, &method_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 548, &arguments);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -153,17 +153,17 @@ PHP_METHOD(Phalcon_Container_Resolver_Lazy_StaticCall, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &ioc);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 547, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 546, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&className, this_ptr, "resolveargument", NULL, 0, ioc, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 549, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 548, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&arguments, this_ptr, "resolvearguments", NULL, 0, ioc, &_1);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 2, 0);
 	zephir_array_fast_append(&_2, &className);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 548, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 547, PH_NOISY_CC);
 	zephir_array_fast_append(&_2, &_3);
 	ZEPHIR_CALL_USER_FUNC_ARRAY(return_value, &_2, &arguments);
 	zephir_check_call_status();

--- a/ext/phalcon/container/resolver/resolver.zep.c
+++ b/ext/phalcon/container/resolver/resolver.zep.c
@@ -85,9 +85,9 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, isResolvableClass)
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, zephir_get_internal_ce(SL("reflectionclass")));
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 239, &className_zv);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 240, &className_zv);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_METHOD(&_0, "isinstantiable", NULL, 481);
+	ZEPHIR_RETURN_CALL_METHOD(&_0, "isinstantiable", NULL, 483);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -136,9 +136,9 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, resolveCall)
 	}
 	ZEPHIR_INIT_VAR(&reflection);
 	object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionfunction")));
-	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 236, &closure);
+	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 237, &closure);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&params, &reflection, "getparameters", NULL, 237);
+	ZEPHIR_CALL_METHOD(&params, &reflection, "getparameters", NULL, 238);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&resolved, this_ptr, "resolveparameters", NULL, 0, ioc, &params, &arguments);
 	zephir_check_call_status();
@@ -188,14 +188,14 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, resolveClass)
 	zephir_get_arrval(&arguments, arguments_param);
 	ZEPHIR_INIT_VAR(&reflection);
 	object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionclass")));
-	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 239, &className_zv);
+	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 240, &className_zv);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&constructor, &reflection, "getconstructor", NULL, 463);
+	ZEPHIR_CALL_METHOD(&constructor, &reflection, "getconstructor", NULL, 465);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&constructor) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		array_init(&_0$$3);
-		ZEPHIR_RETURN_CALL_METHOD(&reflection, "newinstanceargs", NULL, 462, &_0$$3);
+		ZEPHIR_RETURN_CALL_METHOD(&reflection, "newinstanceargs", NULL, 464, &_0$$3);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -203,7 +203,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, resolveClass)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&resolved, this_ptr, "resolveparameters", NULL, 0, ioc, &params, &arguments);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_METHOD(&reflection, "newinstanceargs", NULL, 462, &resolved);
+	ZEPHIR_RETURN_CALL_METHOD(&reflection, "newinstanceargs", NULL, 464, &resolved);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -334,7 +334,7 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, resolveParameter)
 	object_init_ex(&_6, phalcon_container_exceptions_cannotresolveparameter_ce);
 	ZEPHIR_CALL_METHOD(&_7, parameter, "getname", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, &_6, "__construct", NULL, 482, &_7, &declaringName);
+	ZEPHIR_CALL_METHOD(NULL, &_6, "__construct", NULL, 484, &_7, &declaringName);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(&_6, "phalcon/Container/Resolver/Resolver.zep", 183);
 	ZEPHIR_MM_RESTORE();
@@ -399,14 +399,14 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, resolveParameters)
 			zephir_check_call_status();
 			if (zephir_array_key_exists(&arguments, &position)) {
 				zephir_array_fetch(&_4$$4, &arguments, &position, PH_NOISY | PH_READONLY, "phalcon/Container/Resolver/Resolver.zep", 199);
-				ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "resolvearg", &_5, 483, ioc, &_4$$4);
+				ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "resolvearg", &_5, 485, ioc, &_4$$4);
 				zephir_check_call_status();
 				zephir_array_update_zval(&resolved, &position, &_3$$4, PH_COPY | PH_SEPARATE);
 				continue;
 			}
 			if (zephir_array_key_exists(&arguments, &name)) {
 				zephir_array_fetch(&_7$$5, &arguments, &name, PH_NOISY | PH_READONLY, "phalcon/Container/Resolver/Resolver.zep", 204);
-				ZEPHIR_CALL_METHOD(&_6$$5, this_ptr, "resolvearg", &_5, 483, ioc, &_7$$5);
+				ZEPHIR_CALL_METHOD(&_6$$5, this_ptr, "resolvearg", &_5, 485, ioc, &_7$$5);
 				zephir_check_call_status();
 				zephir_array_update_zval(&resolved, &position, &_6$$5, PH_COPY | PH_SEPARATE);
 				continue;
@@ -439,14 +439,14 @@ PHP_METHOD(Phalcon_Container_Resolver_Resolver, resolveParameters)
 				zephir_check_call_status();
 				if (zephir_array_key_exists(&arguments, &position)) {
 					zephir_array_fetch(&_13$$7, &arguments, &position, PH_NOISY | PH_READONLY, "phalcon/Container/Resolver/Resolver.zep", 199);
-					ZEPHIR_CALL_METHOD(&_12$$7, this_ptr, "resolvearg", &_5, 483, ioc, &_13$$7);
+					ZEPHIR_CALL_METHOD(&_12$$7, this_ptr, "resolvearg", &_5, 485, ioc, &_13$$7);
 					zephir_check_call_status();
 					zephir_array_update_zval(&resolved, &position, &_12$$7, PH_COPY | PH_SEPARATE);
 					continue;
 				}
 				if (zephir_array_key_exists(&arguments, &name)) {
 					zephir_array_fetch(&_15$$8, &arguments, &name, PH_NOISY | PH_READONLY, "phalcon/Container/Resolver/Resolver.zep", 204);
-					ZEPHIR_CALL_METHOD(&_14$$8, this_ptr, "resolvearg", &_5, 483, ioc, &_15$$8);
+					ZEPHIR_CALL_METHOD(&_14$$8, this_ptr, "resolvearg", &_5, 485, ioc, &_15$$8);
 					zephir_check_call_status();
 					zephir_array_update_zval(&resolved, &position, &_14$$8, PH_COPY | PH_SEPARATE);
 					continue;

--- a/ext/phalcon/datamapper/pdo/connection.zep.c
+++ b/ext/phalcon/datamapper/pdo/connection.zep.c
@@ -160,7 +160,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection, __construct)
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_datamapper_pdo_exception_drivernotsupported_ce);
 		zephir_array_fetch_long(&_2$$3, &parts, 0, PH_NOISY | PH_READONLY, "phalcon/DataMapper/Pdo/Connection.zep", 66);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 484, &_2$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 486, &_2$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/DataMapper/Pdo/Connection.zep", 66);
 		ZEPHIR_MM_RESTORE();
@@ -178,11 +178,11 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection, __construct)
 	zephir_array_fast_append(&_4, &password_zv);
 	zephir_array_fast_append(&_4, &options);
 	zephir_array_fast_append(&_4, &queries);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 550, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 549, &_4);
 	if (Z_TYPE_P(profiler) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(profiler);
 		object_init_ex(profiler, phalcon_datamapper_pdo_profiler_profiler_ce);
-		ZEPHIR_CALL_METHOD(NULL, profiler, "__construct", NULL, 485);
+		ZEPHIR_CALL_METHOD(NULL, profiler, "__construct", NULL, 487);
 		zephir_check_call_status();
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setprofiler", NULL, 0, profiler);
@@ -218,7 +218,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection, __debugInfo)
 	zephir_create_array(return_value, 1, 0);
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_create_array(&_0, 5, 0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 550, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 549, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&_2);
 	zephir_array_fetch_long(&_2, &_1, 0, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 100);
 	zephir_array_fast_append(&_0, &_2);
@@ -228,11 +228,11 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection, __debugInfo)
 	ZEPHIR_INIT_NVAR(&_3);
 	ZVAL_STRING(&_3, "****");
 	zephir_array_fast_append(&_0, &_3);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 550, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 549, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_OBS_NVAR(&_2);
 	zephir_array_fetch_long(&_2, &_4, 3, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 103);
 	zephir_array_fast_append(&_0, &_2);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 550, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 549, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_OBS_NVAR(&_2);
 	zephir_array_fetch_long(&_2, &_5, 4, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 105);
 	zephir_array_fast_append(&_0, &_2);
@@ -283,34 +283,34 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection, connect)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 551, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 550, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 552, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 551, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "connect");
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "start", NULL, 0, &_2$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 550, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 549, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&dsn);
 		zephir_array_fetch_long(&dsn, &_3$$3, 0, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 120);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 550, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 549, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&username);
 		zephir_array_fetch_long(&username, &_4$$3, 1, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 121);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 550, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 549, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&password);
 		zephir_array_fetch_long(&password, &_5$$3, 2, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 122);
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_2, 550, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_2, 549, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&options);
 		zephir_array_fetch_long(&options, &_6$$3, 3, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 123);
-		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_2, 550, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_2, 549, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&queries);
 		zephir_array_fetch_long(&queries, &_7$$3, 4, PH_NOISY, "phalcon/DataMapper/Pdo/Connection.zep", 124);
 		ZEPHIR_INIT_NVAR(&_2$$3);
 		object_init_ex(&_2$$3, php_pdo_get_dbh_ce());
 		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 0, &dsn, &username, &password, &options);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 551, &_2$$3);
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_1, 552, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 550, &_2$$3);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_1, 551, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_8$$3, "finish", NULL, 0);
 		zephir_check_call_status();
 		zephir_is_iterable(&queries, 0, "phalcon/DataMapper/Pdo/Connection.zep", 134);
@@ -374,13 +374,13 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection, disconnect)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 552, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 551, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "disconnect");
 	ZEPHIR_CALL_METHOD(NULL, &_0, "start", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 551, &__$null);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 552, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 550, &__$null);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 551, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_2, "finish", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/datamapper/pdo/connection/decorated.zep.c
+++ b/ext/phalcon/datamapper/pdo/connection/decorated.zep.c
@@ -84,11 +84,11 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Connection_Decorated, __construct)
 	} else {
 		ZEPHIR_SEPARATE_PARAM(profiler);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 553, pdo);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 552, pdo);
 	if (Z_TYPE_P(profiler) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(profiler);
 		object_init_ex(profiler, phalcon_datamapper_pdo_profiler_profiler_ce);
-		ZEPHIR_CALL_METHOD(NULL, profiler, "__construct", NULL, 485);
+		ZEPHIR_CALL_METHOD(NULL, profiler, "__construct", NULL, 487);
 		zephir_check_call_status();
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setprofiler", NULL, 0, profiler);

--- a/ext/phalcon/datamapper/pdo/connectionlocator.zep.c
+++ b/ext/phalcon/datamapper/pdo/connectionlocator.zep.c
@@ -320,7 +320,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_ConnectionLocator, setMaster)
 		Z_PARAM_OBJECT_OF_CLASS(callableObject, phalcon_datamapper_pdo_connection_connectioninterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &callableObject);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 554, callableObject);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 553, callableObject);
 	RETURN_THISW();
 }
 
@@ -431,7 +431,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_ConnectionLocator, getConnection)
 	zephir_memory_observe(&collection);
 	zephir_read_property_zval(&collection, this_ptr, &type_zv, PH_NOISY_CC);
 	ZEPHIR_CPY_WRT(&requested, &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 555, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 554, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&instances, &_0);
 	if (ZEPHIR_IS_EMPTY(&collection)) {
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getmaster", NULL, 0);
@@ -441,7 +441,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_ConnectionLocator, getConnection)
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "");
 	if (ZEPHIR_IS_IDENTICAL(&_1, &requested)) {
-		ZEPHIR_CALL_FUNCTION(&requested, "array_rand", NULL, 486, &collection);
+		ZEPHIR_CALL_FUNCTION(&requested, "array_rand", NULL, 488, &collection);
 		zephir_check_call_status();
 	}
 	if (!(zephir_array_isset_value(&collection, &requested))) {
@@ -463,7 +463,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_ConnectionLocator, getConnection)
 		ZEPHIR_CALL_USER_FUNC(&_4$$6, &_5$$6);
 		zephir_check_call_status();
 		zephir_array_update_zval(&instances, &instanceName, &_4$$6, PH_COPY | PH_SEPARATE);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 555, &instances);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 554, &instances);
 	}
 	zephir_array_fetch(&_6, &instances, &instanceName, PH_NOISY | PH_READONLY, "phalcon/DataMapper/Pdo/ConnectionLocator.zep", 221);
 	RETURN_CTOR(&_6);

--- a/ext/phalcon/datamapper/pdo/profiler/profiler.zep.c
+++ b/ext/phalcon/datamapper/pdo/profiler/profiler.zep.c
@@ -128,11 +128,11 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, __construct)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "{method} ({duration}s): {statement} {backtrace}");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 556, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 555, &_0);
 	ZVAL_UNDEF(&_1);
 	ZVAL_LONG(&_1, 7);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 557, &_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 558, logger);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 556, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 557, logger);
 	ZEPHIR_INIT_NVAR(&_0);
 	object_init_ex(&_0, phalcon_support_helper_json_encode_ce);
 	if (zephir_has_constructor(&_0)) {
@@ -140,7 +140,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 559, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 558, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -228,20 +228,20 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, finish)
 	} else {
 		zephir_get_arrval(&values, values_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 560, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 559, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&ex);
 		object_init_ex(&ex, phalcon_datamapper_pdo_exception_exception_ce);
 		ZEPHIR_CALL_METHOD(NULL, &ex, "__construct", NULL, 8);
 		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(&finish, "hrtime", NULL, 487, &__$true);
+		ZEPHIR_CALL_FUNCTION(&finish, "hrtime", NULL, 489, &__$true);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(&_1$$3, &ex, "gettraceasstring", NULL, 488);
+		ZEPHIR_CALL_METHOD(&_1$$3, &ex, "gettraceasstring", NULL, 490);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "backtrace");
 		zephir_update_property_array(this_ptr, SL("context"), &_2$$3, &_1$$3);
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_1, 561, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_1, 560, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch_string(&_4$$3, &_3$$3, SL("start"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Pdo/Profiler/Profiler.zep", 91);
 		ZEPHIR_INIT_VAR(&_5$$3);
 		zephir_sub_function(&_5$$3, &finish, &_4$$3);
@@ -259,22 +259,22 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, finish)
 			ZEPHIR_INIT_NVAR(&_5$$3);
 			ZVAL_STRING(&_5$$3, "");
 		} else {
-			zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_2, 559, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_2, 558, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_5$$3, &_9$$3, "__invoke", NULL, 0, &values);
 			zephir_check_call_status();
 		}
 		ZEPHIR_INIT_VAR(&_10$$3);
 		ZVAL_STRING(&_10$$3, "values");
 		zephir_update_property_array(this_ptr, SL("context"), &_10$$3, &_5$$3);
-		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_3, 558, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_12$$3, this_ptr, _zephir_prop_4, 557, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_13$$3, this_ptr, _zephir_prop_5, 556, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_1, 561, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_3, 557, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$3, this_ptr, _zephir_prop_4, 556, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_13$$3, this_ptr, _zephir_prop_5, 555, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_1, 560, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_11$$3, "log", NULL, 0, &_12$$3, &_13$$3, &_14$$3);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_15$$3);
 		array_init(&_15$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 561, &_15$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 560, &_15$$3);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -323,7 +323,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, getLogLevel)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 557, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 556, PH_NOISY_CC);
 	zephir_cast_to_string(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -364,9 +364,9 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, setActive)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &active_param);
 	if (active) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 560, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 559, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 560, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 559, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -394,7 +394,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, setLogFormat)
 		Z_PARAM_STR(logFormat)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&logFormat_zv, logFormat);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 556, &logFormat_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 555, &logFormat_zv);
 	RETURN_THISW();
 }
 
@@ -421,7 +421,7 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, setLogLevel)
 		Z_PARAM_STR(logLevel)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&logLevel_zv, logLevel);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 557, &logLevel_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 556, &logLevel_zv);
 	RETURN_THISW();
 }
 
@@ -460,15 +460,15 @@ PHP_METHOD(Phalcon_DataMapper_Pdo_Profiler_Profiler, start)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&method_zv);
 	ZVAL_STR_COPY(&method_zv, method);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 560, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 559, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		zephir_create_array(&_1$$3, 2, 0);
 		zephir_array_update_string(&_1$$3, SL("method"), &method_zv, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_FUNCTION(&_2$$3, "hrtime", NULL, 487, &__$true);
+		ZEPHIR_CALL_FUNCTION(&_2$$3, "hrtime", NULL, 489, &__$true);
 		zephir_check_call_status();
 		zephir_array_update_string(&_1$$3, SL("start"), &_2$$3, PH_COPY | PH_SEPARATE);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 561, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 560, &_1$$3);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/datamapper/query/bind.zep.c
+++ b/ext/phalcon/datamapper/query/bind.zep.c
@@ -108,11 +108,11 @@ PHP_METHOD(Phalcon_DataMapper_Query_Bind, bindInline)
 		zephir_check_call_status();
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 561, PH_NOISY_CC | PH_READONLY);
 	ZVAL_UNDEF(&_4);
 	ZVAL_LONG(&_4, (zephir_get_numberval(&_3) + 1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 562, &_4);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 561, &_4);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 561, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&key);
 	ZEPHIR_CONCAT_SVS(&key, "__", &_4, "__");
 	ZVAL_LONG(&_5, type);
@@ -149,10 +149,10 @@ PHP_METHOD(Phalcon_DataMapper_Query_Bind, remove)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 563, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&store, &_0);
 	zephir_array_unset(&store, &key_zv, PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 563, &store);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 562, &store);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -383,11 +383,11 @@ PHP_METHOD(Phalcon_DataMapper_Query_Bind, inlineArray)
 		{
 			ZEPHIR_INIT_NVAR(&value);
 			ZVAL_COPY(&value, _0);
-			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 561, PH_NOISY_CC | PH_READONLY);
 			ZVAL_UNDEF(&_2$$3);
 			ZVAL_LONG(&_2$$3, (zephir_get_numberval(&_1$$3) + 1));
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 562, &_2$$3);
-			zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 561, &_2$$3);
+			zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 561, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_NVAR(&key);
 			ZEPHIR_CONCAT_SVS(&key, "__", &_2$$3, "__");
 			ZVAL_LONG(&_3$$3, type);
@@ -415,11 +415,11 @@ PHP_METHOD(Phalcon_DataMapper_Query_Bind, inlineArray)
 			}
 			ZEPHIR_CALL_METHOD(&value, &data, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_0, 561, PH_NOISY_CC | PH_READONLY);
 				ZVAL_UNDEF(&_9$$4);
 				ZVAL_LONG(&_9$$4, (zephir_get_numberval(&_8$$4) + 1));
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 562, &_9$$4);
-				zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 562, PH_NOISY_CC | PH_READONLY);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 561, &_9$$4);
+				zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 561, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_NVAR(&key);
 				ZEPHIR_CONCAT_SVS(&key, "__", &_9$$4, "__");
 				ZVAL_LONG(&_10$$4, type);

--- a/ext/phalcon/datamapper/query/delete.zep.c
+++ b/ext/phalcon/datamapper/query/delete.zep.c
@@ -145,7 +145,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Delete, returning)
 	zephir_fetch_params(1, 1, 0, &columns_param);
 	zephir_get_arrval(&columns, columns_param);
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 564, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 563, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("RETURNING"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Delete.zep", 63);
 	zephir_fast_array_merge(&_0, &_2, &columns);
 	ZEPHIR_INIT_VAR(&_3);
@@ -179,7 +179,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Delete, getStatement)
 
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "buildflags", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 564, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 563, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Delete.zep", 78);
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, "WHERE");

--- a/ext/phalcon/datamapper/query/insert.zep.c
+++ b/ext/phalcon/datamapper/query/insert.zep.c
@@ -141,7 +141,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, column)
 	ZEPHIR_CONCAT_SV(&_0, ":", &column_zv);
 	zephir_update_property_array_multi(this_ptr, SL("store"), &_0, SL("sz"), 3, SL("COLUMNS"), &column_zv);
 	if (Z_TYPE_P(value) != IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 565, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 564, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_2$$3, type);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "setvalue", NULL, 0, &column_zv, value, &_2$$3);
 		zephir_check_call_status();
@@ -297,7 +297,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, getLastInsertId)
 		zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 566, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 565, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "lastinsertid", NULL, 0, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -327,9 +327,9 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, getStatement)
 
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "buildflags", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 567, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 566, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Insert.zep", 113);
-	ZEPHIR_CALL_METHOD(&_3, this_ptr, "buildcolumns", NULL, 489);
+	ZEPHIR_CALL_METHOD(&_3, this_ptr, "buildcolumns", NULL, 491);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_4, this_ptr, "buildreturning", NULL, 0);
 	zephir_check_call_status();
@@ -369,7 +369,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, returning)
 	zephir_fetch_params(1, 1, 0, &columns_param);
 	zephir_get_arrval(&columns, columns_param);
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 567, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 566, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("RETURNING"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Insert.zep", 127);
 	zephir_fast_array_merge(&_0, &_2, &columns);
 	ZEPHIR_INIT_VAR(&_3);
@@ -459,7 +459,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, set)
 		ZVAL_STRING(value, "NULL");
 	}
 	zephir_update_property_array_multi(this_ptr, SL("store"), value, SL("sz"), 3, SL("COLUMNS"), &column_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 565, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 564, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "remove", NULL, 0, &column_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -507,7 +507,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, buildColumns)
 
 	ZEPHIR_INIT_VAR(&columns);
 	array_init(&columns);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 567, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 566, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("COLUMNS"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Insert.zep", 176);
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_is_iterable(&_1, 0, "phalcon/DataMapper/Query/Insert.zep", 180);
@@ -560,7 +560,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Insert, buildColumns)
 	zephir_check_call_status();
 	zephir_fast_trim(&_11, &_12, NULL , ZEPHIR_TRIM_LEFT);
 	ZEPHIR_INIT_NVAR(&_13);
-	zephir_read_property_cached(&_15, this_ptr, _zephir_prop_0, 567, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_15, this_ptr, _zephir_prop_0, 566, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_16, &_15, SL("COLUMNS"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Insert.zep", 183);
 	ZEPHIR_CALL_FUNCTION(&_17, "array_values", NULL, 27, &_16);
 	zephir_check_call_status();

--- a/ext/phalcon/datamapper/query/queryfactory.zep.c
+++ b/ext/phalcon/datamapper/query/queryfactory.zep.c
@@ -80,7 +80,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_QueryFactory, __construct)
 		ZEPHIR_INIT_NVAR(&selectClass);
 		ZVAL_STRING(&selectClass, "Phalcon\\DataMapper\\Query\\Select");
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 568, &selectClass);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 567, &selectClass);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -130,7 +130,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_QueryFactory, newDelete)
 	object_init_ex(return_value, phalcon_datamapper_query_delete_ce);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "newbind", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 490, connection, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 492, connection, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -160,7 +160,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_QueryFactory, newInsert)
 	object_init_ex(return_value, phalcon_datamapper_query_insert_ce);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "newbind", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 491, connection, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 493, connection, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -197,7 +197,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_QueryFactory, newSelect)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &connection);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 568, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 567, PH_NOISY_CC | PH_READONLY);
 	zephir_get_strval(&selectClass, &_0);
 	zephir_fetch_safe_class(&_1, &selectClass);
 	_2 = zephir_fetch_class_str_ex(Z_STRVAL_P(&_1), Z_STRLEN_P(&_1), ZEND_FETCH_CLASS_AUTO);
@@ -242,7 +242,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_QueryFactory, newUpdate)
 	object_init_ex(return_value, phalcon_datamapper_query_update_ce);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "newbind", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 492, connection, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 494, connection, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/datamapper/query/select.zep.c
+++ b/ext/phalcon/datamapper/query/select.zep.c
@@ -131,7 +131,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, __call)
 		ZEPHIR_INIT_VAR(&_0$$3);
 		zephir_create_array(&_0$$3, 2, 0);
 		zephir_memory_observe(&_1$$3);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 569, PH_NOISY_CC);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 568, PH_NOISY_CC);
 		zephir_array_fast_append(&_0$$3, &_1$$3);
 		zephir_array_fast_append(&_0$$3, &method_zv);
 		ZEPHIR_INIT_VAR(&_2$$3);
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, __call)
 	}
 	ZEPHIR_INIT_VAR(&_5);
 	object_init_ex(&_5, phalcon_datamapper_pdo_exception_unknownquerymethod_ce);
-	ZEPHIR_CALL_METHOD(NULL, &_5, "__construct", NULL, 493, &method_zv);
+	ZEPHIR_CALL_METHOD(NULL, &_5, "__construct", NULL, 495, &method_zv);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(&_5, "phalcon/DataMapper/Query/Select.zep", 94);
 	ZEPHIR_MM_RESTORE();
@@ -232,7 +232,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, asAlias)
 		Z_PARAM_STR(asAlias)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&asAlias_zv, asAlias);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 570, &asAlias_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 569, &asAlias_zv);
 	RETURN_THISW();
 }
 
@@ -355,22 +355,22 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, appendJoin)
 	} else {
 		}
 	if (!(ZEPHIR_IS_EMPTY(value))) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 570, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_2$$3, type);
 		ZEPHIR_CALL_METHOD(&_1$$3, &_0$$3, "bindinline", NULL, 0, value, &_2$$3);
 		zephir_check_call_status();
 		zephir_concat_self(&condition, &_1$$3);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_4, &_3, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 169);
 	ZEPHIR_CALL_FUNCTION(&end, "array_key_last", NULL, 20, &_4);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_6, &_5, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 170);
 	zephir_array_fetch(&_7, &_6, &end, PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 170);
 	ZEPHIR_CALL_FUNCTION(&key, "array_key_last", NULL, 20, &_7);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_1, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_1, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_9, &_8, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 172);
 	zephir_array_fetch(&_10, &_9, &end, PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 172);
 	zephir_array_fetch(&_11, &_10, &key, PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 172);
@@ -476,7 +476,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, columns)
 	ZEPHIR_INIT_NVAR(&value);
 	ZEPHIR_INIT_NVAR(&key);
 	ZEPHIR_INIT_VAR(&_7);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_9, &_8, SL("COLUMNS"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 199);
 	zephir_fast_array_merge(&_7, &_9, &localColumns);
 	ZEPHIR_INIT_VAR(&_10);
@@ -584,9 +584,9 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, forUpdate)
 	} else {
 		}
 	if (enable) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 573, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 572, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 573, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 572, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -615,7 +615,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, getStatement)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("UNION"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 253);
 	zephir_fast_join_str(&_0, SL(""), &_2);
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "getcurrentstatement", NULL, 0);
@@ -669,7 +669,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, hasColumns)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("store", 5, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("COLUMNS"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 277);
 	RETURN_BOOL(zephir_fast_count_int(&_1) > 0);
 }
@@ -860,13 +860,13 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, join)
 		ZEPHIR_CPY_WRT(&condition, &_15$$4);
 	}
 	if (!(ZEPHIR_IS_EMPTY(value))) {
-		zephir_read_property_cached(&_16$$5, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_16$$5, this_ptr, _zephir_prop_0, 570, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_18$$5, type);
 		ZEPHIR_CALL_METHOD(&_17$$5, &_16$$5, "bindinline", NULL, 0, value, &_18$$5);
 		zephir_check_call_status();
 		zephir_concat_self(&condition, &_17$$5);
 	}
-	zephir_read_property_cached(&_19, this_ptr, _zephir_prop_1, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_19, this_ptr, _zephir_prop_1, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_20, &_19, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 338);
 	ZEPHIR_CALL_FUNCTION(&key, "array_key_last", NULL, 20, &_20);
 	zephir_check_call_status();
@@ -963,11 +963,11 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, reset)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 570, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 569, &_0);
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 573, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 572, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 573, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 572, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -998,9 +998,9 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, subSelect)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, phalcon_datamapper_query_select_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 569, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 571, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 494, &_0, &_1);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 568, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 570, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 496, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -1118,7 +1118,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, getCurrentStatement)
 	}
 	ZEPHIR_INIT_VAR(&forUpdate);
 	ZVAL_STRING(&forUpdate, "");
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 573, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_INIT_NVAR(&forUpdate);
 		ZVAL_STRING(&forUpdate, " FOR UPDATE");
@@ -1127,9 +1127,9 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, getCurrentStatement)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "buildlimitearly", NULL, 0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_3, this_ptr, "buildcolumns", NULL, 495);
+	ZEPHIR_CALL_METHOD(&_3, this_ptr, "buildcolumns", NULL, 497);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&_4, this_ptr, "buildfrom", NULL, 496);
+	ZEPHIR_CALL_METHOD(&_4, this_ptr, "buildfrom", NULL, 498);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_6);
 	ZVAL_STRING(&_6, "WHERE");
@@ -1151,11 +1151,11 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, getCurrentStatement)
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&statement);
 	ZEPHIR_CONCAT_SVVVVVVVVVV(&statement, "SELECT", &_1, &_2, &_3, &_4, &_5, &_7, &_8, &_9, &_10, &forUpdate);
-	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_1, 570, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_1, 569, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_12);
 	ZVAL_STRING(&_12, "");
 	if (UNEXPECTED(!ZEPHIR_IS_IDENTICAL(&_12, &_11))) {
-		zephir_read_property_cached(&_13$$4, this_ptr, _zephir_prop_1, 570, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_13$$4, this_ptr, _zephir_prop_1, 569, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_14$$4);
 		ZEPHIR_CONCAT_SVSV(&_14$$4, "(", &statement, ") AS ", &_13$$4);
 		ZEPHIR_CPY_WRT(&statement, &_14$$4);
@@ -1197,7 +1197,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, buildColumns)
 		ZVAL_STRING(&_1$$3, "*");
 		zephir_array_fast_append(&columns, &_1$$3);
 	} else {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_OBS_NVAR(&columns);
 		zephir_array_fetch_string(&columns, &_2$$4, SL("COLUMNS"), PH_NOISY, "phalcon/DataMapper/Query/Select.zep", 460);
 	}
@@ -1247,12 +1247,12 @@ PHP_METHOD(Phalcon_DataMapper_Query_Select, buildFrom)
 
 	ZEPHIR_INIT_VAR(&from);
 	array_init(&from);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 476);
 	if (ZEPHIR_IS_EMPTY(&_1)) {
 		RETURN_MM_STRING("");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 572, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 571, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_3, &_2, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Select.zep", 480);
 	zephir_is_iterable(&_3, 0, "phalcon/DataMapper/Query/Select.zep", 484);
 	if (Z_TYPE_P(&_3) == IS_ARRAY) {

--- a/ext/phalcon/datamapper/query/update.zep.c
+++ b/ext/phalcon/datamapper/query/update.zep.c
@@ -140,7 +140,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Update, column)
 	ZEPHIR_CONCAT_SV(&_0, ":", &column_zv);
 	zephir_update_property_array_multi(this_ptr, SL("store"), &_0, SL("sz"), 3, SL("COLUMNS"), &column_zv);
 	if (Z_TYPE_P(value) != IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 574, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 573, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_2$$3, type);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "setvalue", NULL, 0, &column_zv, value, &_2$$3);
 		zephir_check_call_status();
@@ -287,9 +287,9 @@ PHP_METHOD(Phalcon_DataMapper_Query_Update, getStatement)
 
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "buildflags", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 574, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("FROM"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Update.zep", 101);
-	ZEPHIR_CALL_METHOD(&_3, this_ptr, "buildcolumns", NULL, 497);
+	ZEPHIR_CALL_METHOD(&_3, this_ptr, "buildcolumns", NULL, 499);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_5);
 	ZVAL_STRING(&_5, "WHERE");
@@ -317,7 +317,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Update, hasColumns)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("store", 5, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 574, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("COLUMNS"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Update.zep", 113);
 	RETURN_BOOL(zephir_fast_count_int(&_1) > 0);
 }
@@ -354,7 +354,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Update, returning)
 	zephir_fetch_params(1, 1, 0, &columns_param);
 	zephir_get_arrval(&columns, columns_param);
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 574, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("RETURNING"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Update.zep", 126);
 	zephir_fast_array_merge(&_0, &_2, &columns);
 	ZEPHIR_INIT_VAR(&_3);
@@ -444,7 +444,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Update, set)
 		ZVAL_STRING(value, "NULL");
 	}
 	zephir_update_property_array_multi(this_ptr, SL("store"), value, SL("sz"), 3, SL("COLUMNS"), &column_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 574, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 573, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "remove", NULL, 0, &column_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -488,7 +488,7 @@ PHP_METHOD(Phalcon_DataMapper_Query_Update, buildColumns)
 
 	ZEPHIR_INIT_VAR(&assignments);
 	array_init(&assignments);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 574, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("COLUMNS"), PH_NOISY | PH_READONLY, "phalcon/DataMapper/Query/Update.zep", 175);
 	zephir_is_iterable(&_1, 0, "phalcon/DataMapper/Query/Update.zep", 179);
 	if (Z_TYPE_P(&_1) == IS_ARRAY) {

--- a/ext/phalcon/db/adapter/pdo/mysql.zep.c
+++ b/ext/phalcon/db/adapter/pdo/mysql.zep.c
@@ -100,7 +100,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, addForeignKey)
 	ZVAL_STR_COPY(&tableName_zv, tableName);
 	zephir_memory_observe(&schemaName_zv);
 	ZVAL_STR_COPY(&schemaName_zv, schemaName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 576, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getforeignkeychecks", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&foreignKeyCheck, this_ptr, "prepare", NULL, 0, &_1);
@@ -110,13 +110,13 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, addForeignKey)
 	if (UNEXPECTED(!zephir_is_true(&_2))) {
 		ZEPHIR_INIT_VAR(&_3$$3);
 		object_init_ex(&_3$$3, phalcon_db_exceptions_missingforeignkeychecks_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 498);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 500);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$3, "phalcon/Db/Adapter/Pdo/Mysql.zep", 65);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 576, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_4, "addforeignkey", NULL, 0, &tableName_zv, &schemaName_zv, reference);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "execute", NULL, 0, &_5);
@@ -319,7 +319,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeColumns)
 	ZVAL_STRING(&sizePattern, "#\\(([0-9]+)(?:,\\s*([0-9]+))*\\)#");
 	ZEPHIR_INIT_VAR(&columns);
 	array_init(&columns);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 576, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "describecolumns", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_2, 3);
@@ -696,7 +696,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeColumns)
 			zephir_array_fetch_long(&columnName, &field, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Adapter/Pdo/Mysql.zep", 550);
 			ZEPHIR_INIT_NVAR(&_71$$3);
 			object_init_ex(&_71$$3, phalcon_db_column_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_71$$3, "__construct", &_72, 499, &columnName, &definition);
+			ZEPHIR_CALL_METHOD(NULL, &_71$$3, "__construct", &_72, 501, &columnName, &definition);
 			zephir_check_call_status();
 			zephir_array_append(&columns, &_71$$3, PH_SEPARATE, "phalcon/Db/Adapter/Pdo/Mysql.zep", 551);
 			ZEPHIR_CPY_WRT(&oldColumn, &columnName);
@@ -1086,7 +1086,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeColumns)
 				zephir_array_fetch_long(&columnName, &field, 0, PH_NOISY, "phalcon/Db/Adapter/Pdo/Mysql.zep", 550);
 				ZEPHIR_INIT_NVAR(&_143$$62);
 				object_init_ex(&_143$$62, phalcon_db_column_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_143$$62, "__construct", &_72, 499, &columnName, &definition);
+				ZEPHIR_CALL_METHOD(NULL, &_143$$62, "__construct", &_72, 501, &columnName, &definition);
 				zephir_check_call_status();
 				zephir_array_append(&columns, &_143$$62, PH_SEPARATE, "phalcon/Db/Adapter/Pdo/Mysql.zep", 551);
 				ZEPHIR_CPY_WRT(&oldColumn, &columnName);
@@ -1198,7 +1198,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeIndexes)
 	}
 	ZEPHIR_INIT_VAR(&indexes);
 	array_init(&indexes);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 576, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "describeindexes", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 2);
@@ -1561,7 +1561,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Mysql, describeReferences)
 	}
 	ZEPHIR_INIT_VAR(&references);
 	array_init(&references);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 576, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 575, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "describereferences", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 3);

--- a/ext/phalcon/db/adapter/pdo/postgresql.zep.c
+++ b/ext/phalcon/db/adapter/pdo/postgresql.zep.c
@@ -131,7 +131,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, connect)
 		zephir_get_arrval(&descriptor, descriptor_param);
 	}
 	if (ZEPHIR_IS_EMPTY(&descriptor)) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 577, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 576, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&descriptor, &_0$$3);
 	}
 	zephir_memory_observe(&schema);
@@ -229,7 +229,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, createTable)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 578, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 577, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&sql, &_2, "createtable", NULL, 0, &tableName_zv, &schemaName_zv, &definition);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&queries);
@@ -480,7 +480,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns)
 	ZVAL_NULL(&oldColumn);
 	ZEPHIR_INIT_VAR(&columns);
 	array_init(&columns);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 578, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 577, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "describecolumns", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_2, 3);
@@ -859,7 +859,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns)
 			zephir_array_fetch_long(&columnName, &field, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Adapter/Pdo/Postgresql.zep", 624);
 			ZEPHIR_INIT_NVAR(&_73$$3);
 			object_init_ex(&_73$$3, phalcon_db_column_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_73$$3, "__construct", &_74, 499, &columnName, &definition);
+			ZEPHIR_CALL_METHOD(NULL, &_73$$3, "__construct", &_74, 501, &columnName, &definition);
 			zephir_check_call_status();
 			zephir_array_append(&columns, &_73$$3, PH_SEPARATE, "phalcon/Db/Adapter/Pdo/Postgresql.zep", 625);
 			ZEPHIR_CPY_WRT(&oldColumn, &columnName);
@@ -1251,7 +1251,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeColumns)
 				zephir_array_fetch_long(&columnName, &field, 0, PH_NOISY, "phalcon/Db/Adapter/Pdo/Postgresql.zep", 624);
 				ZEPHIR_INIT_NVAR(&_145$$57);
 				object_init_ex(&_145$$57, phalcon_db_column_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_145$$57, "__construct", &_74, 499, &columnName, &definition);
+				ZEPHIR_CALL_METHOD(NULL, &_145$$57, "__construct", &_74, 501, &columnName, &definition);
 				zephir_check_call_status();
 				zephir_array_append(&columns, &_145$$57, PH_SEPARATE, "phalcon/Db/Adapter/Pdo/Postgresql.zep", 625);
 				ZEPHIR_CPY_WRT(&oldColumn, &columnName);
@@ -1345,7 +1345,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, describeReferences)
 	}
 	ZEPHIR_INIT_VAR(&references);
 	array_init(&references);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 578, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 577, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "describereferences", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 3);
@@ -1610,7 +1610,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Postgresql, modifyColumn)
 		currentColumn = &currentColumn_sub;
 		currentColumn = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 578, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 577, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&sql, &_0, "modifycolumn", NULL, 0, &tableName_zv, &schemaName_zv, column, currentColumn);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&queries);

--- a/ext/phalcon/db/adapter/pdo/sqlite.zep.c
+++ b/ext/phalcon/db/adapter/pdo/sqlite.zep.c
@@ -123,7 +123,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, connect)
 		zephir_get_arrval(&descriptor, descriptor_param);
 	}
 	if (ZEPHIR_IS_EMPTY(&descriptor)) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 578, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&descriptor, &_0$$3);
 	}
 	zephir_memory_observe(&dbname);
@@ -133,7 +133,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, connect)
 	} else if (UNEXPECTED(!(zephir_array_isset_value_string(&descriptor, SL("dsn"))))) {
 		ZEPHIR_INIT_VAR(&_1$$5);
 		object_init_ex(&_1$$5, phalcon_db_exceptions_missingsqlitedatabase_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", NULL, 500);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", NULL, 502);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$5, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 81);
 		ZEPHIR_MM_RESTORE();
@@ -286,7 +286,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns)
 	ZVAL_STRING(&sizePattern, "#\\(([0-9]+)(?:,\\s*([0-9]+))*\\)#");
 	ZEPHIR_INIT_VAR(&columns);
 	array_init(&columns);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "describecolumns", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_2, 3);
@@ -471,7 +471,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns)
 			zephir_array_fetch_long(&columnName, &field, 1, PH_NOISY | PH_READONLY, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 330);
 			ZEPHIR_INIT_NVAR(&_4$$3);
 			object_init_ex(&_4$$3, phalcon_db_column_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_4$$3, "__construct", &_46, 499, &columnName, &definition);
+			ZEPHIR_CALL_METHOD(NULL, &_4$$3, "__construct", &_46, 501, &columnName, &definition);
 			zephir_check_call_status();
 			zephir_array_append(&columns, &_4$$3, PH_SEPARATE, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 331);
 			ZEPHIR_CPY_WRT(&oldColumn, &columnName);
@@ -669,7 +669,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeColumns)
 				zephir_array_fetch_long(&columnName, &field, 1, PH_NOISY, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 330);
 				ZEPHIR_INIT_NVAR(&_50$$32);
 				object_init_ex(&_50$$32, phalcon_db_column_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_50$$32, "__construct", &_46, 499, &columnName, &definition);
+				ZEPHIR_CALL_METHOD(NULL, &_50$$32, "__construct", &_46, 501, &columnName, &definition);
 				zephir_check_call_status();
 				zephir_array_append(&columns, &_50$$32, PH_SEPARATE, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 331);
 				ZEPHIR_CPY_WRT(&oldColumn, &columnName);
@@ -777,7 +777,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes)
 	}
 	ZEPHIR_INIT_VAR(&indexes);
 	array_init(&indexes);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "describeindexes", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 2);
@@ -805,7 +805,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes)
 				ZEPHIR_OBS_NVAR(&columns);
 				zephir_array_fetch_string(&columns, &_7$$6, SL("columns"), PH_NOISY, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 364);
 			}
-			zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_9$$3, &_8$$3, "describeindex", NULL, 0, &keyName);
 			zephir_check_call_status();
 			ZVAL_LONG(&_10$$3, 2);
@@ -844,7 +844,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes)
 			}
 			ZEPHIR_INIT_NVAR(&describeIndex);
 			zephir_array_update_multi(&indexes, &columns, SL("zs"), 3, &keyName, SL("columns"));
-			zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_16$$3, &_10$$3, "listindexessql", NULL, 0, &table_zv, &schema_zv, &keyName);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&indexSql, this_ptr, "fetchcolumn", &_17, 0, &_16$$3);
@@ -907,7 +907,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes)
 					ZEPHIR_OBS_NVAR(&columns);
 					zephir_array_fetch_string(&columns, &_30$$16, SL("columns"), PH_NOISY, "phalcon/Db/Adapter/Pdo/Sqlite.zep", 364);
 				}
-				zephir_read_property_cached(&_31$$13, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_31$$13, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&_32$$13, &_31$$13, "describeindex", NULL, 0, &keyName);
 				zephir_check_call_status();
 				ZVAL_LONG(&_33$$13, 2);
@@ -946,7 +946,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeIndexes)
 				}
 				ZEPHIR_INIT_NVAR(&describeIndex);
 				zephir_array_update_multi(&indexes, &columns, SL("zs"), 3, &keyName, SL("columns"));
-				zephir_read_property_cached(&_33$$13, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_33$$13, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&_39$$13, &_33$$13, "listindexessql", NULL, 0, &table_zv, &schema_zv, &keyName);
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&indexSql, this_ptr, "fetchcolumn", &_17, 0, &_39$$13);
@@ -1076,7 +1076,7 @@ PHP_METHOD(Phalcon_Db_Adapter_Pdo_Sqlite, describeReferences)
 	}
 	ZEPHIR_INIT_VAR(&references);
 	array_init(&references);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 580, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 579, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "describereferences", NULL, 0, &table_zv, &schema_zv);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 3);

--- a/ext/phalcon/db/check.zep.c
+++ b/ext/phalcon/db/check.zep.c
@@ -121,7 +121,7 @@ PHP_METHOD(Phalcon_Db_Check, __construct)
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&expression, &definition, SL("expression"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_db_exceptions_checkexpressionrequired_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 501);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 503);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Db/Check.zep", 72);
 		ZEPHIR_MM_RESTORE();
@@ -134,14 +134,14 @@ PHP_METHOD(Phalcon_Db_Check, __construct)
 	if (UNEXPECTED(_1)) {
 		ZEPHIR_INIT_VAR(&_2$$4);
 		object_init_ex(&_2$$4, phalcon_db_exceptions_invalidcheckexpression_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 502);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 504);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$4, "phalcon/Db/Check.zep", 76);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 581, &name_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 582, &expression);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 580, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 581, &expression);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/db/column.zep.c
+++ b/ext/phalcon/db/column.zep.c
@@ -709,48 +709,48 @@ PHP_METHOD(Phalcon_Db_Column, __construct)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_get_arrval(&definition, definition_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 583, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 582, &name_zv);
 	zephir_memory_observe(&type);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&type, &definition, SL("type"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_db_exceptions_columntyperequired_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 503);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 505);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Db/Column.zep", 595);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 584, &type);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 583, &type);
 	zephir_memory_observe(&typeReference);
 	if (zephir_array_isset_string_fetch(&typeReference, &definition, SL("typeReference"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 585, &typeReference);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 584, &typeReference);
 	}
 	zephir_memory_observe(&typeValues);
 	if (zephir_array_isset_string_fetch(&typeValues, &definition, SL("typeValues"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 586, &typeValues);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 585, &typeValues);
 	}
 	zephir_memory_observe(&notNull);
 	if (zephir_array_isset_string_fetch(&notNull, &definition, SL("notNull"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 587, &notNull);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 586, &notNull);
 	}
 	zephir_memory_observe(&primary);
 	if (zephir_array_isset_string_fetch(&primary, &definition, SL("primary"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 588, &primary);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 587, &primary);
 	}
 	zephir_memory_observe(&size);
 	if (zephir_array_isset_string_fetch(&size, &definition, SL("size"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 589, &size);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 588, &size);
 	}
 	zephir_memory_observe(&scale);
 	if (zephir_array_isset_string_fetch(&scale, &definition, SL("scale"), 0)) {
 		do {
 			if (ZEPHIR_IS_LONG(&type, 14) || ZEPHIR_IS_LONG(&type, 3) || ZEPHIR_IS_LONG(&type, 9) || ZEPHIR_IS_LONG(&type, 7) || ZEPHIR_IS_LONG(&type, 0) || ZEPHIR_IS_LONG(&type, 21) || ZEPHIR_IS_LONG(&type, 22) || ZEPHIR_IS_LONG(&type, 26)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 590, &scale);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 589, &scale);
 				break;
 			}
 			ZEPHIR_INIT_VAR(&_1$$11);
 			object_init_ex(&_1$$11, phalcon_db_exceptions_columntyperejectsscale_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_1$$11, "__construct", NULL, 504);
+			ZEPHIR_CALL_METHOD(NULL, &_1$$11, "__construct", NULL, 506);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_1$$11, "phalcon/Db/Column.zep", 643);
 			ZEPHIR_MM_RESTORE();
@@ -760,37 +760,37 @@ PHP_METHOD(Phalcon_Db_Column, __construct)
 	}
 	zephir_memory_observe(&defaultValue);
 	if (zephir_array_isset_string_fetch(&defaultValue, &definition, SL("default"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 591, &defaultValue);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 590, &defaultValue);
 	}
 	zephir_memory_observe(&dunsigned);
 	if (zephir_array_isset_string_fetch(&dunsigned, &definition, SL("unsigned"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 592, &dunsigned);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 591, &dunsigned);
 	}
 	zephir_memory_observe(&isNumeric);
 	if (zephir_array_isset_string_fetch(&isNumeric, &definition, SL("isNumeric"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 593, &isNumeric);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 592, &isNumeric);
 	}
 	zephir_memory_observe(&autoIncrement);
 	if (zephir_array_isset_string_fetch(&autoIncrement, &definition, SL("autoIncrement"), 0)) {
 		if (!(zephir_is_true(&autoIncrement))) {
 			if (0) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 594, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 593, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 594, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 593, &__$false);
 			}
 		} else {
 			do {
 				if (ZEPHIR_IS_LONG(&type, 14) || ZEPHIR_IS_LONG(&type, 0) || ZEPHIR_IS_LONG(&type, 21) || ZEPHIR_IS_LONG(&type, 22) || ZEPHIR_IS_LONG(&type, 26)) {
 					if (1) {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 594, &__$true);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 593, &__$true);
 					} else {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 594, &__$false);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 593, &__$false);
 					}
 					break;
 				}
 				ZEPHIR_INIT_VAR(&_2$$19);
 				object_init_ex(&_2$$19, phalcon_db_exceptions_columntyperejectsautoincrement_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_2$$19, "__construct", NULL, 505);
+				ZEPHIR_CALL_METHOD(NULL, &_2$$19, "__construct", NULL, 507);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_2$$19, "phalcon/Db/Column.zep", 685);
 				ZEPHIR_MM_RESTORE();
@@ -801,19 +801,19 @@ PHP_METHOD(Phalcon_Db_Column, __construct)
 	}
 	zephir_memory_observe(&first);
 	if (zephir_array_isset_string_fetch(&first, &definition, SL("first"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_12, 595, &first);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_12, 594, &first);
 	}
 	zephir_memory_observe(&after);
 	if (zephir_array_isset_string_fetch(&after, &definition, SL("after"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_13, 596, &after);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_13, 595, &after);
 	}
 	zephir_memory_observe(&bindType);
 	if (zephir_array_isset_string_fetch(&bindType, &definition, SL("bindType"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_14, 597, &bindType);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_14, 596, &bindType);
 	}
 	zephir_memory_observe(&comment);
 	if (zephir_array_isset_string_fetch(&comment, &definition, SL("comment"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_15, 598, &comment);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_15, 597, &comment);
 	}
 	zephir_memory_observe(&generated);
 	if (zephir_array_isset_string_fetch(&generated, &definition, SL("generated"), 0)) {
@@ -821,54 +821,54 @@ PHP_METHOD(Phalcon_Db_Column, __construct)
 			if (UNEXPECTED(Z_TYPE_P(&generated) != IS_STRING)) {
 				ZEPHIR_INIT_VAR(&_3$$26);
 				object_init_ex(&_3$$26, phalcon_db_exceptions_invalidgenerationexpression_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_3$$26, "__construct", NULL, 506);
+				ZEPHIR_CALL_METHOD(NULL, &_3$$26, "__construct", NULL, 508);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_3$$26, "phalcon/Db/Column.zep", 726);
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_read_property_cached(&_4$$25, this_ptr, _zephir_prop_11, 594, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$25, this_ptr, _zephir_prop_11, 593, PH_NOISY_CC | PH_READONLY);
 			if (UNEXPECTED(zephir_is_true(&_4$$25))) {
 				ZEPHIR_INIT_VAR(&_5$$27);
 				object_init_ex(&_5$$27, phalcon_db_exceptions_generatedautoincrementconflict_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_5$$27, "__construct", NULL, 507);
+				ZEPHIR_CALL_METHOD(NULL, &_5$$27, "__construct", NULL, 509);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_5$$27, "phalcon/Db/Column.zep", 730);
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_read_property_cached(&_6$$25, this_ptr, _zephir_prop_8, 591, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$25, this_ptr, _zephir_prop_8, 590, PH_NOISY_CC | PH_READONLY);
 			if (UNEXPECTED(Z_TYPE_P(&_6$$25) != IS_NULL)) {
 				ZEPHIR_INIT_VAR(&_7$$28);
 				object_init_ex(&_7$$28, phalcon_db_exceptions_generateddefaultconflict_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_7$$28, "__construct", NULL, 508);
+				ZEPHIR_CALL_METHOD(NULL, &_7$$28, "__construct", NULL, 510);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_7$$28, "phalcon/Db/Column.zep", 734);
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_16, 599, &generated);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_16, 598, &generated);
 		}
 	}
 	if (zephir_array_isset_string_fetch(&generationStored, &definition, SL("generationStored"), 1)) {
 		if (zephir_get_boolval(&generationStored)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_17, 600, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_17, 599, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_17, 600, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_17, 599, &__$false);
 		}
 	}
 	if (zephir_array_isset_string_fetch(&invisible, &definition, SL("invisible"), 1)) {
 		if (zephir_get_boolval(&invisible)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_18, 601, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_18, 600, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_18, 601, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_18, 600, &__$false);
 		}
 	}
 	if (zephir_array_isset_string_fetch(&isArray, &definition, SL("array"), 1)) {
 		if (zephir_get_boolval(&isArray)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_19, 602, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_19, 601, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_19, 602, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_19, 601, &__$false);
 		}
 	}
 	ZEPHIR_MM_RESTORE();
@@ -998,7 +998,7 @@ PHP_METHOD(Phalcon_Db_Column, hasDefault)
 	if (zephir_is_true(&_0)) {
 		RETURN_MM_BOOL(0);
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 591, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 590, PH_NOISY_CC | PH_READONLY);
 	RETURN_MM_BOOL(Z_TYPE_P(&_1) != IS_NULL);
 }
 
@@ -1044,7 +1044,7 @@ PHP_METHOD(Phalcon_Db_Column, isGenerated)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("generated", 9, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 599, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 598, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(Z_TYPE_P(&_0) != IS_NULL);
 }
 

--- a/ext/phalcon/db/dialect/mysql.zep.c
+++ b/ext/phalcon/db/dialect/mysql.zep.c
@@ -166,7 +166,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, addColumn)
 				} else {
 					ZEPHIR_INIT_VAR(&_17$$11);
 					ZVAL_STRING(&_17$$11, "\"");
-					ZEPHIR_CALL_FUNCTION(&_18$$11, "addcslashes", NULL, 509, &defaultValue, &_17$$11);
+					ZEPHIR_CALL_FUNCTION(&_18$$11, "addcslashes", NULL, 511, &defaultValue, &_17$$11);
 					zephir_check_call_status();
 					ZEPHIR_INIT_VAR(&_19$$11);
 					ZEPHIR_CONCAT_SVS(&_19$$11, " DEFAULT \"", &_18$$11, "\"");
@@ -667,7 +667,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, createTable)
 						} else {
 							ZEPHIR_INIT_NVAR(&_21$$16);
 							ZVAL_STRING(&_21$$16, "\"");
-							ZEPHIR_CALL_FUNCTION(&_22$$16, "addcslashes", &_23, 509, &defaultValue, &_21$$16);
+							ZEPHIR_CALL_FUNCTION(&_22$$16, "addcslashes", &_23, 511, &defaultValue, &_21$$16);
 							zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_24$$16);
 							ZEPHIR_CONCAT_SVS(&_24$$16, " DEFAULT \"", &_22$$16, "\"");
@@ -777,7 +777,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, createTable)
 							} else {
 								ZEPHIR_INIT_NVAR(&_47$$29);
 								ZVAL_STRING(&_47$$29, "\"");
-								ZEPHIR_CALL_FUNCTION(&_48$$29, "addcslashes", &_23, 509, &defaultValue, &_47$$29);
+								ZEPHIR_CALL_FUNCTION(&_48$$29, "addcslashes", &_23, 511, &defaultValue, &_47$$29);
 								zephir_check_call_status();
 								ZEPHIR_INIT_NVAR(&_49$$29);
 								ZEPHIR_CONCAT_SVS(&_49$$29, " DEFAULT \"", &_48$$29, "\"");
@@ -1583,7 +1583,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			}
 			ZEPHIR_CALL_METHOD(&_0$$3, this_ptr, "getcolumnsize", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_2$$3);
 			ZEPHIR_CONCAT_VV(&_2$$3, &_0$$3, &_1$$3);
@@ -1645,7 +1645,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			}
 			ZEPHIR_CALL_METHOD(&_7$$18, this_ptr, "getcolumnsizeandscale", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_8$$18, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_8$$18, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_9$$18);
 			ZEPHIR_CONCAT_VV(&_9$$18, &_7$$18, &_8$$18);
@@ -1656,9 +1656,9 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			if (ZEPHIR_IS_EMPTY(&columnSql)) {
 				zephir_concat_self_str(&columnSql, SL("DOUBLE"));
 			}
-			ZEPHIR_CALL_METHOD(&_10$$20, this_ptr, "checkcolumnsizeandscale", NULL, 511, column);
+			ZEPHIR_CALL_METHOD(&_10$$20, this_ptr, "checkcolumnsizeandscale", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_11$$20, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_11$$20, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_12$$20);
 			ZEPHIR_CONCAT_VV(&_12$$20, &_10$$20, &_11$$20);
@@ -1678,9 +1678,9 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			if (ZEPHIR_IS_EMPTY(&columnSql)) {
 				zephir_concat_self_str(&columnSql, SL("FLOAT"));
 			}
-			ZEPHIR_CALL_METHOD(&_14$$24, this_ptr, "checkcolumnsizeandscale", NULL, 511, column);
+			ZEPHIR_CALL_METHOD(&_14$$24, this_ptr, "checkcolumnsizeandscale", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_15$$24, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_15$$24, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_16$$24);
 			ZEPHIR_CONCAT_VV(&_16$$24, &_14$$24, &_15$$24);
@@ -1693,7 +1693,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			}
 			ZEPHIR_CALL_METHOD(&_17$$26, this_ptr, "getcolumnsize", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_18$$26, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_18$$26, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_19$$26);
 			ZEPHIR_CONCAT_VV(&_19$$26, &_17$$26, &_18$$26);
@@ -1730,7 +1730,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			}
 			ZEPHIR_CALL_METHOD(&_20$$36, this_ptr, "getcolumnsize", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_21$$36, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_21$$36, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_22$$36);
 			ZEPHIR_CONCAT_VV(&_22$$36, &_20$$36, &_21$$36);
@@ -1749,7 +1749,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			}
 			ZEPHIR_CALL_METHOD(&_23$$40, this_ptr, "getcolumnsize", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_24$$40, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_24$$40, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_25$$40);
 			ZEPHIR_CONCAT_VV(&_25$$40, &_23$$40, &_24$$40);
@@ -1800,7 +1800,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			}
 			ZEPHIR_CALL_METHOD(&_30$$52, this_ptr, "getcolumnsize", NULL, 0, column);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_31$$52, this_ptr, "checkcolumnunsigned", NULL, 510, column);
+			ZEPHIR_CALL_METHOD(&_31$$52, this_ptr, "checkcolumnunsigned", NULL, 0, column);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_32$$52);
 			ZEPHIR_CONCAT_VV(&_32$$52, &_30$$52, &_31$$52);
@@ -1897,7 +1897,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 						ZVAL_COPY(&value$$77, _37$$77);
 						ZEPHIR_INIT_NVAR(&_38$$78);
 						ZVAL_STRING(&_38$$78, "\"");
-						ZEPHIR_CALL_FUNCTION(&_39$$78, "addcslashes", &_40, 509, &value$$77, &_38$$78);
+						ZEPHIR_CALL_FUNCTION(&_39$$78, "addcslashes", &_40, 511, &value$$77, &_38$$78);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&_41$$78);
 						ZEPHIR_CONCAT_SVS(&_41$$78, "\"", &_39$$78, "\", ");
@@ -1923,7 +1923,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 						zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_44$$79);
 							ZVAL_STRING(&_44$$79, "\"");
-							ZEPHIR_CALL_FUNCTION(&_45$$79, "addcslashes", &_40, 509, &value$$77, &_44$$79);
+							ZEPHIR_CALL_FUNCTION(&_45$$79, "addcslashes", &_40, 511, &value$$77, &_44$$79);
 							zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_46$$79);
 							ZEPHIR_CONCAT_SVS(&_46$$79, "\"", &_45$$79, "\", ");
@@ -1941,7 +1941,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, getColumnDefinition)
 			} else {
 				ZEPHIR_INIT_VAR(&_51$$80);
 				ZVAL_STRING(&_51$$80, "\"");
-				ZEPHIR_CALL_FUNCTION(&_52$$80, "addcslashes", &_40, 509, &typeValues, &_51$$80);
+				ZEPHIR_CALL_FUNCTION(&_52$$80, "addcslashes", &_40, 511, &typeValues, &_51$$80);
 				zephir_check_call_status();
 				ZEPHIR_INIT_VAR(&_53$$80);
 				ZEPHIR_CONCAT_SVS(&_53$$80, "(\"", &_52$$80, "\")");
@@ -2190,7 +2190,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Mysql, modifyColumn)
 				} else {
 					ZEPHIR_INIT_VAR(&_23$$14);
 					ZVAL_STRING(&_23$$14, "\"");
-					ZEPHIR_CALL_FUNCTION(&_24$$14, "addcslashes", NULL, 509, &defaultValue, &_23$$14);
+					ZEPHIR_CALL_FUNCTION(&_24$$14, "addcslashes", NULL, 511, &defaultValue, &_23$$14);
 					zephir_check_call_status();
 					ZEPHIR_INIT_VAR(&_25$$14);
 					ZEPHIR_CONCAT_SVS(&_25$$14, " DEFAULT \"", &_24$$14, "\"");

--- a/ext/phalcon/db/dialect/postgresql.zep.c
+++ b/ext/phalcon/db/dialect/postgresql.zep.c
@@ -1860,7 +1860,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, getColumnDefinition)
 						ZVAL_COPY(&value$$76, _8$$76);
 						ZEPHIR_INIT_NVAR(&_9$$77);
 						ZVAL_STRING(&_9$$77, "\'");
-						ZEPHIR_CALL_FUNCTION(&_10$$77, "addcslashes", &_11, 509, &value$$76, &_9$$77);
+						ZEPHIR_CALL_FUNCTION(&_10$$77, "addcslashes", &_11, 511, &value$$76, &_9$$77);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&_12$$77);
 						ZEPHIR_CONCAT_SVS(&_12$$77, "'", &_10$$77, "', ");
@@ -1886,7 +1886,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, getColumnDefinition)
 						zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_15$$78);
 							ZVAL_STRING(&_15$$78, "\'");
-							ZEPHIR_CALL_FUNCTION(&_16$$78, "addcslashes", &_11, 509, &value$$76, &_15$$78);
+							ZEPHIR_CALL_FUNCTION(&_16$$78, "addcslashes", &_11, 511, &value$$76, &_15$$78);
 							zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_17$$78);
 							ZEPHIR_CONCAT_SVS(&_17$$78, "'", &_16$$78, "', ");
@@ -1904,7 +1904,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, getColumnDefinition)
 			} else {
 				ZEPHIR_INIT_VAR(&_22$$79);
 				ZVAL_STRING(&_22$$79, "\'");
-				ZEPHIR_CALL_FUNCTION(&_23$$79, "addcslashes", &_11, 509, &typeValues, &_22$$79);
+				ZEPHIR_CALL_FUNCTION(&_23$$79, "addcslashes", &_11, 511, &typeValues, &_22$$79);
 				zephir_check_call_status();
 				ZEPHIR_INIT_VAR(&_24$$79);
 				ZEPHIR_CONCAT_SVS(&_24$$79, "('", &_23$$79, "')");
@@ -2557,7 +2557,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Postgresql, castDefault)
 	} else {
 		ZEPHIR_INIT_VAR(&_12$$7);
 		ZVAL_STRING(&_12$$7, "\'");
-		ZEPHIR_CALL_FUNCTION(&_13$$7, "addcslashes", NULL, 509, &defaultValue, &_12$$7);
+		ZEPHIR_CALL_FUNCTION(&_13$$7, "addcslashes", NULL, 511, &defaultValue, &_12$$7);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_14$$7);
 		ZEPHIR_CONCAT_SVS(&_14$$7, "'", &_13$$7, "'");

--- a/ext/phalcon/db/dialect/sqlite.zep.c
+++ b/ext/phalcon/db/dialect/sqlite.zep.c
@@ -140,7 +140,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, addColumn)
 			} else {
 				ZEPHIR_INIT_VAR(&_13$$6);
 				ZVAL_STRING(&_13$$6, "\"");
-				ZEPHIR_CALL_FUNCTION(&_14$$6, "addcslashes", NULL, 509, &defaultValue, &_13$$6);
+				ZEPHIR_CALL_FUNCTION(&_14$$6, "addcslashes", NULL, 511, &defaultValue, &_13$$6);
 				zephir_check_call_status();
 				ZEPHIR_INIT_VAR(&_15$$6);
 				ZEPHIR_CONCAT_SVS(&_15$$6, " DEFAULT \"", &_14$$6, "\"");
@@ -563,7 +563,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable)
 						} else {
 							ZEPHIR_INIT_NVAR(&_18$$14);
 							ZVAL_STRING(&_18$$14, "\"");
-							ZEPHIR_CALL_FUNCTION(&_19$$14, "addcslashes", &_20, 509, &defaultValue, &_18$$14);
+							ZEPHIR_CALL_FUNCTION(&_19$$14, "addcslashes", &_20, 511, &defaultValue, &_18$$14);
 							zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_21$$14);
 							ZEPHIR_CONCAT_SVS(&_21$$14, " DEFAULT \"", &_19$$14, "\"");
@@ -652,7 +652,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, createTable)
 							} else {
 								ZEPHIR_INIT_NVAR(&_38$$24);
 								ZVAL_STRING(&_38$$24, "\"");
-								ZEPHIR_CALL_FUNCTION(&_39$$24, "addcslashes", &_20, 509, &defaultValue, &_38$$24);
+								ZEPHIR_CALL_FUNCTION(&_39$$24, "addcslashes", &_20, 511, &defaultValue, &_38$$24);
 								zephir_check_call_status();
 								ZEPHIR_INIT_NVAR(&_40$$24);
 								ZEPHIR_CONCAT_SVS(&_40$$24, " DEFAULT \"", &_39$$24, "\"");
@@ -1561,7 +1561,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, getColumnDefinition)
 						ZVAL_COPY(&value$$40, _8$$40);
 						ZEPHIR_INIT_NVAR(&_9$$41);
 						ZVAL_STRING(&_9$$41, "\"");
-						ZEPHIR_CALL_FUNCTION(&_10$$41, "addcslashes", &_11, 509, &value$$40, &_9$$41);
+						ZEPHIR_CALL_FUNCTION(&_10$$41, "addcslashes", &_11, 511, &value$$40, &_9$$41);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&_12$$41);
 						ZEPHIR_CONCAT_SVS(&_12$$41, "\"", &_10$$41, "\", ");
@@ -1587,7 +1587,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, getColumnDefinition)
 						zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_15$$42);
 							ZVAL_STRING(&_15$$42, "\"");
-							ZEPHIR_CALL_FUNCTION(&_16$$42, "addcslashes", &_11, 509, &value$$40, &_15$$42);
+							ZEPHIR_CALL_FUNCTION(&_16$$42, "addcslashes", &_11, 511, &value$$40, &_15$$42);
 							zephir_check_call_status();
 							ZEPHIR_INIT_NVAR(&_17$$42);
 							ZEPHIR_CONCAT_SVS(&_17$$42, "\"", &_16$$42, "\", ");
@@ -1605,7 +1605,7 @@ PHP_METHOD(Phalcon_Db_Dialect_Sqlite, getColumnDefinition)
 			} else {
 				ZEPHIR_INIT_VAR(&_22$$43);
 				ZVAL_STRING(&_22$$43, "\"");
-				ZEPHIR_CALL_FUNCTION(&_23$$43, "addcslashes", &_11, 509, &typeValues, &_22$$43);
+				ZEPHIR_CALL_FUNCTION(&_23$$43, "addcslashes", &_11, 511, &typeValues, &_22$$43);
 				zephir_check_call_status();
 				ZEPHIR_INIT_VAR(&_24$$43);
 				ZEPHIR_CONCAT_SVS(&_24$$43, "(\"", &_23$$43, "\")");

--- a/ext/phalcon/db/geometry/geometrycollection.zep.c
+++ b/ext/phalcon/db/geometry/geometrycollection.zep.c
@@ -72,10 +72,10 @@ PHP_METHOD(Phalcon_Db_Geometry_GeometryCollection, __construct)
 		srid = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 603, &geometries);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 602, &geometries);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 604, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 603, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -115,7 +115,7 @@ PHP_METHOD(Phalcon_Db_Geometry_GeometryCollection, toWkt)
 
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 603, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 602, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Db/Geometry/GeometryCollection.zep", 46);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/db/geometry/linestring.zep.c
+++ b/ext/phalcon/db/geometry/linestring.zep.c
@@ -72,10 +72,10 @@ PHP_METHOD(Phalcon_Db_Geometry_LineString, __construct)
 		srid = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 605, &points);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 604, &points);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 606, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 605, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -131,7 +131,7 @@ PHP_METHOD(Phalcon_Db_Geometry_LineString, pointsWkt)
 
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 605, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 604, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Db/Geometry/LineString.zep", 51);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/db/geometry/multilinestring.zep.c
+++ b/ext/phalcon/db/geometry/multilinestring.zep.c
@@ -72,10 +72,10 @@ PHP_METHOD(Phalcon_Db_Geometry_MultiLineString, __construct)
 		srid = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 607, &lineStrings);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 606, &lineStrings);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 608, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 607, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -117,7 +117,7 @@ PHP_METHOD(Phalcon_Db_Geometry_MultiLineString, toWkt)
 
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 607, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 606, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Db/Geometry/MultiLineString.zep", 46);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/db/geometry/multipoint.zep.c
+++ b/ext/phalcon/db/geometry/multipoint.zep.c
@@ -72,10 +72,10 @@ PHP_METHOD(Phalcon_Db_Geometry_MultiPoint, __construct)
 		srid = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 609, &points);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 608, &points);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 610, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 609, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -115,7 +115,7 @@ PHP_METHOD(Phalcon_Db_Geometry_MultiPoint, toWkt)
 
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 609, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 608, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Db/Geometry/MultiPoint.zep", 46);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/db/geometry/multipolygon.zep.c
+++ b/ext/phalcon/db/geometry/multipolygon.zep.c
@@ -72,10 +72,10 @@ PHP_METHOD(Phalcon_Db_Geometry_MultiPolygon, __construct)
 		srid = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 611, &polygons);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 610, &polygons);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 612, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 611, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -117,7 +117,7 @@ PHP_METHOD(Phalcon_Db_Geometry_MultiPolygon, toWkt)
 
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 611, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 610, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Db/Geometry/MultiPolygon.zep", 46);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/db/geometry/point.zep.c
+++ b/ext/phalcon/db/geometry/point.zep.c
@@ -78,13 +78,13 @@ PHP_METHOD(Phalcon_Db_Geometry_Point, __construct)
 		}
 	ZVAL_UNDEF(&_0);
 	ZVAL_DOUBLE(&_0, x);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 613, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 612, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_DOUBLE(&_0, y);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 614, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 613, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 615, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 614, &_0);
 }
 
 PHP_METHOD(Phalcon_Db_Geometry_Point, getType)
@@ -137,8 +137,8 @@ PHP_METHOD(Phalcon_Db_Geometry_Point, coordsWkt)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("y", 1, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 613, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 614, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 612, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 613, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VSV(return_value, &_0, " ", &_1);
 	return;
 }

--- a/ext/phalcon/db/geometry/polygon.zep.c
+++ b/ext/phalcon/db/geometry/polygon.zep.c
@@ -72,10 +72,10 @@ PHP_METHOD(Phalcon_Db_Geometry_Polygon, __construct)
 		srid = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 616, &rings);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 615, &rings);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, srid);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 617, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 616, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -141,7 +141,7 @@ PHP_METHOD(Phalcon_Db_Geometry_Polygon, ringsWkt)
 
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 616, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 615, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Db/Geometry/Polygon.zep", 57);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/db/geometry/wkbparser.zep.c
+++ b/ext/phalcon/db/geometry/wkbparser.zep.c
@@ -130,13 +130,13 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, parse)
 		ZEPHIR_INIT_NVAR(&body);
 		zephir_substr(&body, &raw_zv, 4 , 0, ZEPHIR_SUBSTR_NO_LENGTH);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 618, &body);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 617, &body);
 	ZVAL_UNDEF(&_8);
 	ZVAL_LONG(&_8, zephir_fast_strlen_ev(&body));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 619, &_8);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 618, &_8);
 	ZVAL_UNDEF(&_8);
 	ZVAL_LONG(&_8, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 620, &_8);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 619, &_8);
 	ZVAL_LONG(&_8, srid);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "readgeometry", NULL, 0, &_8);
 	zephir_check_call_status();
@@ -625,14 +625,14 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, readByte)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 619, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 618, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_LT_LONG(&_1, (zephir_get_numberval(&_0) + 1))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_invalidwkb_ce, "truncated buffer", "phalcon/Db/Geometry/WkbParser.zep", 204);
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 618, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 617, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_4, 1);
 	ZEPHIR_INIT_VAR(&_5);
 	zephir_substr(&_5, &_2, zephir_get_intval(&_3), 1 , 0);
@@ -640,10 +640,10 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, readByte)
 	ZVAL_STRING(&_6, "C");
 	ZEPHIR_CALL_FUNCTION(&arr, "unpack", NULL, 0, &_6, &_5);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
 	ZVAL_UNDEF(&_8);
 	ZVAL_LONG(&_8, (zephir_get_numberval(&_7) + 1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 620, &_8);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 619, &_8);
 	zephir_memory_observe(&_9);
 	zephir_array_fetch_long(&_9, &arr, 1, PH_NOISY, "phalcon/Db/Geometry/WkbParser.zep", 210);
 	RETURN_MM_LONG(zephir_get_intval(&_9));
@@ -687,8 +687,8 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, readUint32)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &little_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 619, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 618, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_LT_LONG(&_1, (zephir_get_numberval(&_0) + 4))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_invalidwkb_ce, "truncated buffer", "phalcon/Db/Geometry/WkbParser.zep", 218);
 		return;
@@ -700,17 +700,17 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, readUint32)
 		ZEPHIR_INIT_NVAR(&fmt);
 		ZVAL_STRING(&fmt, "N");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 618, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 617, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_4, 4);
 	ZEPHIR_INIT_VAR(&_5);
 	zephir_substr(&_5, &_2, zephir_get_intval(&_3), 4 , 0);
 	ZEPHIR_CALL_FUNCTION(&arr, "unpack", NULL, 0, &fmt, &_5);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
 	ZVAL_UNDEF(&_7);
 	ZVAL_LONG(&_7, (zephir_get_numberval(&_6) + 4));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 620, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 619, &_7);
 	zephir_memory_observe(&_8);
 	zephir_array_fetch_long(&_8, &arr, 1, PH_NOISY, "phalcon/Db/Geometry/WkbParser.zep", 225);
 	RETURN_MM_LONG(zephir_get_intval(&_8));
@@ -754,8 +754,8 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, readDouble)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &little_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 619, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 618, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_LT_LONG(&_1, (zephir_get_numberval(&_0) + 8))) {
 		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_invalidwkb_ce, "truncated buffer", "phalcon/Db/Geometry/WkbParser.zep", 233);
 		return;
@@ -767,17 +767,17 @@ PHP_METHOD(Phalcon_Db_Geometry_WkbParser, readDouble)
 		ZEPHIR_INIT_NVAR(&fmt);
 		ZVAL_STRING(&fmt, "E");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 618, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 617, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_4, 8);
 	ZEPHIR_INIT_VAR(&_5);
 	zephir_substr(&_5, &_2, zephir_get_intval(&_3), 8 , 0);
 	ZEPHIR_CALL_FUNCTION(&arr, "unpack", NULL, 0, &fmt, &_5);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 620, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 619, PH_NOISY_CC | PH_READONLY);
 	ZVAL_UNDEF(&_7);
 	ZVAL_LONG(&_7, (zephir_get_numberval(&_6) + 8));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 620, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 619, &_7);
 	zephir_memory_observe(&_8);
 	zephir_array_fetch_long(&_8, &arr, 1, PH_NOISY, "phalcon/Db/Geometry/WkbParser.zep", 240);
 	RETURN_MM_DOUBLE(zephir_get_doubleval(&_8));

--- a/ext/phalcon/db/index.zep.c
+++ b/ext/phalcon/db/index.zep.c
@@ -219,7 +219,7 @@ PHP_METHOD(Phalcon_Db_Index, __construct)
 		zephir_memory_observe(&type_zv);
 	ZVAL_STR_COPY(&type_zv, type);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 621, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 620, &name_zv);
 	if (zephir_array_isset_value_string(&columnsOrDefinition, SL("columns"))) {
 		zephir_memory_observe(&_0$$3);
 		zephir_array_fetch_string(&_0$$3, &columnsOrDefinition, SL("columns"), PH_NOISY, "phalcon/Db/Index.zep", 139);
@@ -233,18 +233,18 @@ PHP_METHOD(Phalcon_Db_Index, __construct)
 			return;
 		}
 		zephir_array_fetch_string(&_2$$3, &columnsOrDefinition, SL("columns"), PH_NOISY | PH_READONLY, "phalcon/Db/Index.zep", 143);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 622, &_2$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 621, &_2$$3);
 		zephir_memory_observe(&definitionType);
 		if (zephir_array_isset_string_fetch(&definitionType, &columnsOrDefinition, SL("type"), 0)) {
 			zephir_cast_to_string(&_3$$5, &definitionType);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 623, &_3$$5);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 622, &_3$$5);
 		}
 		zephir_memory_observe(&invisible);
 		if (zephir_array_isset_string_fetch(&invisible, &columnsOrDefinition, SL("invisible"), 0)) {
 			if (zephir_get_boolval(&invisible)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 624, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 623, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 624, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 623, &__$false);
 			}
 		}
 		zephir_memory_observe(&directions);
@@ -258,7 +258,7 @@ PHP_METHOD(Phalcon_Db_Index, __construct)
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 625, &directions);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 624, &directions);
 		}
 		zephir_memory_observe(&where);
 		if (zephir_array_isset_string_fetch(&where, &columnsOrDefinition, SL("where"), 0)) {
@@ -271,18 +271,18 @@ PHP_METHOD(Phalcon_Db_Index, __construct)
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 626, &where);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 625, &where);
 		}
 		if (zephir_array_isset_string_fetch(&concurrent, &columnsOrDefinition, SL("concurrently"), 1)) {
 			if (zephir_get_boolval(&concurrent)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 627, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 626, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 627, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 626, &__$false);
 			}
 		}
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 622, &columnsOrDefinition);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 623, &type_zv);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 621, &columnsOrDefinition);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 622, &type_zv);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/db/profiler.zep.c
+++ b/ext/phalcon/db/profiler.zep.c
@@ -143,7 +143,7 @@ PHP_METHOD(Phalcon_Db_Profiler, getNumberTotalStatements)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("allProfiles", 11, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 628, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 627, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 
@@ -184,7 +184,7 @@ PHP_METHOD(Phalcon_Db_Profiler, reset)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 628, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 627, &_0);
 	RETURN_THIS();
 }
 
@@ -210,7 +210,7 @@ PHP_METHOD(Phalcon_Db_Profiler, setMaxProfiles)
 	zephir_fetch_params_without_memory_grow(1, 0, &maxProfiles_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, maxProfiles);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 629, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 628, &_0);
 	RETURN_THISW();
 }
 
@@ -278,7 +278,7 @@ PHP_METHOD(Phalcon_Db_Profiler, startProfile)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &activeProfile, "setsqlbindtypes", NULL, 0, &sqlBindTypes);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_0, "hrtime", NULL, 487, &__$true);
+	ZEPHIR_CALL_FUNCTION(&_0, "hrtime", NULL, 489, &__$true);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &activeProfile, "setinitialtime", NULL, 0, &_0);
 	zephir_check_call_status();
@@ -286,7 +286,7 @@ PHP_METHOD(Phalcon_Db_Profiler, startProfile)
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "beforestartprofile", NULL, 0, &activeProfile);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 630, &activeProfile);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 629, &activeProfile);
 	RETURN_THIS();
 }
 
@@ -332,35 +332,35 @@ PHP_METHOD(Phalcon_Db_Profiler, stopProfile)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 630, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 629, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&activeProfile, &_0);
-	ZEPHIR_CALL_FUNCTION(&_1, "hrtime", NULL, 487, &__$true);
+	ZEPHIR_CALL_FUNCTION(&_1, "hrtime", NULL, 489, &__$true);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &activeProfile, "setfinaltime", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 629, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 628, PH_NOISY_CC | PH_READONLY);
 	_2 = ZEPHIR_GT_LONG(&_0, 0);
 	if (_2) {
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 628, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 629, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 627, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 628, PH_NOISY_CC | PH_READONLY);
 		_2 = ZEPHIR_LE_LONG(&_4, zephir_fast_count_int(&_3));
 	}
 	if (_2) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 628, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 627, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&firstKey, "array_key_first", NULL, 17, &_5$$3);
 		zephir_check_call_status();
 		if (Z_TYPE_P(&firstKey) != IS_NULL) {
 			zephir_unset_property_array(this_ptr, ZEND_STRL("allProfiles"), &firstKey);
-			zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 628, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 627, PH_NOISY_CC | PH_READONLY);
 			zephir_array_unset(&_6$$4, &firstKey, PH_SEPARATE);
 		}
 	}
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_3, 631, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_3, 630, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_8, &activeProfile, "gettotalelapsednanoseconds", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_9);
 	zephir_add_function(&_9, &_7, &_8);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 631, &_9);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 630, &_9);
 	zephir_update_property_array_append(this_ptr, SL("allProfiles"), &activeProfile);
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("afterendprofile")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "afterendprofile", NULL, 0, &activeProfile);

--- a/ext/phalcon/db/profiler/item.zep.c
+++ b/ext/phalcon/db/profiler/item.zep.c
@@ -129,8 +129,8 @@ PHP_METHOD(Phalcon_Db_Profiler_Item, getTotalElapsedNanoseconds)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("initialTime", 11, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 632, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 633, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 631, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 632, PH_NOISY_CC | PH_READONLY);
 	zephir_sub_function(return_value, &_0, &_1);
 	return;
 }
@@ -157,7 +157,7 @@ PHP_METHOD(Phalcon_Db_Profiler_Item, setFinalTime)
 	finalTime = zephir_get_doubleval(finalTime_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_DOUBLE(&_0, finalTime);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 632, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 631, &_0);
 	RETURN_THISW();
 }
 
@@ -183,7 +183,7 @@ PHP_METHOD(Phalcon_Db_Profiler_Item, setInitialTime)
 	initialTime = zephir_get_doubleval(initialTime_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_DOUBLE(&_0, initialTime);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 633, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 632, &_0);
 	RETURN_THISW();
 }
 
@@ -210,7 +210,7 @@ PHP_METHOD(Phalcon_Db_Profiler_Item, setSqlBindTypes)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &sqlBindTypes_param);
 	zephir_get_arrval(&sqlBindTypes, sqlBindTypes_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 634, &sqlBindTypes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 633, &sqlBindTypes);
 	RETURN_THIS();
 }
 
@@ -233,7 +233,7 @@ PHP_METHOD(Phalcon_Db_Profiler_Item, setSqlStatement)
 		Z_PARAM_STR(sqlStatement)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&sqlStatement_zv, sqlStatement);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 635, &sqlStatement_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 634, &sqlStatement_zv);
 	RETURN_THISW();
 }
 
@@ -260,7 +260,7 @@ PHP_METHOD(Phalcon_Db_Profiler_Item, setSqlVariables)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &sqlVariables_param);
 	zephir_get_arrval(&sqlVariables, sqlVariables_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 636, &sqlVariables);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 635, &sqlVariables);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/db/rawvalue.zep.c
+++ b/ext/phalcon/db/rawvalue.zep.c
@@ -81,15 +81,15 @@ PHP_METHOD(Phalcon_Db_RawValue, __construct)
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZEPHIR_INIT_NVAR(&_0$$3);
 		ZVAL_STRING(&_0$$3, "''");
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 637, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 636, &_0$$3);
 	} else if (Z_TYPE_P(value) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$4);
 		ZEPHIR_INIT_NVAR(&_1$$4);
 		ZVAL_STRING(&_1$$4, "NULL");
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 637, &_1$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 636, &_1$$4);
 	} else {
 		zephir_cast_to_string(&_2$$5, value);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 637, &_2$$5);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 636, &_2$$5);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/db/reference.zep.c
+++ b/ext/phalcon/db/reference.zep.c
@@ -173,7 +173,7 @@ PHP_METHOD(Phalcon_Db_Reference, __construct)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_get_arrval(&definition, definition_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 638, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 637, &name_zv);
 	zephir_memory_observe(&referencedTable);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&referencedTable, &definition, SL("referencedTable"), 0)))) {
 		ZEPHIR_INIT_VAR(&_0$$3);
@@ -184,7 +184,7 @@ PHP_METHOD(Phalcon_Db_Reference, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 639, &referencedTable);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 638, &referencedTable);
 	zephir_memory_observe(&columns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columns, &definition, SL("columns"), 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$4);
@@ -195,7 +195,7 @@ PHP_METHOD(Phalcon_Db_Reference, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 640, &columns);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 639, &columns);
 	zephir_memory_observe(&referencedColumns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&referencedColumns, &definition, SL("referencedColumns"), 0)))) {
 		ZEPHIR_INIT_VAR(&_2$$5);
@@ -206,22 +206,22 @@ PHP_METHOD(Phalcon_Db_Reference, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 641, &referencedColumns);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 640, &referencedColumns);
 	zephir_memory_observe(&schema);
 	if (zephir_array_isset_string_fetch(&schema, &definition, SL("schema"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 642, &schema);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 641, &schema);
 	}
 	zephir_memory_observe(&referencedSchema);
 	if (zephir_array_isset_string_fetch(&referencedSchema, &definition, SL("referencedSchema"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 643, &referencedSchema);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 642, &referencedSchema);
 	}
 	zephir_memory_observe(&onDelete);
 	if (zephir_array_isset_string_fetch(&onDelete, &definition, SL("onDelete"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 644, &onDelete);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 643, &onDelete);
 	}
 	zephir_memory_observe(&onUpdate);
 	if (zephir_array_isset_string_fetch(&onUpdate, &definition, SL("onUpdate"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 645, &onUpdate);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 644, &onUpdate);
 	}
 	if (UNEXPECTED(zephir_fast_count_int(&columns) != zephir_fast_count_int(&referencedColumns))) {
 		ZEPHIR_INIT_VAR(&_3$$10);

--- a/ext/phalcon/db/result/pdoresult.zep.c
+++ b/ext/phalcon/db/result/pdoresult.zep.c
@@ -152,11 +152,11 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, __construct)
 		bindTypes = &bindTypes_sub;
 		bindTypes = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 646, connection);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 647, result);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 648, sqlStatement);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 649, bindParams);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 650, bindTypes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 645, connection);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 646, result);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 647, sqlStatement);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 648, bindParams);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 649, bindTypes);
 }
 
 /**
@@ -228,19 +228,19 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, dataSeek)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &number_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 646, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 645, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&connection, &_0);
 	ZEPHIR_CALL_METHOD(&pdo, &connection, "getinternalhandler", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 648, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 647, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&sqlStatement, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 649, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 648, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&bindParams, &_0);
 	if (Z_TYPE_P(&bindParams) == IS_ARRAY) {
 		ZEPHIR_CALL_METHOD(&statement, &pdo, "prepare", NULL, 0, &sqlStatement);
 		zephir_check_call_status();
 		if (Z_TYPE_P(&statement) == IS_OBJECT) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 650, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 649, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_1$$4, &connection, "executeprepared", NULL, 0, &statement, &bindParams, &_2$$4);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&statement, &_1$$4);
@@ -249,14 +249,14 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, dataSeek)
 		ZEPHIR_CALL_METHOD(&statement, &pdo, "query", NULL, 0, &sqlStatement);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 647, &statement);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 646, &statement);
 	n = -1;
 	number--;
 	while (1) {
 		if (!(n != number)) {
 			break;
 		}
-		zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_5, 651, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_5, 650, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &statement, "fetch", &_4, 0, &_3$$6);
 		zephir_check_call_status();
 		n++;
@@ -289,8 +289,8 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, execute)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 652, &__$null);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 647, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 651, &__$null);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 646, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "execute", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -360,9 +360,9 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, fetch)
 		ZVAL_LONG(&mode, fetchStyle);
 	} else {
 		ZEPHIR_OBS_NVAR(&mode);
-		zephir_read_property_cached(&mode, this_ptr, _zephir_prop_0, 651, PH_NOISY_CC);
+		zephir_read_property_cached(&mode, this_ptr, _zephir_prop_0, 650, PH_NOISY_CC);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 647, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 646, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, cursorOrientation);
 	ZVAL_LONG(&_2, cursorOffset);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "fetch", NULL, 0, &mode, &_1, &_2);
@@ -433,7 +433,7 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, fetchAll)
 		constructorArgs = &__$null;
 	}
 	if (mode == 8) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 647, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 646, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_1$$3, mode);
 		ZEPHIR_RETURN_CALL_METHOD(&_0$$3, "fetchall", NULL, 0, &_1$$3, fetchArgument, constructorArgs);
 		zephir_check_call_status();
@@ -444,13 +444,13 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, fetchAll)
 		_2 = mode == 10;
 	}
 	if (_2) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 647, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 646, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_4$$4, mode);
 		ZEPHIR_RETURN_CALL_METHOD(&_3$$4, "fetchall", NULL, 0, &_4$$4, fetchArgument);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 647, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 646, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_6, mode);
 	ZEPHIR_RETURN_CALL_METHOD(&_5, "fetchall", NULL, 0, &_6);
 	zephir_check_call_status();
@@ -494,8 +494,8 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, fetchArray)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 647, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 651, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 646, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 650, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "fetch", NULL, 0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -575,10 +575,10 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, numRows)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 652, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 651, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&rowCount, &_0);
 	if (Z_TYPE_P(&rowCount) == IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 646, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 645, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&connection, &_1$$3);
 		ZEPHIR_CALL_METHOD(&type, &connection, "gettype", NULL, 0);
 		zephir_check_call_status();
@@ -587,13 +587,13 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, numRows)
 			_2$$3 = ZEPHIR_IS_STRING_IDENTICAL(&type, "pgsql");
 		}
 		if (_2$$3) {
-			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_2, 647, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_2, 646, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&pdoStatement, &_3$$4);
 			ZEPHIR_CALL_METHOD(&rowCount, &pdoStatement, "rowcount", NULL, 0);
 			zephir_check_call_status();
 		}
 		if (Z_TYPE_P(&rowCount) == IS_NULL) {
-			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_3, 648, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_3, 647, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&sqlStatement, &_4$$5);
 			if (!(zephir_start_with_str(&sqlStatement, SL("SELECT COUNT(*) ")))) {
 				ZEPHIR_INIT_VAR(&matches);
@@ -608,8 +608,8 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, numRows)
 					zephir_array_fetch_long(&_8$$7, &matches, 1, PH_NOISY | PH_READONLY, "phalcon/Db/Result/PdoResult.zep", 316);
 					ZEPHIR_INIT_VAR(&_9$$7);
 					ZEPHIR_CONCAT_SVS(&_9$$7, "SELECT COUNT(*) \"numrows\" FROM (SELECT ", &_8$$7, ")");
-					zephir_read_property_cached(&_10$$7, this_ptr, _zephir_prop_4, 649, PH_NOISY_CC | PH_READONLY);
-					zephir_read_property_cached(&_11$$7, this_ptr, _zephir_prop_5, 650, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_10$$7, this_ptr, _zephir_prop_4, 648, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_11$$7, this_ptr, _zephir_prop_5, 649, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(&result, &connection, "query", NULL, 0, &_9$$7, &_10$$7, &_11$$7);
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&row, &result, "fetch", NULL, 0);
@@ -622,7 +622,7 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, numRows)
 				ZVAL_LONG(&rowCount, 1);
 			}
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 652, &rowCount);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 651, &rowCount);
 	}
 	RETURN_CCTOR(&rowCount);
 }
@@ -698,7 +698,7 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, setFetchMode)
 		ctorargs = &ctorargs_sub;
 		ctorargs = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 647, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 646, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&pdoStatement, &_0);
 	_1 = fetchMode == 8;
 	if (!(_1)) {
@@ -728,7 +728,7 @@ PHP_METHOD(Phalcon_Db_Result_PdoResult, setFetchMode)
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, fetchMode);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 651, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 650, &_0);
 	RETURN_MM_BOOL(1);
 }
 

--- a/ext/phalcon/di/factorydefault.zep.c
+++ b/ext/phalcon/di/factorydefault.zep.c
@@ -161,7 +161,7 @@ PHP_METHOD(Phalcon_Di_FactoryDefault, __construct)
 	zephir_array_update_string(&_0, SL("flashSession"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_INIT_NVAR(&_1);
 	object_init_ex(&_1, phalcon_di_service_ce);
-	ZEPHIR_CALL_METHOD(&_7, &filter, "newinstance", NULL, 245);
+	ZEPHIR_CALL_METHOD(&_7, &filter, "newinstance", NULL, 246);
 	zephir_check_call_status();
 	ZVAL_BOOL(&_3, 1);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 176, &_7, &_3);

--- a/ext/phalcon/di/factorydefault/cli.zep.c
+++ b/ext/phalcon/di/factorydefault/cli.zep.c
@@ -113,7 +113,7 @@ PHP_METHOD(Phalcon_Di_FactoryDefault_Cli, __construct)
 	zephir_array_update_string(&_0, SL("eventsManager"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_INIT_NVAR(&_1);
 	object_init_ex(&_1, phalcon_di_service_ce);
-	ZEPHIR_CALL_METHOD(&_4, &filter, "newinstance", NULL, 245);
+	ZEPHIR_CALL_METHOD(&_4, &filter, "newinstance", NULL, 246);
 	zephir_check_call_status();
 	ZVAL_BOOL(&_3, 1);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 176, &_4, &_3);
@@ -200,7 +200,7 @@ PHP_METHOD(Phalcon_Di_FactoryDefault_Cli, __construct)
 	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 176, &_2, &_3);
 	zephir_check_call_status();
 	zephir_array_update_string(&_0, SL("transactionManager"), &_1, PH_COPY | PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 653, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 652, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/di/service.zep.c
+++ b/ext/phalcon/di/service.zep.c
@@ -96,11 +96,11 @@ PHP_METHOD(Phalcon_Di_Service, __construct)
 		shared = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 654, definition);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 653, definition);
 	if (shared) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 655, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 654, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 655, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 654, &__$false);
 	}
 }
 
@@ -142,7 +142,7 @@ PHP_METHOD(Phalcon_Di_Service, getParameter)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &position_param);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 654, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 653, PH_NOISY_CC);
 	if (UNEXPECTED(Z_TYPE_P(&_0) != IS_ARRAY)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_di_exceptions_definitionmustbearrayforread_ce);
@@ -152,7 +152,7 @@ PHP_METHOD(Phalcon_Di_Service, getParameter)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 654, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 653, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&arguments, &_2, SL("arguments"), 1)) {
 		if (zephir_array_isset_long_fetch(&parameter, &arguments, position, 1)) {
 			RETURN_CTOR(&parameter);
@@ -240,10 +240,10 @@ PHP_METHOD(Phalcon_Di_Service, resolve)
 		container = &container_sub;
 		container = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 655, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 654, PH_NOISY_CC | PH_READONLY);
 	_1 = zephir_is_true(&_0);
 	if (_1) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 656, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 655, PH_NOISY_CC | PH_READONLY);
 		_1 = Z_TYPE_P(&_2) != IS_NULL;
 	}
 	if (_1) {
@@ -252,7 +252,7 @@ PHP_METHOD(Phalcon_Di_Service, resolve)
 	found = 1;
 	ZEPHIR_INIT_VAR(&instance);
 	ZVAL_NULL(&instance);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 654, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 653, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&definition, &_3);
 	if (Z_TYPE_P(&definition) == IS_STRING) {
 		if (zephir_class_exists(&definition, 1)) {
@@ -318,14 +318,14 @@ PHP_METHOD(Phalcon_Di_Service, resolve)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 655, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 654, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_3)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 656, &instance);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 655, &instance);
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 657, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 656, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 657, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 656, &__$false);
 	}
 	RETURN_CCTOR(&instance);
 }
@@ -348,7 +348,7 @@ PHP_METHOD(Phalcon_Di_Service, setDefinition)
 		Z_PARAM_ZVAL(definition)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &definition);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 654, definition);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 653, definition);
 }
 
 /**
@@ -383,7 +383,7 @@ PHP_METHOD(Phalcon_Di_Service, setParameter)
 	zephir_fetch_params(1, 2, 0, &position_param, &parameter_param);
 	zephir_get_arrval(&parameter, parameter_param);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 654, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 653, PH_NOISY_CC);
 	if (UNEXPECTED(Z_TYPE_P(&_0) != IS_ARRAY)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_di_exceptions_definitionmustbearrayforupdate_ce);
@@ -394,7 +394,7 @@ PHP_METHOD(Phalcon_Di_Service, setParameter)
 		return;
 	}
 	zephir_memory_observe(&arguments);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 654, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 653, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&arguments, &_2, SL("arguments"), 0)) {
 		zephir_array_update_long(&arguments, position, &parameter, PH_COPY | PH_SEPARATE ZEPHIR_DEBUG_PARAMS_DUMMY);
 	} else {
@@ -430,9 +430,9 @@ PHP_METHOD(Phalcon_Di_Service, setShared)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &shared_param);
 	if (shared) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 655, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 654, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 655, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 654, &__$false);
 	}
 }
 
@@ -454,6 +454,6 @@ PHP_METHOD(Phalcon_Di_Service, setSharedInstance)
 		Z_PARAM_ZVAL(sharedInstance)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &sharedInstance);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 656, sharedInstance);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 655, sharedInstance);
 }
 

--- a/ext/phalcon/domain/payload/payload.zep.c
+++ b/ext/phalcon/domain/payload/payload.zep.c
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Domain_Payload_Payload, setException)
 		Z_PARAM_OBJECT_OF_CLASS(exception, zend_ce_throwable)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &exception);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 658, exception);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 657, exception);
 	RETURN_THISW();
 }
 
@@ -193,7 +193,7 @@ PHP_METHOD(Phalcon_Domain_Payload_Payload, setExtras)
 		Z_PARAM_ZVAL(extras)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &extras);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 659, extras);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 658, extras);
 	RETURN_THISW();
 }
 
@@ -215,7 +215,7 @@ PHP_METHOD(Phalcon_Domain_Payload_Payload, setInput)
 		Z_PARAM_ZVAL(input)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &input);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 660, input);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 659, input);
 	RETURN_THISW();
 }
 
@@ -237,7 +237,7 @@ PHP_METHOD(Phalcon_Domain_Payload_Payload, setMessages)
 		Z_PARAM_ZVAL(messages)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &messages);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 661, messages);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 660, messages);
 	RETURN_THISW();
 }
 
@@ -259,7 +259,7 @@ PHP_METHOD(Phalcon_Domain_Payload_Payload, setOutput)
 		Z_PARAM_ZVAL(output)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &output);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 662, output);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 661, output);
 	RETURN_THISW();
 }
 
@@ -285,7 +285,7 @@ PHP_METHOD(Phalcon_Domain_Payload_Payload, setStatus)
 		Z_PARAM_ZVAL(status)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &status);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 663, status);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 662, status);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/encryption/crypt.zep.c
+++ b/ext/phalcon/encryption/crypt.zep.c
@@ -232,11 +232,11 @@ PHP_METHOD(Phalcon_Encryption_Crypt, __construct)
 		ZEPHIR_CALL_METHOD(NULL, padFactory, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 664, padFactory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 663, padFactory);
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "sha256");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 665, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 664, &_0);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "initializeavailableciphers", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_2, &_1, "setcipher", NULL, 0, &cipher);
@@ -345,7 +345,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decrypt)
 	ZVAL_STR_COPY(&key_zv, key);
 	}
 	zephir_memory_observe(&decryptKey);
-	zephir_read_property_cached(&decryptKey, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC);
+	zephir_read_property_cached(&decryptKey, this_ptr, _zephir_prop_0, 665, PH_NOISY_CC);
 	if (1 != ZEPHIR_IS_EMPTY(&key_zv)) {
 		ZEPHIR_CPY_WRT(&decryptKey, &key_zv);
 	}
@@ -358,9 +358,9 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decrypt)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cipher, &_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 668, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 667, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&ivLength, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "cipher");
@@ -384,16 +384,16 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decrypt)
 	ZVAL_LONG(&_1, 0);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "8bit");
-	ZEPHIR_CALL_FUNCTION(&iv, "mb_substr", NULL, 296, &input_zv, &_1, &ivLength, &_2);
+	ZEPHIR_CALL_FUNCTION(&iv, "mb_substr", NULL, 297, &input_zv, &_1, &ivLength, &_2);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&digest);
 	ZVAL_STRING(&digest, "");
 	ZEPHIR_CALL_METHOD(&hashAlgorithm, this_ptr, "gethashalgorithm", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 669, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 668, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_1)) {
 		zephir_memory_observe(&hashLength);
-		zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_4, 670, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_4, 669, PH_NOISY_CC | PH_READONLY);
 		if (!(zephir_array_isset_fetch(&hashLength, &_5$$6, &hashAlgorithm, 0))) {
 			ZEPHIR_INIT_VAR(&_7$$7);
 			ZVAL_STRING(&_7$$7, "");
@@ -406,23 +406,23 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decrypt)
 		}
 		ZEPHIR_INIT_VAR(&_9$$6);
 		ZVAL_STRING(&_9$$6, "8bit");
-		ZEPHIR_CALL_FUNCTION(&digest, "mb_substr", NULL, 296, &input_zv, &ivLength, &hashLength, &_9$$6);
+		ZEPHIR_CALL_FUNCTION(&digest, "mb_substr", NULL, 297, &input_zv, &ivLength, &hashLength, &_9$$6);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_10$$6);
 		zephir_add_function(&_10$$6, &ivLength, &hashLength);
 		ZEPHIR_INIT_NVAR(&_9$$6);
 		ZVAL_STRING(&_9$$6, "8bit");
-		ZEPHIR_CALL_FUNCTION(&cipherText, "mb_substr", NULL, 296, &input_zv, &_10$$6, &__$null, &_9$$6);
+		ZEPHIR_CALL_FUNCTION(&cipherText, "mb_substr", NULL, 297, &input_zv, &_10$$6, &__$null, &_9$$6);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_INIT_VAR(&_11$$8);
 		ZVAL_STRING(&_11$$8, "8bit");
-		ZEPHIR_CALL_FUNCTION(&cipherText, "mb_substr", NULL, 296, &input_zv, &ivLength, &__$null, &_11$$8);
+		ZEPHIR_CALL_FUNCTION(&cipherText, "mb_substr", NULL, 297, &input_zv, &ivLength, &__$null, &_11$$8);
 		zephir_check_call_status();
 	}
 	ZEPHIR_CALL_METHOD(&decrypted, this_ptr, "decryptgcmccmauth", NULL, 0, &mode, &cipherText, &decryptKey, &iv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_3, 669, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_3, 668, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_12)) {
 		ZVAL_BOOL(&_15$$9, 1);
 		ZEPHIR_CALL_METHOD(&_14$$9, this_ptr, "phphashhmac", NULL, 0, &hashAlgorithm, &decrypted, &decryptKey, &_15$$9);
@@ -577,7 +577,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encrypt)
 	ZVAL_STR_COPY(&key_zv, key);
 	}
 	zephir_memory_observe(&encryptKey);
-	zephir_read_property_cached(&encryptKey, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC);
+	zephir_read_property_cached(&encryptKey, this_ptr, _zephir_prop_0, 665, PH_NOISY_CC);
 	if (1 != ZEPHIR_IS_EMPTY(&key_zv)) {
 		ZEPHIR_CPY_WRT(&encryptKey, &key_zv);
 	}
@@ -590,9 +590,9 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encrypt)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cipher, &_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 668, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 667, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&ivLength, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "cipher");
@@ -631,7 +631,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encrypt)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&encrypted, this_ptr, "encryptgcmccm", NULL, 0, &mode, &padded, &encryptKey, &iv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 669, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 668, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_1)) {
 		ZEPHIR_CALL_METHOD(&_5$$7, this_ptr, "gethashalgorithm", NULL, 0);
 		zephir_check_call_status();
@@ -858,7 +858,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, isValidDecryptLength)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&length, this_ptr, "phpopensslcipherivlength", NULL, 0, &_0);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&length)) {
@@ -888,7 +888,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setAuthData)
 		Z_PARAM_STR(data)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&data_zv, data);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 671, &data_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 670, &data_zv);
 	RETURN_THISW();
 }
 
@@ -913,7 +913,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setAuthTag)
 		Z_PARAM_STR(tag)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&tag_zv, tag);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 672, &tag_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 671, &tag_zv);
 	RETURN_THISW();
 }
 
@@ -959,7 +959,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setAuthTagLength)
 	}
 	ZVAL_UNDEF(&_2);
 	ZVAL_LONG(&_2, length);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 673, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 672, &_2);
 	RETURN_THIS();
 }
 
@@ -1004,8 +1004,8 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setCipher)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getivlength", NULL, 0, &cipher_zv);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 668, &_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 667, &cipher_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 667, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 666, &cipher_zv);
 	RETURN_THIS();
 }
 
@@ -1044,7 +1044,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setKey)
 		Z_PARAM_STR(key)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&key_zv, key);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 666, &key_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 665, &key_zv);
 	RETURN_THISW();
 }
 
@@ -1082,7 +1082,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setHashAlgorithm)
 	ZVAL_STRING(&_0, "hash");
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkcipherhashisavailable", NULL, 0, &hashAlgorithm_zv, &_0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 665, &hashAlgorithm_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 664, &hashAlgorithm_zv);
 	RETURN_THIS();
 }
 
@@ -1111,7 +1111,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, setPadding)
 	zephir_fetch_params_without_memory_grow(1, 0, &scheme_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, scheme);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 674, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 673, &_0);
 	RETURN_THISW();
 }
 
@@ -1140,9 +1140,9 @@ PHP_METHOD(Phalcon_Encryption_Crypt, useSigning)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &useSigning_param);
 	if (useSigning) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 669, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 668, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 669, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 668, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1284,11 +1284,11 @@ PHP_METHOD(Phalcon_Encryption_Crypt, cryptPadText)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 664, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 663, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_6$$3, paddingType);
 		ZEPHIR_CALL_METHOD(&service, &_5$$3, "padnumbertoservice", NULL, 0, &_6$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 664, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 663, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_7$$3, &_6$$3, "newinstance", NULL, 0, &service);
 		zephir_check_call_status();
 		ZVAL_LONG(&_8$$3, paddingSize);
@@ -1383,11 +1383,11 @@ PHP_METHOD(Phalcon_Encryption_Crypt, cryptUnpadText)
 		_1 = ZEPHIR_IS_TRUE_IDENTICAL(&_2);
 	}
 	if (_1) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 664, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 663, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_6$$3, paddingType);
 		ZEPHIR_CALL_METHOD(&service, &_5$$3, "padnumbertoservice", NULL, 0, &_6$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 664, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 663, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_7$$3, &_6$$3, "newinstance", NULL, 0, &service);
 		zephir_check_call_status();
 		ZVAL_LONG(&_8$$3, blockSize);
@@ -1464,7 +1464,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decryptGetUnpadded)
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "checkismode", NULL, 0, &_1, &mode_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 674, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 673, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&padding, &_3$$3);
 		ZVAL_LONG(&_3$$3, blockSize);
 		ZEPHIR_CALL_METHOD(&localDecrypted, this_ptr, "cryptunpadtext", NULL, 0, &decrypted_zv, &mode_zv, &_3$$3, &padding);
@@ -1541,7 +1541,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decryptGcmCcmAuth)
 	ZVAL_STR_COPY(&decryptKey_zv, decryptKey);
 	zephir_memory_observe(&iv_zv);
 	ZVAL_STR_COPY(&iv_zv, iv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cipher, &_0);
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 2, 0);
@@ -1554,9 +1554,9 @@ PHP_METHOD(Phalcon_Encryption_Crypt, decryptGcmCcmAuth)
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "checkismode", NULL, 0, &_2, &mode_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_1)) {
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 671, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 670, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&authData, &_4$$3);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 673, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 672, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&authTagLength, &_4$$3);
 		ZEPHIR_INIT_VAR(&cipherLength);
 		ZVAL_LONG(&cipherLength, zephir_fast_strlen_ev(&cipherText_zv));
@@ -1632,7 +1632,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encryptGetPadded)
 	ZVAL_STR_COPY(&mode_zv, mode);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 674, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 673, PH_NOISY_CC | PH_READONLY);
 	_1 = !ZEPHIR_IS_LONG_IDENTICAL(&_0, 0);
 	if (_1) {
 		ZEPHIR_INIT_VAR(&_3);
@@ -1645,7 +1645,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encryptGetPadded)
 		_1 = ZEPHIR_IS_TRUE_IDENTICAL(&_2);
 	}
 	if (_1) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 674, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_0, 673, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_6$$3, blockSize);
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "cryptpadtext", NULL, 0, &input_zv, &mode_zv, &_6$$3, &_5$$3);
 		zephir_check_call_status();
@@ -1722,7 +1722,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encryptGcmCcm)
 	ZVAL_STR_COPY(&encryptKey_zv, encryptKey);
 	zephir_memory_observe(&iv_zv);
 	ZVAL_STR_COPY(&iv_zv, iv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cipher, &_0);
 	ZEPHIR_INIT_VAR(&authTag);
 	ZVAL_STRING(&authTag, "");
@@ -1737,7 +1737,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encryptGcmCcm)
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "checkismode", NULL, 0, &_2, &mode_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_1)) {
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 671, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 670, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&authData, &_4$$3);
 		if (1 == ZEPHIR_IS_EMPTY(&authData)) {
 			ZEPHIR_INIT_VAR(&_5$$4);
@@ -1748,16 +1748,16 @@ PHP_METHOD(Phalcon_Encryption_Crypt, encryptGcmCcm)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 672, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 671, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&authTag, &_4$$3);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_3, 673, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_3, 672, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&authTagLength, &_4$$3);
 		ZVAL_LONG(&_4$$3, 1);
 		ZEPHIR_MAKE_REF(&authTag);
 		ZEPHIR_CALL_FUNCTION(&encrypted, "openssl_encrypt", NULL, 0, &padded_zv, &cipher, &encryptKey_zv, &_4$$3, &iv_zv, &authTag, &authData, &authTagLength);
 		ZEPHIR_UNREF(&authTag);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 672, &authTag);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 671, &authTag);
 	} else {
 		ZVAL_LONG(&_6$$5, 1);
 		ZEPHIR_CALL_FUNCTION(&encrypted, "openssl_encrypt", NULL, 0, &padded_zv, &cipher, &encryptKey_zv, &_6$$5, &iv_zv);
@@ -1881,7 +1881,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, initializeAvailableCiphers)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&cipher);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 675, &allowed);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 674, &allowed);
 	RETURN_THIS();
 }
 
@@ -1954,13 +1954,13 @@ PHP_METHOD(Phalcon_Encryption_Crypt, getBlockSize)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&mode_zv);
 	ZVAL_STR_COPY(&mode_zv, mode);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 668, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_GT_LONG(&_0, 0)) {
 		RETURN_MM_MEMBER_TYPED(getThis(), "ivLength", IS_LONG);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_CONCAT_SV(&_1, "-", &mode_zv);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "");
 	ZEPHIR_CALL_FUNCTION(&_4, "str_ireplace", NULL, 0, &_1, &_3, &_2);
@@ -2035,15 +2035,15 @@ PHP_METHOD(Phalcon_Encryption_Crypt, getMode)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "-");
 	ZEPHIR_CALL_FUNCTION(&_2, "strrpos", NULL, 0, &_0, &_1);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&position);
 	ZVAL_LONG(&position, zephir_get_intval(&_2));
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 667, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 666, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_5, ((zephir_get_numberval(&position) - zephir_fast_strlen_ev(&_4)) + 1));
 	ZEPHIR_INIT_NVAR(&_1);
 	zephir_substr(&_1, &_3, zephir_get_intval(&_5), 0, ZEPHIR_SUBSTR_NO_LENGTH);
@@ -2362,7 +2362,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/encryption/crypt/padfactory.zep.c
+++ b/ext/phalcon/encryption/crypt/padfactory.zep.c
@@ -38,7 +38,7 @@ ZEPHIR_INIT_CLASS(Phalcon_Encryption_Crypt_PadFactory)
 
 	{
 		zval _zc0;
-		ZVAL_STRINGL(&_zc0, "", 0);
+		ZVAL_STRINGL(&_zc0, "", sizeof("") - 1);
 		zephir_declare_typed_property(phalcon_encryption_crypt_padfactory_ce, SL("exception"), &_zc0, ZEND_ACC_PROTECTED, MAY_BE_STRING, NULL, 0);
 	}
 
@@ -79,7 +79,7 @@ PHP_METHOD(Phalcon_Encryption_Crypt_PadFactory, __construct)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "Phalcon\\Encryption\\Crypt\\Exception\\Exception");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 676, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 675, &_0);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/encryption/security.zep.c
+++ b/ext/phalcon/encryption/security.zep.c
@@ -232,9 +232,9 @@ PHP_METHOD(Phalcon_Encryption_Security, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 677, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 678, request);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 679, session);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 676, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 677, request);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 678, session);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -506,16 +506,16 @@ PHP_METHOD(Phalcon_Encryption_Security, destroyToken)
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getlocalservice", NULL, 0, &_0, &_1);
 	zephir_check_call_status();
 	if (UNEXPECTED(zephir_is_true(&session))) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 680, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 679, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &session, "remove", NULL, 0, &_2$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_1, 681, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_1, 680, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &session, "remove", NULL, 0, &_3$$3);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 682, &__$null);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 683, &__$null);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 684, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 681, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 682, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 683, &__$null);
 	RETURN_THIS();
 }
 
@@ -594,7 +594,7 @@ PHP_METHOD(Phalcon_Encryption_Security, getRequestToken)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 684, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 683, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getsessiontoken", NULL, 0);
 		zephir_check_call_status();
@@ -633,7 +633,7 @@ PHP_METHOD(Phalcon_Encryption_Security, getSessionToken)
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getlocalservice", NULL, 0, &_0, &_1);
 	zephir_check_call_status();
 	if (UNEXPECTED(zephir_is_true(&session))) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 681, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 680, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_RETURN_CALL_METHOD(&session, "get", NULL, 0, &_2$$3);
 		zephir_check_call_status();
 		RETURN_MM();
@@ -683,11 +683,11 @@ PHP_METHOD(Phalcon_Encryption_Security, getSaltBytes)
 	} else {
 		}
 	if (!(numberBytes)) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 685, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 684, PH_NOISY_CC | PH_READONLY);
 		numberBytes = zephir_get_numberval(&_0$$3);
 	}
 	while (1) {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_1, 677, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_1, 676, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_2$$4, numberBytes);
 		ZEPHIR_CALL_METHOD(&safeBytes, &_1$$4, "base64safe", NULL, 0, &_2$$4);
 		zephir_check_call_status();
@@ -757,7 +757,7 @@ PHP_METHOD(Phalcon_Encryption_Security, getToken)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 682, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 681, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "session");
@@ -765,32 +765,32 @@ PHP_METHOD(Phalcon_Encryption_Security, getToken)
 		ZVAL_STRING(&_2$$3, "localSession");
 		ZEPHIR_CALL_METHOD(&session, this_ptr, "getlocalservice", NULL, 0, &_1$$3, &_2$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_1, 686, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_1, 685, PH_NOISY_CC | PH_READONLY);
 		_4$$3 = ZEPHIR_IS_FALSE_IDENTICAL(&_3$$3);
 		if (_4$$3) {
 			_4$$3 = Z_TYPE_P(&session) != IS_NULL;
 		}
 		if (_4$$3) {
-			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_2, 681, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_2, 680, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&sessionToken, &session, "get", NULL, 0, &_5$$4);
 			zephir_check_call_status();
 			if (Z_TYPE_P(&sessionToken) != IS_NULL) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 682, &sessionToken);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 684, &sessionToken);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 681, &sessionToken);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 683, &sessionToken);
 				RETURN_MM_MEMBER(getThis(), "token");
 			}
 		}
 		ZEPHIR_CALL_METHOD(&_6$$3, this_ptr, "getsessiontoken", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 684, &_6$$3);
-		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_4, 677, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_5, 685, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 683, &_6$$3);
+		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_4, 676, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_5, 684, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_8$$3, &_7$$3, "base64safe", NULL, 0, &_9$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 682, &_8$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 681, &_8$$3);
 		if (Z_TYPE_P(&session) != IS_NULL) {
-			zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_2, 681, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_0, 682, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_2, 680, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_0, 681, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &session, "set", NULL, 0, &_10$$6, &_11$$6);
 			zephir_check_call_status();
 		}
@@ -847,7 +847,7 @@ PHP_METHOD(Phalcon_Encryption_Security, getTokenKey)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 683, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 682, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "session");
@@ -856,23 +856,23 @@ PHP_METHOD(Phalcon_Encryption_Security, getTokenKey)
 		ZEPHIR_CALL_METHOD(&session, this_ptr, "getlocalservice", NULL, 0, &_1$$3, &_2$$3);
 		zephir_check_call_status();
 		if (Z_TYPE_P(&session) != IS_NULL) {
-			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 686, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 685, PH_NOISY_CC | PH_READONLY);
 			if (ZEPHIR_IS_FALSE_IDENTICAL(&_3$$4)) {
-				zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_2, 680, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_2, 679, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&sessionTokenKey, &session, "get", NULL, 0, &_4$$5);
 				zephir_check_call_status();
 				if (Z_TYPE_P(&sessionTokenKey) != IS_NULL) {
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 683, &sessionTokenKey);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 682, &sessionTokenKey);
 					RETURN_MM_MEMBER(getThis(), "tokenKey");
 				}
 			}
-			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_3, 677, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_7$$4, this_ptr, _zephir_prop_4, 685, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_3, 676, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$4, this_ptr, _zephir_prop_4, 684, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_6$$4, &_5$$4, "base64safe", NULL, 0, &_7$$4);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 683, &_6$$4);
-			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_2, 680, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 683, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 682, &_6$$4);
+			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_2, 679, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 682, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &session, "set", NULL, 0, &_8$$4, &_9$$4);
 			zephir_check_call_status();
 		}
@@ -958,7 +958,7 @@ PHP_METHOD(Phalcon_Encryption_Security, hash)
 	bytes = 22;
 	legacy = 1;
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 687, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 686, PH_NOISY_CC);
 	do {
 		if (ZEPHIR_IS_LONG(&_1, 3)) {
 			ZEPHIR_INIT_NVAR(&prefix);
@@ -1096,17 +1096,17 @@ PHP_METHOD(Phalcon_Encryption_Security, refreshToken)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 677, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 685, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 676, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 684, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "base64safe", NULL, 0, &_2);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 682, &_1);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 677, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 685, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 681, &_1);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 676, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 684, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_4, &_3, "base64safe", NULL, 0, &_5);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 683, &_4);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 684, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 682, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 683, &__$null);
 	ZEPHIR_INIT_VAR(&_6);
 	ZVAL_STRING(&_6, "session");
 	ZEPHIR_INIT_VAR(&_7);
@@ -1114,12 +1114,12 @@ PHP_METHOD(Phalcon_Encryption_Security, refreshToken)
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getlocalservice", NULL, 0, &_6, &_7);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&session) != IS_NULL) {
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_5, 681, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_2, 682, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_5, 680, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_2, 681, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &session, "set", NULL, 0, &_8$$3, &_9$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_6, 680, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_3, 683, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_6, 679, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_3, 682, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &session, "set", NULL, 0, &_10$$3, &_11$$3);
 		zephir_check_call_status();
 	}
@@ -1154,9 +1154,9 @@ PHP_METHOD(Phalcon_Encryption_Security, setAutoRefresh)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &autoRefresh_param);
 	if (autoRefresh) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 686, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 685, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 686, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 685, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1186,7 +1186,7 @@ PHP_METHOD(Phalcon_Encryption_Security, setDefaultHash)
 	zephir_fetch_params_without_memory_grow(1, 0, &defaultHash_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, defaultHash);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 687, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 686, &_0);
 	RETURN_THISW();
 }
 
@@ -1216,7 +1216,7 @@ PHP_METHOD(Phalcon_Encryption_Security, setRandomBytes)
 	zephir_fetch_params_without_memory_grow(1, 0, &randomBytes_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, randomBytes);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 685, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 684, &_0);
 	RETURN_THISW();
 }
 
@@ -1245,7 +1245,7 @@ PHP_METHOD(Phalcon_Encryption_Security, setWorkFactor)
 	zephir_fetch_params_without_memory_grow(1, 0, &workFactor_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, workFactor);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 688, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 687, &_0);
 	RETURN_THISW();
 }
 
@@ -1292,18 +1292,18 @@ PHP_METHOD(Phalcon_Encryption_Security, getLocalService)
 	zephir_read_property_zval(&_0, this_ptr, &property_zv, PH_NOISY_CC);
 	_1 = Z_TYPE_P(&_0) == IS_NULL;
 	if (_1) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 689, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 688, PH_NOISY_CC | PH_READONLY);
 		_1 = Z_TYPE_P(&_2) != IS_NULL;
 	}
 	_3 = _1;
 	if (_3) {
-		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 689, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 688, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_5, &_4, "has", NULL, 0, &name_zv);
 		zephir_check_call_status();
 		_3 = ZEPHIR_IS_TRUE_IDENTICAL(&_5);
 	}
 	if (_3) {
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 689, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 688, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_7$$3, &_6$$3, "getshared", NULL, 0, &name_zv);
 		zephir_check_call_status();
 		zephir_update_property_zval_zval(this_ptr, &property_zv, &_7$$3);
@@ -1337,12 +1337,12 @@ PHP_METHOD(Phalcon_Encryption_Security, processAlgorithm)
 
 	ZEPHIR_INIT_VAR(&algorithm);
 	ZVAL_STRING(&algorithm, "2y");
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 687, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 686, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_LONG_IDENTICAL(&_0, 10)) {
 		ZEPHIR_INIT_NVAR(&algorithm);
 		ZVAL_STRING(&algorithm, "argon2i");
 	} else {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 687, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 686, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_IS_LONG_IDENTICAL(&_1, 11)) {
 			ZEPHIR_INIT_NVAR(&algorithm);
 			ZVAL_STRING(&algorithm, "argon2id");
@@ -1383,10 +1383,10 @@ PHP_METHOD(Phalcon_Encryption_Security, processArgonOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 687, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 686, PH_NOISY_CC | PH_READONLY);
 	_1 = ZEPHIR_IS_LONG_IDENTICAL(&_0, 10);
 	if (!(_1)) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 687, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 686, PH_NOISY_CC | PH_READONLY);
 		_1 = ZEPHIR_IS_LONG_IDENTICAL(&_2, 11);
 	}
 	if (_1) {
@@ -1450,7 +1450,7 @@ PHP_METHOD(Phalcon_Encryption_Security, processCost)
 	zephir_memory_observe(&cost);
 	if (!(zephir_array_isset_string_fetch(&cost, &options, SL("cost"), 0))) {
 		ZEPHIR_OBS_NVAR(&cost);
-		zephir_read_property_cached(&cost, this_ptr, _zephir_prop_0, 688, PH_NOISY_CC);
+		zephir_read_property_cached(&cost, this_ptr, _zephir_prop_0, 687, PH_NOISY_CC);
 	}
 	if (ZEPHIR_LT_LONG(&cost, 4)) {
 		ZEPHIR_INIT_NVAR(&cost);
@@ -1513,7 +1513,7 @@ PHP_METHOD(Phalcon_Encryption_Security, processTokenKey)
 		_2 = 1 == ZEPHIR_IS_EMPTY(&key);
 	}
 	if (_2) {
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 680, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 679, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&key, &session, "get", NULL, 0, &_3$$3);
 		zephir_check_call_status();
 	}

--- a/ext/phalcon/encryption/security/jwt/builder.zep.c
+++ b/ext/phalcon/encryption/security/jwt/builder.zep.c
@@ -102,7 +102,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, __construct)
 	zephir_fetch_params(1, 1, 0, &signer);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 690, signer);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 689, signer);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, phalcon_support_helper_json_encode_ce);
 	if (zephir_has_constructor(&_0)) {
@@ -110,9 +110,9 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 691, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 692, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 690, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 690, &_0);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 691, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 689, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, &_2, "getalgheader", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_4);
@@ -155,7 +155,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, addClaim)
 	value = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &name_zv, value);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -194,7 +194,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, addHeader)
 	value = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 691, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &name_zv, value);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -220,7 +220,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getAudience)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	array_init(&_1);
 	ZEPHIR_INIT_VAR(&_2);
@@ -248,7 +248,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getClaims)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "toarray", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -275,7 +275,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getContentType)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 691, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "cty");
 	ZVAL_NULL(&_2);
@@ -307,7 +307,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getExpirationTime)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "exp");
 	ZVAL_NULL(&_2);
@@ -336,7 +336,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getHeaders)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 691, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "toarray", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -363,7 +363,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getId)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "jti");
 	ZVAL_NULL(&_2);
@@ -395,7 +395,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getIssuedAt)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "iat");
 	ZVAL_NULL(&_2);
@@ -427,7 +427,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getIssuer)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "iss");
 	ZVAL_NULL(&_2);
@@ -459,7 +459,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getNotBefore)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "nbf");
 	ZVAL_NULL(&_2);
@@ -500,7 +500,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getSubject)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "sub");
 	ZVAL_NULL(&_2);
@@ -557,7 +557,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getToken)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 694, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_encryption_security_jwt_exceptions_emptypassphrase_ce);
@@ -567,7 +567,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getToken)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 691, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 690, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_4, this_ptr, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_3, &_2, "__invoke", NULL, 0, &_4);
@@ -580,7 +580,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getToken)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &claims, "__construct", NULL, 0, &_5, &encodedClaims);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 691, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 690, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_8, this_ptr, "getheaders", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_7, &_6, "__invoke", NULL, 0, &_8);
@@ -593,10 +593,10 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, getToken)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &headers, "__construct", NULL, 0, &_9, &encodedHeaders);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 690, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 689, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_11);
 	ZEPHIR_CONCAT_VSV(&_11, &encodedHeaders, ".", &encodedClaims);
-	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_0, 694, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&signatureHash, &_10, "sign", NULL, 0, &_11, &_12);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&encodedSignature, this_ptr, "doencodeurl", NULL, 0, &signatureHash);
@@ -643,12 +643,12 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, init)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 694, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 693, &_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	object_init_ex(&_0, phalcon_support_collection_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 41);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 693, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 692, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_support_collection_ce);
 	ZEPHIR_INIT_VAR(&_2);
@@ -657,7 +657,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, init)
 	add_assoc_stringl_ex(&_2, SL("alg"), SL("none"));
 	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 41, &_2);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 692, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 691, &_1);
 	RETURN_THIS();
 }
 
@@ -754,7 +754,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, setContentType)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&contentType_zv);
 	ZVAL_STR_COPY(&contentType_zv, contentType);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 691, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "cty");
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &_1, &contentType_zv);
@@ -1015,7 +1015,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, setPassphrase)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 694, &passphrase_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 693, &passphrase_zv);
 	RETURN_THIS();
 }
 
@@ -1089,7 +1089,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Builder, setClaim)
 	value = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 693, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 692, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &name_zv, value);
 	zephir_check_call_status();
 	RETURN_THIS();

--- a/ext/phalcon/encryption/security/jwt/signer/hmac.zep.c
+++ b/ext/phalcon/encryption/security/jwt/signer/hmac.zep.c
@@ -92,7 +92,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Signer_Hmac, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 695, &algo_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 694, &algo_zv);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -119,7 +119,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Signer_Hmac, getAlgHeader)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	ZEPHIR_INIT_VAR(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 695, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 694, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "sha");
 	ZEPHIR_INIT_VAR(&_3);

--- a/ext/phalcon/encryption/security/jwt/token/item.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/item.zep.c
@@ -123,7 +123,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Item, get)
 		RETVAL_ZVAL(defaultValue, 1, 0);
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 696, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 695, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_2, &_1, SL("payload"), PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/JWT/Token/Item.zep", 42);
 	zephir_array_fetch(&_3, &_2, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/JWT/Token/Item.zep", 42);
 	RETURN_CTOR(&_3);
@@ -143,7 +143,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Item, getPayload)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("data", 4, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 696, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 695, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("payload"), PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/JWT/Token/Item.zep", 50);
 	RETURN_CTORW(&_1);
 }
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Item, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 696, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 695, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("payload"), PH_READONLY, "phalcon/Encryption/Security/JWT/Token/Item.zep", 60);
 	RETURN_BOOL(zephir_array_isset_value(&_1, &name_zv));
 }

--- a/ext/phalcon/encryption/security/jwt/token/parser.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/parser.zep.c
@@ -84,7 +84,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Parser, __construct)
 		}
 
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 697, &service);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 696, &service);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -181,7 +181,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Parser, decodeClaims)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&claims_zv);
 	ZVAL_STR_COPY(&claims_zv, claims);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 697, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 696, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "dodecodeurl", NULL, 0, &claims_zv);
 	zephir_check_call_status();
 	ZVAL_BOOL(&_2, 1);
@@ -250,7 +250,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Parser, decodeHeaders)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&headers_zv);
 	ZVAL_STR_COPY(&headers_zv, headers);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 697, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 696, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "dodecodeurl", NULL, 0, &headers_zv);
 	zephir_check_call_status();
 	ZVAL_BOOL(&_2, 1);

--- a/ext/phalcon/encryption/security/jwt/token/signature.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/signature.zep.c
@@ -98,7 +98,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Signature, getHash)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("data", 4, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 698, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 697, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("hash"), PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/JWT/Token/Signature.zep", 35);
 	RETURN_CTORW(&_1);
 }

--- a/ext/phalcon/encryption/security/jwt/token/token.zep.c
+++ b/ext/phalcon/encryption/security/jwt/token/token.zep.c
@@ -93,9 +93,9 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Token, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(signature, phalcon_encryption_security_jwt_token_signature_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(3, 0, &headers, &claims, &signature);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 699, headers);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 700, claims);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 701, signature);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 698, headers);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 699, claims);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 700, signature);
 }
 
 /**
@@ -147,10 +147,10 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Token, getPayload)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 699, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 698, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getencoded", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 700, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 699, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, &_2, "getencoded", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CONCAT_VSV(return_value, &_1, ".", &_3);
@@ -192,7 +192,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Token, getToken)
 
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getpayload", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 700, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "getencoded", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CONCAT_VSV(return_value, &_0, ".", &_2);
@@ -340,7 +340,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Token_Token, verify)
 	if (!ZEPHIR_IS_IDENTICAL(&_0, &_2)) {
 		RETURN_MM_BOOL(0);
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 700, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_4, "gethash", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_6, this_ptr, "getpayload", NULL, 0);

--- a/ext/phalcon/encryption/security/jwt/validator.zep.c
+++ b/ext/phalcon/encryption/security/jwt/validator.zep.c
@@ -124,10 +124,10 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, __construct)
 		ZEPHIR_CALL_METHOD(&now, &_0$$3, "gettimestamp", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 702, token);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 701, token);
 	ZVAL_UNDEF(&_1);
 	ZVAL_LONG(&_1, timeShift);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 703, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 702, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 7, 0);
 	zephir_array_update_string(&_2, SL("aud"), &__$null, PH_COPY | PH_SEPARATE);
@@ -137,7 +137,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, __construct)
 	zephir_array_update_string(&_2, SL("iss"), &__$null, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_2, SL("nbf"), &now, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_2, SL("sub"), &__$null, PH_COPY | PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 704, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 703, &_2);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -178,9 +178,9 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, get)
 		Z_PARAM_STR(claim)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&claim_zv, claim);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 704, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 703, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, &claim_zv)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 704, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 703, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, &claim_zv, PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/JWT/Validator.zep", 103);
 		RETURN_CTORW(&_2$$3);
 	}
@@ -235,7 +235,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, setToken)
 		Z_PARAM_OBJECT_OF_CLASS(token, phalcon_encryption_security_jwt_token_token_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &token);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 702, token);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 701, token);
 	RETURN_THISW();
 }
 
@@ -276,7 +276,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateClaim)
 	value = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&claimValue, &_1, "get", NULL, 0, &name_zv);
@@ -348,7 +348,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateAudience)
 		zephir_array_fast_append(&_2$$4, audience);
 		ZEPHIR_CPY_WRT(audience, &_2$$4);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_4, &_3, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_5);
@@ -436,7 +436,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateExpiration)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &timestamp_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
@@ -444,7 +444,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateExpiration)
 	ZEPHIR_CALL_METHOD(&_2, &_1, "get", NULL, 0, &_3);
 	zephir_check_call_status();
 	tokenExpirationTime = zephir_get_intval(&_2);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_4, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_NVAR(&_3);
@@ -514,7 +514,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateId)
 	if (Z_TYPE_P(&id_zv) == IS_NULL) {
 		RETURN_THIS();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
@@ -567,7 +567,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateIssuedAt)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &timestamp_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
@@ -634,7 +634,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateIssuer)
 	if (Z_TYPE_P(&issuer_zv) == IS_NULL) {
 		RETURN_THIS();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
@@ -687,7 +687,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateNotBefore)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &timestamp_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
@@ -746,12 +746,12 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateSignature)
 	signer = ZEND_CALL_ARG(execute_data, 1);
 	zephir_memory_observe(&passphrase_zv);
 	ZVAL_STR_COPY(&passphrase_zv, passphrase);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "getsignature", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_3, &_2, "gethash", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_4, "getpayload", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_0, signer, "verify", NULL, 0, &_3, &_5, &passphrase_zv);
@@ -812,7 +812,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, validateSubject)
 	if (Z_TYPE_P(&subject_zv) == IS_NULL) {
 		RETURN_THIS();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 701, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "getclaims", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
@@ -851,7 +851,7 @@ PHP_METHOD(Phalcon_Encryption_Security_JWT_Validator, getTimestamp)
 		Z_PARAM_LONG(timestamp)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &timestamp_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 703, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 702, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG((timestamp + (zend_long) zephir_get_numberval(&_0)));
 }
 

--- a/ext/phalcon/encryption/security/random.zep.c
+++ b/ext/phalcon/encryption/security/random.zep.c
@@ -363,7 +363,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Random, bytes)
 		len = 16;
 	}
 	ZVAL_LONG(&_0, len);
-	ZEPHIR_RETURN_CALL_FUNCTION("random_bytes", NULL, 315, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("random_bytes", NULL, 317, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/encryption/security/uuid/randomnodeprovider.zep.c
+++ b/ext/phalcon/encryption/security/uuid/randomnodeprovider.zep.c
@@ -68,7 +68,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_RandomNodeProvider, getNode)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	ZVAL_LONG(&_0, 6);
-	ZEPHIR_CALL_FUNCTION(&nodeBytes, "random_bytes", NULL, 315, &_0);
+	ZEPHIR_CALL_FUNCTION(&nodeBytes, "random_bytes", NULL, 317, &_0);
 	zephir_check_call_status();
 	ZVAL_LONG(&_0, 0);
 	ZVAL_LONG(&_1, 1);
@@ -85,7 +85,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_RandomNodeProvider, getNode)
 	ZEPHIR_INIT_VAR(&_7);
 	ZEPHIR_CONCAT_VV(&_7, &_5, &_6);
 	ZEPHIR_CPY_WRT(&nodeBytes, &_7);
-	ZEPHIR_RETURN_CALL_FUNCTION("bin2hex", NULL, 316, &nodeBytes);
+	ZEPHIR_RETURN_CALL_FUNCTION("bin2hex", NULL, 318, &nodeBytes);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/encryption/security/uuid/sysnodeprovider.zep.c
+++ b/ext/phalcon/encryption/security/uuid/sysnodeprovider.zep.c
@@ -133,7 +133,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_SysNodeProvider, getNode)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 705, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 704, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
 		RETURN_MM_MEMBER_TYPED(getThis(), "node", IS_STRING);
 	}
@@ -144,10 +144,10 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_SysNodeProvider, getNode)
 	if (zephir_is_true(&_1)) {
 		ZEPHIR_INIT_VAR(&_3$$4);
 		ZVAL_STRING(&_3$$4, "__phalcon_uuid_node");
-		ZEPHIR_CALL_FUNCTION(&cached, "apcu_fetch", NULL, 274, &_3$$4);
+		ZEPHIR_CALL_FUNCTION(&cached, "apcu_fetch", NULL, 275, &_3$$4);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_FALSE_IDENTICAL(&cached)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 705, &cached);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 704, &cached);
 			RETURN_MM_MEMBER_TYPED(getThis(), "node", IS_STRING);
 		}
 	}
@@ -353,16 +353,16 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_SysNodeProvider, getNode)
 		ZEPHIR_CALL_METHOD(&node, &_52$$20, "getnode", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 705, &node);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 704, &node);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "apcu_store");
 	ZEPHIR_CALL_METHOD(&_53, this_ptr, "phpfunctionexists", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (zephir_is_true(&_53)) {
-		zephir_read_property_cached(&_54$$21, this_ptr, _zephir_prop_0, 705, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_54$$21, this_ptr, _zephir_prop_0, 704, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_55$$21);
 		ZVAL_STRING(&_55$$21, "__phalcon_uuid_node");
-		ZEPHIR_CALL_FUNCTION(NULL, "apcu_store", NULL, 276, &_55$$21, &_54$$21);
+		ZEPHIR_CALL_FUNCTION(NULL, "apcu_store", NULL, 277, &_55$$21, &_54$$21);
 		zephir_check_call_status();
 	}
 	RETURN_MM_MEMBER_TYPED(getThis(), "node", IS_STRING);
@@ -870,7 +870,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_SysNodeProvider, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/encryption/security/uuid/version1.zep.c
+++ b/ext/phalcon/encryption/security/uuid/version1.zep.c
@@ -143,7 +143,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version1, __construct)
 	ZEPHIR_INIT_VAR(&timeHi);
 	ZVAL_LONG(&timeHi, (((((timestamp >> 48)) & 0x0fff)) | 0x1000));
 	ZVAL_LONG(&_5, 2);
-	ZEPHIR_CALL_FUNCTION(&clockSeqBytes, "random_bytes", NULL, 315, &_5);
+	ZEPHIR_CALL_FUNCTION(&clockSeqBytes, "random_bytes", NULL, 317, &_5);
 	zephir_check_call_status();
 	ZVAL_LONG(&_5, 0);
 	ZVAL_LONG(&_6, 1);
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version1, __construct)
 	ZVAL_STRING(&_13, "%08x-%04x-%04x-%02x%02x-%s");
 	ZEPHIR_CALL_FUNCTION(&_14, "sprintf", NULL, 145, &_13, &timeLow, &timeMid, &timeHi, &clockSeqHiRes, &clockSeqLow, &nodeStr);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 706, &_14);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 705, &_14);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -202,7 +202,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version1, getDateTime)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 706, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 705, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&parts);
 	zephir_fast_explode_str(&parts, SL("-"), &_0, LONG_MAX);
 	zephir_array_fetch_long(&_1, &parts, 0, PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/Uuid/Version1.zep", 82);
@@ -240,7 +240,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version1, getNode)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("uid", 3, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 706, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 705, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, 24);
 	zephir_substr(return_value, &_0, 24 , 0, ZEPHIR_SUBSTR_NO_LENGTH);
 	return;

--- a/ext/phalcon/encryption/security/uuid/version3.zep.c
+++ b/ext/phalcon/encryption/security/uuid/version3.zep.c
@@ -123,11 +123,11 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version3, __construct)
 	ZEPHIR_CALL_FUNCTION(&_14, "substr_replace", NULL, 0, &hash, &_12, &_11, &_13);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&hash, &_14);
-	ZEPHIR_CALL_FUNCTION(&_15, "bin2hex", NULL, 316, &hash);
+	ZEPHIR_CALL_FUNCTION(&_15, "bin2hex", NULL, 318, &hash);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_14, this_ptr, "format", NULL, 0, &_15);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 707, &_14);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 706, &_14);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/encryption/security/uuid/version4.zep.c
+++ b/ext/phalcon/encryption/security/uuid/version4.zep.c
@@ -70,7 +70,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version4, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	ZVAL_LONG(&_0, 16);
-	ZEPHIR_CALL_FUNCTION(&_1, "random_bytes", NULL, 315, &_0);
+	ZEPHIR_CALL_FUNCTION(&_1, "random_bytes", NULL, 317, &_0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "N1a/n1b/n1c/n1d/n1e/N1f");
@@ -97,7 +97,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version4, __construct)
 	ZVAL_STRING(&_8, "sprintf");
 	ZEPHIR_CALL_USER_FUNC_ARRAY(&_7, &_8, &ary);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 708, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 707, &_7);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/encryption/security/uuid/version5.zep.c
+++ b/ext/phalcon/encryption/security/uuid/version5.zep.c
@@ -131,11 +131,11 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version5, __construct)
 	ZEPHIR_CALL_FUNCTION(&_17, "substr_replace", NULL, 0, &hash, &_15, &_14, &_16);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&hash, &_17);
-	ZEPHIR_CALL_FUNCTION(&_18, "bin2hex", NULL, 316, &hash);
+	ZEPHIR_CALL_FUNCTION(&_18, "bin2hex", NULL, 318, &hash);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_17, this_ptr, "format", NULL, 0, &_18);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 709, &_17);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 708, &_17);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/encryption/security/uuid/version6.zep.c
+++ b/ext/phalcon/encryption/security/uuid/version6.zep.c
@@ -106,7 +106,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version6, __construct)
 	ZEPHIR_INIT_VAR(&timeLow12);
 	ZVAL_LONG(&timeLow12, (0x6000 | ((timestamp & 0x0fff))));
 	ZVAL_LONG(&_3, 2);
-	ZEPHIR_CALL_FUNCTION(&clockSeqBytes, "random_bytes", NULL, 315, &_3);
+	ZEPHIR_CALL_FUNCTION(&clockSeqBytes, "random_bytes", NULL, 317, &_3);
 	zephir_check_call_status();
 	ZVAL_LONG(&_3, 0);
 	ZVAL_LONG(&_4, 1);
@@ -130,7 +130,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version6, __construct)
 	ZVAL_STRING(&_11, "%08x-%04x-%04x-%02x%02x-%s");
 	ZEPHIR_CALL_FUNCTION(&_12, "sprintf", NULL, 145, &_11, &timeHigh32, &timeMid16, &timeLow12, &clockSeqHiRes, &clockSeqLow, &nodeStr);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 710, &_12);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 709, &_12);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -161,7 +161,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version6, getDateTime)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 710, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 709, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&parts);
 	zephir_fast_explode_str(&parts, SL("-"), &_0, LONG_MAX);
 	zephir_array_fetch_long(&_1, &parts, 0, PH_NOISY | PH_READONLY, "phalcon/Encryption/Security/Uuid/Version6.zep", 69);
@@ -199,7 +199,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version6, getNode)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("uid", 3, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 710, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 709, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, 24);
 	zephir_substr(return_value, &_0, 24 , 0, ZEPHIR_SUBSTR_NO_LENGTH);
 	return;

--- a/ext/phalcon/encryption/security/uuid/version7.zep.c
+++ b/ext/phalcon/encryption/security/uuid/version7.zep.c
@@ -96,13 +96,13 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version7, __construct)
 	ZEPHIR_INIT_VAR(&timeLow16);
 	ZVAL_LONG(&timeLow16, (msInt & 0xffff));
 	ZVAL_LONG(&_2, 10);
-	ZEPHIR_CALL_FUNCTION(&randBytes, "random_bytes", NULL, 315, &_2);
+	ZEPHIR_CALL_FUNCTION(&randBytes, "random_bytes", NULL, 317, &_2);
 	zephir_check_call_status();
 	ZVAL_LONG(&_2, 0);
 	ZVAL_LONG(&_3, 2);
 	ZEPHIR_INIT_VAR(&_4);
 	zephir_substr(&_4, &randBytes, 0 , 2 , 0);
-	ZEPHIR_CALL_FUNCTION(&_5, "bin2hex", NULL, 316, &_4);
+	ZEPHIR_CALL_FUNCTION(&_5, "bin2hex", NULL, 318, &_4);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_6, "hexdec", NULL, 0, &_5);
 	zephir_check_call_status();
@@ -112,7 +112,7 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version7, __construct)
 	ZVAL_LONG(&_8, 2);
 	ZEPHIR_INIT_VAR(&_9);
 	zephir_substr(&_9, &randBytes, 2 , 2 , 0);
-	ZEPHIR_CALL_FUNCTION(&_10, "bin2hex", NULL, 316, &_9);
+	ZEPHIR_CALL_FUNCTION(&_10, "bin2hex", NULL, 318, &_9);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_11, "hexdec", NULL, 0, &_10);
 	zephir_check_call_status();
@@ -122,13 +122,13 @@ PHP_METHOD(Phalcon_Encryption_Security_Uuid_Version7, __construct)
 	ZVAL_LONG(&_13, 6);
 	ZEPHIR_INIT_VAR(&_14);
 	zephir_substr(&_14, &randBytes, 4 , 6 , 0);
-	ZEPHIR_CALL_FUNCTION(&_15, "bin2hex", NULL, 316, &_14);
+	ZEPHIR_CALL_FUNCTION(&_15, "bin2hex", NULL, 318, &_14);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_16);
 	ZVAL_STRING(&_16, "%08x-%04x-%04x-%04x-%s");
 	ZEPHIR_CALL_FUNCTION(&_17, "sprintf", NULL, 145, &_16, &timeHigh32, &timeLow16, &verRandA, &varRandB, &_15);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 711, &_17);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 710, &_17);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/events/event.zep.c
+++ b/ext/phalcon/events/event.zep.c
@@ -166,13 +166,13 @@ PHP_METHOD(Phalcon_Events_Event, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 712, &type_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 713, source);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 714, data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 711, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 712, source);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 713, data);
 	if (cancelable) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 715, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 714, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 715, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 714, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -254,7 +254,7 @@ PHP_METHOD(Phalcon_Events_Event, setData)
 		data = &data_sub;
 		data = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 714, data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 713, data);
 	RETURN_THISW();
 }
 
@@ -277,7 +277,7 @@ PHP_METHOD(Phalcon_Events_Event, setType)
 		Z_PARAM_STR(type)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&type_zv, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 712, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 711, &type_zv);
 	RETURN_THISW();
 }
 
@@ -312,7 +312,7 @@ PHP_METHOD(Phalcon_Events_Event, stop)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 715, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 714, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_events_exceptions_eventnotcancelable_ce);
@@ -323,9 +323,9 @@ PHP_METHOD(Phalcon_Events_Event, stop)
 		return;
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 716, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 715, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 716, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 715, &__$false);
 	}
 	RETURN_THIS();
 }

--- a/ext/phalcon/events/manager.zep.c
+++ b/ext/phalcon/events/manager.zep.c
@@ -213,7 +213,7 @@ PHP_METHOD(Phalcon_Events_Manager, addSubscriber)
 	ZEPHIR_INIT_VAR(&className);
 	zephir_get_class(&className, subscriber, 0);
 	zephir_memory_observe(&events);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 717, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 716, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&events, &_1, &className, 0))) {
 		_2$$3 = zephir_fetch_class(&className);
 		ZEPHIR_CALL_CE_STATIC(&events, _2$$3, "getsubscribedevents", NULL, 0);
@@ -400,7 +400,7 @@ PHP_METHOD(Phalcon_Events_Manager, clearSubscribers)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&snapshot);
-	zephir_read_property_cached(&snapshot, this_ptr, _zephir_prop_0, 718, PH_NOISY_CC);
+	zephir_read_property_cached(&snapshot, this_ptr, _zephir_prop_0, 717, PH_NOISY_CC);
 	zephir_is_iterable(&snapshot, 0, "phalcon/Events/Manager.zep", 272);
 	if (Z_TYPE_P(&snapshot) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&snapshot), _0)
@@ -458,9 +458,9 @@ PHP_METHOD(Phalcon_Events_Manager, collectResponses)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &collect_param);
 	if (collect) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 719, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 718, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 719, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 718, &__$false);
 	}
 }
 
@@ -516,7 +516,7 @@ PHP_METHOD(Phalcon_Events_Manager, detach)
 		return;
 	}
 	zephir_memory_observe(&queue);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&queue, &_2, &eventType_zv, 0)) {
 		ZEPHIR_INIT_VAR(&newQueue);
 		array_init(&newQueue);
@@ -560,7 +560,7 @@ PHP_METHOD(Phalcon_Events_Manager, detach)
 			zephir_update_property_array(this_ptr, SL("events"), &eventType_zv, &newQueue);
 		} else {
 			zephir_unset_property_array(this_ptr, ZEND_STRL("events"), &eventType_zv);
-			zephir_read_property_cached(&_8$$10, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$10, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 			zephir_array_unset(&_8$$10, &eventType_zv, PH_SEPARATE);
 		}
 	}
@@ -602,12 +602,12 @@ PHP_METHOD(Phalcon_Events_Manager, detachAll)
 	if (ZEPHIR_IS_NULL(&type_zv)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		array_init(&_0$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 720, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 719, &_0$$3);
 	} else {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_1$$4, &type_zv)) {
 			zephir_unset_property_array(this_ptr, ZEND_STRL("events"), &type_zv);
-			zephir_read_property_cached(&_2$$5, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$5, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 			zephir_array_unset(&_2$$5, &type_zv, PH_SEPARATE);
 		}
 	}
@@ -674,7 +674,7 @@ PHP_METHOD(Phalcon_Events_Manager, dispatch)
 		source = &source_sub;
 		source = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		RETURN_MM_NULL();
 	}
@@ -705,7 +705,7 @@ PHP_METHOD(Phalcon_Events_Manager, dispatch)
 	_4 = Z_TYPE_P(name) != IS_NULL;
 	if (_4) {
 		zephir_memory_observe(&queue);
-		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 		_4 = zephir_array_isset_fetch(&queue, &_5, name, 0);
 	}
 	if (_4) {
@@ -716,7 +716,7 @@ PHP_METHOD(Phalcon_Events_Manager, dispatch)
 	ZEPHIR_INIT_VAR(&eventClassName);
 	zephir_get_class(&eventClassName, event, 0);
 	ZEPHIR_OBS_NVAR(&queue);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&queue, &_6, &eventClassName, 0)) {
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "runobjectqueue", NULL, 0, &queue, event, &methodName);
 		zephir_check_call_status();
@@ -754,9 +754,9 @@ PHP_METHOD(Phalcon_Events_Manager, enablePriorities)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &enablePriorities_param);
 	if (enablePriorities) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 721, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 720, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 721, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 720, &__$false);
 	}
 }
 
@@ -885,7 +885,7 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 		cancelable = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 722, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 721, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		RETURN_MM_NULL();
 	}
@@ -899,9 +899,9 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&_1)) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_3)) {
-		zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_2, 723, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_2, 722, PH_NOISY_CC | PH_READONLY);
 		if (UNEXPECTED(zephir_is_true(&_4$$5))) {
 			ZEPHIR_INIT_VAR(&_5$$6);
 			object_init_ex(&_5$$6, phalcon_events_exceptions_nolistenersforevent_ce);
@@ -914,7 +914,7 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 		RETURN_MM_NULL();
 	}
 	zephir_memory_observe(&cached);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 724, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 723, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&cached, &_6, &eventType_zv, 0)) {
 		zephir_memory_observe(&type);
 		zephir_array_fetch_long(&type, &cached, 0, PH_NOISY, "phalcon/Events/Manager.zep", 445);
@@ -946,16 +946,16 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 		zephir_array_fast_append(&_11$$8, &eventName);
 		zephir_update_property_array(this_ptr, SL("eventNameCache"), &eventType_zv, &_11$$8);
 	}
-	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	hasTypeQueue = zephir_array_isset_value(&_12, &type);
-	zephir_read_property_cached(&_13, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_13, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	hasFullQueue = zephir_array_isset_value(&_13, &eventType_zv);
 	_14 = !hasTypeQueue;
 	if (_14) {
 		_14 = !hasFullQueue;
 	}
 	if (_14) {
-		zephir_read_property_cached(&_15$$10, this_ptr, _zephir_prop_2, 723, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_15$$10, this_ptr, _zephir_prop_2, 722, PH_NOISY_CC | PH_READONLY);
 		if (UNEXPECTED(zephir_is_true(&_15$$10))) {
 			ZEPHIR_INIT_VAR(&_16$$11);
 			object_init_ex(&_16$$11, phalcon_events_exceptions_nolistenersforevent_ce);
@@ -968,20 +968,20 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 		RETURN_MM_NULL();
 	}
 	zephir_memory_observe(&wasDepth);
-	zephir_read_property_cached(&wasDepth, this_ptr, _zephir_prop_4, 725, PH_NOISY_CC);
+	zephir_read_property_cached(&wasDepth, this_ptr, _zephir_prop_4, 724, PH_NOISY_CC);
 	ZVAL_UNDEF(&_17);
 	ZVAL_LONG(&_17, (zephir_get_numberval(&wasDepth) + 1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 725, &_17);
-	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_5, 719, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 724, &_17);
+	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_5, 718, PH_NOISY_CC | PH_READONLY);
 	collect = zephir_is_true(&_17);
 	if (collect) {
 		if (ZEPHIR_GT_LONG(&wasDepth, 0)) {
 			zephir_memory_observe(&stashed);
-			zephir_read_property_cached(&stashed, this_ptr, _zephir_prop_6, 726, PH_NOISY_CC);
+			zephir_read_property_cached(&stashed, this_ptr, _zephir_prop_6, 725, PH_NOISY_CC);
 		}
 		ZEPHIR_INIT_VAR(&_18$$12);
 		array_init(&_18$$12);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 726, &_18$$12);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 725, &_18$$12);
 	}
 
 	/* try_start_1: */
@@ -998,7 +998,7 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 		ZEPHIR_INIT_VAR(&status);
 		ZVAL_NULL(&status);
 		if (hasTypeQueue) {
-			zephir_read_property_cached(&_20$$15, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_20$$15, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 			zephir_memory_observe(&fireEvents);
 			zephir_array_fetch(&fireEvents, &_20$$15, &type, PH_NOISY, "phalcon/Events/Manager.zep", 498);
 			if (cancelable) {
@@ -1015,7 +1015,7 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 			zephir_check_call_status_or_jump(try_end_1);
 		}
 		zephir_memory_observe(&_23$$14);
-		zephir_read_property_cached(&_23$$14, this_ptr, _zephir_prop_7, 727, PH_NOISY_CC);
+		zephir_read_property_cached(&_23$$14, this_ptr, _zephir_prop_7, 726, PH_NOISY_CC);
 		_24$$14 = zephir_is_true(&_23$$14);
 		if (_24$$14) {
 			_24$$14 = cancelable;
@@ -1039,7 +1039,7 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 			_27$$14 = _28$$14;
 		}
 		if (_27$$14) {
-			zephir_read_property_cached(&_30$$16, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_30$$16, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_OBS_NVAR(&fireEvents);
 			zephir_array_fetch(&fireEvents, &_30$$16, &eventType_zv, PH_NOISY, "phalcon/Events/Manager.zep", 517);
 			if (cancelable) {
@@ -1070,9 +1070,9 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 				_34$$17 = ZEPHIR_GT_LONG(&wasDepth, 0);
 			}
 			if (_34$$17) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 726, &stashed);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 725, &stashed);
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 725, &wasDepth);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 724, &wasDepth);
 			zephir_throw_exception_debug(&ex, "phalcon/Events/Manager.zep", 534);
 			ZEPHIR_MM_RESTORE();
 			return;
@@ -1083,9 +1083,9 @@ PHP_METHOD(Phalcon_Events_Manager, fire)
 		_35 = ZEPHIR_GT_LONG(&wasDepth, 0);
 	}
 	if (_35) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 726, &stashed);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 725, &stashed);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 725, &wasDepth);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 724, &wasDepth);
 	if (cancelable) {
 		ZVAL_BOOL(&_36, 1);
 	} else {
@@ -1213,14 +1213,14 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 		cancelable = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 722, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 721, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		array_init(return_value);
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_1)) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_2, 723, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_2, 722, PH_NOISY_CC | PH_READONLY);
 		if (UNEXPECTED(zephir_is_true(&_2$$4))) {
 			ZEPHIR_INIT_VAR(&_3$$5);
 			object_init_ex(&_3$$5, phalcon_events_exceptions_nolistenersforevent_ce);
@@ -1234,7 +1234,7 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 		RETURN_MM();
 	}
 	zephir_memory_observe(&cached);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 724, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 723, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&cached, &_4, &eventType_zv, 0)) {
 		zephir_memory_observe(&type);
 		zephir_array_fetch_long(&type, &cached, 0, PH_NOISY, "phalcon/Events/Manager.zep", 582);
@@ -1266,16 +1266,16 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 		zephir_array_fast_append(&_9$$7, &eventName);
 		zephir_update_property_array(this_ptr, SL("eventNameCache"), &eventType_zv, &_9$$7);
 	}
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	hasTypeQueue = zephir_array_isset_value(&_10, &type);
-	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	hasFullQueue = zephir_array_isset_value(&_11, &eventType_zv);
 	_12 = !hasTypeQueue;
 	if (_12) {
 		_12 = !hasFullQueue;
 	}
 	if (_12) {
-		zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_2, 723, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_2, 722, PH_NOISY_CC | PH_READONLY);
 		if (UNEXPECTED(zephir_is_true(&_13$$9))) {
 			ZEPHIR_INIT_VAR(&_14$$10);
 			object_init_ex(&_14$$10, phalcon_events_exceptions_nolistenersforevent_ce);
@@ -1289,15 +1289,15 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 		RETURN_MM();
 	}
 	zephir_memory_observe(&wasDepth);
-	zephir_read_property_cached(&wasDepth, this_ptr, _zephir_prop_4, 725, PH_NOISY_CC);
+	zephir_read_property_cached(&wasDepth, this_ptr, _zephir_prop_4, 724, PH_NOISY_CC);
 	ZVAL_UNDEF(&_15);
 	ZVAL_LONG(&_15, (zephir_get_numberval(&wasDepth) + 1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 725, &_15);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 724, &_15);
 	zephir_memory_observe(&stashed);
-	zephir_read_property_cached(&stashed, this_ptr, _zephir_prop_5, 726, PH_NOISY_CC);
+	zephir_read_property_cached(&stashed, this_ptr, _zephir_prop_5, 725, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&_16);
 	array_init(&_16);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 726, &_16);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 725, &_16);
 
 	/* try_start_1: */
 
@@ -1313,7 +1313,7 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 		ZEPHIR_INIT_VAR(&dispatchStatus);
 		ZVAL_NULL(&dispatchStatus);
 		if (hasTypeQueue) {
-			zephir_read_property_cached(&_18$$12, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_18$$12, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 			zephir_memory_observe(&fireEvents);
 			zephir_array_fetch(&fireEvents, &_18$$12, &type, PH_NOISY, "phalcon/Events/Manager.zep", 620);
 			if (cancelable) {
@@ -1326,7 +1326,7 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 			zephir_check_call_status_or_jump(try_end_1);
 		}
 		zephir_memory_observe(&_21$$11);
-		zephir_read_property_cached(&_21$$11, this_ptr, _zephir_prop_6, 727, PH_NOISY_CC);
+		zephir_read_property_cached(&_21$$11, this_ptr, _zephir_prop_6, 726, PH_NOISY_CC);
 		_22$$11 = zephir_is_true(&_21$$11);
 		if (_22$$11) {
 			_22$$11 = cancelable;
@@ -1350,7 +1350,7 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 			_25$$11 = _26$$11;
 		}
 		if (_25$$11) {
-			zephir_read_property_cached(&_28$$13, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_28$$13, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_OBS_NVAR(&fireEvents);
 			zephir_array_fetch(&fireEvents, &_28$$13, &eventType_zv, PH_NOISY, "phalcon/Events/Manager.zep", 637);
 			if (cancelable) {
@@ -1372,17 +1372,17 @@ PHP_METHOD(Phalcon_Events_Manager, fireAll)
 		if (zephir_is_instance_of(&_31, SL("Throwable"))) {
 			zend_clear_exception();
 			ZEPHIR_CPY_WRT(&ex, &_31);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 726, &stashed);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 725, &wasDepth);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 725, &stashed);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 724, &wasDepth);
 			zephir_throw_exception_debug(&ex, "phalcon/Events/Manager.zep", 651);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
 	}
-	zephir_read_property_cached(&_15, this_ptr, _zephir_prop_5, 726, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_15, this_ptr, _zephir_prop_5, 725, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&responses, &_15);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 726, &stashed);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 725, &wasDepth);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 725, &stashed);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 724, &wasDepth);
 	RETURN_CCTOR(&responses);
 }
 
@@ -1429,7 +1429,7 @@ PHP_METHOD(Phalcon_Events_Manager, fireQueue)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &queue_param, &event);
 	zephir_get_arrval(&queue, queue_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 722, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 721, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		RETURN_MM_NULL();
 	}
@@ -1441,7 +1441,7 @@ PHP_METHOD(Phalcon_Events_Manager, fireQueue)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_4, event, "iscancelable", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 718, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "runqueue", NULL, 0, &queue, event, &_1, &_2, &_3, &_4, &_5);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -1466,9 +1466,9 @@ PHP_METHOD(Phalcon_Events_Manager, halt)
 		_zephir_prop_0 = zend_string_init("halted", 6, 1);
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 722, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 721, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 722, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 721, &__$false);
 	}
 }
 
@@ -1508,7 +1508,7 @@ PHP_METHOD(Phalcon_Events_Manager, getListeners)
 	ZEPHIR_INIT_VAR(&listeners);
 	array_init(&listeners);
 	zephir_memory_observe(&queue);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&queue, &_0, &type_zv, 0)) {
 		zephir_is_iterable(&queue, 0, "phalcon/Events/Manager.zep", 714);
 		if (Z_TYPE_P(&queue) == IS_ARRAY) {
@@ -1585,7 +1585,7 @@ PHP_METHOD(Phalcon_Events_Manager, getSubscribers)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 718, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 717, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_FUNCTION("array_values", NULL, 27, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -1611,7 +1611,7 @@ PHP_METHOD(Phalcon_Events_Manager, hasListeners)
 		Z_PARAM_STR(type)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&type_zv, type);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &type_zv));
 }
 
@@ -1721,17 +1721,17 @@ PHP_METHOD(Phalcon_Events_Manager, removeSubscriber)
 	zephir_fetch_params(1, 1, 0, &subscriber);
 	ZEPHIR_CALL_FUNCTION(&key, "spl_object_id", NULL, 52, subscriber);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 718, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 717, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_0, &key))) {
 		RETURN_MM_NULL();
 	}
 	zephir_unset_property_array(this_ptr, ZEND_STRL("subscribers"), &key);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 718, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 717, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_1, &key, PH_SEPARATE);
 	ZEPHIR_INIT_VAR(&className);
 	zephir_get_class(&className, subscriber, 0);
 	zephir_memory_observe(&events);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 717, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 716, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&events, &_2, &className, 0))) {
 		_3$$4 = zephir_fetch_class(&className);
 		ZEPHIR_CALL_CE_STATIC(&events, _3$$4, "getsubscribedevents", NULL, 0);
@@ -1800,9 +1800,9 @@ PHP_METHOD(Phalcon_Events_Manager, resume)
 		_zephir_prop_0 = zend_string_init("halted", 6, 1);
 	}
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 722, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 721, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 722, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 721, &__$false);
 	}
 }
 
@@ -1831,7 +1831,7 @@ PHP_METHOD(Phalcon_Events_Manager, setMethodExistsCacheLimit)
 	zephir_fetch_params_without_memory_grow(1, 0, &methodExistsCacheLimit_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, methodExistsCacheLimit);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 728, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 727, &_0);
 }
 
 /**
@@ -1861,9 +1861,9 @@ PHP_METHOD(Phalcon_Events_Manager, setStopOnFalse)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 727, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 726, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 727, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 726, &__$false);
 	}
 }
 
@@ -1889,9 +1889,9 @@ PHP_METHOD(Phalcon_Events_Manager, setStrict)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &strict_param);
 	if (strict) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 723, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 722, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 723, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 722, &__$false);
 	}
 }
 
@@ -2041,7 +2041,7 @@ PHP_METHOD(Phalcon_Events_Manager, runObjectQueue)
 	zephir_get_arrval(&queue, queue_param);
 	ZEPHIR_INIT_VAR(&status);
 	ZVAL_NULL(&status);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 719, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 718, PH_NOISY_CC | PH_READONLY);
 	collect = zephir_is_true(&_0);
 	zephir_is_iterable(&queue, 0, "phalcon/Events/Manager.zep", 965);
 	if (Z_TYPE_P(&queue) == IS_ARRAY) {
@@ -2309,31 +2309,31 @@ PHP_METHOD(Phalcon_Events_Manager, runQueue)
 		} else if (ZEPHIR_IS_LONG(&type, 2)) {
 			zephir_memory_observe(&handlerClass);
 			zephir_array_fetch_long(&handlerClass, &tuple, 3, PH_NOISY, "phalcon/Events/Manager.zep", 1022);
-			zephir_read_property_cached(&_0$$6, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_0$$6, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch(&_1$$6, &_0$$6, &handlerClass, PH_READONLY, "phalcon/Events/Manager.zep", 1024);
 			if (!(zephir_array_isset_value(&_1$$6, &eventName_zv))) {
-				zephir_read_property_cached(&_2$$7, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_2$$7, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 				_3$$7 = !(zephir_array_isset_value(&_2$$7, &handlerClass));
 				if (_3$$7) {
-					zephir_read_property_cached(&_4$$7, this_ptr, _zephir_prop_1, 728, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_4$$7, this_ptr, _zephir_prop_1, 727, PH_NOISY_CC | PH_READONLY);
 					_3$$7 = ZEPHIR_GT_LONG(&_4$$7, 0);
 				}
 				_5$$7 = _3$$7;
 				if (_5$$7) {
-					zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
-					zephir_read_property_cached(&_7$$7, this_ptr, _zephir_prop_1, 728, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_7$$7, this_ptr, _zephir_prop_1, 727, PH_NOISY_CC | PH_READONLY);
 					_5$$7 = ZEPHIR_LE_LONG(&_7$$7, zephir_fast_count_int(&_6$$7));
 				}
 				if (_5$$7) {
 					ZEPHIR_INIT_VAR(&_8$$8);
 					array_init(&_8$$8);
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 729, &_8$$8);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 728, &_8$$8);
 				}
 				ZEPHIR_INIT_VAR(&_9$$7);
 				ZVAL_BOOL(&_9$$7, (zephir_method_exists(&handler, &eventName_zv)  == SUCCESS));
 				zephir_update_property_array_multi(this_ptr, SL("methodExistsCache"), &_9$$7, SL("zz"), 2, &handlerClass, &eventName_zv);
 			}
-			zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch(&_11$$6, &_10$$6, &handlerClass, PH_NOISY | PH_READONLY, "phalcon/Events/Manager.zep", 1033);
 			zephir_array_fetch(&_12$$6, &_11$$6, &eventName_zv, PH_NOISY | PH_READONLY, "phalcon/Events/Manager.zep", 1033);
 			if (!(zephir_is_true(&_12$$6))) {
@@ -2354,7 +2354,7 @@ PHP_METHOD(Phalcon_Events_Manager, runQueue)
 		if (collect) {
 			zephir_update_property_array_append(this_ptr, SL("responses"), &ret);
 		}
-		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_2, 727, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_2, 726, PH_NOISY_CC | PH_READONLY);
 		_15$$3 = zephir_is_true(&_14$$3);
 		if (_15$$3) {
 			_15$$3 = cancelable;
@@ -2391,31 +2391,31 @@ PHP_METHOD(Phalcon_Events_Manager, runQueue)
 			} else if (ZEPHIR_IS_LONG(&type, 2)) {
 				ZEPHIR_OBS_NVAR(&handlerClass);
 				zephir_array_fetch_long(&handlerClass, &tuple, 3, PH_NOISY, "phalcon/Events/Manager.zep", 1076);
-				zephir_read_property_cached(&_18$$16, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_18$$16, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 				zephir_array_fetch(&_19$$16, &_18$$16, &handlerClass, PH_READONLY, "phalcon/Events/Manager.zep", 1078);
 				if (!(zephir_array_isset_value(&_19$$16, &eventName_zv))) {
-					zephir_read_property_cached(&_20$$17, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_20$$17, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 					_21$$17 = !(zephir_array_isset_value(&_20$$17, &handlerClass));
 					if (_21$$17) {
-						zephir_read_property_cached(&_22$$17, this_ptr, _zephir_prop_1, 728, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_22$$17, this_ptr, _zephir_prop_1, 727, PH_NOISY_CC | PH_READONLY);
 						_21$$17 = ZEPHIR_GT_LONG(&_22$$17, 0);
 					}
 					_23$$17 = _21$$17;
 					if (_23$$17) {
-						zephir_read_property_cached(&_24$$17, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
-						zephir_read_property_cached(&_25$$17, this_ptr, _zephir_prop_1, 728, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_24$$17, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_25$$17, this_ptr, _zephir_prop_1, 727, PH_NOISY_CC | PH_READONLY);
 						_23$$17 = ZEPHIR_LE_LONG(&_25$$17, zephir_fast_count_int(&_24$$17));
 					}
 					if (_23$$17) {
 						ZEPHIR_INIT_NVAR(&_26$$18);
 						array_init(&_26$$18);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 729, &_26$$18);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 728, &_26$$18);
 					}
 					ZEPHIR_INIT_NVAR(&_27$$17);
 					ZVAL_BOOL(&_27$$17, (zephir_method_exists(&handler, &eventName_zv)  == SUCCESS));
 					zephir_update_property_array_multi(this_ptr, SL("methodExistsCache"), &_27$$17, SL("zz"), 2, &handlerClass, &eventName_zv);
 				}
-				zephir_read_property_cached(&_28$$16, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_28$$16, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 				zephir_array_fetch(&_29$$16, &_28$$16, &handlerClass, PH_NOISY | PH_READONLY, "phalcon/Events/Manager.zep", 1087);
 				zephir_array_fetch(&_30$$16, &_29$$16, &eventName_zv, PH_NOISY | PH_READONLY, "phalcon/Events/Manager.zep", 1087);
 				if (!(zephir_is_true(&_30$$16))) {
@@ -2436,7 +2436,7 @@ PHP_METHOD(Phalcon_Events_Manager, runQueue)
 			if (collect) {
 				zephir_update_property_array_append(this_ptr, SL("responses"), &ret);
 			}
-			zephir_read_property_cached(&_32$$13, this_ptr, _zephir_prop_2, 727, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_32$$13, this_ptr, _zephir_prop_2, 726, PH_NOISY_CC | PH_READONLY);
 			_33$$13 = zephir_is_true(&_32$$13);
 			if (_33$$13) {
 				_33$$13 = cancelable;
@@ -2496,31 +2496,31 @@ PHP_METHOD(Phalcon_Events_Manager, runQueue)
 				} else if (ZEPHIR_IS_LONG(&type, 2)) {
 					ZEPHIR_OBS_NVAR(&handlerClass);
 					zephir_array_fetch_long(&handlerClass, &tuple, 3, PH_NOISY, "phalcon/Events/Manager.zep", 1076);
-					zephir_read_property_cached(&_39$$28, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_39$$28, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 					zephir_array_fetch(&_40$$28, &_39$$28, &handlerClass, PH_READONLY, "phalcon/Events/Manager.zep", 1078);
 					if (!(zephir_array_isset_value(&_40$$28, &eventName_zv))) {
-						zephir_read_property_cached(&_41$$29, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_41$$29, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 						_42$$29 = !(zephir_array_isset_value(&_41$$29, &handlerClass));
 						if (_42$$29) {
-							zephir_read_property_cached(&_43$$29, this_ptr, _zephir_prop_1, 728, PH_NOISY_CC | PH_READONLY);
+							zephir_read_property_cached(&_43$$29, this_ptr, _zephir_prop_1, 727, PH_NOISY_CC | PH_READONLY);
 							_42$$29 = ZEPHIR_GT_LONG(&_43$$29, 0);
 						}
 						_44$$29 = _42$$29;
 						if (_44$$29) {
-							zephir_read_property_cached(&_45$$29, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
-							zephir_read_property_cached(&_46$$29, this_ptr, _zephir_prop_1, 728, PH_NOISY_CC | PH_READONLY);
+							zephir_read_property_cached(&_45$$29, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
+							zephir_read_property_cached(&_46$$29, this_ptr, _zephir_prop_1, 727, PH_NOISY_CC | PH_READONLY);
 							_44$$29 = ZEPHIR_LE_LONG(&_46$$29, zephir_fast_count_int(&_45$$29));
 						}
 						if (_44$$29) {
 							ZEPHIR_INIT_NVAR(&_47$$30);
 							array_init(&_47$$30);
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 729, &_47$$30);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 728, &_47$$30);
 						}
 						ZEPHIR_INIT_NVAR(&_48$$29);
 						ZVAL_BOOL(&_48$$29, (zephir_method_exists(&handler, &eventName_zv)  == SUCCESS));
 						zephir_update_property_array_multi(this_ptr, SL("methodExistsCache"), &_48$$29, SL("zz"), 2, &handlerClass, &eventName_zv);
 					}
-					zephir_read_property_cached(&_49$$28, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_49$$28, this_ptr, _zephir_prop_0, 728, PH_NOISY_CC | PH_READONLY);
 					zephir_array_fetch(&_50$$28, &_49$$28, &handlerClass, PH_NOISY | PH_READONLY, "phalcon/Events/Manager.zep", 1087);
 					zephir_array_fetch(&_51$$28, &_50$$28, &eventName_zv, PH_NOISY | PH_READONLY, "phalcon/Events/Manager.zep", 1087);
 					if (!(zephir_is_true(&_51$$28))) {
@@ -2541,7 +2541,7 @@ PHP_METHOD(Phalcon_Events_Manager, runQueue)
 				if (collect) {
 					zephir_update_property_array_append(this_ptr, SL("responses"), &ret);
 				}
-				zephir_read_property_cached(&_53$$25, this_ptr, _zephir_prop_2, 727, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_53$$25, this_ptr, _zephir_prop_2, 726, PH_NOISY_CC | PH_READONLY);
 				_54$$25 = zephir_is_true(&_53$$25);
 				if (_54$$25) {
 					_54$$25 = cancelable;
@@ -2645,7 +2645,7 @@ PHP_METHOD(Phalcon_Events_Manager, insertHandlerEntry)
 		className = &__$null;
 	}
 	zephir_memory_observe(&prioritiesOn);
-	zephir_read_property_cached(&prioritiesOn, this_ptr, _zephir_prop_0, 721, PH_NOISY_CC);
+	zephir_read_property_cached(&prioritiesOn, this_ptr, _zephir_prop_0, 720, PH_NOISY_CC);
 	if (!(zephir_is_true(&prioritiesOn))) {
 		priority = 100;
 	}
@@ -2675,7 +2675,7 @@ PHP_METHOD(Phalcon_Events_Manager, insertHandlerEntry)
 		ZEPHIR_CPY_WRT(&tuple, &_2$$5);
 	}
 	zephir_memory_observe(&queue);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 720, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 719, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&queue, &_4, &eventType_zv, 0))) {
 		ZEPHIR_INIT_VAR(&_5$$6);
 		zephir_create_array(&_5$$6, 1, 0);

--- a/ext/phalcon/filter/filter.zep.c
+++ b/ext/phalcon/filter/filter.zep.c
@@ -311,7 +311,7 @@ PHP_METHOD(Phalcon_Filter_Filter, get)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 730, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
 	if (1 != zephir_array_isset_value(&_0, &name_zv)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_filter_exceptions_filternotregistered_ce);
@@ -321,16 +321,16 @@ PHP_METHOD(Phalcon_Filter_Filter, get)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 731, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 730, PH_NOISY_CC | PH_READONLY);
 	if (1 != zephir_array_isset_value(&_2, &name_zv)) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 730, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&definition);
 		zephir_array_fetch(&definition, &_3$$4, &name_zv, PH_NOISY, "phalcon/Filter/Filter.zep", 219);
 		ZEPHIR_CALL_METHOD(&_4$$4, this_ptr, "createinstance", NULL, 0, &definition);
 		zephir_check_call_status();
 		zephir_update_property_array(this_ptr, SL("services"), &name_zv, &_4$$4);
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 731, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 730, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_6, &_5, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Filter/Filter.zep", 223);
 	RETURN_CTOR(&_6);
 }
@@ -396,7 +396,7 @@ PHP_METHOD(Phalcon_Filter_Filter, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 730, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 729, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &name_zv));
 }
 
@@ -494,7 +494,7 @@ PHP_METHOD(Phalcon_Filter_Filter, set)
 	ZVAL_STR(&name_zv, name);
 	zephir_update_property_array(this_ptr, SL("mapper"), &name_zv, service);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("services"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 731, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 730, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 }
 

--- a/ext/phalcon/filter/validation.zep.c
+++ b/ext/phalcon/filter/validation.zep.c
@@ -141,19 +141,19 @@ PHP_METHOD(Phalcon_Filter_Validation, __construct)
 	object_init_ex(&_0, phalcon_messages_messages_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 13);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 732, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 731, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_INIT_NVAR(&_1);
 	zephir_create_closure_ex(&_1, NULL, phalcon_18__closure_ce, SL("__invoke"));
 	ZEPHIR_CALL_FUNCTION(&_2, "array_filter", NULL, 30, &validators, &_1);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 733, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 732, &_2);
 	ZEPHIR_INIT_VAR(&_3);
 	ZEPHIR_INIT_NVAR(&_3);
 	zephir_create_closure_ex(&_3, NULL, phalcon_19__closure_ce, SL("__invoke"));
 	ZEPHIR_CALL_FUNCTION(&_4, "array_filter", NULL, 30, &validators, &_3);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 734, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 733, &_4);
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("initialize")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "initialize", NULL, 0);
 		zephir_check_call_status();
@@ -269,7 +269,7 @@ PHP_METHOD(Phalcon_Filter_Validation, appendMessage)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &message);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 732, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 731, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "appendmessage", NULL, 0, message);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -364,7 +364,7 @@ PHP_METHOD(Phalcon_Filter_Validation, bind)
 	} else {
 		zephir_get_arrval(&whitelist, whitelist_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 735, data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 734, data);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setentity", NULL, 0, entity);
 	zephir_check_call_status();
 	_0 = Z_TYPE_P(data) != IS_ARRAY;
@@ -412,10 +412,10 @@ PHP_METHOD(Phalcon_Filter_Validation, bind)
 		return;
 	}
 	if (ZEPHIR_IS_EMPTY(&whitelist)) {
-		zephir_read_property_cached(&_7$$7, this_ptr, _zephir_prop_1, 736, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$7, this_ptr, _zephir_prop_1, 735, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&whitelist, &_7$$7);
 	}
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_2, 737, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_2, 736, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&filters, &_8);
 	zephir_is_iterable(data, 0, "phalcon/Filter/Validation.zep", 251);
 	if (Z_TYPE_P(data) == IS_ARRAY) {
@@ -449,17 +449,17 @@ PHP_METHOD(Phalcon_Filter_Validation, bind)
 			zephir_camelize(&_15$$8, &field, NULL );
 			ZEPHIR_INIT_NVAR(&method);
 			ZEPHIR_CONCAT_SV(&method, "set", &_15$$8);
-			zephir_read_property_cached(&_16$$8, this_ptr, _zephir_prop_3, 738, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_16$$8, this_ptr, _zephir_prop_3, 737, PH_NOISY_CC | PH_READONLY);
 			if ((zephir_method_exists(&_16$$8, &method)  == SUCCESS)) {
 				ZEPHIR_CALL_METHOD_ZVAL(NULL, entity, &method, NULL, 0, &value);
 				zephir_check_call_status();
 			} else {
-				zephir_read_property_cached(&_17$$8, this_ptr, _zephir_prop_3, 738, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_17$$8, this_ptr, _zephir_prop_3, 737, PH_NOISY_CC | PH_READONLY);
 				if ((zephir_method_exists_ex(&_17$$8, ZEND_STRL("writeattribute")) == SUCCESS)) {
 					ZEPHIR_CALL_METHOD(NULL, entity, "writeattribute", NULL, 0, &field, &value);
 					zephir_check_call_status();
 				} else {
-					zephir_read_property_cached(&_18$$8, this_ptr, _zephir_prop_3, 738, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_18$$8, this_ptr, _zephir_prop_3, 737, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_FUNCTION(&_19$$8, "property_exists", &_20, 9, &_18$$8, &field);
 					zephir_check_call_status();
 					if (zephir_is_true(&_19$$8)) {
@@ -508,17 +508,17 @@ PHP_METHOD(Phalcon_Filter_Validation, bind)
 				zephir_camelize(&_26$$15, &field, NULL );
 				ZEPHIR_INIT_NVAR(&method);
 				ZEPHIR_CONCAT_SV(&method, "set", &_26$$15);
-				zephir_read_property_cached(&_27$$15, this_ptr, _zephir_prop_3, 738, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_27$$15, this_ptr, _zephir_prop_3, 737, PH_NOISY_CC | PH_READONLY);
 				if ((zephir_method_exists(&_27$$15, &method)  == SUCCESS)) {
 					ZEPHIR_CALL_METHOD_ZVAL(NULL, entity, &method, NULL, 0, &value);
 					zephir_check_call_status();
 				} else {
-					zephir_read_property_cached(&_28$$15, this_ptr, _zephir_prop_3, 738, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_28$$15, this_ptr, _zephir_prop_3, 737, PH_NOISY_CC | PH_READONLY);
 					if ((zephir_method_exists_ex(&_28$$15, ZEND_STRL("writeattribute")) == SUCCESS)) {
 						ZEPHIR_CALL_METHOD(NULL, entity, "writeattribute", NULL, 0, &field, &value);
 						zephir_check_call_status();
 					} else {
-						zephir_read_property_cached(&_29$$15, this_ptr, _zephir_prop_3, 738, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_29$$15, this_ptr, _zephir_prop_3, 737, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_FUNCTION(&_30$$15, "property_exists", &_20, 9, &_29$$15, &field);
 						zephir_check_call_status();
 						if (zephir_is_true(&_30$$15)) {
@@ -617,7 +617,7 @@ PHP_METHOD(Phalcon_Filter_Validation, getFilters)
 		zephir_memory_observe(&field_zv);
 	ZVAL_STR_COPY(&field_zv, field);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 737, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 736, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&filters, &_0);
 	if (!(!(ZEPHIR_IS_EMPTY(&field_zv)))) {
 		RETURN_CCTOR(&filters);
@@ -655,7 +655,7 @@ PHP_METHOD(Phalcon_Filter_Validation, getLabel)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &field);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 739, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 738, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&labels, &_0);
 	if (Z_TYPE_P(field) == IS_ARRAY) {
 		zephir_fast_join_str(return_value, SL(", "), field);
@@ -772,7 +772,7 @@ PHP_METHOD(Phalcon_Filter_Validation, getValueByData)
 	data = ZEND_CALL_ARG(execute_data, 1);
 	zephir_memory_observe(&field_zv);
 	ZVAL_STR_COPY(&field_zv, field);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 740, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 739, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&values, &_0);
 	zephir_memory_observe(&value);
 	if (zephir_array_isset_fetch(&value, &values, &field_zv, 0)) {
@@ -846,9 +846,9 @@ PHP_METHOD(Phalcon_Filter_Validation, getValue)
 	zephir_memory_observe(&field_zv);
 	ZVAL_STR_COPY(&field_zv, field);
 	isRawFetched = 0;
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 738, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 737, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&entity, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 735, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 734, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&data, &_0);
 	if (Z_TYPE_P(&entity) == IS_OBJECT) {
 		ZEPHIR_CALL_METHOD(&value, this_ptr, "getvaluebyentity", NULL, 0, &entity, &field_zv);
@@ -878,7 +878,7 @@ PHP_METHOD(Phalcon_Filter_Validation, getValue)
 	if (Z_TYPE_P(&value) == IS_NULL) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 737, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 736, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&filters, &_0);
 	zephir_memory_observe(&fieldFilters);
 	if (zephir_array_isset_fetch(&fieldFilters, &filters, &field_zv, 0)) {
@@ -1116,7 +1116,7 @@ PHP_METHOD(Phalcon_Filter_Validation, setEntity)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 738, entity);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 737, entity);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1214,7 +1214,7 @@ PHP_METHOD(Phalcon_Filter_Validation, setLabels)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &labels_param);
 	zephir_get_arrval(&labels, labels_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 739, &labels);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 738, &labels);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1238,7 +1238,7 @@ PHP_METHOD(Phalcon_Filter_Validation, setValidators)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &validators_param);
 	zephir_get_arrval(&validators, validators_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 733, &validators);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 732, &validators);
 	RETURN_THIS();
 }
 
@@ -1388,8 +1388,8 @@ PHP_METHOD(Phalcon_Filter_Validation, validate)
 	ZEPHIR_INIT_VAR(&inputData);
 	ZVAL_NULL(&inputData);
 	zephir_memory_observe(&validatorData);
-	zephir_read_property_cached(&validatorData, this_ptr, _zephir_prop_0, 733, PH_NOISY_CC);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 734, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&validatorData, this_ptr, _zephir_prop_0, 732, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 733, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&combinedFieldsValidators, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&validatorData) != IS_ARRAY)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -1402,12 +1402,12 @@ PHP_METHOD(Phalcon_Filter_Validation, validate)
 	}
 	ZEPHIR_INIT_VAR(&_2);
 	array_init(&_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 740, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 739, &_2);
 	ZEPHIR_INIT_VAR(&_3);
 	object_init_ex(&_3, phalcon_messages_messages_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_3, "__construct", NULL, 13);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 732, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 731, &_3);
 	if (Z_TYPE_P(data) != IS_NULL) {
 		_4$$4 = Z_TYPE_P(data) != IS_ARRAY;
 		if (_4$$4) {
@@ -1422,13 +1422,13 @@ PHP_METHOD(Phalcon_Filter_Validation, validate)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 735, data);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 734, data);
 		ZEPHIR_CPY_WRT(&inputData, data);
 	} else {
-		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 735, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 734, PH_NOISY_CC | PH_READONLY);
 		if (!(ZEPHIR_IS_EMPTY(&_0))) {
 			ZEPHIR_OBS_NVAR(&inputData);
-			zephir_read_property_cached(&inputData, this_ptr, _zephir_prop_4, 735, PH_NOISY_CC);
+			zephir_read_property_cached(&inputData, this_ptr, _zephir_prop_4, 734, PH_NOISY_CC);
 		}
 	}
 	if (Z_TYPE_P(entity) != IS_NULL) {
@@ -1436,8 +1436,8 @@ PHP_METHOD(Phalcon_Filter_Validation, validate)
 		zephir_check_call_status();
 	}
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("beforevalidation")) == SUCCESS)) {
-		zephir_read_property_cached(&_6$$8, this_ptr, _zephir_prop_5, 738, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_7$$8, this_ptr, _zephir_prop_3, 732, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$8, this_ptr, _zephir_prop_5, 737, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$8, this_ptr, _zephir_prop_3, 731, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&status, this_ptr, "beforevalidation", NULL, 0, &inputData, &_6$$8, &_7$$8);
 		zephir_check_call_status();
 		if (ZEPHIR_IS_FALSE_IDENTICAL(&status)) {
@@ -1742,8 +1742,8 @@ PHP_METHOD(Phalcon_Filter_Validation, validate)
 	}
 	ZEPHIR_INIT_NVAR(&scope);
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("aftervalidation")) == SUCCESS)) {
-		zephir_read_property_cached(&_57$$44, this_ptr, _zephir_prop_5, 738, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_58$$44, this_ptr, _zephir_prop_3, 732, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_57$$44, this_ptr, _zephir_prop_5, 737, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_58$$44, this_ptr, _zephir_prop_3, 731, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "aftervalidation", NULL, 0, &inputData, &_57$$44, &_58$$44);
 		zephir_check_call_status();
 	}
@@ -1769,7 +1769,7 @@ PHP_METHOD(Phalcon_Filter_Validation, fails)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 732, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 731, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "count", NULL, 0);
 	zephir_check_call_status();
 	if (ZEPHIR_GT_LONG(&_1, 0)) {

--- a/ext/phalcon/filter/validation/traits/validatorcompositetrait.zep.c
+++ b/ext/phalcon/filter/validation/traits/validatorcompositetrait.zep.c
@@ -64,7 +64,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Traits_ValidatorCompositeTrait, getValidato
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 741, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 740, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }

--- a/ext/phalcon/filter/validation/validator/callback.zep.c
+++ b/ext/phalcon/filter/validation/validator/callback.zep.c
@@ -171,11 +171,11 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, validate)
 			zephir_check_call_status();
 		}
 		zephir_memory_observe(&savedTemplate);
-		zephir_read_property_cached(&savedTemplate, this_ptr, _zephir_prop_0, 742, PH_NOISY_CC);
+		zephir_read_property_cached(&savedTemplate, this_ptr, _zephir_prop_0, 741, PH_NOISY_CC);
 		zephir_memory_observe(&savedChanged);
-		zephir_read_property_cached(&savedChanged, this_ptr, _zephir_prop_1, 743, PH_NOISY_CC);
+		zephir_read_property_cached(&savedChanged, this_ptr, _zephir_prop_1, 742, PH_NOISY_CC);
 		zephir_memory_observe(&savedTemplates);
-		zephir_read_property_cached(&savedTemplates, this_ptr, _zephir_prop_2, 744, PH_NOISY_CC);
+		zephir_read_property_cached(&savedTemplates, this_ptr, _zephir_prop_2, 743, PH_NOISY_CC);
 		if (zephir_is_instance_of(&callback, SL("Closure"))) {
 			_2$$5 = zephir_fetch_class_str_ex(SL("Closure"), ZEND_FETCH_CLASS_AUTO);
 			ZEPHIR_CALL_CE_STATIC(&_1$$5, _2$$5, "bind", NULL, 0, &callback, this_ptr);
@@ -194,9 +194,9 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, validate)
 			ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_4$$6);
 			zephir_check_call_status();
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 742, &savedTemplate);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 743, &savedChanged);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 744, &savedTemplates);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 741, &savedTemplate);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 742, &savedChanged);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 743, &savedTemplates);
 		if (((Z_TYPE_P(&returnedValue) == IS_TRUE || Z_TYPE_P(&returnedValue) == IS_FALSE) == 1)) {
 			RETURN_CCTOR(&returnedValue);
 		}

--- a/ext/phalcon/filter/validation/validator/confirmation.zep.c
+++ b/ext/phalcon/filter/validation/validator/confirmation.zep.c
@@ -276,7 +276,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Confirmation, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/filter/validation/validator/creditcard.zep.c
+++ b/ext/phalcon/filter/validation/validator/creditcard.zep.c
@@ -189,7 +189,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_CreditCard, verifyByLuhnAlgorithm
 	}
 	ZEPHIR_CALL_FUNCTION(&_1, "str_split", NULL, 206, &number_zv);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&digits, "array_reverse", NULL, 261, &_1);
+	ZEPHIR_CALL_FUNCTION(&digits, "array_reverse", NULL, 262, &_1);
 	zephir_check_call_status();
 	zephir_is_iterable(&digits, 0, "phalcon/Filter/Validation/Validator/CreditCard.zep", 112);
 	if (Z_TYPE_P(&digits) == IS_ARRAY) {

--- a/ext/phalcon/filter/validation/validator/file/mimetype.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/mimetype.zep.c
@@ -285,7 +285,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_MimeType, phpExtensionLoaded
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/filter/validation/validator/files.zep.c
+++ b/ext/phalcon/filter/validation/validator/files.zep.c
@@ -209,7 +209,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Files, validate)
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&validator);
 	object_init_ex(&validator, phalcon_filter_validation_validator_file_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 745, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 744, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &validator, "__construct", NULL, 0, &_0);
 	zephir_check_call_status();
 	zephir_is_iterable(&files, 0, "phalcon/Filter/Validation/Validator/Files.zep", 114);

--- a/ext/phalcon/filter/validation/validator/stringlength/max.zep.c
+++ b/ext/phalcon/filter/validation/validator/stringlength/max.zep.c
@@ -239,7 +239,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_StringLength_Max, phpExtensionLoa
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/filter/validation/validator/stringlength/min.zep.c
+++ b/ext/phalcon/filter/validation/validator/stringlength/min.zep.c
@@ -239,7 +239,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_StringLength_Min, phpExtensionLoa
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/filter/validation/validator/uniqueness.zep.c
+++ b/ext/phalcon/filter/validation/validator/uniqueness.zep.c
@@ -292,7 +292,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Uniqueness, getColumnNameReal)
 	zephir_check_call_status();
 	_2 = zephir_is_true(&_0);
 	if (_2) {
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 746, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 745, PH_NOISY_CC | PH_READONLY);
 		_2 = !zephir_is_true(&_3);
 	}
 	if (_2) {
@@ -304,17 +304,17 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Uniqueness, getColumnNameReal)
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&_7$$3, &_5$$3, "getcolumnmap", NULL, 0, record);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 746, &_7$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 745, &_7$$3);
 	}
 	zephir_memory_observe(&_8);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 746, PH_NOISY_CC);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 745, PH_NOISY_CC);
 	_9 = Z_TYPE_P(&_8) == IS_ARRAY;
 	if (_9) {
-		zephir_read_property_cached(&_10, this_ptr, _zephir_prop_0, 746, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10, this_ptr, _zephir_prop_0, 745, PH_NOISY_CC | PH_READONLY);
 		_9 = zephir_array_isset_value(&_10, &field_zv);
 	}
 	if (_9) {
-		zephir_read_property_cached(&_11$$4, this_ptr, _zephir_prop_0, 746, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_11$$4, this_ptr, _zephir_prop_0, 745, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_12$$4, &_11$$4, &field_zv, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/Uniqueness.zep", 182);
 		RETURN_CTOR(&_12$$4);
 	}

--- a/ext/phalcon/filter/validation/validator/url.zep.c
+++ b/ext/phalcon/filter/validation/validator/url.zep.c
@@ -145,7 +145,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Url, validate)
 		RETURN_MM_BOOL(1);
 	}
 	zephir_memory_observe(&options);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 747, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 746, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&options, &_1, SL("options"), 0)) {
 		ZVAL_LONG(&_2$$4, 273);
 		ZEPHIR_CALL_FUNCTION(&result, "filter_var", NULL, 0, &value, &_2$$4, &options);

--- a/ext/phalcon/flash/direct.zep.c
+++ b/ext/phalcon/flash/direct.zep.c
@@ -101,7 +101,7 @@ PHP_METHOD(Phalcon_Flash_Direct, output)
 		remove = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 748, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 747, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Flash/Direct.zep", 45);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/flash/session.zep.c
+++ b/ext/phalcon/flash/session.zep.c
@@ -116,7 +116,7 @@ PHP_METHOD(Phalcon_Flash_Session, __construct)
 		ZEPHIR_INIT_NVAR(&_0);
 		ZVAL_STRING(&_0, "_flashMessages");
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 749, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 748, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -365,7 +365,7 @@ PHP_METHOD(Phalcon_Flash_Session, output)
 	}
 	ZEPHIR_INIT_NVAR(&message);
 	ZEPHIR_INIT_NVAR(&type);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 750, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 749, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_7)) {
 		ZEPHIR_CALL_PARENT(NULL, phalcon_flash_session_ce, getThis(), "clear", NULL, 0);
 		zephir_check_call_status();
@@ -420,7 +420,7 @@ PHP_METHOD(Phalcon_Flash_Session, getSessionMessages)
 	}
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getsessionservice", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 749, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 748, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&messages, &session, "get", NULL, 0, &_0);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&messages) != IS_ARRAY) {
@@ -432,7 +432,7 @@ PHP_METHOD(Phalcon_Flash_Session, getSessionMessages)
 		if (zephir_array_isset_fetch(&returnMessages, &messages, &type_zv, 0)) {
 			if (remove) {
 				zephir_array_unset(&messages, &type_zv, PH_SEPARATE);
-				zephir_read_property_cached(&_1$$6, this_ptr, _zephir_prop_0, 749, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_1$$6, this_ptr, _zephir_prop_0, 748, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &session, "set", NULL, 0, &_1$$6, &messages);
 				zephir_check_call_status();
 			}
@@ -442,7 +442,7 @@ PHP_METHOD(Phalcon_Flash_Session, getSessionMessages)
 		RETURN_MM();
 	}
 	if (remove) {
-		zephir_read_property_cached(&_2$$7, this_ptr, _zephir_prop_0, 749, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$7, this_ptr, _zephir_prop_0, 748, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &session, "remove", NULL, 0, &_2$$7);
 		zephir_check_call_status();
 	}
@@ -482,7 +482,7 @@ PHP_METHOD(Phalcon_Flash_Session, setSessionMessages)
 	zephir_get_arrval(&messages, messages_param);
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getsessionservice", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 749, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 748, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &session, "set", NULL, 0, &_0, &messages);
 	zephir_check_call_status();
 	RETURN_CTOR(&messages);
@@ -521,14 +521,14 @@ PHP_METHOD(Phalcon_Flash_Session, getSessionService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 751, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 750, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
 		RETURN_MM_MEMBER(getThis(), "sessionService");
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 752, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 751, PH_NOISY_CC | PH_READONLY);
 	_2 = Z_TYPE_P(&_1) != IS_NULL;
 	if (_2) {
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 752, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 751, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_5);
 		ZVAL_STRING(&_5, "session");
 		ZEPHIR_CALL_METHOD(&_4, &_3, "has", NULL, 0, &_5);
@@ -536,12 +536,12 @@ PHP_METHOD(Phalcon_Flash_Session, getSessionService)
 		_2 = ZEPHIR_IS_TRUE_IDENTICAL(&_4);
 	}
 	if (_2) {
-		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_1, 752, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_1, 751, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_8$$4);
 		ZVAL_STRING(&_8$$4, "session");
 		ZEPHIR_CALL_METHOD(&_7$$4, &_6$$4, "getshared", NULL, 0, &_8$$4);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 751, &_7$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 750, &_7$$4);
 		RETURN_MM_MEMBER(getThis(), "sessionService");
 	}
 	ZEPHIR_INIT_NVAR(&_5);

--- a/ext/phalcon/forms/element/check.zep.c
+++ b/ext/phalcon/forms/element/check.zep.c
@@ -92,11 +92,11 @@ PHP_METHOD(Phalcon_Forms_Element_Check, setUncheckedValue)
 		Z_PARAM_ZVAL(value)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &value);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 753, value);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 752, value);
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 754, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 753, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 754, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 753, &__$false);
 	}
 	RETURN_THISW();
 }

--- a/ext/phalcon/forms/element/checkgroup.zep.c
+++ b/ext/phalcon/forms/element/checkgroup.zep.c
@@ -105,7 +105,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, __construct)
 		ZEPHIR_CONCAT_VS(&_0$$3, &name, "[]");
 		ZEPHIR_CPY_WRT(&name, &_0$$3);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 755, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 754, &options);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_forms_element_checkgroup_ce, getThis(), "__construct", NULL, 0, &name, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -177,7 +177,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, render)
 	}
 	ZEPHIR_CALL_METHOD(&value, this_ptr, "getvalue", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 756, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 755, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&merged);
 	zephir_fast_array_merge(&merged, &_0, &attributes);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getlocaltagfactory", NULL, 0);
@@ -186,8 +186,8 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, render)
 	ZVAL_STRING(&_2, "inputCheckboxGroup");
 	ZEPHIR_CALL_METHOD(&helper, &_1, "newinstance", NULL, 0, &_2);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 757, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 755, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 756, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 754, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, &helper, "__invoke", NULL, 0, &_4, &_5, &value, &merged);
 	zephir_check_call_status();
 	zephir_cast_to_string(&_6, &_3);
@@ -221,7 +221,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 755, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 754, &options);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/forms/element/radiogroup.zep.c
+++ b/ext/phalcon/forms/element/radiogroup.zep.c
@@ -100,7 +100,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, __construct)
 	} else {
 		zephir_get_arrval(&attributes, attributes_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 758, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 757, &options);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_forms_element_radiogroup_ce, getThis(), "__construct", NULL, 0, &name_zv, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, render)
 	}
 	ZEPHIR_CALL_METHOD(&value, this_ptr, "getvalue", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 759, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 758, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&merged);
 	zephir_fast_array_merge(&merged, &_0, &attributes);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getlocaltagfactory", NULL, 0);
@@ -181,8 +181,8 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, render)
 	ZVAL_STRING(&_2, "inputRadioGroup");
 	ZEPHIR_CALL_METHOD(&helper, &_1, "newinstance", NULL, 0, &_2);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 760, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 758, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 759, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 757, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, &helper, "__invoke", NULL, 0, &_4, &_5, &value, &merged);
 	zephir_check_call_status();
 	zephir_cast_to_string(&_6, &_3);
@@ -216,7 +216,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 758, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 757, &options);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/forms/element/select.zep.c
+++ b/ext/phalcon/forms/element/select.zep.c
@@ -93,7 +93,7 @@ PHP_METHOD(Phalcon_Forms_Element_Select, __construct)
 	} else {
 		zephir_get_arrval(&attributes, attributes_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 761, options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 760, options);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_forms_element_select_ce, getThis(), "__construct", NULL, 0, &name_zv, &attributes);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -215,7 +215,7 @@ PHP_METHOD(Phalcon_Forms_Element_Select, render)
 	}
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "prepareattributes", NULL, 0, &attributes);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 761, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 760, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_CE_STATIC(phalcon_tag_select_ce, "selectfield", NULL, 0, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -241,7 +241,7 @@ PHP_METHOD(Phalcon_Forms_Element_Select, setOptions)
 		Z_PARAM_ZVAL(options)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &options);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 761, options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 760, options);
 	RETURN_THISW();
 }
 
@@ -285,11 +285,11 @@ PHP_METHOD(Phalcon_Forms_Element_Select, prepareAttributes)
 	} else {
 		zephir_get_arrval(&attributes, attributes_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 762, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 761, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&name, &_0);
 	zephir_array_update_long(&attributes, 0, &name, PH_COPY | PH_SEPARATE ZEPHIR_DEBUG_PARAMS_DUMMY);
 	zephir_memory_observe(&defaultAttributes);
-	zephir_read_property_cached(&defaultAttributes, this_ptr, _zephir_prop_1, 763, PH_NOISY_CC);
+	zephir_read_property_cached(&defaultAttributes, this_ptr, _zephir_prop_1, 762, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&mergedAttributes);
 	zephir_fast_array_merge(&mergedAttributes, &defaultAttributes, &attributes);
 	ZEPHIR_CALL_METHOD(&value, this_ptr, "getvalue", NULL, 0);

--- a/ext/phalcon/forms/form.zep.c
+++ b/ext/phalcon/forms/form.zep.c
@@ -161,18 +161,18 @@ PHP_METHOD(Phalcon_Forms_Form, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 764, entity);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 765, &userOptions);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 763, entity);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 764, &userOptions);
 	ZEPHIR_INIT_VAR(&_2);
 	object_init_ex(&_2, phalcon_html_attributes_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_2, "__construct", NULL, 41);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 766, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 765, &_2);
 	ZEPHIR_INIT_VAR(&_3);
 	object_init_ex(&_3, phalcon_messages_messages_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_3, "__construct", NULL, 13);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 767, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 766, &_3);
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("initialize")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "initialize", NULL, 0, entity, &userOptions);
 		zephir_check_call_status();
@@ -243,17 +243,17 @@ PHP_METHOD(Phalcon_Forms_Form, add)
 	zephir_check_call_status();
 	_0 = (zephir_method_exists_ex(element, ZEND_STRL("settagfactory")) == SUCCESS);
 	if (_0) {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 767, PH_NOISY_CC | PH_READONLY);
 		_0 = Z_TYPE_P(&_1) != IS_NULL;
 	}
 	if (_0) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 767, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, element, "settagfactory", NULL, 0, &_2$$3);
 		zephir_check_call_status();
 	}
 	_3 = ZEPHIR_IS_NULL(&position_zv);
 	if (!(_3)) {
-		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 769, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 768, PH_NOISY_CC | PH_READONLY);
 		_3 = ZEPHIR_IS_EMPTY(&_4);
 	}
 	if (_3) {
@@ -261,7 +261,7 @@ PHP_METHOD(Phalcon_Forms_Form, add)
 	} else {
 		ZEPHIR_INIT_VAR(&elements);
 		array_init(&elements);
-		zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 769, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 768, PH_NOISY_CC | PH_READONLY);
 		zephir_is_iterable(&_5$$5, 0, "phalcon/Forms/Form.zep", 183);
 		if (Z_TYPE_P(&_5$$5) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_5$$5), _7$$5, _8$$5, _6$$5)
@@ -321,7 +321,7 @@ PHP_METHOD(Phalcon_Forms_Form, add)
 		}
 		ZEPHIR_INIT_NVAR(&value);
 		ZEPHIR_INIT_NVAR(&key);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 769, &elements);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 768, &elements);
 	}
 	RETURN_THIS();
 }
@@ -443,7 +443,7 @@ PHP_METHOD(Phalcon_Forms_Form, bind)
 	} else {
 		zephir_get_arrval(&whitelist, whitelist_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(ZEPHIR_IS_EMPTY(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_noformelements_ce);
@@ -461,10 +461,10 @@ PHP_METHOD(Phalcon_Forms_Form, bind)
 		}
 	}
 	if (ZEPHIR_IS_EMPTY(&whitelist)) {
-		zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_1, 770, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_1, 769, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&whitelist, &_3$$6);
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_4, 0, "phalcon/Forms/Form.zep", 237);
 	if (Z_TYPE_P(&_4) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_4), _6, _7, _5)
@@ -561,11 +561,11 @@ PHP_METHOD(Phalcon_Forms_Form, bind)
 			ZEPHIR_INIT_NVAR(&value);
 			ZVAL_COPY(&value, _18);
 			ZEPHIR_OBS_NVAR(&element);
-			zephir_read_property_cached(&_21$$15, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_21$$15, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 			if (!(zephir_array_isset_fetch(&element, &_21$$15, &key, 0))) {
 				ZEPHIR_INIT_NVAR(&element);
 				ZVAL_NULL(&element);
-				zephir_read_property_cached(&_22$$16, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_22$$16, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 				zephir_is_iterable(&_22$$16, 0, "phalcon/Forms/Form.zep", 255);
 				if (Z_TYPE_P(&_22$$16) == IS_ARRAY) {
 					ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_22$$16), _23$$16)
@@ -687,11 +687,11 @@ PHP_METHOD(Phalcon_Forms_Form, bind)
 			ZEPHIR_CALL_METHOD(&value, &data, "current", NULL, 0);
 			zephir_check_call_status();
 				ZEPHIR_OBS_NVAR(&element);
-				zephir_read_property_cached(&_43$$30, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_43$$30, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 				if (!(zephir_array_isset_fetch(&element, &_43$$30, &key, 0))) {
 					ZEPHIR_INIT_NVAR(&element);
 					ZVAL_NULL(&element);
-					zephir_read_property_cached(&_44$$31, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_44$$31, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 					zephir_is_iterable(&_44$$31, 0, "phalcon/Forms/Form.zep", 255);
 					if (Z_TYPE_P(&_44$$31) == IS_ARRAY) {
 						ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_44$$31), _45$$31)
@@ -795,8 +795,8 @@ PHP_METHOD(Phalcon_Forms_Form, bind)
 	}
 	ZEPHIR_INIT_NVAR(&value);
 	ZEPHIR_INIT_NVAR(&key);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 771, &assignData);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 772, &filteredData);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 770, &assignData);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 771, &filteredData);
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("afterbind")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "afterbind", NULL, 0, entity);
 		zephir_check_call_status();
@@ -858,9 +858,9 @@ PHP_METHOD(Phalcon_Forms_Form, clear)
 	} else {
 		ZEPHIR_SEPARATE_PARAM(fields);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 771, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 770, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&data, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 768, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&elements, &_0);
 	if (Z_TYPE_P(fields) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(&data);
@@ -961,7 +961,7 @@ PHP_METHOD(Phalcon_Forms_Form, clear)
 		}
 		ZEPHIR_INIT_NVAR(&field);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 771, &data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 770, &data);
 	RETURN_THIS();
 }
 
@@ -978,7 +978,7 @@ PHP_METHOD(Phalcon_Forms_Form, count)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("elements", 8, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 
@@ -1006,8 +1006,8 @@ PHP_METHOD(Phalcon_Forms_Form, current)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&element);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 773, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 774, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 772, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 773, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&element, &_0, &_1, 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -1042,7 +1042,7 @@ PHP_METHOD(Phalcon_Forms_Form, get)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&element);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!(zephir_array_isset_fetch(&element, &_0, &name_zv, 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_elementnotinform_ce);
@@ -1102,13 +1102,13 @@ PHP_METHOD(Phalcon_Forms_Form, getAttributes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 766, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 765, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(Z_TYPE_P(&_0) == IS_NULL)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_html_attributes_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 41);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 766, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 765, &_1$$3);
 	}
 	RETURN_MM_MEMBER(getThis(), "attributes");
 }
@@ -1160,7 +1160,7 @@ PHP_METHOD(Phalcon_Forms_Form, getFilteredValue)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 772, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 771, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&filteredData, &_0);
 	if (Z_TYPE_P(&filteredData) == IS_ARRAY) {
 		zephir_memory_observe(&value);
@@ -1202,7 +1202,7 @@ PHP_METHOD(Phalcon_Forms_Form, getLabel)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&element);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!(zephir_array_isset_fetch(&element, &_0, &name_zv, 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_elementnotinform_ce);
@@ -1322,7 +1322,7 @@ PHP_METHOD(Phalcon_Forms_Form, getUserOption)
 		defaultValue = &__$null;
 	}
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 765, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 764, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &option_zv, 0))) {
 		RETVAL_ZVAL(defaultValue, 1, 0);
 		RETURN_MM();
@@ -1388,9 +1388,9 @@ PHP_METHOD(Phalcon_Forms_Form, getValue)
 	zephir_get_global(&_POST, SL("_POST"));
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 764, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 763, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&entity, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 771, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 770, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&data, &_0);
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("getcustomvalue")) == SUCCESS)) {
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getcustomvalue", NULL, 0, &name_zv, &entity, &data);
@@ -1455,7 +1455,7 @@ PHP_METHOD(Phalcon_Forms_Form, getValue)
 		RETURN_MM();
 	}
 	zephir_memory_observe(&element);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 768, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&element, &_0, &name_zv, 0)) {
 		ZEPHIR_RETURN_CALL_METHOD(&element, "getdefault", NULL, 0);
 		zephir_check_call_status();
@@ -1502,7 +1502,7 @@ PHP_METHOD(Phalcon_Forms_Form, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &name_zv));
 }
 
@@ -1626,26 +1626,26 @@ PHP_METHOD(Phalcon_Forms_Form, isValid)
 	} else {
 		zephir_get_arrval(&whitelist, whitelist_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		RETURN_MM_BOOL(1);
 	}
 	if (ZEPHIR_IS_EMPTY(&whitelist)) {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_1, 770, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_1, 769, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&whitelist, &_1$$4);
 	}
 	if (Z_TYPE_P(data) != IS_ARRAY) {
-		zephir_read_property_cached(&_2$$5, this_ptr, _zephir_prop_2, 771, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$5, this_ptr, _zephir_prop_2, 770, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(data, &_2$$5);
 	}
 	_3 = Z_TYPE_P(entity) != IS_OBJECT;
 	if (_3) {
 		zephir_memory_observe(&_4);
-		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 764, PH_NOISY_CC);
+		zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 763, PH_NOISY_CC);
 		_3 = Z_TYPE_P(&_4) == IS_OBJECT;
 	}
 	if (_3) {
-		zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_3, 764, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_3, 763, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(entity, &_5$$6);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "bind", NULL, 0, data, entity, &whitelist);
@@ -1670,7 +1670,7 @@ PHP_METHOD(Phalcon_Forms_Form, isValid)
 		ZEPHIR_CALL_METHOD(NULL, &validation, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_8, 0, "phalcon/Forms/Form.zep", 776);
 	if (Z_TYPE_P(&_8) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_8), _9)
@@ -1825,7 +1825,7 @@ PHP_METHOD(Phalcon_Forms_Form, isValid)
 		validationStatus = 0;
 	}
 	if (!(validationStatus)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 767, &messages);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 766, &messages);
 	}
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("aftervalidation")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "aftervalidation", NULL, 0, &messages);
@@ -2137,7 +2137,7 @@ PHP_METHOD(Phalcon_Forms_Form, label)
 		zephir_get_arrval(&attributes, attributes_param);
 	}
 	zephir_memory_observe(&element);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!(zephir_array_isset_fetch(&element, &_0, &name_zv, 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_elementnotinform_ce);
@@ -2202,7 +2202,7 @@ PHP_METHOD(Phalcon_Forms_Form, render)
 		zephir_get_arrval(&attributes, attributes_param);
 	}
 	zephir_memory_observe(&element);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!(zephir_array_isset_fetch(&element, &_0, &name_zv, 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_elementnotinform_ce);
@@ -2247,16 +2247,16 @@ PHP_METHOD(Phalcon_Forms_Form, remove)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, &name_zv)) {
 		zephir_unset_property_array(this_ptr, ZEND_STRL("elements"), &name_zv);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 769, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 768, PH_NOISY_CC | PH_READONLY);
 		zephir_array_unset(&_1$$3, &name_zv, PH_SEPARATE);
 		RETURN_MM_BOOL(1);
 	}
 	ZEPHIR_INIT_VAR(&_2);
 	array_init(&_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 773, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 772, &_2);
 	RETURN_MM_BOOL(0);
 }
 
@@ -2289,11 +2289,11 @@ PHP_METHOD(Phalcon_Forms_Form, rewind)
 
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 774, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 769, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 773, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 768, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&_1, "array_values", NULL, 27, &_0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 773, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 772, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -2347,7 +2347,7 @@ PHP_METHOD(Phalcon_Forms_Form, setAttributes)
 		Z_PARAM_OBJECT_OF_CLASS(attributes, phalcon_html_attributes_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &attributes);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 766, attributes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 765, attributes);
 	RETURN_THISW();
 }
 
@@ -2371,7 +2371,7 @@ PHP_METHOD(Phalcon_Forms_Form, setEntity)
 		Z_PARAM_ZVAL(entity)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &entity);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 764, entity);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 763, entity);
 	RETURN_THISW();
 }
 
@@ -2393,7 +2393,7 @@ PHP_METHOD(Phalcon_Forms_Form, setTagFactory)
 		Z_PARAM_OBJECT_OF_CLASS(tagFactory, phalcon_html_tagfactory_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &tagFactory);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 768, tagFactory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 767, tagFactory);
 	RETURN_THISW();
 }
 
@@ -2417,7 +2417,7 @@ PHP_METHOD(Phalcon_Forms_Form, setValidation)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_validationinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &validation);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 775, validation);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 774, validation);
 	RETURN_THISW();
 }
 
@@ -2446,7 +2446,7 @@ PHP_METHOD(Phalcon_Forms_Form, setWhitelist)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &whitelist_param);
 	zephir_get_arrval(&whitelist, whitelist_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 770, &whitelist);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 769, &whitelist);
 	RETURN_THIS();
 }
 
@@ -2494,7 +2494,7 @@ PHP_METHOD(Phalcon_Forms_Form, setUserOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 765, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 764, &options);
 	RETURN_THIS();
 }
 
@@ -2516,8 +2516,8 @@ PHP_METHOD(Phalcon_Forms_Form, valid)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("position", 8, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 773, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 774, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 772, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 773, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &_1));
 }
 

--- a/ext/phalcon/forms/formslocator.zep.c
+++ b/ext/phalcon/forms/formslocator.zep.c
@@ -108,7 +108,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, __construct)
 	}
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getdefaultservices", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 776, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 775, &_0);
 	zephir_is_iterable(&definitions, 0, "phalcon/Forms/FormsLocator.zep", 78);
 	if (Z_TYPE_P(&definitions) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&definitions), _2, _3, _1)
@@ -220,7 +220,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, get)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 777, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 776, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&factory);
 	zephir_array_fetch(&factory, &_2, &name_zv, PH_NOISY, "phalcon/Forms/FormsLocator.zep", 100);
 	if (Z_TYPE_P(entity) != IS_NULL) {
@@ -229,7 +229,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, get)
 		RETURN_MM();
 	}
 	zephir_memory_observe(&instance);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 778, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 777, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&instance, &_3, &name_zv, 0))) {
 		ZVAL_NULL(&_4$$5);
 		ZEPHIR_CALL_ZVAL_FUNCTION(&instance, &factory, NULL, 0, &_4$$5);
@@ -272,7 +272,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, getElement)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&type_zv);
 	ZVAL_STR_COPY(&type_zv, type);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 776, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 775, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_0, &type_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_unknownformelementtype_ce);
@@ -282,7 +282,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, getElement)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 776, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 775, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_3, &_2, &type_zv, PH_NOISY | PH_READONLY, "phalcon/Forms/FormsLocator.zep", 128);
 	RETURN_CTOR(&_3);
 }
@@ -311,7 +311,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 777, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 776, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &name_zv));
 }
 
@@ -339,7 +339,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, hasElement)
 		Z_PARAM_STR(type)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&type_zv, type);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 776, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 775, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &type_zv));
 }
 
@@ -374,7 +374,7 @@ PHP_METHOD(Phalcon_Forms_FormsLocator, set)
 	factory = ZEND_CALL_ARG(execute_data, 2);
 	ZVAL_STR(&name_zv, name);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("instances"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 778, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 777, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 	zephir_update_property_array(this_ptr, SL("factories"), &name_zv, factory);
 }

--- a/ext/phalcon/forms/loader/arrayloader.zep.c
+++ b/ext/phalcon/forms/loader/arrayloader.zep.c
@@ -66,7 +66,7 @@ PHP_METHOD(Phalcon_Forms_Loader_ArrayLoader, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &definitions_param);
 	zephir_get_arrval(&definitions, definitions_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 779, &definitions);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 778, &definitions);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -98,7 +98,7 @@ PHP_METHOD(Phalcon_Forms_Loader_ArrayLoader, load)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 779, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 778, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Forms/Loader/ArrayLoader.zep", 48);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_0), _2, _3, _1)

--- a/ext/phalcon/forms/loader/jsonloader.zep.c
+++ b/ext/phalcon/forms/loader/jsonloader.zep.c
@@ -66,7 +66,7 @@ PHP_METHOD(Phalcon_Forms_Loader_JsonLoader, __construct)
 		Z_PARAM_STR(source)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&source_zv, source);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 780, &source_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 779, &source_zv);
 }
 
 /**
@@ -107,8 +107,8 @@ PHP_METHOD(Phalcon_Forms_Loader_JsonLoader, load)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&json);
-	zephir_read_property_cached(&json, this_ptr, _zephir_prop_0, 780, PH_NOISY_CC);
-	ZEPHIR_CALL_FUNCTION(&_0, "is_file", NULL, 438, &json);
+	zephir_read_property_cached(&json, this_ptr, _zephir_prop_0, 779, PH_NOISY_CC);
+	ZEPHIR_CALL_FUNCTION(&_0, "is_file", NULL, 440, &json);
 	zephir_check_call_status();
 	_1 = zephir_is_true(&_0);
 	if (_1) {
@@ -135,7 +135,7 @@ PHP_METHOD(Phalcon_Forms_Loader_JsonLoader, load)
 		ZVAL_BOOL(&_6$$4, 1);
 		ZVAL_LONG(&_7$$4, 512);
 		ZVAL_LONG(&_8$$4, 4194304);
-		ZEPHIR_CALL_METHOD(&definitions, &_5$$4, "__invoke", NULL, 381, &json, &_6$$4, &_7$$4, &_8$$4);
+		ZEPHIR_CALL_METHOD(&definitions, &_5$$4, "__invoke", NULL, 383, &json, &_6$$4, &_7$$4, &_8$$4);
 		zephir_check_call_status_or_jump(try_end_1);
 
 	try_end_1:

--- a/ext/phalcon/forms/loader/yamlloader.zep.c
+++ b/ext/phalcon/forms/loader/yamlloader.zep.c
@@ -66,7 +66,7 @@ PHP_METHOD(Phalcon_Forms_Loader_YamlLoader, __construct)
 		Z_PARAM_STR(source)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&source_zv, source);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 781, &source_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 780, &source_zv);
 }
 
 /**
@@ -111,9 +111,9 @@ PHP_METHOD(Phalcon_Forms_Loader_YamlLoader, load)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 781, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 780, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&source, &_3);
-	ZEPHIR_CALL_FUNCTION(&_4, "is_file", NULL, 438, &source);
+	ZEPHIR_CALL_FUNCTION(&_4, "is_file", NULL, 440, &source);
 	zephir_check_call_status();
 	_5 = zephir_is_true(&_4);
 	if (_5) {
@@ -122,7 +122,7 @@ PHP_METHOD(Phalcon_Forms_Loader_YamlLoader, load)
 		_5 = zephir_is_true(&_6);
 	}
 	if (_5) {
-		ZEPHIR_CALL_FUNCTION(&definitions, "yaml_parse_file", NULL, 441, &source);
+		ZEPHIR_CALL_FUNCTION(&definitions, "yaml_parse_file", NULL, 443, &source);
 		zephir_check_call_status();
 	} else {
 		ZEPHIR_CALL_FUNCTION(&definitions, "yaml_parse", NULL, 0, &source);
@@ -170,7 +170,7 @@ PHP_METHOD(Phalcon_Forms_Loader_YamlLoader, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/forms/manager.zep.c
+++ b/ext/phalcon/forms/manager.zep.c
@@ -87,7 +87,7 @@ PHP_METHOD(Phalcon_Forms_Manager, __construct)
 		ZEPHIR_CALL_METHOD(NULL, locator, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 782, locator);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 781, locator);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -161,7 +161,7 @@ PHP_METHOD(Phalcon_Forms_Manager, get)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&form);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 783, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 782, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!(zephir_array_isset_fetch(&form, &_0, &name_zv, 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_formnotregistered_ce);
@@ -203,7 +203,7 @@ PHP_METHOD(Phalcon_Forms_Manager, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 783, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 782, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &name_zv));
 }
 
@@ -259,7 +259,7 @@ PHP_METHOD(Phalcon_Forms_Manager, loadForm)
 		entity = &entity_sub;
 		entity = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 782, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 781, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&locator, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_forms_form_ce);
@@ -268,7 +268,7 @@ PHP_METHOD(Phalcon_Forms_Manager, loadForm)
 	ZEPHIR_CALL_METHOD(&form, &_1, "load", NULL, 0, schema, &locator);
 	zephir_check_call_status();
 	zephir_update_property_array(this_ptr, SL("forms"), &name_zv, &form);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 782, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 781, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZEPHIR_INIT_NVAR(&_2);
 	zephir_create_closure_ex(&_2, NULL, phalcon_34__closure_ce, SL("__invoke"));

--- a/ext/phalcon/html/breadcrumbs.zep.c
+++ b/ext/phalcon/html/breadcrumbs.zep.c
@@ -138,7 +138,7 @@ PHP_METHOD(Phalcon_Html_Breadcrumbs, clear)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 784, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 783, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -185,10 +185,10 @@ PHP_METHOD(Phalcon_Html_Breadcrumbs, remove)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&link_zv);
 	ZVAL_STR_COPY(&link_zv, link);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 784, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 783, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&elements, &_0);
 	zephir_array_unset(&elements, &link_zv, PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 784, &elements);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 783, &elements);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -250,14 +250,14 @@ PHP_METHOD(Phalcon_Html_Breadcrumbs, render)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 784, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 783, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&elements, &_0);
 	if (ZEPHIR_IS_EMPTY(&elements)) {
 		RETURN_MM_STRING("");
 	}
 	ZEPHIR_INIT_VAR(&output);
 	array_init(&output);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 785, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 784, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&template, &_0);
 	ZEPHIR_INIT_VAR(&urls);
 	zephir_array_keys(&urls, &elements);
@@ -357,7 +357,7 @@ PHP_METHOD(Phalcon_Html_Breadcrumbs, render)
 		zephir_array_append(&output, &_15$$7, PH_SEPARATE, "phalcon/Html/Breadcrumbs.zep", 174);
 	}
 	ZEPHIR_INIT_VAR(&_19);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 786, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 785, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_20);
 	ZEPHIR_CONCAT_SVS(&_20, "<dt>", &_0, "</dt>");
 	zephir_fast_join(&_19, &_20, &output);
@@ -386,7 +386,7 @@ PHP_METHOD(Phalcon_Html_Breadcrumbs, setSeparator)
 		Z_PARAM_STR(separator)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&separator_zv, separator);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 786, &separator_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 785, &separator_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/html/escaper.zep.c
+++ b/ext/phalcon/html/escaper.zep.c
@@ -164,7 +164,7 @@ PHP_METHOD(Phalcon_Html_Escaper, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 787, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 786, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_html_escaper_cssescaper_ce);
 	if (zephir_has_constructor(&_1)) {
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Html_Escaper, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 788, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 787, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	object_init_ex(&_2, phalcon_html_escaper_htmlescaper_ce);
 	if (zephir_has_constructor(&_2)) {
@@ -180,7 +180,7 @@ PHP_METHOD(Phalcon_Html_Escaper, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 789, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 788, &_2);
 	ZEPHIR_INIT_VAR(&_3);
 	object_init_ex(&_3, phalcon_html_escaper_jsescaper_ce);
 	if (zephir_has_constructor(&_3)) {
@@ -188,7 +188,7 @@ PHP_METHOD(Phalcon_Html_Escaper, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 790, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 789, &_3);
 	ZEPHIR_INIT_VAR(&_4);
 	object_init_ex(&_4, phalcon_html_escaper_urlescaper_ce);
 	if (zephir_has_constructor(&_4)) {
@@ -196,7 +196,7 @@ PHP_METHOD(Phalcon_Html_Escaper, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 791, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 790, &_4);
 	ZEPHIR_INIT_VAR(&_5);
 	ZVAL_STRING(&_5, "utf-8");
 	if (!ZEPHIR_IS_IDENTICAL(&_5, &encoding_zv)) {
@@ -255,7 +255,7 @@ PHP_METHOD(Phalcon_Html_Escaper, attributes)
 		input = &input_sub;
 		input = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 787, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 786, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "escape", NULL, 0, input);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -290,7 +290,7 @@ PHP_METHOD(Phalcon_Html_Escaper, css)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 788, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 787, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "escape", NULL, 0, &input_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -323,7 +323,7 @@ PHP_METHOD(Phalcon_Html_Escaper, detectEncoding)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 788, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "detectencoding", NULL, 0, &input_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -518,7 +518,7 @@ PHP_METHOD(Phalcon_Html_Escaper, getEncoding)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 788, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getencoding", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -542,7 +542,7 @@ PHP_METHOD(Phalcon_Html_Escaper, getFlags)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 788, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getflags", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -610,7 +610,7 @@ PHP_METHOD(Phalcon_Html_Escaper, html)
 		zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 788, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "escape", NULL, 0, &input_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -645,7 +645,7 @@ PHP_METHOD(Phalcon_Html_Escaper, js)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 790, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 789, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "escape", NULL, 0, &input_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -678,7 +678,7 @@ PHP_METHOD(Phalcon_Html_Escaper, normalizeEncoding)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 788, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "normalizeencoding", NULL, 0, &input_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -704,7 +704,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setAttributeEscaper)
 		Z_PARAM_OBJECT_OF_CLASS(escaper, phalcon_html_escaper_attributeescaper_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &escaper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 787, escaper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 786, escaper);
 	RETURN_THISW();
 }
 
@@ -728,7 +728,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setCssEscaper)
 		Z_PARAM_OBJECT_OF_CLASS(escaper, phalcon_html_escaper_cssescaper_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &escaper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 788, escaper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 787, escaper);
 	RETURN_THISW();
 }
 
@@ -782,7 +782,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setDoubleEncode)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &doubleEncode_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 787, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 786, PH_NOISY_CC | PH_READONLY);
 	if (doubleEncode) {
 		ZVAL_BOOL(&_1, 1);
 	} else {
@@ -790,7 +790,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setDoubleEncode)
 	}
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setdoubleencode", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 788, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 787, PH_NOISY_CC | PH_READONLY);
 	if (doubleEncode) {
 		ZVAL_BOOL(&_3, 1);
 	} else {
@@ -798,7 +798,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setDoubleEncode)
 	}
 	ZEPHIR_CALL_METHOD(NULL, &_2, "setdoubleencode", NULL, 0, &_3);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 788, PH_NOISY_CC | PH_READONLY);
 	if (doubleEncode) {
 		ZVAL_BOOL(&_5, 1);
 	} else {
@@ -806,7 +806,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setDoubleEncode)
 	}
 	ZEPHIR_CALL_METHOD(NULL, &_4, "setdoubleencode", NULL, 0, &_5);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 790, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 789, PH_NOISY_CC | PH_READONLY);
 	if (doubleEncode) {
 		ZVAL_BOOL(&_7, 1);
 	} else {
@@ -814,7 +814,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setDoubleEncode)
 	}
 	ZEPHIR_CALL_METHOD(NULL, &_6, "setdoubleencode", NULL, 0, &_7);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_4, 791, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_4, 790, PH_NOISY_CC | PH_READONLY);
 	if (doubleEncode) {
 		ZVAL_BOOL(&_9, 1);
 	} else {
@@ -872,19 +872,19 @@ PHP_METHOD(Phalcon_Html_Escaper, setEncoding)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&encoding_zv);
 	ZVAL_STR_COPY(&encoding_zv, encoding);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 787, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 786, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setencoding", NULL, 0, &encoding_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 788, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 787, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setencoding", NULL, 0, &encoding_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 788, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_2, "setencoding", NULL, 0, &encoding_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 790, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 789, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_3, "setencoding", NULL, 0, &encoding_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_4, 791, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_4, 790, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_4, "setencoding", NULL, 0, &encoding_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -935,23 +935,23 @@ PHP_METHOD(Phalcon_Html_Escaper, setFlags)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &flags_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 787, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 786, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, flags);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setflags", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 788, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 787, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, flags);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setflags", NULL, 0, &_2);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 789, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 788, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_3, flags);
 	ZEPHIR_CALL_METHOD(NULL, &_2, "setflags", NULL, 0, &_3);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 790, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 789, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_4, flags);
 	ZEPHIR_CALL_METHOD(NULL, &_3, "setflags", NULL, 0, &_4);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_4, 791, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_4, 790, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_5, flags);
 	ZEPHIR_CALL_METHOD(NULL, &_4, "setflags", NULL, 0, &_5);
 	zephir_check_call_status();
@@ -978,7 +978,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setHtmlEscaper)
 		Z_PARAM_OBJECT_OF_CLASS(escaper, phalcon_html_escaper_htmlescaper_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &escaper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 789, escaper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 788, escaper);
 	RETURN_THISW();
 }
 
@@ -1027,7 +1027,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setJsEscaper)
 		Z_PARAM_OBJECT_OF_CLASS(escaper, phalcon_html_escaper_jsescaper_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &escaper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 790, escaper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 789, escaper);
 	RETURN_THISW();
 }
 
@@ -1051,7 +1051,7 @@ PHP_METHOD(Phalcon_Html_Escaper, setUrlEscaper)
 		Z_PARAM_OBJECT_OF_CLASS(escaper, phalcon_html_escaper_urlescaper_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &escaper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 791, escaper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 790, escaper);
 	RETURN_THISW();
 }
 
@@ -1084,7 +1084,7 @@ PHP_METHOD(Phalcon_Html_Escaper, url)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 791, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 790, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "escape", NULL, 0, &input_zv);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/html/escaper/attributeescaper.zep.c
+++ b/ext/phalcon/html/escaper/attributeescaper.zep.c
@@ -271,9 +271,9 @@ PHP_METHOD(Phalcon_Html_Escaper_AttributeEscaper, escapeValue)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&input_zv);
 	ZVAL_STR_COPY(&input_zv, input);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 792, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 793, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 794, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 791, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 792, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 793, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_FUNCTION("htmlspecialchars", NULL, 0, &input_zv, &_0, &_1, &_2);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/html/escaper/htmlescaper.zep.c
+++ b/ext/phalcon/html/escaper/htmlescaper.zep.c
@@ -118,9 +118,9 @@ PHP_METHOD(Phalcon_Html_Escaper_HtmlEscaper, escape)
 	if (Z_TYPE_P(&input_zv) == IS_NULL) {
 		RETURN_MM_STRING("");
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 795, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 796, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 797, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 794, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 795, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 796, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_FUNCTION("htmlspecialchars", NULL, 0, &input_zv, &_0, &_1, &_2);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/html/escaper/traits/escapertrait.zep.c
+++ b/ext/phalcon/html/escaper/traits/escapertrait.zep.c
@@ -215,9 +215,9 @@ PHP_METHOD(Phalcon_Html_Escaper_Traits_EscaperTrait, setDoubleEncode)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &doubleEncode_param);
 	if (doubleEncode) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 798, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 797, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 798, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 797, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -241,7 +241,7 @@ PHP_METHOD(Phalcon_Html_Escaper_Traits_EscaperTrait, setEncoding)
 		Z_PARAM_STR(encoding)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&encoding_zv, encoding);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 799, &encoding_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 798, &encoding_zv);
 	RETURN_THISW();
 }
 
@@ -266,7 +266,7 @@ PHP_METHOD(Phalcon_Html_Escaper_Traits_EscaperTrait, setFlags)
 	zephir_fetch_params_without_memory_grow(1, 0, &flags_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, flags);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 800, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 799, &_0);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/html/helper/anchor.zep.c
+++ b/ext/phalcon/html/helper/anchor.zep.c
@@ -90,9 +90,9 @@ PHP_METHOD(Phalcon_Html_Helper_Anchor, __construct)
 	ZEPHIR_CALL_PARENT(NULL, phalcon_html_helper_anchor_ce, getThis(), "__construct", NULL, 0, escaper, doctype);
 	zephir_check_call_status();
 	if (forceRaw) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 801, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 800, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 801, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 800, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -166,7 +166,7 @@ PHP_METHOD(Phalcon_Html_Helper_Anchor, __invoke)
 	_2 = raw;
 	if (!(_2)) {
 		zephir_memory_observe(&_3);
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 801, PH_NOISY_CC);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 800, PH_NOISY_CC);
 		_2 = zephir_is_true(&_3);
 	}
 	ZEPHIR_INIT_NVAR(&_1);

--- a/ext/phalcon/html/helper/breadcrumbs.zep.c
+++ b/ext/phalcon/html/helper/breadcrumbs.zep.c
@@ -149,8 +149,8 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 802, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 803, url);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 801, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 802, url);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -205,8 +205,8 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, __invoke)
 	} else {
 		ZEPHIR_CPY_WRT(&_0, &delimiter_zv);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 804, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 805, &indent_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 803, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 804, &indent_zv);
 	RETURN_THIS();
 }
 
@@ -280,7 +280,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, add)
 	} else {
 		zephir_get_arrval(&attributes, attributes_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 806, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 805, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&count);
 	ZVAL_LONG(&count, (zephir_fast_count_int(&_0) + 1));
 	ZEPHIR_INIT_VAR(&_1);
@@ -316,7 +316,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, clear)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 806, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 805, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -339,7 +339,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, clearAttributes)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 807, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 806, &_0);
 	RETURN_THIS();
 }
 
@@ -411,9 +411,9 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, remove)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &index_param);
 	zephir_memory_observe(&elements);
-	zephir_read_property_cached(&elements, this_ptr, _zephir_prop_0, 806, PH_NOISY_CC);
+	zephir_read_property_cached(&elements, this_ptr, _zephir_prop_0, 805, PH_NOISY_CC);
 	zephir_array_unset_long(&elements, index, PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 806, &elements);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 805, &elements);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -493,11 +493,11 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, render)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 806, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 805, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		RETURN_MM_STRING("");
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 806, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 805, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&data, &_1);
 	ZEPHIR_INIT_VAR(&output);
 	array_init(&output);
@@ -512,7 +512,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, render)
 		{
 			ZEPHIR_INIT_NVAR(&element);
 			ZVAL_COPY(&element, _2);
-			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 808, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 807, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch_string(&_5$$4, &_4$$4, SL("line"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 249);
 			ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "getlink", &_6, 0, &_5$$4, &element);
 			zephir_check_call_status();
@@ -536,7 +536,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, render)
 			}
 			ZEPHIR_CALL_METHOD(&element, &data, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_10$$5, this_ptr, _zephir_prop_1, 808, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_10$$5, this_ptr, _zephir_prop_1, 807, PH_NOISY_CC | PH_READONLY);
 				zephir_array_fetch_string(&_11$$5, &_10$$5, SL("line"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 249);
 				ZEPHIR_CALL_METHOD(&_9$$5, this_ptr, "getlink", &_6, 0, &_11$$5, &element);
 				zephir_check_call_status();
@@ -544,30 +544,30 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, render)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&element);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 808, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 807, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_13, &_1, SL("last"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 255);
 	ZEPHIR_CALL_METHOD(&_12, this_ptr, "getlink", &_6, 0, &_13, &lastElement);
 	zephir_check_call_status();
 	zephir_array_append(&output, &_12, PH_SEPARATE, "phalcon/Html/Helper/Breadcrumbs.zep", 255);
-	zephir_read_property_cached(&_14, this_ptr, _zephir_prop_2, 802, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_15, this_ptr, _zephir_prop_1, 808, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_14, this_ptr, _zephir_prop_2, 801, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_15, this_ptr, _zephir_prop_1, 807, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_16, &_15, SL("main"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 258);
 	ZEPHIR_INIT_VAR(&_17);
 	zephir_create_array(&_17, 4, 0);
-	zephir_read_property_cached(&_19, this_ptr, _zephir_prop_3, 807, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_19, this_ptr, _zephir_prop_3, 806, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_18, this_ptr, "processattributes", NULL, 0, &_19);
 	zephir_check_call_status();
 	zephir_array_update_string(&_17, SL("attributes"), &_18, PH_COPY | PH_SEPARATE);
 	zephir_memory_observe(&_20);
-	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_4, 804, PH_NOISY_CC);
+	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_4, 803, PH_NOISY_CC);
 	zephir_array_update_string(&_17, SL("delimiter"), &_20, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_20);
-	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_5, 805, PH_NOISY_CC);
+	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_5, 804, PH_NOISY_CC);
 	zephir_array_update_string(&_17, SL("indent"), &_20, PH_COPY | PH_SEPARATE);
 	ZEPHIR_INIT_VAR(&_21);
-	zephir_read_property_cached(&_22, this_ptr, _zephir_prop_5, 805, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_6, 809, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_24, this_ptr, _zephir_prop_4, 804, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_22, this_ptr, _zephir_prop_5, 804, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_23, this_ptr, _zephir_prop_6, 808, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_24, this_ptr, _zephir_prop_4, 803, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_25);
 	ZEPHIR_CONCAT_VVV(&_25, &_22, &_23, &_24);
 	zephir_fast_join(&_21, &_25, &output);
@@ -600,7 +600,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, setAttributes)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &attributes_param);
 	zephir_get_arrval(&attributes, attributes_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 807, &attributes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 806, &attributes);
 	RETURN_THIS();
 }
 
@@ -629,8 +629,8 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, setPrefix)
 		Z_PARAM_STR(prefix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&prefix_zv, prefix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 810, &prefix_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 803, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 809, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 802, &__$null);
 	RETURN_THISW();
 }
 
@@ -653,7 +653,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, setSeparator)
 		Z_PARAM_STR(separator)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&separator_zv, separator);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 809, &separator_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 808, &separator_zv);
 	RETURN_THISW();
 }
 
@@ -695,7 +695,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, setTemplate)
 	zephir_array_update_string(&_0, SL("main"), &main_zv, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_0, SL("line"), &line_zv, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_0, SL("last"), &last_zv, PH_COPY | PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 808, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 807, &_0);
 	RETURN_THIS();
 }
 
@@ -782,11 +782,11 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, getLink)
 	zephir_array_fetch_string(&_0, &element, SL("link"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 339);
 	_1 = !(ZEPHIR_IS_EMPTY(&_0));
 	if (_1) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 803, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 802, PH_NOISY_CC | PH_READONLY);
 		_1 = Z_TYPE_P(&_2) != IS_NULL;
 	}
 	if (_1) {
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 803, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 802, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch_string(&_7$$3, &element, SL("link"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 340);
 		ZEPHIR_CALL_METHOD(&link, &_6$$3, "get", NULL, 0, &_7$$3);
 		zephir_check_call_status();
@@ -794,11 +794,11 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, getLink)
 		zephir_array_fetch_string(&_3, &element, SL("link"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 341);
 		_4 = !(ZEPHIR_IS_EMPTY(&_3));
 		if (_4) {
-			zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 810, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 809, PH_NOISY_CC | PH_READONLY);
 			_4 = !(ZEPHIR_IS_EMPTY(&_5));
 		}
 		if (_4) {
-			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_1, 810, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_1, 809, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch_string(&_9$$4, &element, SL("link"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 342);
 			ZEPHIR_INIT_NVAR(&link);
 			ZEPHIR_CONCAT_VV(&link, &_8$$4, &_9$$4);
@@ -807,8 +807,8 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, getLink)
 			zephir_array_fetch_string(&link, &element, SL("link"), PH_NOISY, "phalcon/Html/Helper/Breadcrumbs.zep", 344);
 		}
 	}
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 805, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_3, 802, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 804, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_3, 801, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_13);
 	zephir_create_array(&_13, 4, 0);
 	zephir_array_fetch_string(&_15, &element, SL("attributes"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 351);
@@ -818,7 +818,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, getLink)
 	zephir_memory_observe(&_16);
 	zephir_array_fetch_string(&_16, &element, SL("icon"), PH_NOISY, "phalcon/Html/Helper/Breadcrumbs.zep", 352);
 	zephir_array_update_string(&_13, SL("icon"), &_16, PH_COPY | PH_SEPARATE);
-	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_4, 811, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_4, 810, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_18, &element, SL("text"), PH_NOISY | PH_READONLY, "phalcon/Html/Helper/Breadcrumbs.zep", 353);
 	ZEPHIR_CALL_METHOD(&_14, &_17, "html", NULL, 0, &_18);
 	zephir_check_call_status();
@@ -826,7 +826,7 @@ PHP_METHOD(Phalcon_Html_Helper_Breadcrumbs, getLink)
 	zephir_array_update_string(&_13, SL("link"), &link, PH_COPY | PH_SEPARATE);
 	ZEPHIR_CALL_METHOD(&_12, &_11, "__invoke", NULL, 0, &template_zv, &_13);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_19, this_ptr, _zephir_prop_5, 804, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_19, this_ptr, _zephir_prop_5, 803, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VVV(return_value, &_10, &_12, &_19);
 	RETURN_MM();
 }

--- a/ext/phalcon/html/helper/button.zep.c
+++ b/ext/phalcon/html/helper/button.zep.c
@@ -90,9 +90,9 @@ PHP_METHOD(Phalcon_Html_Helper_Button, __construct)
 	ZEPHIR_CALL_PARENT(NULL, phalcon_html_helper_button_ce, getThis(), "__construct", NULL, 0, escaper, doctype);
 	zephir_check_call_status();
 	if (forceRaw) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 812, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 811, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 812, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 811, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_Html_Helper_Button, __invoke)
 	_0 = raw;
 	if (!(_0)) {
 		zephir_memory_observe(&_1);
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 812, PH_NOISY_CC);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 811, PH_NOISY_CC);
 		_0 = zephir_is_true(&_1);
 	}
 	ZEPHIR_INIT_VAR(&_2);

--- a/ext/phalcon/html/helper/doctype.zep.c
+++ b/ext/phalcon/html/helper/doctype.zep.c
@@ -122,10 +122,10 @@ PHP_METHOD(Phalcon_Html_Helper_Doctype, __construct)
 
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 5);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 813, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 812, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_GET_CONSTANT(&_1, "PHP_EOL");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 814, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 813, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -178,8 +178,8 @@ PHP_METHOD(Phalcon_Html_Helper_Doctype, __invoke)
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 813, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 814, &delimiter_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 812, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 813, &delimiter_zv);
 	RETURN_THIS();
 }
 
@@ -218,64 +218,64 @@ PHP_METHOD(Phalcon_Html_Helper_Doctype, __toString)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("delimiter", 9, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 813, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 812, PH_NOISY_CC | PH_READONLY);
 	do {
 		if (ZEPHIR_IS_LONG(&_0, 1)) {
-			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\">", &_1$$3);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 2)) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01//EN\"", &_2$$4, "\t\"http://www.w3.org/TR/html4/strict.dtd\">", &_3$$4);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 3)) {
-			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"", &_4$$5, "\t\"http://www.w3.org/TR/html4/loose.dtd\">", &_5$$5);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 4)) {
-			zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Frameset//EN\"", &_6$$6, "\t\"http://www.w3.org/TR/html4/frameset.dtd\">", &_7$$6);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 6)) {
-			zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_9$$7, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$7, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\"", &_8$$7, "\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">", &_9$$7);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 7)) {
-			zephir_read_property_cached(&_10$$8, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_11$$8, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$8, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_11$$8, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"", &_10$$8, "\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">", &_11$$8);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 8)) {
-			zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Frameset//EN\"", &_12$$9, "\t\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd\">", &_13$$9);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 9)) {
-			zephir_read_property_cached(&_14$$10, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_15$$10, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_14$$10, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_15$$10, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.1//EN\"", &_14$$10, "\t\"http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd\">", &_15$$10);
 			return;
 		}
 		if (ZEPHIR_IS_LONG(&_0, 10)) {
-			zephir_read_property_cached(&_16$$11, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_17$$11, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_16$$11, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_17$$11, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CONCAT_SVSV(return_value, "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 2.0//EN\"", &_16$$11, "\t\"http://www.w3.org/MarkUp/DTD/xhtml2.dtd\">", &_17$$11);
 			return;
 		}
 	} while(0);
 
-	zephir_read_property_cached(&_18, this_ptr, _zephir_prop_1, 814, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_18, this_ptr, _zephir_prop_1, 813, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_SV(return_value, "<!DOCTYPE html>", &_18);
 	return;
 }

--- a/ext/phalcon/html/helper/element.zep.c
+++ b/ext/phalcon/html/helper/element.zep.c
@@ -90,9 +90,9 @@ PHP_METHOD(Phalcon_Html_Helper_Element, __construct)
 	ZEPHIR_CALL_PARENT(NULL, phalcon_html_helper_element_ce, getThis(), "__construct", NULL, 0, escaper, doctype);
 	zephir_check_call_status();
 	if (forceRaw) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 815, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 814, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 815, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 814, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -160,7 +160,7 @@ PHP_METHOD(Phalcon_Html_Helper_Element, __invoke)
 	_0 = raw;
 	if (!(_0)) {
 		zephir_memory_observe(&_1);
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 815, PH_NOISY_CC);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 814, PH_NOISY_CC);
 		_0 = zephir_is_true(&_1);
 	}
 	ZVAL_BOOL(&_2, _0);

--- a/ext/phalcon/html/helper/friendlytitle.zep.c
+++ b/ext/phalcon/html/helper/friendlytitle.zep.c
@@ -77,7 +77,7 @@ PHP_METHOD(Phalcon_Html_Helper_FriendlyTitle, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 816, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 815, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_Html_Helper_FriendlyTitle, __invoke)
 	}
 	/* try_start_1: */
 
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 816, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 815, PH_NOISY_CC | PH_READONLY);
 		if (lowercase) {
 			ZVAL_BOOL(&_1$$3, 1);
 		} else {

--- a/ext/phalcon/html/helper/input/checkboxgroup.zep.c
+++ b/ext/phalcon/html/helper/input/checkboxgroup.zep.c
@@ -82,20 +82,20 @@ PHP_METHOD(Phalcon_Html_Helper_Input_CheckboxGroup, isChecked)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&value_zv);
 	ZVAL_STR_COPY(&value_zv, value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 817, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 816, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		RETURN_MM_BOOL(0);
 	}
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 817, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 816, PH_NOISY_CC);
 	if (Z_TYPE_P(&_1) == IS_ARRAY) {
 		zephir_memory_observe(&selected);
-		zephir_read_property_cached(&selected, this_ptr, _zephir_prop_0, 817, PH_NOISY_CC);
+		zephir_read_property_cached(&selected, this_ptr, _zephir_prop_0, 816, PH_NOISY_CC);
 	} else {
 		ZEPHIR_INIT_VAR(&_2$$5);
 		zephir_create_array(&_2$$5, 1, 0);
 		zephir_memory_observe(&_3$$5);
-		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_0, 817, PH_NOISY_CC);
+		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_0, 816, PH_NOISY_CC);
 		zephir_array_fast_append(&_2$$5, &_3$$5);
 		ZEPHIR_CPY_WRT(&selected, &_2$$5);
 	}

--- a/ext/phalcon/html/helper/input/generic.zep.c
+++ b/ext/phalcon/html/helper/input/generic.zep.c
@@ -92,7 +92,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Generic, __construct)
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_html_helper_input_generic_ce, getThis(), "__construct", NULL, 0, escaper, doctype);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 818, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 817, &type_zv);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -119,7 +119,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Generic, setType)
 		Z_PARAM_STR(type)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&type_zv, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 818, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 817, &type_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/html/helper/input/radiogroup.zep.c
+++ b/ext/phalcon/html/helper/input/radiogroup.zep.c
@@ -77,12 +77,12 @@ PHP_METHOD(Phalcon_Html_Helper_Input_RadioGroup, isChecked)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&value_zv);
 	ZVAL_STR_COPY(&value_zv, value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 819, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 818, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		RETURN_MM_BOOL(0);
 	}
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 819, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 818, PH_NOISY_CC);
 	zephir_cast_to_string(&_2, &_1);
 	RETURN_MM_BOOL(ZEPHIR_IS_IDENTICAL(&_2, &value_zv));
 }

--- a/ext/phalcon/html/helper/input/select.zep.c
+++ b/ext/phalcon/html/helper/input/select.zep.c
@@ -136,7 +136,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, add)
 	ZEPHIR_INIT_VAR(&_3);
 	zephir_create_array(&_3, 4, 0);
 	zephir_memory_observe(&_4);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 820, PH_NOISY_CC);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 819, PH_NOISY_CC);
 	zephir_array_fast_append(&_3, &_4);
 	zephir_array_fast_append(&_3, &text_zv);
 	zephir_array_fast_append(&_3, &attributes);
@@ -229,7 +229,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, addPlaceholder)
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 4, 0);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 820, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 819, PH_NOISY_CC);
 	zephir_array_fast_append(&_2, &_3);
 	zephir_array_fast_append(&_2, &text_zv);
 	zephir_array_fast_append(&_2, &attributes);
@@ -567,7 +567,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, optGroup)
 	} else {
 		zephir_get_arrval(&attributes, attributes_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 821, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 820, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		zephir_create_array(&_1$$3, 3, 0);
@@ -585,15 +585,15 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, optGroup)
 		zephir_update_property_array_append(this_ptr, SL("store"), &_1$$3);
 		ZEPHIR_INIT_NVAR(&_2$$3);
 		ZVAL_LONG(&_2$$3, 1);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 822, PH_NOISY_CC);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 821, PH_NOISY_CC);
 		ZEPHIR_ADD_ASSIGN(&_5$$3, &_2$$3)
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 822, &_5$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 821, &_5$$3);
 	} else {
 		ZEPHIR_INIT_VAR(&_7$$4);
 		ZVAL_LONG(&_7$$4, 1);
-		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_1, 822, PH_NOISY_CC);
+		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_1, 821, PH_NOISY_CC);
 		ZEPHIR_SUB_ASSIGN(&_6$$4, &_7$$4)
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 822, &_6$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 821, &_6$$4);
 		ZEPHIR_INIT_VAR(&_8$$4);
 		zephir_create_array(&_8$$4, 3, 0);
 		ZEPHIR_INIT_VAR(&_9$$4);
@@ -608,11 +608,11 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, optGroup)
 		zephir_update_property_array_append(this_ptr, SL("store"), &_8$$4);
 	}
 	zephir_memory_observe(&_11);
-	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_0, 821, PH_NOISY_CC);
+	zephir_read_property_cached(&_11, this_ptr, _zephir_prop_0, 820, PH_NOISY_CC);
 	if (!zephir_is_true(&_11)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 821, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 820, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 821, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 820, &__$false);
 	}
 	RETURN_THIS();
 }
@@ -663,7 +663,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, placeholder)
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 4, 0);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 820, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 819, PH_NOISY_CC);
 	zephir_array_fast_append(&_2, &_3);
 	zephir_array_fast_append(&_2, &text_zv);
 	ZEPHIR_INIT_VAR(&_4);
@@ -702,7 +702,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, selected)
 		Z_PARAM_STR(selected)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&selected_zv, selected);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 823, &selected_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 822, &selected_zv);
 	RETURN_THISW();
 }
 
@@ -739,9 +739,9 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, strict)
 	} else {
 		}
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 824, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 823, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 824, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 823, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -856,14 +856,14 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select, processValue)
 	}
 	if (_0) {
 		zephir_array_update_string(&attributes, SL("value"), &value_zv, PH_COPY | PH_SEPARATE);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 823, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 822, PH_NOISY_CC | PH_READONLY);
 		if (!ZEPHIR_IS_STRING_IDENTICAL(&_1$$3, "")) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 824, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 823, PH_NOISY_CC | PH_READONLY);
 			if (zephir_is_true(&_2$$4)) {
-				zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_0, 823, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_0, 822, PH_NOISY_CC | PH_READONLY);
 				matched = ZEPHIR_IS_IDENTICAL(&value_zv, &_3$$5);
 			} else {
-				zephir_read_property_cached(&_4$$6, this_ptr, _zephir_prop_0, 823, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_4$$6, this_ptr, _zephir_prop_0, 822, PH_NOISY_CC | PH_READONLY);
 				matched = ZEPHIR_IS_EQUAL(&value_zv, &_4$$6);
 			}
 			if (matched) {

--- a/ext/phalcon/html/helper/input/select/arraydata.zep.c
+++ b/ext/phalcon/html/helper/input/select/arraydata.zep.c
@@ -95,8 +95,8 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ArrayData, __construct)
 	} else {
 		zephir_get_arrval(&attributes, attributes_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 825, &data);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 826, &attributes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 824, &data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 825, &attributes);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/html/helper/input/select/resultsetdata.zep.c
+++ b/ext/phalcon/html/helper/input/select/resultsetdata.zep.c
@@ -117,9 +117,9 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 827, resultset);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 828, &using);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 829, &attributesMap);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 826, resultset);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 827, &using);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 828, &attributesMap);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -143,7 +143,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, getAttributes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 830, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 829, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "resolve", NULL, 0);
 		zephir_check_call_status();
@@ -169,7 +169,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, getOptions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 831, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 830, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "resolve", NULL, 0);
 		zephir_check_call_status();
@@ -283,17 +283,17 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, resolve)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 828, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 827, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&usingZero);
 	zephir_array_fetch_long(&usingZero, &_0, 0, PH_NOISY, "phalcon/Html/Helper/Input/Select/ResultsetData.zep", 123);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 828, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 827, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&usingOne);
 	zephir_array_fetch_long(&usingOne, &_1, 1, PH_NOISY, "phalcon/Html/Helper/Input/Select/ResultsetData.zep", 124);
 	ZEPHIR_INIT_VAR(&options);
 	array_init(&options);
 	ZEPHIR_INIT_VAR(&attrs);
 	array_init(&attrs);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 827, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 826, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_2, 0, "phalcon/Html/Helper/Input/Select/ResultsetData.zep", 159);
 	if (Z_TYPE_P(&_2) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_2), _3)
@@ -319,11 +319,11 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, resolve)
 			zephir_check_call_status();
 			zephir_array_update_zval(&options, &optionValue, &optionText, PH_COPY | PH_SEPARATE);
 			ZEPHIR_OBS_NVAR(&_8$$3);
-			zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_2, 829, PH_NOISY_CC);
+			zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_2, 828, PH_NOISY_CC);
 			if (!(ZEPHIR_IS_EMPTY(&_8$$3))) {
 				ZEPHIR_INIT_NVAR(&optionAttrs);
 				array_init(&optionAttrs);
-				zephir_read_property_cached(&_9$$5, this_ptr, _zephir_prop_2, 829, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_9$$5, this_ptr, _zephir_prop_2, 828, PH_NOISY_CC | PH_READONLY);
 				zephir_is_iterable(&_9$$5, 0, "phalcon/Html/Helper/Input/Select/ResultsetData.zep", 153);
 				if (Z_TYPE_P(&_9$$5) == IS_ARRAY) {
 					ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_9$$5), _11$$5, _12$$5, _10$$5)
@@ -431,11 +431,11 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, resolve)
 				zephir_check_call_status();
 				zephir_array_update_zval(&options, &optionValue, &optionText, PH_COPY | PH_SEPARATE);
 				ZEPHIR_OBS_NVAR(&_24$$15);
-				zephir_read_property_cached(&_24$$15, this_ptr, _zephir_prop_2, 829, PH_NOISY_CC);
+				zephir_read_property_cached(&_24$$15, this_ptr, _zephir_prop_2, 828, PH_NOISY_CC);
 				if (!(ZEPHIR_IS_EMPTY(&_24$$15))) {
 					ZEPHIR_INIT_NVAR(&optionAttrs);
 					array_init(&optionAttrs);
-					zephir_read_property_cached(&_25$$17, this_ptr, _zephir_prop_2, 829, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_25$$17, this_ptr, _zephir_prop_2, 828, PH_NOISY_CC | PH_READONLY);
 					zephir_is_iterable(&_25$$17, 0, "phalcon/Html/Helper/Input/Select/ResultsetData.zep", 153);
 					if (Z_TYPE_P(&_25$$17) == IS_ARRAY) {
 						ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_25$$17), _27$$17, _28$$17, _26$$17)
@@ -508,8 +508,8 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Select_ResultsetData, resolve)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&option);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 831, &options);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 830, &attrs);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 830, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 829, &attrs);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/html/helper/input/textarea.zep.c
+++ b/ext/phalcon/html/helper/input/textarea.zep.c
@@ -74,11 +74,11 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Textarea, __toString)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 832, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 831, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&attributes, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	array_init(&_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 832, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 831, &_1);
 	zephir_memory_observe(&value);
 	if (!(zephir_array_isset_string_fetch(&value, &attributes, SL("value"), 0))) {
 		ZEPHIR_INIT_NVAR(&value);
@@ -86,7 +86,7 @@ PHP_METHOD(Phalcon_Html_Helper_Input_Textarea, __toString)
 	}
 	zephir_array_unset_string(&attributes, SL("type"), PH_SEPARATE);
 	zephir_array_unset_string(&attributes, SL("value"), PH_SEPARATE);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 833, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 832, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "renderfullelement", NULL, 0, &_2, &value, &attributes);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/html/helper/label.zep.c
+++ b/ext/phalcon/html/helper/label.zep.c
@@ -90,9 +90,9 @@ PHP_METHOD(Phalcon_Html_Helper_Label, __construct)
 	ZEPHIR_CALL_PARENT(NULL, phalcon_html_helper_label_ce, getThis(), "__construct", NULL, 0, escaper, doctype);
 	zephir_check_call_status();
 	if (forceRaw) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 834, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 833, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 834, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 833, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_Html_Helper_Label, __invoke)
 	_0 = raw;
 	if (!(_0)) {
 		zephir_memory_observe(&_1);
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 834, PH_NOISY_CC);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 833, PH_NOISY_CC);
 		_0 = zephir_is_true(&_1);
 	}
 	ZEPHIR_INIT_VAR(&_2);

--- a/ext/phalcon/html/helper/preload.zep.c
+++ b/ext/phalcon/html/helper/preload.zep.c
@@ -81,7 +81,7 @@ PHP_METHOD(Phalcon_Html_Helper_Preload, __construct)
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_html_helper_preload_ce, getThis(), "__construct", NULL, 0, escaper);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 835, response);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 834, response);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -157,7 +157,7 @@ PHP_METHOD(Phalcon_Html_Helper_Preload, __invoke)
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_fast_array_merge(&_0, &overrides, &attributes);
 	ZEPHIR_CPY_WRT(&overrides, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 835, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 834, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_1) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&link);
 		object_init_ex(&link, phalcon_html_link_link_ce);
@@ -182,7 +182,7 @@ PHP_METHOD(Phalcon_Html_Helper_Preload, __invoke)
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&header);
 		ZEPHIR_CONCAT_SV(&header, "Link: ", &_4$$3);
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 835, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 834, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_6$$3, "setrawheader", NULL, 0, &header);
 		zephir_check_call_status();
 	}

--- a/ext/phalcon/html/helper/title.zep.c
+++ b/ext/phalcon/html/helper/title.zep.c
@@ -124,8 +124,8 @@ PHP_METHOD(Phalcon_Html_Helper_Title, __invoke)
 	} else {
 		ZEPHIR_CPY_WRT(&_0, &delimiter_zv);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 836, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 837, &indent_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 835, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 836, &indent_zv);
 	RETURN_THIS();
 }
 
@@ -184,28 +184,28 @@ PHP_METHOD(Phalcon_Html_Helper_Title, __toString)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 838, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 837, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_create_array(&_1, 1, 0);
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 839, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 838, PH_NOISY_CC);
 	zephir_array_fast_append(&_1, &_2);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 840, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 839, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&items, "array_merge", NULL, 195, &_0, &_1, &_3);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_4);
 	array_init(&_4);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 840, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 839, &_4);
 	ZEPHIR_INIT_VAR(&_5);
 	array_init(&_5);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 838, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 837, &_5);
 	ZEPHIR_INIT_VAR(&_6);
 	ZEPHIR_INIT_NVAR(&_6);
 	ZVAL_STRING(&_6, "");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 839, &_6);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_3, 837, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 838, &_6);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_3, 836, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_6);
-	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_4, 841, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_4, 840, PH_NOISY_CC | PH_READONLY);
 	zephir_fast_join(&_6, &_9, &items);
 	ZEPHIR_INIT_VAR(&_10);
 	array_init(&_10);
@@ -214,7 +214,7 @@ PHP_METHOD(Phalcon_Html_Helper_Title, __toString)
 	ZVAL_BOOL(&_12, 1);
 	ZEPHIR_CALL_METHOD(&_8, this_ptr, "renderfullelement", NULL, 0, &_11, &_6, &_10, &_12);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_5, 836, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_5, 835, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VVV(return_value, &_7, &_8, &_12);
 	RETURN_MM();
 }
@@ -261,7 +261,7 @@ PHP_METHOD(Phalcon_Html_Helper_Title, append)
 	if (raw) {
 		ZEPHIR_CPY_WRT(&_0, &text);
 	} else {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 842, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 841, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_0, &_1, "html", NULL, 0, &text);
 		zephir_check_call_status();
 	}
@@ -327,12 +327,12 @@ PHP_METHOD(Phalcon_Html_Helper_Title, set)
 	if (raw) {
 		ZEPHIR_CPY_WRT(&_0, &text);
 	} else {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 842, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 841, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_0, &_1, "html", NULL, 0, &text);
 		zephir_check_call_status();
 	}
 	zephir_get_strval(&text, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 839, &text);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 838, &text);
 	RETURN_THIS();
 }
 
@@ -385,11 +385,11 @@ PHP_METHOD(Phalcon_Html_Helper_Title, setSeparator)
 	if (raw) {
 		ZEPHIR_CPY_WRT(&_0, &separator_zv);
 	} else {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 842, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 841, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_0, &_1, "html", NULL, 0, &separator_zv);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 841, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 840, &_0);
 	RETURN_THIS();
 }
 
@@ -441,18 +441,18 @@ PHP_METHOD(Phalcon_Html_Helper_Title, prepend)
 	if (raw) {
 		ZEPHIR_CPY_WRT(&_0, &text);
 	} else {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 842, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 841, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_0, &_1, "html", NULL, 0, &text);
 		zephir_check_call_status();
 	}
 	zephir_get_strval(&text, &_0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 838, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 837, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&prepend, &_2);
 	ZEPHIR_MAKE_REF(&prepend);
 	ZEPHIR_CALL_FUNCTION(NULL, "array_unshift", NULL, 0, &prepend, &text);
 	ZEPHIR_UNREF(&prepend);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 838, &prepend);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 837, &prepend);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/html/helper/voidtag.zep.c
+++ b/ext/phalcon/html/helper/voidtag.zep.c
@@ -90,10 +90,10 @@ PHP_METHOD(Phalcon_Html_Helper_VoidTag, __invoke)
 	}
 	ZEPHIR_INIT_VAR(&closeTag);
 	ZVAL_STRING(&closeTag, "");
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 843, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 842, PH_NOISY_CC | PH_READONLY);
 	_1 = Z_TYPE_P(&_0) != IS_NULL;
 	if (_1) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 843, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 842, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_3, &_2, "gettype", NULL, 0);
 		zephir_check_call_status();
 		_1 = ZEPHIR_GT_LONG(&_3, 5);

--- a/ext/phalcon/html/tagfactory.zep.c
+++ b/ext/phalcon/html/tagfactory.zep.c
@@ -202,17 +202,17 @@ PHP_METHOD(Phalcon_Html_TagFactory, __construct)
 		url = &url_sub;
 		url = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 844, escaper);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 845, response);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 846, url);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 843, escaper);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 844, response);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 845, url);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, phalcon_html_helper_doctype_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 847, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 846, &_0);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getdefaultservices", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 848, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 847, &_1);
 	zephir_is_iterable(&services, 0, "phalcon/Html/TagFactory.zep", 169);
 	if (Z_TYPE_P(&services) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&services), _3, _4, _2)
@@ -325,7 +325,7 @@ PHP_METHOD(Phalcon_Html_TagFactory, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 848, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 847, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &name_zv));
 }
 
@@ -370,7 +370,7 @@ PHP_METHOD(Phalcon_Html_TagFactory, newInstance)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 848, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 847, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_0, &name_zv))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_html_exceptions_servicenotregistered_ce);
@@ -380,9 +380,9 @@ PHP_METHOD(Phalcon_Html_TagFactory, newInstance)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 849, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 848, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_2, &name_zv))) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 848, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 847, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&factory);
 		zephir_array_fetch(&factory, &_3$$4, &name_zv, PH_NOISY, "phalcon/Html/TagFactory.zep", 216);
 		ZEPHIR_INIT_VAR(&_4$$4);
@@ -390,7 +390,7 @@ PHP_METHOD(Phalcon_Html_TagFactory, newInstance)
 		zephir_check_call_status();
 		zephir_update_property_array(this_ptr, SL("instances"), &name_zv, &_4$$4);
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 849, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 848, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_6, &_5, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Html/TagFactory.zep", 220);
 	RETURN_CTOR(&_6);
 }
@@ -426,7 +426,7 @@ PHP_METHOD(Phalcon_Html_TagFactory, set)
 	ZVAL_STR(&name_zv, name);
 	zephir_update_property_array(this_ptr, SL("factories"), &name_zv, definition);
 	zephir_unset_property_array(this_ptr, ZEND_STRL("instances"), &name_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 849, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 848, PH_NOISY_CC | PH_READONLY);
 	zephir_array_unset(&_0, &name_zv, PH_SEPARATE);
 }
 
@@ -462,11 +462,11 @@ PHP_METHOD(Phalcon_Html_TagFactory, getDefaultServices)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 844, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 843, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&escaper, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 845, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 844, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&response, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 846, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 845, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&url, &_0);
 	zephir_create_array(return_value, 59, 0);
 	ZEPHIR_INIT_VAR(&_1);

--- a/ext/phalcon/http/cookie.zep.c
+++ b/ext/phalcon/http/cookie.zep.c
@@ -217,23 +217,23 @@ PHP_METHOD(Phalcon_Http_Cookie, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 850, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 849, &name_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, expire);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 851, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 852, &path_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 850, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 851, &path_zv);
 	if (secure) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 853, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 852, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 853, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 852, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 854, &domain_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 853, &domain_zv);
 	if (httpOnly) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 855, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 854, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 855, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 854, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 856, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 855, &options);
 	if (Z_TYPE_P(value) != IS_NULL) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setvalue", NULL, 0, value);
 		zephir_check_call_status();
@@ -321,15 +321,15 @@ PHP_METHOD(Phalcon_Http_Cookie, delete)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 850, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 849, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&name, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 854, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 853, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&domain, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 852, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 851, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&path, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 853, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 852, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&secure, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 855, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 854, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&httpOnly, &_0);
 	ZEPHIR_CALL_METHOD(&session, this_ptr, "getstartedsession", NULL, 0);
 	zephir_check_call_status();
@@ -339,8 +339,8 @@ PHP_METHOD(Phalcon_Http_Cookie, delete)
 		ZEPHIR_CALL_METHOD(NULL, &session, "remove", NULL, 0, &_1$$3);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 857, &__$null);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 856, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 856, &__$null);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 855, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	ZEPHIR_INIT_VAR(&_3);
 	zephir_time(&_3);
@@ -395,7 +395,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getDomain)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
@@ -421,7 +421,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getExpiration)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
@@ -447,7 +447,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getHttpOnly)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
@@ -491,7 +491,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getPath)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
@@ -518,7 +518,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getSecure)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
@@ -611,25 +611,25 @@ PHP_METHOD(Phalcon_Http_Cookie, getValue)
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(&container);
 	ZVAL_NULL(&container);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 850, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 849, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&name, &_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 859, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 858, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&_1)) {
 		zephir_memory_observe(&value);
 		if (!(zephir_array_isset_fetch(&value, &_COOKIE, &name, 0))) {
 			RETVAL_ZVAL(defaultValue, 1, 0);
 			RETURN_MM();
 		}
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 860, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 859, PH_NOISY_CC | PH_READONLY);
 		if (zephir_is_true(&_2$$4)) {
-			zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_4, 861, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_4, 860, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&container, &_3$$6);
 			if (Z_TYPE_P(&container) == IS_NULL) {
 				ZEPHIR_INIT_VAR(&_4$$7);
@@ -654,7 +654,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getValue)
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_5, 862, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_5, 861, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&signKey, &_3$$6);
 			if (Z_TYPE_P(&signKey) == IS_STRING) {
 				ZEPHIR_CALL_METHOD(&decryptedValue, &crypt, "decryptbase64", NULL, 0, &value, &signKey);
@@ -666,13 +666,13 @@ PHP_METHOD(Phalcon_Http_Cookie, getValue)
 		} else {
 			ZEPHIR_CPY_WRT(&decryptedValue, &value);
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 857, &decryptedValue);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 856, &decryptedValue);
 		if (Z_TYPE_P(filters) != IS_NULL) {
-			zephir_read_property_cached(&_8$$12, this_ptr, _zephir_prop_7, 863, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$12, this_ptr, _zephir_prop_7, 862, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&filter, &_8$$12);
 			if (Z_TYPE_P(&filter) != IS_OBJECT) {
 				if (Z_TYPE_P(&container) == IS_NULL) {
-					zephir_read_property_cached(&_9$$14, this_ptr, _zephir_prop_4, 861, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_9$$14, this_ptr, _zephir_prop_4, 860, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CPY_WRT(&container, &_9$$14);
 					if (Z_TYPE_P(&container) == IS_NULL) {
 						ZEPHIR_INIT_VAR(&_10$$15);
@@ -689,7 +689,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getValue)
 				ZEPHIR_CALL_METHOD(&_11$$13, &container, "getshared", NULL, 0, &_12$$13);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&filter, &_11$$13);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 863, &filter);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 862, &filter);
 			}
 			ZEPHIR_RETURN_CALL_METHOD(&filter, "sanitize", NULL, 0, &decryptedValue, filters);
 			zephir_check_call_status();
@@ -757,7 +757,7 @@ PHP_METHOD(Phalcon_Http_Cookie, restore)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(&session, this_ptr, "getstartedsession", NULL, 0);
 		zephir_check_call_status();
@@ -767,28 +767,28 @@ PHP_METHOD(Phalcon_Http_Cookie, restore)
 			ZEPHIR_CALL_METHOD(&definition, &session, "get", NULL, 0, &_1$$4);
 			zephir_check_call_status();
 			if (zephir_array_isset_string_fetch(&expire, &definition, SL("expire"), 1)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 851, &expire);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 850, &expire);
 			}
 			if (zephir_array_isset_string_fetch(&domain, &definition, SL("domain"), 1)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 854, &domain);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 853, &domain);
 			}
 			if (zephir_array_isset_string_fetch(&path, &definition, SL("path"), 1)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 852, &path);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 851, &path);
 			}
 			if (zephir_array_isset_string_fetch(&secure, &definition, SL("secure"), 1)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 853, &secure);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 852, &secure);
 			}
 			if (zephir_array_isset_string_fetch(&httpOnly, &definition, SL("httpOnly"), 1)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 855, &httpOnly);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 854, &httpOnly);
 			}
 			if (zephir_array_isset_string_fetch(&options, &definition, SL("options"), 1)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 856, &options);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 855, &options);
 			}
 		}
 		if (1) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 858, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 857, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 858, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 857, &__$false);
 		}
 	}
 	RETURN_THIS();
@@ -884,23 +884,23 @@ PHP_METHOD(Phalcon_Http_Cookie, send)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 850, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 849, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&name, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 857, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 856, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&value, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 851, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 850, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&expire, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 854, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 853, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&domain, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 852, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 851, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&path, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 853, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 852, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&secure, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 855, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 854, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&httpOnly, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_7, 856, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_7, 855, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_8, 861, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_8, 860, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	ZEPHIR_INIT_VAR(&definition);
 	array_init(&definition);
@@ -923,7 +923,7 @@ PHP_METHOD(Phalcon_Http_Cookie, send)
 			zephir_check_call_status();
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_9, 860, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_9, 859, PH_NOISY_CC | PH_READONLY);
 	_3 = zephir_is_true(&_0);
 	if (_3) {
 		_3 = !(ZEPHIR_IS_EMPTY(&value));
@@ -952,7 +952,7 @@ PHP_METHOD(Phalcon_Http_Cookie, send)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_8$$5, this_ptr, _zephir_prop_10, 862, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$5, this_ptr, _zephir_prop_10, 861, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&signKey, &_8$$5);
 		if (Z_TYPE_P(&signKey) == IS_STRING) {
 			zephir_cast_to_string(&_9$$8, &value);
@@ -1025,12 +1025,12 @@ PHP_METHOD(Phalcon_Http_Cookie, setDomain)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&domain_zv);
 	ZVAL_STR_COPY(&domain_zv, domain);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 854, &domain_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 853, &domain_zv);
 	RETURN_THIS();
 }
 
@@ -1061,14 +1061,14 @@ PHP_METHOD(Phalcon_Http_Cookie, setExpiration)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &expire_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
 	}
 	ZVAL_UNDEF(&_1);
 	ZVAL_LONG(&_1, expire);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 851, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 850, &_1);
 	RETURN_THIS();
 }
 
@@ -1101,15 +1101,15 @@ PHP_METHOD(Phalcon_Http_Cookie, setHttpOnly)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &httpOnly_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
 	}
 	if (httpOnly) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 855, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 854, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 855, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 854, &__$false);
 	}
 	RETURN_THIS();
 }
@@ -1137,7 +1137,7 @@ PHP_METHOD(Phalcon_Http_Cookie, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 856, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 855, &options);
 	RETURN_THIS();
 }
 
@@ -1170,12 +1170,12 @@ PHP_METHOD(Phalcon_Http_Cookie, setPath)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&path_zv);
 	ZVAL_STR_COPY(&path_zv, path);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 852, &path_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 851, &path_zv);
 	RETURN_THIS();
 }
 
@@ -1208,15 +1208,15 @@ PHP_METHOD(Phalcon_Http_Cookie, setSecure)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &secure_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 858, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 857, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "restore", NULL, 0);
 		zephir_check_call_status();
 	}
 	if (secure) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 853, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 852, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 853, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 852, &__$false);
 	}
 	RETURN_THIS();
 }
@@ -1263,7 +1263,7 @@ PHP_METHOD(Phalcon_Http_Cookie, setSignKey)
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "assertsignkeyislongenough", NULL, 0, &signKey_zv);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 862, &signKey_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 861, &signKey_zv);
 	RETURN_THIS();
 }
 
@@ -1293,11 +1293,11 @@ PHP_METHOD(Phalcon_Http_Cookie, setValue)
 		Z_PARAM_ZVAL(value)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &value);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 857, value);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 856, value);
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 859, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 858, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 859, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 858, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1323,9 +1323,9 @@ PHP_METHOD(Phalcon_Http_Cookie, useEncryption)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &useEncryption_param);
 	if (useEncryption) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 860, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 859, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 860, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 859, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1379,7 +1379,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getSessionKey)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("name", 4, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 850, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 849, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_SV(return_value, "_PHCOOKIE_", &_0);
 	return;
 }
@@ -1409,7 +1409,7 @@ PHP_METHOD(Phalcon_Http_Cookie, getStartedSession)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 861, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 860, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	_1 = Z_TYPE_P(&container) != IS_OBJECT;
 	if (!(_1)) {

--- a/ext/phalcon/http/request.zep.c
+++ b/ext/phalcon/http/request.zep.c
@@ -249,13 +249,13 @@ PHP_METHOD(Phalcon_Http_Request, getAttributes)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 864, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 863, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_http_request_bag_attributebag_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 864, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 863, &_1$$3);
 	}
 	RETURN_MM_MEMBER(getThis(), "attributes");
 }
@@ -450,16 +450,16 @@ PHP_METHOD(Phalcon_Http_Request, getClientAddress)
 		RETURN_MM_BOOL(0);
 	}
 	if (trustForwardedHeader) {
-		zephir_read_property_cached(&_0$$4, this_ptr, _zephir_prop_0, 865, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$4, this_ptr, _zephir_prop_0, 864, PH_NOISY_CC | PH_READONLY);
 		if (!ZEPHIR_IS_STRING_IDENTICAL(&_0$$4, "")) {
 			zephir_memory_observe(&trustedProxyHeaderIp);
-			zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_0, 865, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_0, 864, PH_NOISY_CC | PH_READONLY);
 			if (zephir_array_isset_fetch(&trustedProxyHeaderIp, &server, &_1$$5, 0)) {
 				RETURN_CCTOR(&trustedProxyHeaderIp);
 			}
 		}
 		zephir_memory_observe(&_2$$4);
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 866, PH_NOISY_CC);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 865, PH_NOISY_CC);
 		_3$$4 = !(ZEPHIR_IS_EMPTY(&_2$$4));
 		if (_3$$4) {
 			ZEPHIR_CALL_METHOD(&_4$$4, this_ptr, "isproxytrusted", NULL, 0, &address);
@@ -478,7 +478,7 @@ PHP_METHOD(Phalcon_Http_Request, getClientAddress)
 			ZVAL_STRING(&_6$$8, "trim");
 			ZEPHIR_CALL_FUNCTION(&forwardedIps, "array_map", NULL, 19, &_6$$8, &_5$$8);
 			zephir_check_call_status();
-			ZEPHIR_CALL_FUNCTION(&reverseForwardedIps, "array_reverse", NULL, 261, &forwardedIps);
+			ZEPHIR_CALL_FUNCTION(&reverseForwardedIps, "array_reverse", NULL, 262, &forwardedIps);
 			zephir_check_call_status();
 			zephir_is_iterable(&reverseForwardedIps, 0, "phalcon/Http/Request.zep", 289);
 			if (Z_TYPE_P(&reverseForwardedIps) == IS_ARRAY) {
@@ -487,7 +487,7 @@ PHP_METHOD(Phalcon_Http_Request, getClientAddress)
 					ZEPHIR_INIT_NVAR(&forwardedIp);
 					ZVAL_COPY(&forwardedIp, _7$$8);
 					ZEPHIR_OBS_NVAR(&_8$$9);
-					zephir_read_property_cached(&_8$$9, this_ptr, _zephir_prop_1, 866, PH_NOISY_CC);
+					zephir_read_property_cached(&_8$$9, this_ptr, _zephir_prop_1, 865, PH_NOISY_CC);
 					_9$$9 = !(ZEPHIR_IS_EMPTY(&_8$$9));
 					if (_9$$9) {
 						ZEPHIR_CALL_METHOD(&_10$$9, this_ptr, "isproxytrusted", NULL, 0, &forwardedIp);
@@ -522,7 +522,7 @@ PHP_METHOD(Phalcon_Http_Request, getClientAddress)
 					ZEPHIR_CALL_METHOD(&forwardedIp, &reverseForwardedIps, "current", NULL, 0);
 					zephir_check_call_status();
 						ZEPHIR_OBS_NVAR(&_14$$12);
-						zephir_read_property_cached(&_14$$12, this_ptr, _zephir_prop_1, 866, PH_NOISY_CC);
+						zephir_read_property_cached(&_14$$12, this_ptr, _zephir_prop_1, 865, PH_NOISY_CC);
 						_15$$12 = !(ZEPHIR_IS_EMPTY(&_14$$12));
 						if (_15$$12) {
 							ZEPHIR_CALL_METHOD(&_16$$12, this_ptr, "isproxytrusted", NULL, 0, &forwardedIp);
@@ -721,7 +721,7 @@ PHP_METHOD(Phalcon_Http_Request, getFilteredData)
 	} else {
 		}
 	zephir_memory_observe(&filters);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 867, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 866, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_1, &_0, &methodKey_zv, PH_READONLY, "phalcon/Http/Request.zep", 366);
 	if (!(zephir_array_isset_fetch(&filters, &_1, &name_zv, 0))) {
 		ZEPHIR_INIT_NVAR(&filters);
@@ -1196,7 +1196,7 @@ PHP_METHOD(Phalcon_Http_Request, getHeaders)
 				ZVAL_STRING(&_8$$4, " ");
 				zephir_fast_str_replace(&_4$$4, &_7$$4, &_8$$4, &_6$$4);
 				zephir_fast_strtolower(&_3$$4, &_4$$4);
-				ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 330, &_3$$4);
+				ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 332, &_3$$4);
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_10$$4);
 				ZEPHIR_INIT_NVAR(&_11$$4);
@@ -1220,7 +1220,7 @@ PHP_METHOD(Phalcon_Http_Request, getHeaders)
 				ZVAL_STRING(&_17$$5, " ");
 				zephir_fast_str_replace(&_15$$5, &_16$$5, &_17$$5, &name);
 				zephir_fast_strtolower(&_14$$5, &_15$$5);
-				ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 330, &_14$$5);
+				ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 332, &_14$$5);
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_18$$5);
 				ZEPHIR_INIT_NVAR(&_19$$5);
@@ -1264,7 +1264,7 @@ PHP_METHOD(Phalcon_Http_Request, getHeaders)
 					ZVAL_STRING(&_28$$7, " ");
 					zephir_fast_str_replace(&_24$$7, &_27$$7, &_28$$7, &_26$$7);
 					zephir_fast_strtolower(&_23$$7, &_24$$7);
-					ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 330, &_23$$7);
+					ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 332, &_23$$7);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&_29$$7);
 					ZEPHIR_INIT_NVAR(&_30$$7);
@@ -1288,7 +1288,7 @@ PHP_METHOD(Phalcon_Http_Request, getHeaders)
 					ZVAL_STRING(&_36$$8, " ");
 					zephir_fast_str_replace(&_34$$8, &_35$$8, &_36$$8, &name);
 					zephir_fast_strtolower(&_33$$8, &_34$$8);
-					ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 330, &_33$$8);
+					ZEPHIR_CALL_FUNCTION(&name, "ucwords", &_9, 332, &_33$$8);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&_37$$8);
 					ZEPHIR_INIT_NVAR(&_38$$8);
@@ -1378,7 +1378,7 @@ PHP_METHOD(Phalcon_Http_Request, getHttpHost)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&strict);
-	zephir_read_property_cached(&strict, this_ptr, _zephir_prop_0, 868, PH_NOISY_CC);
+	zephir_read_property_cached(&strict, this_ptr, _zephir_prop_0, 867, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "HTTP_HOST");
 	ZEPHIR_CALL_METHOD(&host, this_ptr, "getserver", NULL, 0, &_0);
@@ -1517,7 +1517,7 @@ PHP_METHOD(Phalcon_Http_Request, getJsonRawBody)
 	} else {
 		ZVAL_BOOL(&_1, 0);
 	}
-	ZEPHIR_RETURN_CALL_METHOD(&_0, "__invoke", NULL, 381, &rawBody, &_1);
+	ZEPHIR_RETURN_CALL_METHOD(&_0, "__invoke", NULL, 383, &rawBody, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -1606,7 +1606,7 @@ PHP_METHOD(Phalcon_Http_Request, getMethod)
 			ZEPHIR_INIT_NVAR(&returnMethod);
 			zephir_fast_strtoupper(&returnMethod, &overridedMethod);
 		} else {
-			zephir_read_property_cached(&_2$$5, this_ptr, _zephir_prop_0, 869, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$5, this_ptr, _zephir_prop_0, 868, PH_NOISY_CC | PH_READONLY);
 			if (zephir_is_true(&_2$$5)) {
 				zephir_memory_observe(&spoofedMethod);
 				if (zephir_array_isset_string_fetch(&spoofedMethod, &_REQUEST, SL("_method"), 0)) {
@@ -1703,11 +1703,11 @@ PHP_METHOD(Phalcon_Http_Request, getPatch)
 		noRecursive = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 870, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 869, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getpostdata", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 870, &_0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 870, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 869, &_0);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 869, PH_NOISY_CC | PH_READONLY);
 	if (notAllowEmpty) {
 		ZVAL_BOOL(&_3, 1);
 	} else {
@@ -1867,8 +1867,8 @@ PHP_METHOD(Phalcon_Http_Request, getPost)
 		}
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getpostdata", NULL, 0, &_POST);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 870, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 870, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 869, &_0);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 869, PH_NOISY_CC | PH_READONLY);
 	if (notAllowEmpty) {
 		ZVAL_BOOL(&_2, 1);
 	} else {
@@ -2009,11 +2009,11 @@ PHP_METHOD(Phalcon_Http_Request, getPut)
 		noRecursive = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 870, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 869, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getpostdata", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 870, &_0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 870, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 869, &_0);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 869, PH_NOISY_CC | PH_READONLY);
 	if (notAllowEmpty) {
 		ZVAL_BOOL(&_3, 1);
 	} else {
@@ -2142,14 +2142,14 @@ PHP_METHOD(Phalcon_Http_Request, getRawBody)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 871, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 870, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&rawBody, &_0);
 	if (ZEPHIR_IS_EMPTY(&rawBody)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "php://input");
 		ZEPHIR_CALL_METHOD(&contents, this_ptr, "phpfilegetcontents", NULL, 0, &_1$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 871, &contents);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 870, &contents);
 		RETURN_CCTOR(&contents);
 	}
 	RETURN_CCTOR(&rawBody);
@@ -3331,9 +3331,9 @@ PHP_METHOD(Phalcon_Http_Request, setHttpMethodParameterOverride)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &override_param);
 	if (override) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 869, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 868, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 869, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 868, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -3515,9 +3515,9 @@ PHP_METHOD(Phalcon_Http_Request, setStrictHostCheck)
 	} else {
 		}
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 868, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 867, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 868, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 867, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -3652,7 +3652,7 @@ PHP_METHOD(Phalcon_Http_Request, setTrustedProxyHeader)
 		ZEPHIR_CONCAT_SV(&_5$$3, "HTTP_", &trustedHeader);
 		ZEPHIR_CPY_WRT(&trustedHeader, &_5$$3);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 865, &trustedHeader);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 864, &trustedHeader);
 	RETURN_THIS();
 }
 
@@ -4377,7 +4377,7 @@ PHP_METHOD(Phalcon_Http_Request, isIpAddressInCIDR)
 	maskBytes = (int) zephir_floor(&_5);
 	remainingBits = (long) (zephir_safe_mod_zval_long(&maskLength, 8));
 	ZVAL_LONG(&_8, maskBytes);
-	ZEPHIR_CALL_FUNCTION(&_9, "strncmp", NULL, 333, &ipBits, &subnetBits, &_8);
+	ZEPHIR_CALL_FUNCTION(&_9, "strncmp", NULL, 335, &ipBits, &subnetBits, &_8);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_LONG_IDENTICAL(&_9, 0)) {
 		RETURN_MM_BOOL(0);
@@ -4887,10 +4887,10 @@ PHP_METHOD(Phalcon_Http_Request, getFilterService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 872, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 871, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&filterService, &_0);
 	if (Z_TYPE_P(&filterService) != IS_OBJECT) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 873, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 872, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&container, &_1$$3);
 		if (Z_TYPE_P(&container) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_2$$4);
@@ -4906,7 +4906,7 @@ PHP_METHOD(Phalcon_Http_Request, getFilterService)
 		ZEPHIR_CALL_METHOD(&_3$$3, &container, "getshared", NULL, 0, &_4$$3);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&filterService, &_3$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 872, &filterService);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 871, &filterService);
 	}
 	RETURN_MM_MEMBER(getThis(), "filterService");
 }
@@ -5634,7 +5634,7 @@ PHP_METHOD(Phalcon_Http_Request, isProxyTrusted)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&ip_zv);
 	ZVAL_STR_COPY(&ip_zv, ip);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 866, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 865, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Http/Request.zep", 2019);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)

--- a/ext/phalcon/http/request/bag/abstractbag.zep.c
+++ b/ext/phalcon/http/request/bag/abstractbag.zep.c
@@ -610,7 +610,7 @@ PHP_METHOD(Phalcon_Http_Request_Bag_AbstractBag, offsetSet)
 	if (Z_TYPE_P(offset) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		object_init_ex(&_0$$3, phalcon_http_request_exceptions_nullkeyexception_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 246);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 247);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_0$$3, "phalcon/Http/Request/Bag/AbstractBag.zep", 275);
 		ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/http/request/file.zep.c
+++ b/ext/phalcon/http/request/file.zep.c
@@ -162,7 +162,7 @@ PHP_METHOD(Phalcon_Http_Request_File, __construct)
 	}
 	zephir_memory_observe(&name);
 	if (zephir_array_isset_string_fetch(&name, &file, SL("name"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 874, &name);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 873, &name);
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZVAL_STRING(&_0$$3, "PATHINFO_EXTENSION");
 		ZEPHIR_CALL_FUNCTION(&_1$$3, "defined", NULL, 147, &_0$$3);
@@ -171,31 +171,31 @@ PHP_METHOD(Phalcon_Http_Request_File, __construct)
 			ZVAL_LONG(&_2$$4, 4);
 			ZEPHIR_CALL_FUNCTION(&_3$$4, "pathinfo", NULL, 199, &name, &_2$$4);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 875, &_3$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 874, &_3$$4);
 		}
 	}
 	ZEPHIR_INIT_VAR(&_5);
 	ZVAL_STRING(&_5, "tmp_name");
 	ZEPHIR_CALL_METHOD(&_4, this_ptr, "getarrval", NULL, 0, &file, &_5);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 876, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 875, &_4);
 	ZEPHIR_INIT_NVAR(&_5);
 	ZVAL_STRING(&_5, "size");
 	ZEPHIR_CALL_METHOD(&_6, this_ptr, "getarrval", NULL, 0, &file, &_5);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 877, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 876, &_6);
 	ZEPHIR_INIT_NVAR(&_5);
 	ZVAL_STRING(&_5, "type");
 	ZEPHIR_CALL_METHOD(&_7, this_ptr, "getarrval", NULL, 0, &file, &_5);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 878, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 877, &_7);
 	ZEPHIR_INIT_NVAR(&_5);
 	ZVAL_STRING(&_5, "error");
 	ZEPHIR_CALL_METHOD(&_8, this_ptr, "getarrval", NULL, 0, &file, &_5);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 879, &_8);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 878, &_8);
 	if (!(ZEPHIR_IS_EMPTY(&key_zv))) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 880, &key_zv);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 879, &key_zv);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -265,16 +265,16 @@ PHP_METHOD(Phalcon_Http_Request_File, getRealType)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 880, PH_NOISY_CC);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		ZVAL_LONG(&_1$$3, 16);
 		ZEPHIR_CALL_FUNCTION(&finfo, "finfo_open", NULL, 0, &_1$$3);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_FALSE_IDENTICAL(&finfo)) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 876, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 875, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(&mime, "finfo_file", NULL, 0, &finfo, &_2$$4);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 881, &mime);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 880, &mime);
 		}
 	}
 	RETURN_MM_MEMBER_TYPED(getThis(), "realType", IS_STRING);
@@ -329,7 +329,7 @@ PHP_METHOD(Phalcon_Http_Request_File, isUploadedFile)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&name);
-	zephir_read_property_cached(&name, this_ptr, _zephir_prop_0, 876, PH_NOISY_CC);
+	zephir_read_property_cached(&name, this_ptr, _zephir_prop_0, 875, PH_NOISY_CC);
 	_0 = !(ZEPHIR_IS_EMPTY(&name));
 	if (_0) {
 		ZEPHIR_CALL_FUNCTION(&_1, "is_uploaded_file", NULL, 34, &name);
@@ -364,7 +364,7 @@ PHP_METHOD(Phalcon_Http_Request_File, moveTo)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&destination_zv);
 	ZVAL_STR_COPY(&destination_zv, destination);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 876, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 875, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_FUNCTION("move_uploaded_file", NULL, 0, &_0, &destination_zv);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/http/response.zep.c
+++ b/ext/phalcon/http/response.zep.c
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_Http_Response, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 882, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 881, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_support_helper_json_encode_ce);
 	if (zephir_has_constructor(&_1)) {
@@ -158,7 +158,7 @@ PHP_METHOD(Phalcon_Http_Response, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 883, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 882, &_1);
 	if (!ZEPHIR_IS_NULL(&content_zv)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setcontent", NULL, 0, &content_zv);
 		zephir_check_call_status();
@@ -198,7 +198,7 @@ PHP_METHOD(Phalcon_Http_Response, appendContent)
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_CONCAT_VV(&_1, &_0, content);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 884, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 883, &_1);
 	RETURN_THIS();
 }
 
@@ -222,7 +222,7 @@ PHP_METHOD(Phalcon_Http_Response, getContent)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 884, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 883, PH_NOISY_CC);
 	zephir_cast_to_string(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -256,7 +256,7 @@ PHP_METHOD(Phalcon_Http_Response, getDI)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 885, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 884, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_CALL_CE_STATIC(&container, phalcon_di_di_ce, "getdefault", NULL, 0);
@@ -270,7 +270,7 @@ PHP_METHOD(Phalcon_Http_Response, getDI)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 885, &container);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 884, &container);
 	}
 	RETURN_CCTOR(&container);
 }
@@ -321,7 +321,7 @@ PHP_METHOD(Phalcon_Http_Response, getReasonPhrase)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "Status");
 	ZEPHIR_CALL_METHOD(&_1, &_0, "get", NULL, 0, &_2);
@@ -369,7 +369,7 @@ PHP_METHOD(Phalcon_Http_Response, getStatusCode)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "Status");
 	ZEPHIR_CALL_METHOD(&_1, &_0, "get", NULL, 0, &_2);
@@ -604,7 +604,7 @@ PHP_METHOD(Phalcon_Http_Response, removeHeader)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "remove", NULL, 0, &name_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -628,7 +628,7 @@ PHP_METHOD(Phalcon_Http_Response, resetHeaders)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "reset", NULL, 0);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -668,7 +668,7 @@ PHP_METHOD(Phalcon_Http_Response, send)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 886, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 885, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_http_response_exceptions_responsealreadysent_ce);
@@ -682,12 +682,12 @@ PHP_METHOD(Phalcon_Http_Response, send)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "sendcookies", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 884, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 883, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&content, &_2);
 	if (Z_TYPE_P(&content) != IS_NULL) {
 		zend_print_zval(&content, 0);
 	} else {
-		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_2, 887, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_2, 886, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&file, &_3$$5);
 		_4$$5 = Z_TYPE_P(&file) == IS_STRING;
 		if (_4$$5) {
@@ -699,9 +699,9 @@ PHP_METHOD(Phalcon_Http_Response, send)
 		}
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 886, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 885, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 886, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 885, &__$false);
 	}
 	RETURN_THIS();
 }
@@ -725,7 +725,7 @@ PHP_METHOD(Phalcon_Http_Response, sendCookies)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 888, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 887, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cookies, &_0);
 	if (Z_TYPE_P(&cookies) == IS_OBJECT) {
 		ZEPHIR_CALL_METHOD(NULL, &cookies, "send", NULL, 0);
@@ -763,9 +763,9 @@ PHP_METHOD(Phalcon_Http_Response, sendHeaders)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&headers, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 889, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 888, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_2$$3);
@@ -864,7 +864,7 @@ PHP_METHOD(Phalcon_Http_Response, setContent)
 		Z_PARAM_STR(content)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&content_zv, content);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 884, &content_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 883, &content_zv);
 	RETURN_THISW();
 }
 
@@ -963,7 +963,7 @@ PHP_METHOD(Phalcon_Http_Response, setCookies)
 		Z_PARAM_OBJECT_OF_CLASS(cookies, phalcon_http_response_cookiesinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &cookies);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 888, cookies);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 887, cookies);
 	RETURN_THISW();
 }
 
@@ -985,7 +985,7 @@ PHP_METHOD(Phalcon_Http_Response, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 885, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 884, container);
 }
 
 /**
@@ -1041,7 +1041,7 @@ PHP_METHOD(Phalcon_Http_Response, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 889, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 888, eventsManager);
 }
 
 /**
@@ -1206,7 +1206,7 @@ PHP_METHOD(Phalcon_Http_Response, setFileToSend)
 		} else {
 			ZEPHIR_INIT_VAR(&_7$$8);
 			ZVAL_STRING(&_7$$8, "\15\17\\\"");
-			ZEPHIR_CALL_FUNCTION(&_8$$8, "addcslashes", NULL, 509, &basePath, &_7$$8);
+			ZEPHIR_CALL_FUNCTION(&_8$$8, "addcslashes", NULL, 511, &basePath, &_7$$8);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&basePath, &_8$$8);
 			ZEPHIR_INIT_VAR(&_9$$8);
@@ -1215,7 +1215,7 @@ PHP_METHOD(Phalcon_Http_Response, setFileToSend)
 			zephir_check_call_status();
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 887, &filePath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 886, &filePath_zv);
 	RETURN_THIS();
 }
 
@@ -1251,7 +1251,7 @@ PHP_METHOD(Phalcon_Http_Response, setHeader)
 	value = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &name_zv, value);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -1302,7 +1302,7 @@ PHP_METHOD(Phalcon_Http_Response, setHeaders)
 			}
 			ZEPHIR_INIT_NVAR(&value);
 			ZVAL_COPY(&value, _0);
-			zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_3$$3, "set", NULL, 0, &name, &value);
 			zephir_check_call_status();
 		} ZEND_HASH_FOREACH_END();
@@ -1326,7 +1326,7 @@ PHP_METHOD(Phalcon_Http_Response, setHeaders)
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&value, &data, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &_6$$4, "set", NULL, 0, &name, &value);
 				zephir_check_call_status();
 		}
@@ -1387,7 +1387,7 @@ PHP_METHOD(Phalcon_Http_Response, setJsonContent)
 	ZVAL_STRING(&_0, "application/json");
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setcontenttype", NULL, 0, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 883, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_3, jsonOptions);
 	ZVAL_LONG(&_4, depth);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "__invoke", NULL, 0, content, &_3, &_4);
@@ -1502,7 +1502,7 @@ PHP_METHOD(Phalcon_Http_Response, setRawHeader)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&header_zv);
 	ZVAL_STR_COPY(&header_zv, header);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setraw", NULL, 0, &header_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -1568,7 +1568,7 @@ PHP_METHOD(Phalcon_Http_Response, setStatusCode)
 	} else {
 		zephir_get_strval(&message, message_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&currentHeadersRaw, &_0, "toarray", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_1);
@@ -1593,7 +1593,7 @@ PHP_METHOD(Phalcon_Http_Response, setStatusCode)
 				_5$$3 = zephir_is_true(&_7$$3);
 			}
 			if (_5$$3) {
-				zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &_9$$4, "remove", NULL, 0, &key);
 				zephir_check_call_status();
 			}
@@ -1627,7 +1627,7 @@ PHP_METHOD(Phalcon_Http_Response, setStatusCode)
 					_12$$5 = zephir_is_true(&_14$$5);
 				}
 				if (_12$$5) {
-					zephir_read_property_cached(&_15$$6, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_15$$6, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_15$$6, "remove", NULL, 0, &key);
 					zephir_check_call_status();
 				}
@@ -1739,14 +1739,14 @@ PHP_METHOD(Phalcon_Http_Response, setStatusCode)
 		zephir_array_fetch_long(&defaultMessage, &statusCodes, code, PH_NOISY, "phalcon/Http/Response.zep", 840);
 		zephir_get_strval(&message, &defaultMessage);
 	}
-	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_18);
 	ZVAL_LONG(&_18, code);
 	ZEPHIR_INIT_VAR(&_19);
 	ZEPHIR_CONCAT_SVSV(&_19, "HTTP/1.1 ", &_18, " ", &message);
 	ZEPHIR_CALL_METHOD(NULL, &_17, "setraw", NULL, 0, &_19);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_0, 882, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_0, 881, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_21);
 	ZVAL_LONG(&_21, code);
 	ZEPHIR_INIT_VAR(&_22);
@@ -1782,7 +1782,7 @@ PHP_METHOD(Phalcon_Http_Response, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/http/response/cookies.zep.c
+++ b/ext/phalcon/http/response/cookies.zep.c
@@ -147,9 +147,9 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, __construct)
 	ZVAL_STR_COPY(&signKey_zv, signKey);
 	}
 	if (useEncryption) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 890, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 889, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 890, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 889, &__$false);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setsignkey", NULL, 0, &signKey_zv);
 	zephir_check_call_status();
@@ -184,7 +184,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, delete)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&cookie);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 891, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 890, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&cookie, &_0, &name_zv, 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -235,7 +235,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, get)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&cookie);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 891, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 890, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&cookie, &_0, &name_zv, 0)) {
 		RETURN_CCTOR(&cookie);
 	}
@@ -252,11 +252,11 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, get)
 	ZEPHIR_CALL_METHOD(NULL, &cookie, "setdi", NULL, 0, &container);
 	zephir_check_call_status();
 	zephir_memory_observe(&encryption);
-	zephir_read_property_cached(&encryption, this_ptr, _zephir_prop_1, 890, PH_NOISY_CC);
+	zephir_read_property_cached(&encryption, this_ptr, _zephir_prop_1, 889, PH_NOISY_CC);
 	if (zephir_is_true(&encryption)) {
 		ZEPHIR_CALL_METHOD(NULL, &cookie, "useencryption", NULL, 0, &encryption);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_2, 892, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_2, 891, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &cookie, "setsignkey", NULL, 0, &_4$$4);
 		zephir_check_call_status();
 	}
@@ -296,7 +296,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, has)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_get_global(&_COOKIE, SL("_COOKIE"));
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 891, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 890, PH_NOISY_CC | PH_READONLY);
 	_1 = zephir_array_isset_value(&_0, &name_zv);
 	if (!(_1)) {
 		_1 = zephir_array_isset_value(&_COOKIE, &name_zv);
@@ -332,7 +332,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, reset)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 891, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 890, &_0);
 	RETURN_THIS();
 }
 
@@ -366,7 +366,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, send)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_CALL_FUNCTION(&_0, "headers_sent", NULL, 215);
+	ZEPHIR_CALL_FUNCTION(&_0, "headers_sent", NULL, 216);
 	zephir_check_call_status();
 	_1 = ZEPHIR_IS_TRUE_IDENTICAL(&_0);
 	if (!(_1)) {
@@ -377,7 +377,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, send)
 	if (_1) {
 		RETURN_MM_BOOL(0);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 891, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 890, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_3, 0, "phalcon/Http/Response/Cookies.zep", 213);
 	if (Z_TYPE_P(&_3) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_3), _4)
@@ -411,9 +411,9 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, send)
 	}
 	ZEPHIR_INIT_NVAR(&cookie);
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 893, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 892, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 893, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 892, &__$false);
 	}
 	RETURN_MM_BOOL(1);
 }
@@ -562,11 +562,11 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, set)
 		zephir_get_arrval(&options, options_param);
 	}
 	zephir_memory_observe(&encryption);
-	zephir_read_property_cached(&encryption, this_ptr, _zephir_prop_0, 890, PH_NOISY_CC);
+	zephir_read_property_cached(&encryption, this_ptr, _zephir_prop_0, 889, PH_NOISY_CC);
 	zephir_memory_observe(&cookie);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 891, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 890, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&cookie, &_0, &name_zv, 0))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_2, 894, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_2, 893, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_3$$3);
 		zephir_create_array(&_3$$3, 8, 0);
 		zephir_array_fast_append(&_3$$3, &name_zv);
@@ -588,13 +588,13 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, set)
 		ZEPHIR_CALL_METHOD(&_2$$3, &_1$$3, "get", NULL, 0, &_4$$3, &_3$$3);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&cookie, &_2$$3);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 894, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 893, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &cookie, "setdi", NULL, 0, &_5$$3);
 		zephir_check_call_status();
 		if (zephir_is_true(&encryption)) {
 			ZEPHIR_CALL_METHOD(NULL, &cookie, "useencryption", NULL, 0, &encryption);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_3, 892, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_3, 891, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &cookie, "setsignkey", NULL, 0, &_6$$4);
 			zephir_check_call_status();
 		}
@@ -625,11 +625,11 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, set)
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &cookie, "setoptions", NULL, 0, &options);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_9$$5, this_ptr, _zephir_prop_3, 892, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_9$$5, this_ptr, _zephir_prop_3, 891, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &cookie, "setsignkey", NULL, 0, &_9$$5);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_4, 895, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_4, 894, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&_10)) {
 		ZEPHIR_CALL_METHOD(&container, this_ptr, "checkcontainer", NULL, 0);
 		zephir_check_call_status();
@@ -640,9 +640,9 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, set)
 		ZEPHIR_CALL_METHOD(NULL, &response, "setcookies", NULL, 0, this_ptr);
 		zephir_check_call_status();
 		if (1) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 895, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 894, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 895, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 894, &__$false);
 		}
 	}
 	RETURN_THIS();
@@ -684,7 +684,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, setSignKey)
 		zephir_memory_observe(&signKey_zv);
 	ZVAL_STR_COPY(&signKey_zv, signKey);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 892, &signKey_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 891, &signKey_zv);
 	RETURN_THIS();
 }
 
@@ -709,9 +709,9 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, useEncryption)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &useEncryption_param);
 	if (useEncryption) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 890, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 889, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 890, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 889, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -733,7 +733,7 @@ PHP_METHOD(Phalcon_Http_Response_Cookies, checkContainer)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 894, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 893, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);

--- a/ext/phalcon/http/response/headers.zep.c
+++ b/ext/phalcon/http/response/headers.zep.c
@@ -82,7 +82,7 @@ PHP_METHOD(Phalcon_Http_Response_Headers, get)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 896, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 895, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&headers, &_0);
 	zephir_memory_observe(&headerValue);
 	if (!(zephir_array_isset_fetch(&headerValue, &headers, &name_zv, 0))) {
@@ -110,7 +110,7 @@ PHP_METHOD(Phalcon_Http_Response_Headers, getIterator)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, spl_ce_ArrayIterator);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 896, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 895, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 18, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -140,7 +140,7 @@ PHP_METHOD(Phalcon_Http_Response_Headers, has)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 896, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 895, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_key_exists(&_0, &name_zv));
 }
 
@@ -178,10 +178,10 @@ PHP_METHOD(Phalcon_Http_Response_Headers, remove)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&header_zv);
 	ZVAL_STR_COPY(&header_zv, header);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 896, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 895, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&headers, &_0);
 	zephir_array_unset(&headers, &header_zv, PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 896, &headers);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 895, &headers);
 	RETURN_THIS();
 }
 
@@ -206,7 +206,7 @@ PHP_METHOD(Phalcon_Http_Response_Headers, reset)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 896, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 895, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -253,17 +253,17 @@ PHP_METHOD(Phalcon_Http_Response_Headers, send)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_CALL_FUNCTION(&_0, "headers_sent", NULL, 215);
+	ZEPHIR_CALL_FUNCTION(&_0, "headers_sent", NULL, 216);
 	zephir_check_call_status();
 	_1 = ZEPHIR_IS_TRUE_IDENTICAL(&_0);
 	if (!(_1)) {
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 896, PH_NOISY_CC | PH_READONLY);
 		_1 = ZEPHIR_IS_TRUE_IDENTICAL(&_2);
 	}
 	if (_1) {
 		RETURN_MM_BOOL(0);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 896, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 895, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_3, 0, "phalcon/Http/Response/Headers.zep", 126);
 	if (Z_TYPE_P(&_3) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_3), _5, _6, _4)
@@ -279,7 +279,7 @@ PHP_METHOD(Phalcon_Http_Response_Headers, send)
 			if (Z_TYPE_P(&value) != IS_NULL) {
 				ZEPHIR_INIT_NVAR(&_7$$5);
 				ZEPHIR_CONCAT_VSV(&_7$$5, &header, ": ", &value);
-				ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 217, &_7$$5, &__$true);
+				ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 218, &_7$$5, &__$true);
 				zephir_check_call_status();
 			} else {
 				_9$$6 = zephir_memnstr_str(&header, SL(":"), "phalcon/Http/Response/Headers.zep", 118);
@@ -291,12 +291,12 @@ PHP_METHOD(Phalcon_Http_Response_Headers, send)
 					_9$$6 = ZEPHIR_IS_STRING(&_12$$6, "HTTP/");
 				}
 				if (_9$$6) {
-					ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 217, &header, &__$true);
+					ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 218, &header, &__$true);
 					zephir_check_call_status();
 				} else {
 					ZEPHIR_INIT_NVAR(&_13$$8);
 					ZEPHIR_CONCAT_VS(&_13$$8, &header, ": ");
-					ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 217, &_13$$8, &__$true);
+					ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 218, &_13$$8, &__$true);
 					zephir_check_call_status();
 				}
 			}
@@ -324,7 +324,7 @@ PHP_METHOD(Phalcon_Http_Response_Headers, send)
 				if (Z_TYPE_P(&value) != IS_NULL) {
 					ZEPHIR_INIT_NVAR(&_16$$10);
 					ZEPHIR_CONCAT_VSV(&_16$$10, &header, ": ", &value);
-					ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 217, &_16$$10, &__$true);
+					ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 218, &_16$$10, &__$true);
 					zephir_check_call_status();
 				} else {
 					_17$$11 = zephir_memnstr_str(&header, SL(":"), "phalcon/Http/Response/Headers.zep", 118);
@@ -336,12 +336,12 @@ PHP_METHOD(Phalcon_Http_Response_Headers, send)
 						_17$$11 = ZEPHIR_IS_STRING(&_20$$11, "HTTP/");
 					}
 					if (_17$$11) {
-						ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 217, &header, &__$true);
+						ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 218, &header, &__$true);
 						zephir_check_call_status();
 					} else {
 						ZEPHIR_INIT_NVAR(&_21$$13);
 						ZEPHIR_CONCAT_VS(&_21$$13, &header, ": ");
-						ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 217, &_21$$13, &__$true);
+						ZEPHIR_CALL_FUNCTION(NULL, "header", &_8, 218, &_21$$13, &__$true);
 						zephir_check_call_status();
 					}
 				}
@@ -350,9 +350,9 @@ PHP_METHOD(Phalcon_Http_Response_Headers, send)
 	ZEPHIR_INIT_NVAR(&value);
 	ZEPHIR_INIT_NVAR(&header);
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 897, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 896, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 897, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 896, &__$false);
 	}
 	RETURN_MM_BOOL(1);
 }

--- a/ext/phalcon/image/adapter/gd.zep.c
+++ b/ext/phalcon/image/adapter/gd.zep.c
@@ -173,34 +173,34 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, __construct)
 		}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "check", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &file_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 897, &file_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 899, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 898, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "phpfileexists", NULL, 0, &_0);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_1)) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_3$$3, "realpath", NULL, 157, &_2$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 900, &_3$$3);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 899, &_3$$3);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&imageInfo, "getimagesize", NULL, 0, &_4$$3);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_FALSE_IDENTICAL(&imageInfo)) {
 			zephir_array_fetch_long(&_5$$4, &imageInfo, 0, PH_NOISY | PH_READONLY, "phalcon/Image/Adapter/Gd.zep", 77);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 901, &_5$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 900, &_5$$4);
 			zephir_array_fetch_long(&_6$$4, &imageInfo, 1, PH_NOISY | PH_READONLY, "phalcon/Image/Adapter/Gd.zep", 78);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 902, &_6$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 901, &_6$$4);
 			zephir_array_fetch_long(&_7$$4, &imageInfo, 2, PH_NOISY | PH_READONLY, "phalcon/Image/Adapter/Gd.zep", 79);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 899, &_7$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 898, &_7$$4);
 			zephir_array_fetch_string(&_8$$4, &imageInfo, SL("mime"), PH_NOISY | PH_READONLY, "phalcon/Image/Adapter/Gd.zep", 80);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 903, &_8$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 902, &_8$$4);
 		} else {
 			ZEPHIR_INIT_VAR(&_9$$5);
 			object_init_ex(&_9$$5, phalcon_image_exceptions_imageloadfailed_ce);
-			zephir_read_property_cached(&_10$$5, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$5, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_9$$5, "__construct", NULL, 0, &_10$$5);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_9$$5, "phalcon/Image/Adapter/Gd.zep", 82);
@@ -208,53 +208,53 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, __construct)
 			return;
 		}
 		zephir_memory_observe(&_11$$3);
-		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_1, 899, PH_NOISY_CC);
+		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_1, 898, PH_NOISY_CC);
 		do {
 			if (ZEPHIR_IS_LONG(&_11$$3, 1)) {
-				zephir_read_property_cached(&_12$$6, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_12$$6, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(&_13$$6, "imagecreatefromgif", NULL, 0, &_12$$6);
 				zephir_check_call_status();
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_13$$6);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_13$$6);
 				break;
 			}
 			if (ZEPHIR_IS_LONG(&_11$$3, 2) || ZEPHIR_IS_LONG(&_11$$3, 9)) {
-				zephir_read_property_cached(&_14$$7, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_14$$7, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(&_15$$7, "imagecreatefromjpeg", NULL, 0, &_14$$7);
 				zephir_check_call_status();
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_15$$7);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_15$$7);
 				break;
 			}
 			if (ZEPHIR_IS_LONG(&_11$$3, 3)) {
-				zephir_read_property_cached(&_16$$8, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_16$$8, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(&_17$$8, "imagecreatefrompng", NULL, 0, &_16$$8);
 				zephir_check_call_status();
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_17$$8);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_17$$8);
 				break;
 			}
 			if (ZEPHIR_IS_LONG(&_11$$3, 18)) {
-				zephir_read_property_cached(&_18$$9, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_18$$9, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(&_19$$9, "imagecreatefromwebp", NULL, 0, &_18$$9);
 				zephir_check_call_status();
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_19$$9);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_19$$9);
 				break;
 			}
 			if (ZEPHIR_IS_LONG(&_11$$3, 15)) {
-				zephir_read_property_cached(&_20$$10, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_20$$10, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(&_21$$10, "imagecreatefromwbmp", NULL, 0, &_20$$10);
 				zephir_check_call_status();
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_21$$10);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_21$$10);
 				break;
 			}
 			if (ZEPHIR_IS_LONG(&_11$$3, 16)) {
-				zephir_read_property_cached(&_22$$11, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_22$$11, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(&_23$$11, "imagecreatefromxbm", NULL, 0, &_22$$11);
 				zephir_check_call_status();
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_23$$11);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_23$$11);
 				break;
 			}
 			ZEPHIR_INIT_VAR(&_24$$12);
 			object_init_ex(&_24$$12, phalcon_image_exceptions_unsupportedimagetype_ce);
-			zephir_read_property_cached(&_25$$12, this_ptr, _zephir_prop_5, 903, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_25$$12, this_ptr, _zephir_prop_5, 902, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_24$$12, "__construct", NULL, 0, &_25$$12);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_24$$12, "phalcon/Image/Adapter/Gd.zep", 112);
@@ -262,7 +262,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, __construct)
 			return;
 		} while(0);
 
-		zephir_read_property_cached(&_26$$3, this_ptr, _zephir_prop_6, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_26$$3, this_ptr, _zephir_prop_6, 903, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagesavealpha", NULL, 0, &_26$$3, &__$true);
 		zephir_check_call_status();
 	} else {
@@ -273,7 +273,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, __construct)
 		if (_27$$13) {
 			ZEPHIR_INIT_VAR(&_28$$14);
 			object_init_ex(&_28$$14, phalcon_image_exceptions_imageloadfailed_ce);
-			zephir_read_property_cached(&_29$$14, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_29$$14, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_28$$14, "__construct", NULL, 0, &_29$$14);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_28$$14, "phalcon/Image/Adapter/Gd.zep", 118);
@@ -284,28 +284,28 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, __construct)
 		ZVAL_LONG(&_31$$13, height);
 		ZEPHIR_CALL_FUNCTION(&_32$$13, "imagecreatetruecolor", NULL, 0, &_30$$13, &_31$$13);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 904, &_32$$13);
-		zephir_read_property_cached(&_30$$13, this_ptr, _zephir_prop_6, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 903, &_32$$13);
+		zephir_read_property_cached(&_30$$13, this_ptr, _zephir_prop_6, 903, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagealphablending", NULL, 0, &_30$$13, &__$true);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_31$$13, this_ptr, _zephir_prop_6, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_31$$13, this_ptr, _zephir_prop_6, 903, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagesavealpha", NULL, 0, &_31$$13, &__$true);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_33$$13, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 900, &_33$$13);
+		zephir_read_property_cached(&_33$$13, this_ptr, _zephir_prop_0, 897, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 899, &_33$$13);
 		ZVAL_UNDEF(&_34$$13);
 		ZVAL_LONG(&_34$$13, width);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 901, &_34$$13);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 900, &_34$$13);
 		ZVAL_UNDEF(&_34$$13);
 		ZVAL_LONG(&_34$$13, height);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 902, &_34$$13);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 901, &_34$$13);
 		ZVAL_UNDEF(&_34$$13);
 		ZVAL_LONG(&_34$$13, 3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 899, &_34$$13);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 898, &_34$$13);
 		ZEPHIR_INIT_VAR(&_35$$13);
 		ZEPHIR_INIT_NVAR(&_35$$13);
 		ZVAL_STRING(&_35$$13, "image/png");
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 903, &_35$$13);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 902, &_35$$13);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -323,7 +323,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, __destruct)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("image", 5, 1);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 904, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 903, &__$null);
 }
 
 /**
@@ -481,10 +481,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processBackground)
 	zephir_check_call_status();
 	zephir_round(&_0, &_2, NULL, NULL);
 	opacity = zephir_get_intval(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&image, &_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 902, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 900, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 901, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&background, this_ptr, "processcreate", NULL, 0, &_1, &_3);
 	zephir_check_call_status();
 	ZVAL_LONG(&_4, red);
@@ -495,8 +495,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processBackground)
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(NULL, "imagealphablending", NULL, 0, &background, &__$true);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 902, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 900, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 901, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_6, 0);
 	ZVAL_LONG(&_7, 0);
 	ZVAL_LONG(&_8, 0);
@@ -504,7 +504,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processBackground)
 	ZEPHIR_CALL_FUNCTION(&copy, "imagecopy", NULL, 0, &background, &image, &_6, &_7, &_8, &_9, &_4, &_5);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&copy)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 904, &background);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 903, &background);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -540,7 +540,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processBlur)
 		if (!(counter < radius)) {
 			break;
 		}
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_1$$3, 7);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagefilter", &_2, 0, &_0$$3, &_1$$3);
 		zephir_check_call_status();
@@ -642,16 +642,16 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processCrop)
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_LONG(&_0, height);
 	zephir_array_update_string(&rect, SL("height"), &_0, PH_COPY | PH_SEPARATE);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&image, "imagecrop", NULL, 0, &_1, &rect);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 904, &image);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 903, &image);
 	ZEPHIR_CALL_FUNCTION(&_2, "imagesx", NULL, 0, &image);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 901, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 900, &_2);
 	ZEPHIR_CALL_FUNCTION(&_3, "imagesy", NULL, 0, &image);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 902, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 901, &_3);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -683,12 +683,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processFlip)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &direction_param);
 	if (direction == 11) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_1$$3, 1);
 		ZEPHIR_CALL_FUNCTION(NULL, "imageflip", NULL, 0, &_0$$3, &_1$$3);
 		zephir_check_call_status();
 	} else {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_3$$4, 2);
 		ZEPHIR_CALL_FUNCTION(NULL, "imageflip", NULL, 0, &_2$$4, &_3$$4);
 		zephir_check_call_status();
@@ -778,8 +778,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processMask)
 	alpha = 127;
 	ZEPHIR_CALL_FUNCTION(NULL, "imagesavealpha", NULL, 0, &maskImage, &__$true);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&newImage, this_ptr, "processcreate", NULL, 0, &_3, &_4);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(NULL, "imagesavealpha", NULL, 0, &newImage, &__$true);
@@ -794,19 +794,19 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processMask)
 	ZVAL_LONG(&_6, 0);
 	ZEPHIR_CALL_FUNCTION(NULL, "imagefill", NULL, 0, &newImage, &_5, &_6, &color);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 	_9 = !ZEPHIR_IS_LONG_IDENTICAL(&_5, maskWidth);
 	if (!(_9)) {
-		zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 		_9 = !ZEPHIR_IS_LONG_IDENTICAL(&_6, maskHeight);
 	}
 	if (_9) {
-		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_11$$3, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&tempImage, "imagecreatetruecolor", NULL, 0, &_10$$3, &_11$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_12$$3, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_13$$3, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$3, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_13$$3, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_14$$3, 0);
 		ZVAL_LONG(&_15$$3, 0);
 		ZVAL_LONG(&_16$$3, 0);
@@ -819,13 +819,13 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processMask)
 	}
 	x = 0;
 	while (1) {
-		zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 		if (!(ZEPHIR_GT_LONG(&_7, x))) {
 			break;
 		}
 		y = 0;
 		while (1) {
-			zephir_read_property_cached(&_20$$4, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_20$$4, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 			if (!(ZEPHIR_GT_LONG(&_20$$4, y))) {
 				break;
 			}
@@ -840,12 +840,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processMask)
 				ZVAL_DOUBLE(&_26$$6, zephir_safe_div_zval_long(&_25$$6, 2));
 				alpha = (127 - zephir_get_intval(&_26$$6));
 			}
-			zephir_read_property_cached(&_21$$5, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_21$$5, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 			ZVAL_LONG(&_22$$5, x);
 			ZVAL_LONG(&_27$$5, y);
 			ZEPHIR_CALL_FUNCTION(&index, "imagecolorat", &_23, 0, &_21$$5, &_22$$5, &_27$$5);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_22$$5, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_22$$5, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(&color, "imagecolorsforindex", &_24, 0, &_22$$5, &index);
 			zephir_check_call_status();
 			ZEPHIR_OBS_NVAR(&red);
@@ -865,7 +865,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processMask)
 		}
 		x++;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 904, &newImage);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 903, &newImage);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -915,28 +915,28 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processPixelate)
 	zephir_fetch_params(1, 1, 0, &amount_param);
 	x = 0;
 	while (1) {
-		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 		if (!(ZEPHIR_GT_LONG(&_0, x))) {
 			break;
 		}
 		y = 0;
 		while (1) {
-			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 			if (!(ZEPHIR_GT_LONG(&_1$$3, y))) {
 				break;
 			}
 			x1 = ((x + (zephir_safe_div_long_long(amount, 2))));
 			y1 = ((y + (zephir_safe_div_long_long(amount, 2))));
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 			_3$$4 = ZEPHIR_LE_LONG(&_2$$4, x1);
 			if (!(_3$$4)) {
-				zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 				_3$$4 = ZEPHIR_LE_LONG(&_4$$4, y1);
 			}
 			if (_3$$4) {
 				break;
 			}
-			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 			ZVAL_LONG(&_6$$4, x1);
 			ZVAL_LONG(&_7$$4, y1);
 			ZEPHIR_CALL_FUNCTION(&color, "imagecolorat", &_8, 0, &_5$$4, &_6$$4, &_7$$4);
@@ -945,7 +945,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processPixelate)
 			ZVAL_LONG(&x2, (x + amount));
 			ZEPHIR_INIT_NVAR(&y2);
 			ZVAL_LONG(&y2, (y + amount));
-			zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 			ZVAL_LONG(&_7$$4, x);
 			ZVAL_LONG(&_9$$4, y);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagefilledrectangle", &_10, 0, &_6$$4, &_7$$4, &_9$$4, &x2, &y2, &color);
@@ -1035,14 +1035,14 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processReflection)
 	} else {
 		stepping = (long) (zephir_safe_div_long_long(127, height));
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_4, (zephir_get_numberval(&_3) + height));
 	ZEPHIR_CALL_METHOD(&reflection, this_ptr, "processcreate", NULL, 0, &_1, &_4);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_7, 0);
 	ZVAL_LONG(&_8, 0);
 	ZVAL_LONG(&_9, 0);
@@ -1054,9 +1054,9 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processReflection)
 		if (!(height >= offset)) {
 			break;
 		}
-		zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_11$$5, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 		sourceY = ((zephir_get_numberval(&_11$$5) - offset) - 1);
-		zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 		destinationY = (zephir_get_numberval(&_12$$5) + offset);
 		if (fadeIn) {
 			ZEPHIR_INIT_NVAR(&_13$$6);
@@ -1069,12 +1069,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processReflection)
 			zephir_round(&_15$$7, &_16$$7, NULL, NULL);
 			destinationOpacity = zephir_get_intval(&_15$$7);
 		}
-		zephir_read_property_cached(&_17$$5, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_17$$5, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_18$$5, 1);
 		ZEPHIR_CALL_METHOD(&line, this_ptr, "processcreate", NULL, 0, &_17$$5, &_18$$5);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_18$$5, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_19$$5, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_18$$5, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_19$$5, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_20$$5, 0);
 		ZVAL_LONG(&_21$$5, 0);
 		ZVAL_LONG(&_22$$5, 0);
@@ -1089,7 +1089,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processReflection)
 		ZVAL_LONG(&_24$$5, destinationOpacity);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagefilter", &_25, 0, &line, &_20$$5, &_21$$5, &_22$$5, &_23$$5, &_24$$5);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_20$$5, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_20$$5, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_21$$5, 0);
 		ZVAL_LONG(&_22$$5, destinationY);
 		ZVAL_LONG(&_23$$5, 0);
@@ -1099,13 +1099,13 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processReflection)
 		zephir_check_call_status();
 		offset++;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 904, &reflection);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 903, &reflection);
 	ZEPHIR_CALL_FUNCTION(&_27, "imagesx", NULL, 0, &reflection);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 901, &_27);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 900, &_27);
 	ZEPHIR_CALL_FUNCTION(&_28, "imagesy", NULL, 0, &reflection);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 902, &_28);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 901, &_28);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1155,38 +1155,38 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processRender)
 	zephir_check_call_status();
 	do {
 		if (ZEPHIR_IS_STRING(&extension, "gif")) {
-			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagegif", NULL, 0, &_1$$3);
 			zephir_check_call_status();
 			break;
 		}
 		if (ZEPHIR_IS_STRING(&extension, "jpg") || ZEPHIR_IS_STRING(&extension, "jpeg")) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 			ZVAL_LONG(&_3$$4, quality);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagejpeg", NULL, 0, &_2$$4, &__$null, &_3$$4);
 			zephir_check_call_status();
 			break;
 		}
 		if (ZEPHIR_IS_STRING(&extension, "png")) {
-			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagepng", NULL, 0, &_4$$5);
 			zephir_check_call_status();
 			break;
 		}
 		if (ZEPHIR_IS_STRING(&extension, "wbmp")) {
-			zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagewbmp", NULL, 0, &_5$$6);
 			zephir_check_call_status();
 			break;
 		}
 		if (ZEPHIR_IS_STRING(&extension, "webp")) {
-			zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagewebp", NULL, 0, &_6$$7);
 			zephir_check_call_status();
 			break;
 		}
 		if (ZEPHIR_IS_STRING(&extension, "xbm")) {
-			zephir_read_property_cached(&_7$$8, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$8, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagexbm", NULL, 0, &_7$$8, &__$null);
 			zephir_check_call_status();
 			break;
@@ -1260,9 +1260,9 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processResize)
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(NULL, "imagesavealpha", NULL, 0, &image, &__$true);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 902, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 900, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 901, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_3, 0);
 	ZVAL_LONG(&_4, 0);
 	ZVAL_LONG(&_5, 0);
@@ -1271,13 +1271,13 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processResize)
 	ZVAL_LONG(&_8, height);
 	ZEPHIR_CALL_FUNCTION(NULL, "imagecopyresampled", NULL, 0, &image, &_0, &_3, &_4, &_5, &_6, &_7, &_8, &_1, &_2);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 904, &image);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 903, &image);
 	ZEPHIR_CALL_FUNCTION(&_9, "imagesx", NULL, 0, &image);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 901, &_9);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 900, &_9);
 	ZEPHIR_CALL_FUNCTION(&_10, "imagesy", NULL, 0, &image);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 902, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 901, &_10);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1326,14 +1326,14 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processRotate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &degrees_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, 0);
 	ZVAL_LONG(&_2, 0);
 	ZVAL_LONG(&_3, 0);
 	ZVAL_LONG(&_4, 127);
 	ZEPHIR_CALL_FUNCTION(&transparent, "imagecolorallocatealpha", NULL, 0, &_0, &_1, &_2, &_3, &_4);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, (360 - degrees));
 	ZEPHIR_CALL_FUNCTION(&image, "imagerotate", NULL, 0, &_1, &_2, &transparent);
 	zephir_check_call_status();
@@ -1343,7 +1343,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processRotate)
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&height, "imagesy", NULL, 0, &image);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_3, 0);
 	ZVAL_LONG(&_4, 0);
 	ZVAL_LONG(&_5, 0);
@@ -1352,9 +1352,9 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processRotate)
 	ZEPHIR_CALL_FUNCTION(&copy, "imagecopymerge", NULL, 0, &_2, &image, &_3, &_4, &_5, &_6, &width, &height, &_7);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&copy)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 904, &image);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 901, &width);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 902, &height);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 903, &image);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 900, &width);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 901, &height);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -1418,7 +1418,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 	ZEPHIR_CALL_FUNCTION(&extension, "pathinfo", NULL, 199, &file_zv, &_0);
 	zephir_check_call_status();
 	if (1 == ZEPHIR_IS_EMPTY(&extension)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 899, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&extension, "image_type_to_extension", NULL, 0, &_1$$3, &__$false);
 		zephir_check_call_status();
 	}
@@ -1429,8 +1429,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		if (ZEPHIR_IS_STRING(&extension, "gif")) {
 			ZVAL_UNDEF(&_3$$4);
 			ZVAL_LONG(&_3$$4, 1);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 899, &_3$$4);
-			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &_3$$4);
+			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagegif", NULL, 0, &_3$$4, &file_zv);
 			zephir_check_call_status();
 			break;
@@ -1438,19 +1438,19 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		if (ZEPHIR_IS_STRING(&extension, "jpg") || ZEPHIR_IS_STRING(&extension, "jpeg")) {
 			ZVAL_UNDEF(&_4$$5);
 			ZVAL_LONG(&_4$$5, 2);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 899, &_4$$5);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &_4$$5);
 			if (quality >= 0) {
 				ZVAL_LONG(&_6$$6, quality);
 				ZVAL_LONG(&_7$$6, 1);
 				ZEPHIR_CALL_METHOD(&_5$$6, this_ptr, "checkhighlow", NULL, 0, &_6$$6, &_7$$6);
 				zephir_check_call_status();
 				quality = zephir_get_numberval(&_5$$6);
-				zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 				ZVAL_LONG(&_7$$6, quality);
 				ZEPHIR_CALL_FUNCTION(NULL, "imagejpeg", NULL, 0, &_6$$6, &file_zv, &_7$$6);
 				zephir_check_call_status();
 			} else {
-				zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_FUNCTION(NULL, "imagejpeg", NULL, 0, &_8$$7, &file_zv);
 				zephir_check_call_status();
 			}
@@ -1459,8 +1459,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		if (ZEPHIR_IS_STRING(&extension, "png")) {
 			ZVAL_UNDEF(&_9$$8);
 			ZVAL_LONG(&_9$$8, 3);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 899, &_9$$8);
-			zephir_read_property_cached(&_9$$8, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &_9$$8);
+			zephir_read_property_cached(&_9$$8, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagepng", NULL, 0, &_9$$8, &file_zv);
 			zephir_check_call_status();
 			break;
@@ -1468,8 +1468,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		if (ZEPHIR_IS_STRING(&extension, "wbmp")) {
 			ZVAL_UNDEF(&_10$$9);
 			ZVAL_LONG(&_10$$9, 15);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 899, &_10$$9);
-			zephir_read_property_cached(&_10$$9, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &_10$$9);
+			zephir_read_property_cached(&_10$$9, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagewbmp", NULL, 0, &_10$$9, &file_zv);
 			zephir_check_call_status();
 			break;
@@ -1477,8 +1477,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		if (ZEPHIR_IS_STRING(&extension, "webp")) {
 			ZVAL_UNDEF(&_11$$10);
 			ZVAL_LONG(&_11$$10, 18);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 899, &_11$$10);
-			zephir_read_property_cached(&_11$$10, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &_11$$10);
+			zephir_read_property_cached(&_11$$10, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagewebp", NULL, 0, &_11$$10, &file_zv);
 			zephir_check_call_status();
 			break;
@@ -1486,8 +1486,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		if (ZEPHIR_IS_STRING(&extension, "xbm")) {
 			ZVAL_UNDEF(&_12$$11);
 			ZVAL_LONG(&_12$$11, 16);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 899, &_12$$11);
-			zephir_read_property_cached(&_12$$11, this_ptr, _zephir_prop_1, 904, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 898, &_12$$11);
+			zephir_read_property_cached(&_12$$11, this_ptr, _zephir_prop_1, 903, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_FUNCTION(NULL, "imagexbm", NULL, 0, &_12$$11, &file_zv);
 			zephir_check_call_status();
 			break;
@@ -1501,10 +1501,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSave)
 		return;
 	} while(0);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 899, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 898, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(&_14, "image_type_to_mime_type", NULL, 0, &_0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 903, &_14);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 902, &_14);
 	RETURN_MM_BOOL(1);
 }
 
@@ -1599,20 +1599,20 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processSharpen)
 	ZVAL_LONG(&_4, -1);
 	zephir_array_fast_append(&_3, &_4);
 	zephir_array_fast_append(&matrix, &_3);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_6, (amount - 8));
 	ZVAL_LONG(&_7, 0);
 	ZEPHIR_CALL_FUNCTION(&result, "imageconvolution", NULL, 0, &_5, &matrix, &_6, &_7);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&result)) {
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_9$$3, "imagesx", NULL, 0, &_8$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 901, &_9$$3);
-		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 900, &_9$$3);
+		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_11$$3, "imagesy", NULL, 0, &_10$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 902, &_11$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 901, &_11$$3);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -1780,7 +1780,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processText)
 		ZEPHIR_INIT_VAR(&height);
 		ZVAL_LONG(&height, (zephir_get_numberval(&_13$$3) + 10));
 		if (ZEPHIR_LT_LONG(offsetX, 0)) {
-			zephir_read_property_cached(&_14$$6, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_14$$6, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_15$$6);
 			zephir_sub_function(&_15$$6, &_14$$6, &width);
 			ZEPHIR_INIT_VAR(&_16$$6);
@@ -1788,14 +1788,14 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processText)
 			ZEPHIR_CPY_WRT(offsetX, &_16$$6);
 		}
 		if (ZEPHIR_LT_LONG(offsetY, 0)) {
-			zephir_read_property_cached(&_17$$7, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_17$$7, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_18$$7);
 			zephir_sub_function(&_18$$7, &_17$$7, &height);
 			ZEPHIR_INIT_VAR(&_19$$7);
 			zephir_add_function(&_19$$7, &_18$$7, offsetY);
 			ZEPHIR_CPY_WRT(offsetY, &_19$$7);
 		}
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_6$$3, red);
 		ZVAL_LONG(&_20$$3, green);
 		ZVAL_LONG(&_21$$3, blue);
@@ -1803,7 +1803,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processText)
 		ZEPHIR_CALL_FUNCTION(&color, "imagecolorallocatealpha", NULL, 0, &_5$$3, &_6$$3, &_20$$3, &_21$$3, &_22$$3);
 		zephir_check_call_status();
 		angle = 0;
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_20$$3, size);
 		ZVAL_LONG(&_21$$3, angle);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagettftext", NULL, 0, &_6$$3, &_20$$3, &_21$$3, offsetX, offsetY, &color, &fontFile_zv, &text_zv);
@@ -1817,7 +1817,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processText)
 		ZEPHIR_CALL_FUNCTION(&height, "imagefontheight", NULL, 0, &_23$$8);
 		zephir_check_call_status();
 		if (ZEPHIR_LT_LONG(offsetX, 0)) {
-			zephir_read_property_cached(&_25$$9, this_ptr, _zephir_prop_0, 901, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_25$$9, this_ptr, _zephir_prop_0, 900, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_26$$9);
 			zephir_sub_function(&_26$$9, &_25$$9, &width);
 			ZEPHIR_INIT_VAR(&_27$$9);
@@ -1825,21 +1825,21 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processText)
 			ZEPHIR_CPY_WRT(offsetX, &_27$$9);
 		}
 		if (ZEPHIR_LT_LONG(offsetY, 0)) {
-			zephir_read_property_cached(&_28$$10, this_ptr, _zephir_prop_1, 902, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_28$$10, this_ptr, _zephir_prop_1, 901, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_29$$10);
 			zephir_sub_function(&_29$$10, &_28$$10, &height);
 			ZEPHIR_INIT_VAR(&_30$$10);
 			zephir_add_function(&_30$$10, &_29$$10, offsetY);
 			ZEPHIR_CPY_WRT(offsetY, &_30$$10);
 		}
-		zephir_read_property_cached(&_23$$8, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_23$$8, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_31$$8, red);
 		ZVAL_LONG(&_32$$8, green);
 		ZVAL_LONG(&_33$$8, blue);
 		ZVAL_LONG(&_34$$8, opacity);
 		ZEPHIR_CALL_FUNCTION(&color, "imagecolorallocatealpha", NULL, 0, &_23$$8, &_31$$8, &_32$$8, &_33$$8, &_34$$8);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_31$$8, this_ptr, _zephir_prop_2, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_31$$8, this_ptr, _zephir_prop_2, 903, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_32$$8, size);
 		ZEPHIR_CALL_FUNCTION(NULL, "imagestring", NULL, 0, &_31$$8, &_32$$8, offsetX, offsetY, &text_zv, &color);
 		zephir_check_call_status();
@@ -1924,10 +1924,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, processWatermark)
 		ZEPHIR_CALL_FUNCTION(NULL, "imagefilledrectangle", NULL, 0, &overlay, &_4$$3, &_6$$3, &_7$$3, &_8$$3, &color);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(NULL, "imagealphablending", NULL, 0, &_9, &__$true);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_0, 903, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_11, offsetX);
 	ZVAL_LONG(&_12, offsetY);
 	ZVAL_LONG(&_13, 0);
@@ -2444,7 +2444,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Gd, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/image/adapter/imagick.zep.c
+++ b/ext/phalcon/image/adapter/imagick.zep.c
@@ -190,39 +190,39 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, __construct)
 		}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "check", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 905, &file_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 904, &file_zv);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, zephir_get_internal_ce(SL("imagick")));
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 906, &_0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 905, &_0);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "phpfileexists", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&_1)) {
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_4$$3, "realpath", NULL, 157, &_3$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 907, &_4$$3);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_2, 907, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 906, &_4$$3);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_2, 906, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_6$$3, &_5$$3, "readimage", NULL, 0, &_7$$3);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_6$$3)) {
 			ZEPHIR_INIT_VAR(&_8$$4);
 			object_init_ex(&_8$$4, phalcon_image_exceptions_imageloadfailed_ce);
-			zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$4, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_8$$4, "__construct", NULL, 0, &_9$$4);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_8$$4, "phalcon/Image/Adapter/Imagick.zep", 96);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_11$$3, &_10$$3, "getimagealphachannel", NULL, 0);
 		zephir_check_call_status();
 		if (!zephir_is_true(&_11$$3)) {
-			zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_12$$5, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_13$$5);
 			ZVAL_STRING(&_13$$5, "Imagick::ALPHACHANNEL_SET");
 			ZEPHIR_CALL_FUNCTION(&_14$$5, "constant", NULL, 148, &_13$$5);
@@ -230,24 +230,24 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, __construct)
 			ZEPHIR_CALL_METHOD(NULL, &_12$$5, "setimagealphachannel", NULL, 0, &_14$$5);
 			zephir_check_call_status();
 		}
-		zephir_read_property_cached(&_15$$3, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_15$$3, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_16$$3, &_15$$3, "getimagetype", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 908, &_16$$3);
-		zephir_read_property_cached(&_17$$3, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 907, &_16$$3);
+		zephir_read_property_cached(&_17$$3, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_18$$3, &_17$$3, "getimagetype", NULL, 0);
 		zephir_check_call_status();
 		if (ZEPHIR_IS_LONG(&_18$$3, 1)) {
-			zephir_read_property_cached(&_19$$6, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_19$$6, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&image, &_19$$6, "coalesceimages", NULL, 0);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_20$$6, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_20$$6, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_20$$6, "clear", NULL, 0);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_21$$6, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_21$$6, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_21$$6, "destroy", NULL, 0);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 906, &image);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 905, &image);
 		}
 	} else {
 		_22$$7 = 0 == width;
@@ -257,14 +257,14 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, __construct)
 		if (_22$$7) {
 			ZEPHIR_INIT_VAR(&_23$$8);
 			object_init_ex(&_23$$8, phalcon_image_exceptions_imageloadfailed_ce);
-			zephir_read_property_cached(&_24$$8, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_24$$8, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_23$$8, "__construct", NULL, 0, &_24$$8);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_23$$8, "phalcon/Image/Adapter/Imagick.zep", 119);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_25$$7, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_25$$7, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_26$$7);
 		object_init_ex(&_26$$7, zephir_get_internal_ce(SL("imagickpixel")));
 		ZEPHIR_INIT_VAR(&_27$$7);
@@ -275,37 +275,37 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, __construct)
 		ZVAL_LONG(&_29$$7, height);
 		ZEPHIR_CALL_METHOD(NULL, &_25$$7, "newimage", NULL, 0, &_28$$7, &_29$$7, &_26$$7);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_28$$7, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_28$$7, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_27$$7);
 		ZVAL_STRING(&_27$$7, "png");
 		ZEPHIR_CALL_METHOD(NULL, &_28$$7, "setformat", NULL, 0, &_27$$7);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_29$$7, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_29$$7, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_27$$7);
 		ZVAL_STRING(&_27$$7, "png");
 		ZEPHIR_CALL_METHOD(NULL, &_29$$7, "setimageformat", NULL, 0, &_27$$7);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_30$$7, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 907, &_30$$7);
+		zephir_read_property_cached(&_30$$7, this_ptr, _zephir_prop_0, 904, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 906, &_30$$7);
 	}
-	zephir_read_property_cached(&_31, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_31, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_32, &_31, "getimagewidth", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 909, &_32);
-	zephir_read_property_cached(&_33, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 908, &_32);
+	zephir_read_property_cached(&_33, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_34, &_33, "getimageheight", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 910, &_34);
-	zephir_read_property_cached(&_35, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 909, &_34);
+	zephir_read_property_cached(&_35, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_36, &_35, "getimagetype", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 908, &_36);
-	zephir_read_property_cached(&_37, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 907, &_36);
+	zephir_read_property_cached(&_37, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_38, &_37, "getimageformat", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_39);
 	ZEPHIR_CONCAT_SV(&_39, "image/", &_38);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 911, &_39);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 910, &_39);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -330,12 +330,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, __destruct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC);
 	if (zephir_is_instance_of(&_0, SL("Imagick"))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "clear", NULL, 0);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "destroy", NULL, 0);
 		zephir_check_call_status();
 	}
@@ -444,7 +444,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, liquidRescale)
 		rigidity = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&image, &_0);
 	ZVAL_LONG(&_0, 0);
 	ZEPHIR_CALL_METHOD(NULL, &image, "setiteratorindex", NULL, 0, &_0);
@@ -476,10 +476,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, liquidRescale)
 	}
 	ZEPHIR_CALL_METHOD(&_10, &image, "getimagewidth", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 909, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 908, &_10);
 	ZEPHIR_CALL_METHOD(&_11, &image, "getimageheight", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 910, &_11);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 909, &_11);
 	RETURN_THIS();
 }
 
@@ -524,7 +524,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, setResourceLimit)
 		_0 = type <= 6;
 	}
 	if (_0) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_2$$3, type);
 		ZVAL_LONG(&_3$$3, limit);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "setresourcelimit", NULL, 0, &_2$$3, &_3$$3);
@@ -634,7 +634,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processBackground)
 	object_init_ex(&background, zephir_get_internal_ce(SL("imagick")));
 	ZEPHIR_CALL_METHOD(NULL, &background, "__construct", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setiteratorindex", NULL, 0, &_2);
 	zephir_check_call_status();
@@ -642,8 +642,8 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processBackground)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 909, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 910, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 908, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 909, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &background, "newimage", &_6, 0, &_4$$3, &_5$$3, &pixel1);
 		zephir_check_call_status();
 
@@ -687,12 +687,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processBackground)
 		ZVAL_LONG(&_19$$3, localOpacity);
 		ZEPHIR_CALL_METHOD(NULL, &background, "evaluateimage", &_20, 0, &_17$$3, &_19$$3, &_18$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_19$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_19$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_21$$3, &_19$$3, "getcolorspace", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &background, "setcolorspace", &_22, 0, &_21$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_23$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_23$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_16$$3);
 		ZVAL_STRING(&_16$$3, "Imagick::COMPOSITE_DISSOLVE");
 		ZEPHIR_CALL_FUNCTION(&_24$$3, "constant", &_11, 148, &_16$$3);
@@ -710,20 +710,20 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processBackground)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_25$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_25$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_30$$3, &_25$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_30$$3)) {
 			break;
 		}
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_2, "clear", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_3, "destroy", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 906, &background);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 905, &background);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -759,7 +759,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processBlur)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &radius_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setiteratorindex", NULL, 0, &_1);
 	zephir_check_call_status();
@@ -767,12 +767,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processBlur)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_3$$3, radius);
 		ZVAL_LONG(&_4$$3, 100);
 		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "blurimage", NULL, 0, &_3$$3, &_4$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_5$$3, &_3$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_5$$3)) {
@@ -832,7 +832,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processCrop)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 4, 0, &width_param, &height_param, &offsetX_param, &offsetY_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&image, &_0);
 	ZVAL_LONG(&_0, 0);
 	ZEPHIR_CALL_METHOD(NULL, &image, "setiteratorindex", NULL, 0, &_0);
@@ -861,10 +861,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processCrop)
 	}
 	ZEPHIR_CALL_METHOD(&_9, &image, "getimagewidth", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 909, &_9);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 908, &_9);
 	ZEPHIR_CALL_METHOD(&_10, &image, "getimageheight", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 910, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 909, &_10);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -907,7 +907,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processFlip)
 		ZEPHIR_INIT_NVAR(&method);
 		ZVAL_STRING(&method, "flopImage");
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setiteratorindex", NULL, 0, &_1);
 	zephir_check_call_status();
@@ -915,10 +915,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processFlip)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD_ZVAL(NULL, &_2$$3, &method, NULL, 0);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_4$$3, &_3$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_4$$3)) {
@@ -978,7 +978,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processMask)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &image, "readimageblob", NULL, 0, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setiteratorindex", NULL, 0, &_2);
 	zephir_check_call_status();
@@ -986,11 +986,11 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processMask)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_BOOL(&_4$$3, 1);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "setimagematte", NULL, 0, &_4$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_5$$3);
 		ZVAL_STRING(&_5$$3, "Imagick::COMPOSITE_DSTIN");
 		ZEPHIR_CALL_FUNCTION(&_6$$3, "constant", &_7, 148, &_5$$3);
@@ -1008,7 +1008,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processMask)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_12$$3, &_8$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_12$$3)) {
@@ -1066,11 +1066,11 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processPixelate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &amount_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 909, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 908, PH_NOISY_CC | PH_READONLY);
 	width = (int) (zephir_safe_div_zval_long(&_0, amount));
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 910, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 909, PH_NOISY_CC | PH_READONLY);
 	height = (int) (zephir_safe_div_zval_long(&_1, amount));
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_3, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_2, "setiteratorindex", NULL, 0, &_3);
 	zephir_check_call_status();
@@ -1078,17 +1078,17 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processPixelate)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_2, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_5$$3, width);
 		ZVAL_LONG(&_6$$3, height);
 		ZEPHIR_CALL_METHOD(NULL, &_4$$3, "scaleimage", NULL, 0, &_5$$3, &_6$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 906, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 909, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_1, 910, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 905, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 908, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$3, this_ptr, _zephir_prop_1, 909, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_5$$3, "scaleimage", NULL, 0, &_6$$3, &_7$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_2, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_2, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_9$$3, &_8$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_9$$3)) {
@@ -1198,15 +1198,15 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 3, 0, &height_param, &opacity_param, &fadeIn_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 912, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 911, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&reflection);
 	if (ZEPHIR_GE_LONG(&_0, 30100)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		if (zephir_clone(&reflection, &_1$$3) == FAILURE) {
 			RETURN_MM();
 		}
 	} else {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_3$$4, &_2$$4, "clone", NULL, 0);
 		zephir_check_call_status();
 		if (zephir_clone(&reflection, &_3$$4) == FAILURE) {
@@ -1236,7 +1236,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 		ZVAL_LONG(&_10$$5, 0);
 		ZEPHIR_CALL_METHOD(NULL, &reflection, "setimagepage", &_14, 0, &_12$$5, &_8$$5, &_9$$5, &_10$$5);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_8$$5, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$5, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_15$$5, &_8$$5, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_15$$5)) {
@@ -1296,7 +1296,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 		ZVAL_LONG(&_21$$7, opacity);
 		ZEPHIR_CALL_METHOD(NULL, &reflection, "evaluateimage", &_28, 0, &_26$$7, &_21$$7, &_27$$7);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_21$$7, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_21$$7, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_29$$7, &_21$$7, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_29$$7)) {
@@ -1313,11 +1313,11 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 	object_init_ex(&pixel, zephir_get_internal_ce(SL("imagickpixel")));
 	ZEPHIR_CALL_METHOD(NULL, &pixel, "__construct", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_30, &_4, "getimageheight", NULL, 0);
 	zephir_check_call_status();
 	height = (zephir_get_numberval(&_30) + height);
-	zephir_read_property_cached(&_31, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_31, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_32, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_31, "setiteratorindex", NULL, 0, &_32);
 	zephir_check_call_status();
@@ -1325,7 +1325,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_33$$10, this_ptr, _zephir_prop_2, 909, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_33$$10, this_ptr, _zephir_prop_2, 908, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_34$$10, height);
 		ZEPHIR_CALL_METHOD(NULL, &image, "newimage", &_35, 0, &_33$$10, &_34$$10, &pixel);
 		zephir_check_call_status();
@@ -1335,17 +1335,17 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &image, "setimagealphachannel", &_38, 0, &_37$$10);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_34$$10, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_34$$10, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_39$$10, &_34$$10, "getcolorspace", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &image, "setcolorspace", &_40, 0, &_39$$10);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_41$$10, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_41$$10, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_42$$10, &_41$$10, "getimagedelay", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &image, "setimagedelay", &_43, 0, &_42$$10);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_44$$10, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_44$$10, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_36$$10);
 		ZVAL_STRING(&_36$$10, "Imagick::COMPOSITE_SRC");
 		ZEPHIR_CALL_FUNCTION(&_45$$10, "constant", &_20, 148, &_36$$10);
@@ -1363,7 +1363,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_46$$10, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_46$$10, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_50$$10, &_46$$10, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_50$$10)) {
@@ -1384,7 +1384,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 		ZVAL_STRING(&_51$$13, "Imagick::COMPOSITE_OVER");
 		ZEPHIR_CALL_FUNCTION(&_52$$13, "constant", &_20, 148, &_51$$13);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_53$$13, this_ptr, _zephir_prop_3, 910, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_53$$13, this_ptr, _zephir_prop_3, 909, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_54$$13, 0);
 		ZEPHIR_CALL_METHOD(&result, &image, "compositeimage", &_48, 0, &reflection, &_52$$13, &_54$$13, &_53$$13);
 		zephir_check_call_status();
@@ -1411,21 +1411,21 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processReflection)
 	}
 	ZEPHIR_CALL_METHOD(NULL, &reflection, "destroy", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_32, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_32, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_32, "clear", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_60, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_60, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_60, "destroy", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 906, &image);
-	zephir_read_property_cached(&_61, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 905, &image);
+	zephir_read_property_cached(&_61, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_62, &_61, "getimagewidth", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 909, &_62);
-	zephir_read_property_cached(&_63, this_ptr, _zephir_prop_1, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 908, &_62);
+	zephir_read_property_cached(&_63, this_ptr, _zephir_prop_1, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_64, &_63, "getimageheight", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 910, &_64);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 909, &_64);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1477,7 +1477,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processRender)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &extension_param, &quality_param);
 	zephir_get_strval(&extension, extension_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&image, &_0);
 	ZEPHIR_CALL_METHOD(NULL, &image, "setformat", NULL, 0, &extension);
 	zephir_check_call_status();
@@ -1487,12 +1487,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processRender)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, &image, "getimagetype", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 908, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 907, &_1);
 	ZEPHIR_CALL_METHOD(&_2, &image, "getimageformat", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_3);
 	ZEPHIR_CONCAT_SV(&_3, "image/", &_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 911, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 910, &_3);
 	ZEPHIR_INIT_VAR(&_4);
 	zephir_fast_strtolower(&_4, &extension);
 	zephir_get_strval(&extension, &_4);
@@ -1564,7 +1564,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processResize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &width_param, &height_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&image, &_0);
 	ZVAL_LONG(&_0, 0);
 	ZEPHIR_CALL_METHOD(NULL, &image, "setiteratorindex", NULL, 0, &_0);
@@ -1585,10 +1585,10 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processResize)
 	}
 	ZEPHIR_CALL_METHOD(&_6, &image, "getimagewidth", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 909, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 908, &_6);
 	ZEPHIR_CALL_METHOD(&_7, &image, "getimageheight", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 910, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 909, &_7);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1639,7 +1639,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processRotate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &degrees_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setiteratorindex", NULL, 0, &_1);
 	zephir_check_call_status();
@@ -1651,32 +1651,32 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processRotate)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_3$$3, degrees);
 		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "rotateimage", NULL, 0, &pixel, &_3$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 909, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 910, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 908, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 909, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_6$$3, 0);
 		ZVAL_LONG(&_7$$3, 0);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "setimagepage", NULL, 0, &_4$$3, &_5$$3, &_6$$3, &_7$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_8$$3, &_6$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_8$$3)) {
 			break;
 		}
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_9, &_1, "getimagewidth", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 909, &_9);
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 908, &_9);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_11, &_10, "getimageheight", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 910, &_11);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 909, &_11);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1743,35 +1743,35 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processSave)
 	ZVAL_LONG(&_0, 4);
 	ZEPHIR_CALL_FUNCTION(&extension, "pathinfo", NULL, 199, &file_zv, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setformat", NULL, 0, &extension);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setimageformat", NULL, 0, &extension);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, &_2, "getimagetype", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 908, &_3);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 907, &_3);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_4, "getimageformat", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_6);
 	ZEPHIR_CONCAT_SV(&_6, "image/", &_5);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 911, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 910, &_6);
 	ZEPHIR_INIT_VAR(&_7);
 	zephir_fast_strtolower(&_7, &extension);
 	ZEPHIR_CPY_WRT(&extension, &_7);
 	do {
 		if (ZEPHIR_IS_STRING(&extension, "gif")) {
-			zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_8$$3, "optimizeimagelayers", NULL, 0);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_9$$3);
 			ZVAL_STRING(&_9$$3, "w");
 			ZEPHIR_CALL_METHOD(&fp, this_ptr, "phpfopen", NULL, 0, &file_zv, &_9$$3);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_10$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_10$$3, "writeimagesfile", NULL, 0, &fp);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfclose", NULL, 0, &fp);
@@ -1779,7 +1779,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processSave)
 			RETURN_MM_NULL();
 		}
 		if (ZEPHIR_IS_STRING(&extension, "jpg") || ZEPHIR_IS_STRING(&extension, "jpeg")) {
-			zephir_read_property_cached(&_11$$4, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_11$$4, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_12$$4);
 			ZVAL_STRING(&_12$$4, "Imagick::COMPRESSION_JPEG");
 			ZEPHIR_CALL_FUNCTION(&_13$$4, "constant", NULL, 148, &_12$$4);
@@ -1795,12 +1795,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processSave)
 		ZEPHIR_CALL_METHOD(&_14$$5, this_ptr, "checkhighlow", NULL, 0, &_15$$5, &_16$$5);
 		zephir_check_call_status();
 		quality = zephir_get_numberval(&_14$$5);
-		zephir_read_property_cached(&_15$$5, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_15$$5, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_16$$5, quality);
 		ZEPHIR_CALL_METHOD(NULL, &_15$$5, "setimagecompressionquality", NULL, 0, &_16$$5);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_17, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_17, "writeimage", NULL, 0, &file_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -1849,7 +1849,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processSharpen)
 	}
 	amount = zephir_get_numberval(&_0);
 	amount = (long) (zephir_safe_div_long_long(((amount * 3.0)), 100));
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setiteratorindex", NULL, 0, &_2);
 	zephir_check_call_status();
@@ -1857,12 +1857,12 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processSharpen)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_4$$3, 0);
 		ZVAL_LONG(&_5$$3, amount);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "sharpenimage", NULL, 0, &_4$$3, &_5$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_6$$3, &_4$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_6$$3)) {
@@ -2149,7 +2149,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processText)
 		ZEPHIR_CALL_METHOD(NULL, &draw, "setgravity", NULL, 0, &gravity);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "setiteratorindex", NULL, 0, &_2);
 	zephir_check_call_status();
@@ -2157,11 +2157,11 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processText)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_18$$14, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_18$$14, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_19$$14, 0);
 		ZEPHIR_CALL_METHOD(NULL, &_18$$14, "annotateimage", NULL, 0, &draw, offsetX, offsetY, &_19$$14, &text_zv);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_19$$14, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_19$$14, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_20$$14, &_19$$14, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_20$$14)) {
@@ -2243,7 +2243,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processWatermark)
 	ZVAL_LONG(&_4, opacity);
 	ZEPHIR_CALL_METHOD(NULL, &image, "evaluateimage", NULL, 0, &_2, &_4, &_3);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_5, 0);
 	ZEPHIR_CALL_METHOD(NULL, &_4, "setiteratorindex", NULL, 0, &_5);
 	zephir_check_call_status();
@@ -2251,7 +2251,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processWatermark)
 		if (!(1)) {
 			break;
 		}
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_7$$3);
 		ZVAL_STRING(&_7$$3, "Imagick::COMPOSITE_OVER");
 		ZEPHIR_CALL_FUNCTION(&_8$$3, "constant", NULL, 148, &_7$$3);
@@ -2269,7 +2269,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, processWatermark)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_0, 906, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_0, 905, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_13$$3, &_9$$3, "nextimage", NULL, 0);
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_TRUE_IDENTICAL(&_13$$3)) {
@@ -2323,7 +2323,7 @@ PHP_METHOD(Phalcon_Image_Adapter_Imagick, check)
 		ZVAL_STRING(&_3$$4, "Imagick::IMAGICK_EXTNUM");
 		ZEPHIR_CALL_FUNCTION(&_4$$4, "constant", NULL, 148, &_3$$4);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 912, &_4$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 911, &_4$$4);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/logger/abstractlogger.zep.c
+++ b/ext/phalcon/logger/abstractlogger.zep.c
@@ -220,7 +220,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, __construct)
 		ZEPHIR_SEPARATE_PARAM(clock);
 	}
 	if (Z_TYPE_P(timezone) == IS_NULL) {
-		ZEPHIR_CALL_FUNCTION(&defaultTimezone, "date_default_timezone_get", NULL, 247);
+		ZEPHIR_CALL_FUNCTION(&defaultTimezone, "date_default_timezone_get", NULL, 248);
 		zephir_check_call_status();
 		if (UNEXPECTED(1 == ZEPHIR_IS_EMPTY(&defaultTimezone))) {
 			ZEPHIR_INIT_NVAR(&defaultTimezone);
@@ -236,7 +236,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, __construct)
 	if (Z_TYPE_P(clock) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(clock);
 		object_init_ex(clock, phalcon_time_clock_systemclock_ce);
-		ZEPHIR_CALL_METHOD(NULL, clock, "__construct", NULL, 248, timezone);
+		ZEPHIR_CALL_METHOD(NULL, clock, "__construct", NULL, 249, timezone);
 		zephir_check_call_status();
 	}
 	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 270, clock);
@@ -302,7 +302,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, begin)
 
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 271, PH_NOISY_CC | PH_READONLY);
 	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 272, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 249, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 250, &_0, &_1);
 	zephir_check_call_status();
 	zephir_is_iterable(&collection, 0, "phalcon/Logger/AbstractLogger.zep", 194);
 	if (Z_TYPE_P(&collection) == IS_ARRAY) {
@@ -370,7 +370,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, commit)
 
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 271, PH_NOISY_CC | PH_READONLY);
 	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 272, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 249, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 250, &_0, &_1);
 	zephir_check_call_status();
 	zephir_is_iterable(&collection, 0, "phalcon/Logger/AbstractLogger.zep", 211);
 	if (Z_TYPE_P(&collection) == IS_ARRAY) {
@@ -522,7 +522,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, getAdapter)
 	if (1 != zephir_array_isset_value(&_0, &name_zv)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_logger_exceptions_adapternotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 250, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 251, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Logger/AbstractLogger.zep", 257);
 		ZEPHIR_MM_RESTORE();
@@ -598,7 +598,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, removeAdapter)
 	if (1 != zephir_array_isset_value(&_0, &name_zv)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_logger_exceptions_adapternotfound_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 250, &name_zv);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 251, &name_zv);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Logger/AbstractLogger.zep", 300);
 		ZEPHIR_MM_RESTORE();
@@ -641,7 +641,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, rollback)
 
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 271, PH_NOISY_CC | PH_READONLY);
 	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 272, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 249, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 250, &_0, &_1);
 	zephir_check_call_status();
 	zephir_is_iterable(&collection, 0, "phalcon/Logger/AbstractLogger.zep", 322);
 	if (Z_TYPE_P(&collection) == IS_ARRAY) {
@@ -836,7 +836,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, addMessage)
 		if (zephir_fast_count_int(&_1$$3) == 0) {
 			ZEPHIR_INIT_VAR(&_2$$4);
 			object_init_ex(&_2$$4, phalcon_logger_exceptions_noadaptersconfigured_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 251);
+			ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 252);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_2$$4, "phalcon/Logger/AbstractLogger.zep", 380);
 			ZEPHIR_MM_RESTORE();
@@ -857,11 +857,11 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, addMessage)
 		ZEPHIR_CALL_METHOD(&_4$$3, &_3$$3, "now", NULL, 0);
 		zephir_check_call_status();
 		ZVAL_LONG(&_5$$3, level);
-		ZEPHIR_CALL_METHOD(NULL, &item, "__construct", NULL, 252, &message_zv, &levelName, &_5$$3, &_4$$3, &context);
+		ZEPHIR_CALL_METHOD(NULL, &item, "__construct", NULL, 253, &message_zv, &levelName, &_5$$3, &_4$$3, &context);
 		zephir_check_call_status();
 		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 271, PH_NOISY_CC | PH_READONLY);
 		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_3, 272, PH_NOISY_CC | PH_READONLY);
-		ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 249, &_5$$3, &_6$$3);
+		ZEPHIR_CALL_FUNCTION(&collection, "array_diff_key", NULL, 250, &_5$$3, &_6$$3);
 		zephir_check_call_status();
 		zephir_is_iterable(&collection, 0, "phalcon/Logger/AbstractLogger.zep", 405);
 		if (Z_TYPE_P(&collection) == IS_ARRAY) {
@@ -946,7 +946,7 @@ PHP_METHOD(Phalcon_Logger_AbstractLogger, getLevelNumber)
 		zephir_fast_strtolower(&levelName, level);
 		ZEPHIR_CALL_METHOD(&_0$$3, this_ptr, "getlevels", NULL, 0);
 		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(&levels, "array_flip", NULL, 253, &_0$$3);
+		ZEPHIR_CALL_FUNCTION(&levels, "array_flip", NULL, 254, &_0$$3);
 		zephir_check_call_status();
 		if (zephir_array_isset_value(&levels, &levelName)) {
 			zephir_array_fetch(&_1$$4, &levels, &levelName, PH_NOISY | PH_READONLY, "phalcon/Logger/AbstractLogger.zep", 436);

--- a/ext/phalcon/logger/adapter/stream.zep.c
+++ b/ext/phalcon/logger/adapter/stream.zep.c
@@ -144,8 +144,8 @@ PHP_METHOD(Phalcon_Logger_Adapter_Stream, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 913, &name_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 914, &mode);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 912, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 913, &mode);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -170,11 +170,11 @@ PHP_METHOD(Phalcon_Logger_Adapter_Stream, close)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 915, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 914, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 915, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 914, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&handler, &_1$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 915, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 914, &__$null);
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "phpfclose", NULL, 0, &handler);
 		zephir_check_call_status();
 		RETURN_MM();
@@ -237,25 +237,25 @@ PHP_METHOD(Phalcon_Logger_Adapter_Stream, process)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &item);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 915, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 914, PH_NOISY_CC | PH_READONLY);
 	if (!(Z_TYPE_P(&_0) == IS_RESOURCE)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 913, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 914, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 912, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 913, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&fileHandler, this_ptr, "phpfopen", NULL, 0, &_1$$3, &_2$$3);
 		zephir_check_call_status();
 		if (!(Z_TYPE_P(&fileHandler) == IS_RESOURCE)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 915, &__$null);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 914, &__$null);
 			ZEPHIR_INIT_VAR(&_3$$4);
 			object_init_ex(&_3$$4, phalcon_logger_adapter_exceptions_fileopenfailed_ce);
-			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 913, PH_NOISY_CC | PH_READONLY);
-			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_2, 914, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_1, 912, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_5$$4, this_ptr, _zephir_prop_2, 913, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_3$$4, "__construct", NULL, 0, &_4$$4, &_5$$4);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_3$$4, "phalcon/Logger/Adapter/Stream.zep", 127);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 915, &fileHandler);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 914, &fileHandler);
 	}
 	ZEPHIR_CALL_METHOD(&_6, this_ptr, "getformatteditem", NULL, 0, item);
 	zephir_check_call_status();
@@ -263,7 +263,7 @@ PHP_METHOD(Phalcon_Logger_Adapter_Stream, process)
 	ZEPHIR_GET_CONSTANT(&_7, "PHP_EOL");
 	ZEPHIR_INIT_VAR(&message);
 	ZEPHIR_CONCAT_VV(&message, &_6, &_7);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 915, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 914, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfwrite", NULL, 0, &_8, &message);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/logger/adapter/syslog.zep.c
+++ b/ext/phalcon/logger/adapter/syslog.zep.c
@@ -119,9 +119,9 @@ PHP_METHOD(Phalcon_Logger_Adapter_Syslog, __construct)
 		ZEPHIR_INIT_NVAR(&option);
 		ZVAL_LONG(&option, 4);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 916, &name_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 917, &option);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 918, &facility);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 915, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 916, &option);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 917, &facility);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -143,7 +143,7 @@ PHP_METHOD(Phalcon_Logger_Adapter_Syslog, close)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 919, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 918, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		RETURN_MM_BOOL(1);
 	}
@@ -204,16 +204,16 @@ PHP_METHOD(Phalcon_Logger_Adapter_Syslog, process)
 	zephir_fetch_params(1, 1, 0, &item);
 	ZEPHIR_CALL_METHOD(&message, this_ptr, "getformatteditem", NULL, 0, item);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 916, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 917, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 918, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 915, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 916, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 917, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&result, this_ptr, "openlog", NULL, 0, &_0, &_1, &_2);
 	zephir_check_call_status();
 	if (!zephir_is_true(&result)) {
 		ZEPHIR_INIT_VAR(&_3$$3);
 		object_init_ex(&_3$$3, phalcon_logger_adapter_exceptions_syslogopenfailed_ce);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 916, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 918, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 915, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_2, 917, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 0, &_4$$3, &_5$$3);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$3, "phalcon/Logger/Adapter/Syslog.zep", 100);
@@ -221,9 +221,9 @@ PHP_METHOD(Phalcon_Logger_Adapter_Syslog, process)
 		return;
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 919, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 918, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 919, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 918, &__$false);
 	}
 	ZEPHIR_CALL_METHOD(&_6, item, "getlevel", NULL, 0);
 	zephir_check_call_status();

--- a/ext/phalcon/logger/formatter/json.zep.c
+++ b/ext/phalcon/logger/formatter/json.zep.c
@@ -101,9 +101,9 @@ PHP_METHOD(Phalcon_Logger_Formatter_Json, __construct)
 		zephir_memory_observe(&interpolatorRight_zv);
 	ZVAL_STR_COPY(&interpolatorRight_zv, interpolatorRight);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 920, &dateFormat_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 921, &interpolatorLeft_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 922, &interpolatorRight_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 919, &dateFormat_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 920, &interpolatorLeft_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 921, &interpolatorRight_zv);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/logger/formatter/line.zep.c
+++ b/ext/phalcon/logger/formatter/line.zep.c
@@ -120,10 +120,10 @@ PHP_METHOD(Phalcon_Logger_Formatter_Line, __construct)
 		zephir_memory_observe(&interpolatorRight_zv);
 	ZVAL_STR_COPY(&interpolatorRight_zv, interpolatorRight);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 923, &format_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 924, &dateFormat_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 925, &interpolatorLeft_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 926, &interpolatorRight_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 922, &format_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 923, &dateFormat_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 924, &interpolatorLeft_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 925, &interpolatorRight_zv);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -176,25 +176,25 @@ PHP_METHOD(Phalcon_Logger_Formatter_Line, format)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &item);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 923, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 922, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_create_array(&_1, 3, 0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 925, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 926, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 924, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 925, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_4);
 	ZEPHIR_CONCAT_VSV(&_4, &_2, "date", &_3);
 	ZEPHIR_CALL_METHOD(&_5, this_ptr, "getformatteddate", NULL, 0, item);
 	zephir_check_call_status();
 	zephir_array_update_zval(&_1, &_4, &_5, PH_COPY);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 925, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 926, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 924, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 925, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_8);
 	ZEPHIR_CONCAT_VSV(&_8, &_6, "level", &_7);
 	ZEPHIR_CALL_METHOD(&_5, item, "getlevelname", NULL, 0);
 	zephir_check_call_status();
 	zephir_array_update_zval(&_1, &_8, &_5, PH_COPY);
-	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_1, 925, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 926, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_1, 924, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_10, this_ptr, _zephir_prop_2, 925, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_11);
 	ZEPHIR_CONCAT_VSV(&_11, &_9, "message", &_10);
 	ZEPHIR_CALL_METHOD(&_5, item, "getmessage", NULL, 0);
@@ -241,7 +241,7 @@ PHP_METHOD(Phalcon_Logger_Formatter_Line, setFormat)
 		Z_PARAM_STR(format)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&format_zv, format);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 923, &format_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 922, &format_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/logger/item.zep.c
+++ b/ext/phalcon/logger/item.zep.c
@@ -133,13 +133,13 @@ PHP_METHOD(Phalcon_Logger_Item, __construct)
 	} else {
 		zephir_get_arrval(&context, context_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 927, &message_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 928, &levelName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 926, &message_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 927, &levelName_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, level);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 929, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 930, dateTime);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 931, &context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 928, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 929, dateTime);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 930, &context);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/logger/loggerfactory.zep.c
+++ b/ext/phalcon/logger/loggerfactory.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Phalcon_Logger_LoggerFactory, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(factory, phalcon_logger_adapterfactory_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &factory);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 932, factory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 931, factory);
 }
 
 /**
@@ -182,7 +182,7 @@ PHP_METHOD(Phalcon_Logger_LoggerFactory, load)
 			ZVAL_STRING(&_8$$3, "options");
 			ZEPHIR_CALL_METHOD(&adapterOptions, this_ptr, "getarrval", NULL, 0, &adapter, &_8$$3, &_7$$3);
 			zephir_check_call_status();
-			zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_0, 932, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$3, this_ptr, _zephir_prop_0, 931, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_10$$3, &_9$$3, "newinstance", NULL, 0, &adapterClass, &adapterFileName, &adapterOptions);
 			zephir_check_call_status();
 			zephir_array_update_zval(&data, &adapterName, &_10$$3, PH_COPY | PH_SEPARATE);
@@ -221,7 +221,7 @@ PHP_METHOD(Phalcon_Logger_LoggerFactory, load)
 				ZVAL_STRING(&_14$$4, "options");
 				ZEPHIR_CALL_METHOD(&adapterOptions, this_ptr, "getarrval", NULL, 0, &adapter, &_14$$4, &_13$$4);
 				zephir_check_call_status();
-				zephir_read_property_cached(&_15$$4, this_ptr, _zephir_prop_0, 932, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_15$$4, this_ptr, _zephir_prop_0, 931, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&_16$$4, &_15$$4, "newinstance", NULL, 0, &adapterClass, &adapterFileName, &adapterOptions);
 				zephir_check_call_status();
 				zephir_array_update_zval(&data, &adapterName, &_16$$4, PH_COPY | PH_SEPARATE);

--- a/ext/phalcon/messages/message.zep.c
+++ b/ext/phalcon/messages/message.zep.c
@@ -145,13 +145,13 @@ PHP_METHOD(Phalcon_Messages_Message, __construct)
 	} else {
 		zephir_get_arrval(&metaData, metaData_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 933, &message_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 934, &field_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 935, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 932, &message_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 933, &field_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 934, &type_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, code);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 936, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 937, &metaData);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 935, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 936, &metaData);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -244,19 +244,19 @@ PHP_METHOD(Phalcon_Messages_Message, jsonSerialize)
 
 	zephir_create_array(return_value, 5, 0);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 934, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 933, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("field"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 933, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 932, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("message"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 935, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 934, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("type"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 936, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 935, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("code"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 937, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 936, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("metaData"), &_0, PH_COPY | PH_SEPARATE);
 	RETURN_MM();
 }
@@ -282,7 +282,7 @@ PHP_METHOD(Phalcon_Messages_Message, setCode)
 	zephir_fetch_params_without_memory_grow(1, 0, &code_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, code);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 936, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 935, &_0);
 	RETURN_THISW();
 }
 
@@ -305,7 +305,7 @@ PHP_METHOD(Phalcon_Messages_Message, setField)
 		Z_PARAM_STR(field)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&field_zv, field);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 934, &field_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 933, &field_zv);
 	RETURN_THISW();
 }
 
@@ -328,7 +328,7 @@ PHP_METHOD(Phalcon_Messages_Message, setMessage)
 		Z_PARAM_STR(message)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&message_zv, message);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 933, &message_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 932, &message_zv);
 	RETURN_THISW();
 }
 
@@ -355,7 +355,7 @@ PHP_METHOD(Phalcon_Messages_Message, setMetaData)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &metaData_param);
 	zephir_get_arrval(&metaData, metaData_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 937, &metaData);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 936, &metaData);
 	RETURN_THIS();
 }
 
@@ -378,7 +378,7 @@ PHP_METHOD(Phalcon_Messages_Message, setType)
 		Z_PARAM_STR(type)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&type_zv, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 935, &type_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 934, &type_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/messages/messages.zep.c
+++ b/ext/phalcon/messages/messages.zep.c
@@ -85,7 +85,7 @@ PHP_METHOD(Phalcon_Messages_Messages, __construct)
 	} else {
 		zephir_get_arrval(&messages, messages_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 938, &messages);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 937, &messages);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -164,7 +164,7 @@ PHP_METHOD(Phalcon_Messages_Messages, appendMessages)
 		return;
 	}
 	zephir_memory_observe(&currentMessages);
-	zephir_read_property_cached(&currentMessages, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC);
+	zephir_read_property_cached(&currentMessages, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC);
 	if (Z_TYPE_P(messages) == IS_ARRAY) {
 		if (Z_TYPE_P(&currentMessages) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&finalMessages);
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Messages_Messages, appendMessages)
 		} else {
 			ZEPHIR_CPY_WRT(&finalMessages, messages);
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 938, &finalMessages);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 937, &finalMessages);
 	} else {
 		ZEPHIR_CALL_METHOD(NULL, messages, "rewind", NULL, 0);
 		zephir_check_call_status();
@@ -206,7 +206,7 @@ PHP_METHOD(Phalcon_Messages_Messages, count)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("messages", 8, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	RETURN_LONG(zephir_fast_count_int(&_0));
 }
 
@@ -233,9 +233,9 @@ PHP_METHOD(Phalcon_Messages_Messages, current)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 939, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 938, PH_NOISY_CC);
 	zephir_array_fetch(&_1, &_0, &_2, PH_NOISY | PH_READONLY, "phalcon/Messages/Messages.zep", 121);
 	RETURN_CTOR(&_1);
 }
@@ -274,7 +274,7 @@ PHP_METHOD(Phalcon_Messages_Messages, filter)
 	ZVAL_STR_COPY(&fieldName_zv, fieldName);
 	ZEPHIR_INIT_VAR(&filtered);
 	array_init(&filtered);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&messages, &_0);
 	if (Z_TYPE_P(&messages) == IS_ARRAY) {
 		zephir_is_iterable(&messages, 0, "phalcon/Messages/Messages.zep", 149);
@@ -356,7 +356,7 @@ PHP_METHOD(Phalcon_Messages_Messages, jsonSerialize)
 
 	ZEPHIR_INIT_VAR(&records);
 	array_init(&records);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Messages/Messages.zep", 178);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)
@@ -456,7 +456,7 @@ PHP_METHOD(Phalcon_Messages_Messages, offsetExists)
 		Z_PARAM_ZVAL(index)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &index);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, index));
 }
 
@@ -494,7 +494,7 @@ PHP_METHOD(Phalcon_Messages_Messages, offsetGet)
 	ZEPHIR_INIT_VAR(&returnValue);
 	ZVAL_NULL(&returnValue);
 	zephir_memory_observe(&message);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&message, &_0, index, 0)) {
 		ZEPHIR_CPY_WRT(&returnValue, &message);
 	}
@@ -580,9 +580,9 @@ PHP_METHOD(Phalcon_Messages_Messages, offsetUnset)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &index);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, index)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_2$$3, 1);
 		ZEPHIR_MAKE_REF(&_1$$3);
 		ZEPHIR_CALL_FUNCTION(NULL, "array_splice", NULL, 0, &_1$$3, index, &_2$$3);
@@ -607,7 +607,7 @@ PHP_METHOD(Phalcon_Messages_Messages, rewind)
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 939, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 938, &_0);
 }
 
 /**
@@ -628,8 +628,8 @@ PHP_METHOD(Phalcon_Messages_Messages, valid)
 	if (UNEXPECTED(!_zephir_prop_1)) {
 		_zephir_prop_1 = zend_string_init("position", 8, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 938, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 939, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 937, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 938, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &_1));
 }
 

--- a/ext/phalcon/mvc/application.zep.c
+++ b/ext/phalcon/mvc/application.zep.c
@@ -201,7 +201,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&uri_zv);
 	ZVAL_STR_COPY(&uri_zv, uri);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 940, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 939, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -212,7 +212,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 941, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 940, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	_2 = Z_TYPE_P(&eventsManager) != IS_NULL;
 	if (_2) {
@@ -276,7 +276,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle)
 	zephir_check_call_status();
 	if (!(zephir_is_true(&moduleName))) {
 		ZEPHIR_OBS_NVAR(&moduleName);
-		zephir_read_property_cached(&moduleName, this_ptr, _zephir_prop_2, 942, PH_NOISY_CC);
+		zephir_read_property_cached(&moduleName, this_ptr, _zephir_prop_2, 941, PH_NOISY_CC);
 	}
 	ZEPHIR_INIT_VAR(&moduleObject);
 	ZVAL_NULL(&moduleObject);
@@ -365,7 +365,7 @@ PHP_METHOD(Phalcon_Mvc_Application, handle)
 			zephir_check_call_status();
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 943, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 942, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&implicitView, &_0);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&implicitView)) {
 		ZEPHIR_INIT_VAR(&_25$$23);
@@ -492,12 +492,12 @@ PHP_METHOD(Phalcon_Mvc_Application, handle)
 		ZEPHIR_CALL_METHOD(NULL, &eventsManager, "fire", NULL, 0, &_44$$40, this_ptr, &response);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 944, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 943, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_CALL_METHOD(NULL, &response, "sendheaders", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_45, this_ptr, _zephir_prop_5, 945, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_45, this_ptr, _zephir_prop_5, 944, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_45)) {
 		ZEPHIR_CALL_METHOD(NULL, &response, "sendcookies", NULL, 0);
 		zephir_check_call_status();
@@ -526,9 +526,9 @@ PHP_METHOD(Phalcon_Mvc_Application, sendCookiesOnHandleRequest)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &sendCookies_param);
 	if (sendCookies) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 945, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 944, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 945, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 944, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -554,9 +554,9 @@ PHP_METHOD(Phalcon_Mvc_Application, sendHeadersOnHandleRequest)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &sendHeaders_param);
 	if (sendHeaders) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 944, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 943, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 944, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 943, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -583,9 +583,9 @@ PHP_METHOD(Phalcon_Mvc_Application, useImplicitView)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &implicitView_param);
 	if (implicitView) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 943, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 942, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 943, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 942, &__$false);
 	}
 	RETURN_THISW();
 }

--- a/ext/phalcon/mvc/controller.zep.c
+++ b/ext/phalcon/mvc/controller.zep.c
@@ -113,7 +113,7 @@ PHP_METHOD(Phalcon_Mvc_Controller, getEventsManager)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 946, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 945, PH_NOISY_CC);
 	RETURN_CCTOR(&_0);
 }
 
@@ -137,7 +137,7 @@ PHP_METHOD(Phalcon_Mvc_Controller, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 946, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 945, eventsManager);
 }
 
 /**
@@ -194,7 +194,7 @@ PHP_METHOD(Phalcon_Mvc_Controller, fireManagerEvent)
 	} else {
 		}
 	zephir_memory_observe(&eventsManager);
-	zephir_read_property_cached(&eventsManager, this_ptr, _zephir_prop_0, 946, PH_NOISY_CC);
+	zephir_read_property_cached(&eventsManager, this_ptr, _zephir_prop_0, 945, PH_NOISY_CC);
 	if (Z_TYPE_P(&eventsManager) != IS_NULL) {
 		if (cancellable) {
 			ZVAL_BOOL(&_0$$3, 1);

--- a/ext/phalcon/mvc/dispatcher.zep.c
+++ b/ext/phalcon/mvc/dispatcher.zep.c
@@ -141,7 +141,7 @@ PHP_METHOD(Phalcon_Mvc_Dispatcher, forward)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &forward_param);
 	zephir_get_arrval(&forward, forward_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 947, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 946, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -229,7 +229,7 @@ PHP_METHOD(Phalcon_Mvc_Dispatcher, setControllerName)
 		Z_PARAM_STR(controllerName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&controllerName_zv, controllerName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 948, &controllerName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 947, &controllerName_zv);
 	RETURN_THISW();
 }
 
@@ -252,7 +252,7 @@ PHP_METHOD(Phalcon_Mvc_Dispatcher, setControllerSuffix)
 		Z_PARAM_STR(controllerSuffix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&controllerSuffix_zv, controllerSuffix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 949, &controllerSuffix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 948, &controllerSuffix_zv);
 	RETURN_THISW();
 }
 
@@ -275,7 +275,7 @@ PHP_METHOD(Phalcon_Mvc_Dispatcher, setDefaultController)
 		Z_PARAM_STR(controllerName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&controllerName_zv, controllerName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 950, &controllerName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 949, &controllerName_zv);
 	RETURN_THISW();
 }
 
@@ -305,7 +305,7 @@ PHP_METHOD(Phalcon_Mvc_Dispatcher, handleException)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &exception);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 947, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 946, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_2$$3);
@@ -359,7 +359,7 @@ PHP_METHOD(Phalcon_Mvc_Dispatcher, throwDispatchException)
 		exceptionCode = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 951, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 950, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);

--- a/ext/phalcon/mvc/micro.zep.c
+++ b/ext/phalcon/mvc/micro.zep.c
@@ -263,7 +263,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, error)
 		Z_PARAM_ZVAL(handler)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &handler);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 952, handler);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 951, handler);
 	RETURN_THISW();
 }
 
@@ -348,7 +348,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, getBoundModels)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 953, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 952, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&modelBinder, &_0);
 	if (Z_TYPE_P(&modelBinder) == IS_NULL) {
 		array_init(return_value);
@@ -386,7 +386,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 954, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 953, eventsManager);
 }
 
 /**
@@ -441,17 +441,17 @@ PHP_METHOD(Phalcon_Mvc_Micro, getRouter)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 954, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "router");
 		ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "getsharedservice", NULL, 0, &_2$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 955, &_1$$3);
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 954, &_1$$3);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 954, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "clear", NULL, 0);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 954, PH_NOISY_CC | PH_READONLY);
 		ZVAL_BOOL(&_5$$3, 1);
 		ZEPHIR_CALL_METHOD(NULL, &_4$$3, "removeextraslashes", NULL, 0, &_5$$3);
 		zephir_check_call_status();
@@ -488,7 +488,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, getService)
 	ZVAL_STR_COPY(&serviceName_zv, serviceName);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkdicontainer", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "get", NULL, 0, &serviceName_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -523,7 +523,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, getSharedService)
 	ZVAL_STR_COPY(&serviceName_zv, serviceName);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkdicontainer", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getshared", NULL, 0, &serviceName_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -729,7 +729,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 	ZVAL_NULL(&status);
 	ZEPHIR_INIT_VAR(&realHandler);
 	ZVAL_NULL(&realHandler);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -745,9 +745,9 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 
 		ZEPHIR_INIT_VAR(&returnedValue);
 		ZVAL_NULL(&returnedValue);
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_2$$4) != IS_NULL) {
-			zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_5$$5);
 			ZVAL_STRING(&_5$$5, "micro:beforeHandleRoute");
 			ZEPHIR_CALL_METHOD(&_4$$5, &_3$$5, "fire", NULL, 0, &_5$$5, this_ptr);
@@ -767,7 +767,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 		zephir_check_call_status_or_jump(try_end_1);
 		if (Z_TYPE_P(&matchedRoute) != IS_NULL) {
 			zephir_memory_observe(&handler);
-			zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_2, 957, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_2, 956, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_9$$7, &matchedRoute, "getrouteid", NULL, 0);
 			zephir_check_call_status_or_jump(try_end_1);
 			if (UNEXPECTED(!(zephir_array_isset_fetch(&handler, &_8$$7, &_9$$7, 0)))) {
@@ -779,10 +779,10 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 				goto try_end_1;
 
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 958, &handler);
-			zephir_read_property_cached(&_11$$7, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 957, &handler);
+			zephir_read_property_cached(&_11$$7, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			if (Z_TYPE_P(&_11$$7) != IS_NULL) {
-				zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_12$$9, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_14$$9);
 				ZVAL_STRING(&_14$$9, "micro:beforeExecuteRoute");
 				ZEPHIR_CALL_METHOD(&_13$$9, &_12$$9, "fire", NULL, 0, &_14$$9, this_ptr);
@@ -791,14 +791,14 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 					RETURN_MM_BOOL(0);
 				}
 				ZEPHIR_OBS_NVAR(&handler);
-				zephir_read_property_cached(&handler, this_ptr, _zephir_prop_3, 958, PH_NOISY_CC);
+				zephir_read_property_cached(&handler, this_ptr, _zephir_prop_3, 957, PH_NOISY_CC);
 			}
-			zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_4, 959, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_4, 958, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&beforeHandlers, &_15$$7);
 			if (0) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$false);
 			}
 			zephir_is_iterable(&beforeHandlers, 0, "phalcon/Mvc/Micro.zep", 444);
 			if (Z_TYPE_P(&beforeHandlers) == IS_ARRAY) {
@@ -829,7 +829,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 						ZEPHIR_CALL_USER_FUNC(&status, &before);
 						zephir_check_call_status_or_jump(try_end_1);
 					}
-					zephir_read_property_cached(&_21$$11, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_21$$11, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 					if (zephir_is_true(&_21$$11)) {
 						RETURN_CCTOR(&status);
 					}
@@ -875,7 +875,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 							ZEPHIR_CALL_USER_FUNC(&status, &before);
 							zephir_check_call_status_or_jump(try_end_1);
 						}
-						zephir_read_property_cached(&_27$$16, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_27$$16, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 						if (zephir_is_true(&_27$$16)) {
 							RETURN_CCTOR(&status);
 						}
@@ -884,7 +884,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 			ZEPHIR_INIT_NVAR(&before);
 			ZEPHIR_CALL_METHOD(&params, &router, "getparams", NULL, 0);
 			zephir_check_call_status_or_jump(try_end_1);
-			zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_6, 953, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_6, 952, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&modelBinder, &_15$$7);
 			_28$$7 = Z_TYPE_P(&handler) == IS_OBJECT;
 			if (_28$$7) {
@@ -949,9 +949,9 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 				zephir_check_call_status_or_jump(try_end_1);
 			}
 			ZEPHIR_CPY_WRT(&returnedValue, &lazyReturned);
-			zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			if (Z_TYPE_P(&_15$$7) != IS_NULL) {
-				zephir_read_property_cached(&_40$$29, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_40$$29, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_42$$29);
 				ZVAL_STRING(&_42$$29, "micro:afterBinding");
 				ZEPHIR_CALL_METHOD(&_41$$29, &_40$$29, "fire", NULL, 0, &_42$$29, this_ptr);
@@ -960,12 +960,12 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 					RETURN_MM_BOOL(0);
 				}
 			}
-			zephir_read_property_cached(&_43$$7, this_ptr, _zephir_prop_7, 961, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_43$$7, this_ptr, _zephir_prop_7, 960, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&afterBindingHandlers, &_43$$7);
 			if (0) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$false);
 			}
 			zephir_is_iterable(&afterBindingHandlers, 0, "phalcon/Mvc/Micro.zep", 556);
 			if (Z_TYPE_P(&afterBindingHandlers) == IS_ARRAY) {
@@ -996,7 +996,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 						ZEPHIR_CALL_USER_FUNC(&status, &afterBinding);
 						zephir_check_call_status_or_jump(try_end_1);
 					}
-					zephir_read_property_cached(&_48$$31, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_48$$31, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 					if (zephir_is_true(&_48$$31)) {
 						RETURN_CCTOR(&status);
 					}
@@ -1042,28 +1042,28 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 							ZEPHIR_CALL_USER_FUNC(&status, &afterBinding);
 							zephir_check_call_status_or_jump(try_end_1);
 						}
-						zephir_read_property_cached(&_54$$36, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_54$$36, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 						if (zephir_is_true(&_54$$36)) {
 							RETURN_CCTOR(&status);
 						}
 				}
 			}
 			ZEPHIR_INIT_NVAR(&afterBinding);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 962, &returnedValue);
-			zephir_read_property_cached(&_43$$7, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 961, &returnedValue);
+			zephir_read_property_cached(&_43$$7, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			if (Z_TYPE_P(&_43$$7) != IS_NULL) {
-				zephir_read_property_cached(&_55$$41, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_55$$41, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_56$$41);
 				ZVAL_STRING(&_56$$41, "micro:afterExecuteRoute");
 				ZEPHIR_CALL_METHOD(NULL, &_55$$41, "fire", NULL, 0, &_56$$41, this_ptr);
 				zephir_check_call_status_or_jump(try_end_1);
 			}
-			zephir_read_property_cached(&_57$$7, this_ptr, _zephir_prop_9, 963, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_57$$7, this_ptr, _zephir_prop_9, 962, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&afterHandlers, &_57$$7);
 			if (0) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$false);
 			}
 			zephir_is_iterable(&afterHandlers, 0, "phalcon/Mvc/Micro.zep", 593);
 			if (Z_TYPE_P(&afterHandlers) == IS_ARRAY) {
@@ -1094,7 +1094,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 						ZEPHIR_CALL_USER_FUNC(&status, &after);
 						zephir_check_call_status_or_jump(try_end_1);
 					}
-					zephir_read_property_cached(&_62$$42, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_62$$42, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 					if (zephir_is_true(&_62$$42)) {
 						break;
 					}
@@ -1140,7 +1140,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 							ZEPHIR_CALL_USER_FUNC(&status, &after);
 							zephir_check_call_status_or_jump(try_end_1);
 						}
-						zephir_read_property_cached(&_68$$47, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_68$$47, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 						if (zephir_is_true(&_68$$47)) {
 							break;
 						}
@@ -1148,9 +1148,9 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 			}
 			ZEPHIR_INIT_NVAR(&after);
 		} else {
-			zephir_read_property_cached(&_69$$52, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_69$$52, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			if (Z_TYPE_P(&_69$$52) != IS_NULL) {
-				zephir_read_property_cached(&_70$$53, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_70$$53, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_72$$53);
 				ZVAL_STRING(&_72$$53, "micro:beforeNotFound");
 				ZEPHIR_CALL_METHOD(&_71$$53, &_70$$53, "fire", NULL, 0, &_72$$53, this_ptr);
@@ -1159,7 +1159,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 					RETURN_MM_BOOL(0);
 				}
 			}
-			zephir_read_property_cached(&_73$$52, this_ptr, _zephir_prop_10, 964, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_73$$52, this_ptr, _zephir_prop_10, 963, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&notFoundHandler, &_73$$52);
 			if (UNEXPECTED(!(zephir_is_callable(&notFoundHandler)))) {
 				ZEPHIR_INIT_VAR(&_74$$55);
@@ -1174,20 +1174,20 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 			ZEPHIR_CALL_USER_FUNC(&returnedValue, &notFoundHandler);
 			zephir_check_call_status_or_jump(try_end_1);
 		}
-		zephir_read_property_cached(&_75$$4, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_75$$4, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_75$$4) != IS_NULL) {
-			zephir_read_property_cached(&_76$$56, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_76$$56, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_77$$56);
 			ZVAL_STRING(&_77$$56, "micro:afterHandleRoute");
 			ZEPHIR_CALL_METHOD(NULL, &_76$$56, "fire", NULL, 0, &_77$$56, this_ptr, &returnedValue);
 			zephir_check_call_status_or_jump(try_end_1);
 		}
-		zephir_read_property_cached(&_78$$4, this_ptr, _zephir_prop_11, 965, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_78$$4, this_ptr, _zephir_prop_11, 964, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&finishHandlers, &_78$$4);
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 960, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 959, &__$false);
 		}
 		zephir_is_iterable(&finishHandlers, 0, "phalcon/Mvc/Micro.zep", 661);
 		if (Z_TYPE_P(&finishHandlers) == IS_ARRAY) {
@@ -1221,7 +1221,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 					ZEPHIR_CALL_USER_FUNC_ARRAY(&status, &finish, &_83$$59);
 					zephir_check_call_status_or_jump(try_end_1);
 				}
-				zephir_read_property_cached(&_84$$57, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_84$$57, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 				if (zephir_is_true(&_84$$57)) {
 					break;
 				}
@@ -1270,7 +1270,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 						ZEPHIR_CALL_USER_FUNC_ARRAY(&status, &finish, &_90$$64);
 						zephir_check_call_status_or_jump(try_end_1);
 					}
-					zephir_read_property_cached(&_91$$62, this_ptr, _zephir_prop_5, 960, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_91$$62, this_ptr, _zephir_prop_5, 959, PH_NOISY_CC | PH_READONLY);
 					if (zephir_is_true(&_91$$62)) {
 						break;
 					}
@@ -1287,17 +1287,17 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 		if (zephir_is_instance_of(&_92, SL("Throwable"))) {
 			zend_clear_exception();
 			ZEPHIR_CPY_WRT(&e, &_92);
-			zephir_read_property_cached(&_93$$67, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_93$$67, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 			if (Z_TYPE_P(&_93$$67) != IS_NULL) {
-				zephir_read_property_cached(&_94$$68, this_ptr, _zephir_prop_1, 954, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_94$$68, this_ptr, _zephir_prop_1, 953, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_95$$68);
 				ZVAL_STRING(&_95$$68, "micro:beforeException");
 				ZEPHIR_CALL_METHOD(NULL, &_94$$68, "fire", NULL, 0, &_95$$68, this_ptr, &e);
 				zephir_check_call_status();
 			}
-			zephir_read_property_cached(&_96$$67, this_ptr, _zephir_prop_12, 952, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_96$$67, this_ptr, _zephir_prop_12, 951, PH_NOISY_CC | PH_READONLY);
 			if (Z_TYPE_P(&_96$$67) != IS_NULL) {
-				zephir_read_property_cached(&_97$$69, this_ptr, _zephir_prop_12, 952, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_97$$69, this_ptr, _zephir_prop_12, 951, PH_NOISY_CC | PH_READONLY);
 				if (UNEXPECTED(!(zephir_is_callable(&_97$$69)))) {
 					ZEPHIR_INIT_VAR(&_98$$70);
 					object_init_ex(&_98$$70, phalcon_mvc_micro_exceptions_errorhandlernotcallable_ce);
@@ -1307,7 +1307,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 					ZEPHIR_MM_RESTORE();
 					return;
 				}
-				zephir_read_property_cached(&_99$$69, this_ptr, _zephir_prop_12, 952, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_99$$69, this_ptr, _zephir_prop_12, 951, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_100$$69);
 				zephir_create_array(&_100$$69, 1, 0);
 				zephir_array_fast_append(&_100$$69, &e);
@@ -1336,9 +1336,9 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 			}
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_13, 966, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_13, 965, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
-		zephir_read_property_cached(&_101$$77, this_ptr, _zephir_prop_13, 966, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_101$$77, this_ptr, _zephir_prop_13, 965, PH_NOISY_CC | PH_READONLY);
 		if (UNEXPECTED(!(zephir_is_callable(&_101$$77)))) {
 			ZEPHIR_INIT_VAR(&_102$$78);
 			object_init_ex(&_102$$78, phalcon_mvc_micro_exceptions_responsehandlernotcallable_ce);
@@ -1348,7 +1348,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, handle)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_103$$77, this_ptr, _zephir_prop_13, 966, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_103$$77, this_ptr, _zephir_prop_13, 965, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&returnedValue);
 		ZEPHIR_CALL_USER_FUNC(&returnedValue, &_103$$77);
 		zephir_check_call_status();
@@ -1413,7 +1413,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, hasService)
 	ZVAL_STR_COPY(&serviceName_zv, serviceName);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkdicontainer", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "has", NULL, 0, &serviceName_zv);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -1706,7 +1706,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, notFound)
 		Z_PARAM_ZVAL(handler)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &handler);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 964, handler);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 963, handler);
 	RETURN_THISW();
 }
 
@@ -1825,7 +1825,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, offsetUnset)
 	zephir_fetch_params(1, 1, 0, &offset);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkdicontainer", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "remove", NULL, 0, offset);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -1979,7 +1979,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, setActiveHandler)
 		Z_PARAM_ZVAL(activeHandler)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &activeHandler);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 958, activeHandler);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 957, activeHandler);
 	RETURN_THISW();
 }
 
@@ -2001,7 +2001,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 956, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 955, container);
 }
 
 /**
@@ -2061,7 +2061,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, setModelBinder)
 		ZEPHIR_CALL_METHOD(NULL, modelBinder, "setcache", NULL, 0, cache);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 953, modelBinder);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 952, modelBinder);
 	RETURN_THIS();
 }
 
@@ -2086,7 +2086,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, setResponseHandler)
 		Z_PARAM_ZVAL(handler)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &handler);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 966, handler);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 965, handler);
 	RETURN_THISW();
 }
 
@@ -2131,7 +2131,7 @@ PHP_METHOD(Phalcon_Mvc_Micro, setService)
 		}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "checkdicontainer", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	if (isShared) {
 		ZVAL_BOOL(&_1, 1);
 	} else {
@@ -2158,9 +2158,9 @@ PHP_METHOD(Phalcon_Mvc_Micro, stop)
 		_zephir_prop_0 = zend_string_init("stopped", 7, 1);
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 960, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 959, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 960, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 959, &__$false);
 	}
 }
 
@@ -2228,13 +2228,13 @@ PHP_METHOD(Phalcon_Mvc_Micro, checkDiContainer)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 956, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 955, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_di_factorydefault_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 956, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 955, &_1$$3);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/mvc/micro/collection.zep.c
+++ b/ext/phalcon/mvc/micro/collection.zep.c
@@ -570,11 +570,11 @@ PHP_METHOD(Phalcon_Mvc_Micro_Collection, setHandler)
 		isLazy = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 967, handler);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 966, handler);
 	if (isLazy) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 968, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 967, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 968, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 967, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -604,9 +604,9 @@ PHP_METHOD(Phalcon_Mvc_Micro_Collection, setLazy)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &isLazy_param);
 	if (isLazy) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 968, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 967, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 968, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 967, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -634,7 +634,7 @@ PHP_METHOD(Phalcon_Mvc_Micro_Collection, setPrefix)
 		Z_PARAM_STR(prefix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&prefix_zv, prefix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 969, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 968, &prefix_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/mvc/micro/lazyloader.zep.c
+++ b/ext/phalcon/mvc/micro/lazyloader.zep.c
@@ -68,7 +68,7 @@ PHP_METHOD(Phalcon_Mvc_Micro_LazyLoader, __construct)
 		Z_PARAM_STR(definition)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&definition_zv, definition);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 970, &definition_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 969, &definition_zv);
 }
 
 /**
@@ -127,9 +127,9 @@ PHP_METHOD(Phalcon_Mvc_Micro_LazyLoader, callMethod)
 		modelBinder = &modelBinder_sub;
 		modelBinder = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 971, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 970, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&handler, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 970, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 969, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&definition, &_0);
 	if (Z_TYPE_P(&handler) != IS_OBJECT) {
 		if (!(zephir_class_exists(&definition, 1))) {
@@ -144,7 +144,7 @@ PHP_METHOD(Phalcon_Mvc_Micro_LazyLoader, callMethod)
 		ZEPHIR_INIT_NVAR(&handler);
 		ZEPHIR_LAST_CALL_STATUS = zephir_create_instance(&handler, &definition);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 971, &handler);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 970, &handler);
 	}
 	if (Z_TYPE_P(modelBinder) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&bindCacheKey);

--- a/ext/phalcon/mvc/model.zep.c
+++ b/ext/phalcon/mvc/model.zep.c
@@ -283,7 +283,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 972, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 971, container);
 	if (Z_TYPE_P(modelsManager) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_3$$5);
 		ZVAL_STRING(&_3$$5, "modelsManager");
@@ -302,7 +302,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __construct)
 			return;
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 973, modelsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 972, modelsManager);
 	ZEPHIR_CALL_METHOD(NULL, modelsManager, "initialize", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("onconstruct")) == SUCCESS)) {
@@ -366,7 +366,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __call)
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&records)) {
 		RETURN_CCTOR(&records);
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&status, &_1, "missingmethod", NULL, 0, this_ptr, &method_zv, &arguments);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&status) != IS_NULL) {
@@ -490,13 +490,13 @@ PHP_METHOD(Phalcon_Mvc_Model, __get)
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&relation, &_0);
 	if (Z_TYPE_P(&relation) == IS_OBJECT) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 974, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_1$$3, &lowerProperty)) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 974, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch(&_3$$4, &_2$$4, &lowerProperty, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model.zep", 407);
 			RETURN_CTOR(&_3$$4);
 		}
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 		_5$$3 = zephir_array_isset_value(&_4$$3, &lowerProperty);
 		if (_5$$3) {
 			ZEPHIR_CALL_METHOD(&_6$$3, &relation, "isreusable", NULL, 0);
@@ -504,18 +504,18 @@ PHP_METHOD(Phalcon_Mvc_Model, __get)
 			_5$$3 = !zephir_is_true(&_6$$3);
 		}
 		if (_5$$3) {
-			zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 			zephir_memory_observe(&_8$$5);
 			zephir_array_fetch(&_8$$5, &_7$$5, &lowerProperty, PH_NOISY, "phalcon/Mvc/Model.zep", 418);
 			_9$$5 = Z_TYPE_P(&_8$$5) == IS_OBJECT;
 			if (_9$$5) {
-				zephir_read_property_cached(&_10$$5, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_10$$5, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 				zephir_memory_observe(&_11$$5);
 				zephir_array_fetch(&_11$$5, &_10$$5, &lowerProperty, PH_NOISY, "phalcon/Mvc/Model.zep", 418);
 				_9$$5 = zephir_instance_of_ev(&_11$$5, phalcon_mvc_modelinterface_ce);
 			}
 			if (_9$$5) {
-				zephir_read_property_cached(&_12$$6, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_12$$6, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 				zephir_array_fetch(&_13$$6, &_12$$6, &lowerProperty, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model.zep", 419);
 				RETURN_CTOR(&_13$$6);
 			}
@@ -625,7 +625,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __serialize)
 	ZVAL_BOOL(&_1, 0);
 	ZEPHIR_CALL_METHOD(&attributes, this_ptr, "toarray", NULL, 0, &_0, &_1);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&dirtyState, &_0);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "getmodelsmanager", NULL, 0);
 	zephir_check_call_status();
@@ -634,16 +634,16 @@ PHP_METHOD(Phalcon_Mvc_Model, __serialize)
 	zephir_check_call_status();
 	_3 = zephir_is_true(&_2);
 	if (_3) {
-		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 976, PH_NOISY_CC | PH_READONLY);
 		_3 = Z_TYPE_P(&_0) != IS_NULL;
 	}
 	_4 = _3;
 	if (_4) {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 976, PH_NOISY_CC | PH_READONLY);
 		_4 = !ZEPHIR_IS_EQUAL(&attributes, &_1);
 	}
 	if (_4) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 976, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&snapshot, &_5$$3);
 	}
 	zephir_create_array(return_value, 3, 0);
@@ -737,7 +737,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __set)
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&relation, &_1$$3);
 		if (Z_TYPE_P(&relation) == IS_OBJECT) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&dirtyState, &_2$$4);
 			ZEPHIR_CALL_METHOD(&_3$$4, value, "getdirtystate", NULL, 0);
 			zephir_check_call_status();
@@ -746,10 +746,10 @@ PHP_METHOD(Phalcon_Mvc_Model, __set)
 				ZVAL_LONG(&dirtyState, 1);
 			}
 			zephir_unset_property_array(this_ptr, ZEND_STRL("related"), &lowerProperty);
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 			zephir_array_unset(&_2$$4, &lowerProperty, PH_SEPARATE);
 			zephir_update_property_array(this_ptr, SL("dirtyRelated"), &lowerProperty, value);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 976, &dirtyState);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 975, &dirtyState);
 			RETVAL_ZVAL(value, 1, 0);
 			RETURN_MM();
 		}
@@ -776,12 +776,12 @@ PHP_METHOD(Phalcon_Mvc_Model, __set)
 						ZEPHIR_CALL_METHOD(NULL, &referencedModel, "assign", NULL, 0, value);
 						zephir_check_call_status();
 						zephir_unset_property_array(this_ptr, ZEND_STRL("related"), &lowerProperty);
-						zephir_read_property_cached(&_7$$9, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_7$$9, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 						zephir_array_unset(&_7$$9, &lowerProperty, PH_SEPARATE);
 						zephir_update_property_array(this_ptr, SL("dirtyRelated"), &lowerProperty, &referencedModel);
 						ZVAL_UNDEF(&_8$$9);
 						ZVAL_LONG(&_8$$9, 1);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 976, &_8$$9);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 975, &_8$$9);
 						RETVAL_ZVAL(value, 1, 0);
 						RETURN_MM();
 					}
@@ -829,7 +829,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __set)
 					}
 					ZEPHIR_INIT_NVAR(&item);
 					zephir_unset_property_array(this_ptr, ZEND_STRL("related"), &lowerProperty);
-					zephir_read_property_cached(&_12$$10, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_12$$10, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 					zephir_array_unset(&_12$$10, &lowerProperty, PH_SEPARATE);
 					_13$$10 = zephir_fast_count_int(&related) > 0;
 					if (!(_13$$10)) {
@@ -841,10 +841,10 @@ PHP_METHOD(Phalcon_Mvc_Model, __set)
 						zephir_update_property_array(this_ptr, SL("dirtyRelated"), &lowerProperty, &related);
 						ZVAL_UNDEF(&_15$$17);
 						ZVAL_LONG(&_15$$17, 1);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 976, &_15$$17);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 975, &_15$$17);
 					} else {
 						zephir_unset_property_array(this_ptr, ZEND_STRL("dirtyRelated"), &lowerProperty);
-						zephir_read_property_cached(&_16$$18, this_ptr, _zephir_prop_2, 974, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_16$$18, this_ptr, _zephir_prop_2, 973, PH_NOISY_CC | PH_READONLY);
 						zephir_array_unset(&_16$$18, &lowerProperty, PH_SEPARATE);
 					}
 					RETVAL_ZVAL(value, 1, 0);
@@ -865,10 +865,10 @@ PHP_METHOD(Phalcon_Mvc_Model, __set)
 		ZEPHIR_CPY_WRT(&relation, &_17$$19);
 		if (Z_TYPE_P(&relation) == IS_OBJECT) {
 			zephir_unset_property_array(this_ptr, ZEND_STRL("related"), &lowerProperty);
-			zephir_read_property_cached(&_18$$20, this_ptr, _zephir_prop_1, 975, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_18$$20, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
 			zephir_array_unset(&_18$$20, &lowerProperty, PH_SEPARATE);
 			zephir_unset_property_array(this_ptr, ZEND_STRL("dirtyRelated"), &lowerProperty);
-			zephir_read_property_cached(&_19$$20, this_ptr, _zephir_prop_2, 974, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_19$$20, this_ptr, _zephir_prop_2, 973, PH_NOISY_CC | PH_READONLY);
 			zephir_array_unset(&_19$$20, &lowerProperty, PH_SEPARATE);
 			zephir_update_property_zval_zval(this_ptr, &property_zv, &__$null);
 			RETURN_MM_NULL();
@@ -978,7 +978,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __unserialize)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 972, &container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 971, &container);
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, "modelsManager");
 	ZEPHIR_CALL_METHOD(&_3, &container, "getshared", NULL, 0, &_4);
@@ -995,7 +995,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __unserialize)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 973, &manager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 972, &manager);
 	ZEPHIR_CALL_METHOD(NULL, &manager, "initialize", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("onconstruct")) == SUCCESS)) {
@@ -1049,7 +1049,7 @@ PHP_METHOD(Phalcon_Mvc_Model, __unserialize)
 	}
 	zephir_memory_observe(&dirtyState);
 	if (zephir_array_isset_string_fetch(&dirtyState, &data, SL("dirtyState"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 976, &dirtyState);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 975, &dirtyState);
 	}
 	ZEPHIR_CALL_METHOD(&_3, &manager, "iskeepingsnapshots", NULL, 0, this_ptr);
 	zephir_check_call_status();
@@ -1061,9 +1061,9 @@ PHP_METHOD(Phalcon_Mvc_Model, __unserialize)
 			} else {
 				ZEPHIR_CPY_WRT(&_12$$13, &properties);
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 977, &_12$$13);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &_12$$13);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 977, &properties);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &properties);
 		}
 	}
 	ZEPHIR_MM_RESTORE();
@@ -1125,7 +1125,7 @@ PHP_METHOD(Phalcon_Mvc_Model, addBehavior)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &behavior);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "addbehavior", NULL, 0, this_ptr, behavior);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -1290,7 +1290,7 @@ PHP_METHOD(Phalcon_Mvc_Model, assign)
 	}
 	ZEPHIR_INIT_VAR(&rawValues);
 	array_init(&rawValues);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 978, &rawValues);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 977, &rawValues);
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "orm.disable_assign_setters");
 	ZEPHIR_CALL_CE_STATIC(&disableAssignSetters, phalcon_support_settings_ce, "get", NULL, 0, &_0);
@@ -1514,7 +1514,7 @@ PHP_METHOD(Phalcon_Mvc_Model, assign)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&attribute);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 978, &rawValues);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 977, &rawValues);
 	RETURN_THIS();
 }
 
@@ -2585,9 +2585,9 @@ PHP_METHOD(Phalcon_Mvc_Model, collectRelatedToSave)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 974, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&related, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&dirtyRelated, &_1);
 	zephir_is_iterable(&related, 0, "phalcon/Mvc/Model.zep", 1378);
 	ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&related), _3, _4, _2)
@@ -2772,7 +2772,7 @@ PHP_METHOD(Phalcon_Mvc_Model, create)
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 5, &_5$$3, &_6$$3, &_7$$3, &_8$$3, &_4$$3);
 		zephir_check_call_status();
 		zephir_array_fast_append(&_2$$3, &_3$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 979, &_2$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 978, &_2$$3);
 		RETURN_MM_BOOL(0);
 	}
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "save", NULL, 0);
@@ -2898,10 +2898,10 @@ PHP_METHOD(Phalcon_Mvc_Model, delete)
 	zephir_check_call_status();
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 3);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 980, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 979, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	array_init(&_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 979, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 978, &_1);
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "orm.virtual_foreign_keys");
 	ZEPHIR_CALL_CE_STATIC(&_2, phalcon_support_settings_ce, "get", NULL, 0, &_3);
@@ -3073,9 +3073,9 @@ PHP_METHOD(Phalcon_Mvc_Model, delete)
 	zephir_check_call_status();
 	if (zephir_is_true(&_32)) {
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 981, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 980, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 981, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 980, &__$false);
 		}
 		ZEPHIR_INIT_VAR(&_34$$20);
 		ZVAL_STRING(&_34$$20, "beforeDelete");
@@ -3084,7 +3084,7 @@ PHP_METHOD(Phalcon_Mvc_Model, delete)
 		if (ZEPHIR_IS_FALSE_IDENTICAL(&_33$$20)) {
 			RETURN_MM_BOOL(0);
 		}
-		zephir_read_property_cached(&_35$$20, this_ptr, _zephir_prop_2, 981, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_35$$20, this_ptr, _zephir_prop_2, 980, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_IS_TRUE_IDENTICAL(&_35$$20)) {
 			RETURN_MM_BOOL(1);
 		}
@@ -3129,22 +3129,22 @@ PHP_METHOD(Phalcon_Mvc_Model, delete)
 		}
 	}
 	if (zephir_is_true(&success)) {
-		zephir_read_property_cached(&_41$$29, this_ptr, _zephir_prop_3, 973, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_41$$29, this_ptr, _zephir_prop_3, 972, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_41$$29, "registerwrite", NULL, 0, this_ptr);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_42$$29);
 		array_init(&_42$$29);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 975, &_42$$29);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 974, &_42$$29);
 		ZEPHIR_INIT_VAR(&_43$$29);
 		array_init(&_43$$29);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 974, &_43$$29);
-		zephir_read_property_cached(&_44$$29, this_ptr, _zephir_prop_3, 973, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 973, &_43$$29);
+		zephir_read_property_cached(&_44$$29, this_ptr, _zephir_prop_3, 972, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_44$$29, "clearreusableobjects", NULL, 0);
 		zephir_check_call_status();
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 976, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 975, &_0);
 	RETURN_CCTOR(&success);
 }
 
@@ -3166,7 +3166,7 @@ PHP_METHOD(Phalcon_Mvc_Model, dump)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_RETURN_CALL_FUNCTION("get_object_vars", NULL, 335, this_ptr);
+	ZEPHIR_RETURN_CALL_FUNCTION("get_object_vars", NULL, 337, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -3579,7 +3579,7 @@ PHP_METHOD(Phalcon_Mvc_Model, fireEvent)
 		ZEPHIR_CALL_METHOD_ZVAL(NULL, this_ptr, &eventName_zv, NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "notifyevent", NULL, 0, &eventName_zv, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -3620,7 +3620,7 @@ PHP_METHOD(Phalcon_Mvc_Model, fireEventCancel)
 			RETURN_MM_BOOL(0);
 		}
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_1, "notifyevent", NULL, 0, &eventName_zv, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -3671,7 +3671,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getChangedFields)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 977, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&snapshot, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&snapshot) != IS_ARRAY)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -3793,7 +3793,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getEventsManager)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getcustomeventsmanager", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -3876,7 +3876,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getMessages)
 			zephir_array_fast_append(&_2$$4, filter);
 			ZEPHIR_CPY_WRT(filter, &_2$$4);
 		}
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 979, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 978, PH_NOISY_CC | PH_READONLY);
 		zephir_is_iterable(&_3$$3, 0, "phalcon/Mvc/Model.zep", 2191);
 		if (Z_TYPE_P(&_3$$3) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_3$$3), _4$$3)
@@ -3958,9 +3958,9 @@ PHP_METHOD(Phalcon_Mvc_Model, getModelsMetaData)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&metaData);
-	zephir_read_property_cached(&metaData, this_ptr, _zephir_prop_0, 982, PH_NOISY_CC);
+	zephir_read_property_cached(&metaData, this_ptr, _zephir_prop_0, 981, PH_NOISY_CC);
 	if (Z_TYPE_P(&metaData) == IS_NULL) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_1, 972, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_1, 971, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&container, &_0$$3);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "modelsMetadata");
@@ -3978,7 +3978,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getModelsMetaData)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 982, &metaData);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 981, &metaData);
 	}
 	RETURN_CCTOR(&metaData);
 }
@@ -4026,14 +4026,14 @@ PHP_METHOD(Phalcon_Mvc_Model, getReadConnection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 983, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 982, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 983, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 982, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_RETURN_CALL_METHOD(&_1$$3, "getconnection", NULL, 0);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_2, "getreadconnection", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -4058,7 +4058,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getReadConnectionService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getreadconnectionservice", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -4127,7 +4127,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getRelated)
 	}
 	ZEPHIR_INIT_VAR(&className);
 	zephir_get_class(&className, this_ptr, 0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_INIT_VAR(&lowerAlias);
 	zephir_fast_strtolower(&lowerAlias, &alias_zv);
@@ -4144,15 +4144,15 @@ PHP_METHOD(Phalcon_Mvc_Model, getRelated)
 		return;
 	}
 	if (Z_TYPE_P(arguments) == IS_NULL) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_3$$4, &lowerAlias)) {
-			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_1, 974, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$5, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch(&_5$$5, &_4$$5, &lowerAlias, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model.zep", 2321);
 			RETURN_CTOR(&_5$$5);
 		}
-		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 975, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_2, 974, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_6$$4, &lowerAlias)) {
-			zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_2, 975, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_2, 974, PH_NOISY_CC | PH_READONLY);
 			zephir_array_fetch(&_8$$6, &_7$$6, &lowerAlias, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model.zep", 2324);
 			RETURN_CTOR(&_8$$6);
 		}
@@ -4208,7 +4208,7 @@ PHP_METHOD(Phalcon_Mvc_Model, isRelationshipLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&relationshipAlias_zv);
 	ZVAL_STR_COPY(&relationshipAlias_zv, relationshipAlias);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 974, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_fast_strtolower(&_1, &relationshipAlias_zv);
 	RETURN_MM_BOOL(zephir_array_isset_value(&_0, &_1));
@@ -4232,7 +4232,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getSchema)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getmodelschema", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -4265,7 +4265,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getSource)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getmodelsource", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -4330,9 +4330,9 @@ PHP_METHOD(Phalcon_Mvc_Model, getUpdatedFields)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 977, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&snapshot, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 984, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 983, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&oldSnapshot, &_0);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "orm.update_snapshot_on_save");
@@ -4360,7 +4360,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getUpdatedFields)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 976, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 975, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!ZEPHIR_IS_LONG(&_0, 0))) {
 		ZEPHIR_INIT_VAR(&_7$$5);
 		object_init_ex(&_7$$5, phalcon_mvc_model_exceptions_recordnotpersisted_ce);
@@ -4454,14 +4454,14 @@ PHP_METHOD(Phalcon_Mvc_Model, getWriteConnection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 983, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 982, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 983, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 982, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_RETURN_CALL_METHOD(&_1$$3, "getconnection", NULL, 0);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_2, "getwriteconnection", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -4486,7 +4486,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getWriteConnectionService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getwriteconnectionservice", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -4573,7 +4573,7 @@ PHP_METHOD(Phalcon_Mvc_Model, hasSnapshotData)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("snapshot", 8, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 977, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(!(ZEPHIR_IS_EMPTY(&_0)));
 }
 
@@ -4922,7 +4922,7 @@ PHP_METHOD(Phalcon_Mvc_Model, refresh)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!ZEPHIR_IS_LONG(&_0, 0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_mvc_model_exceptions_recordcannotrefresh_ce);
@@ -4938,7 +4938,7 @@ PHP_METHOD(Phalcon_Mvc_Model, refresh)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&readConnection, this_ptr, "getreadconnection", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_3);
 	ZEPHIR_CALL_METHOD(&schema, this_ptr, "getschema", NULL, 0);
 	zephir_check_call_status();
@@ -4952,7 +4952,7 @@ PHP_METHOD(Phalcon_Mvc_Model, refresh)
 	} else {
 		ZEPHIR_CPY_WRT(&table, &source);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 985, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 984, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&uniqueKey, &_3);
 	if (!(zephir_is_true(&uniqueKey))) {
 		ZEPHIR_CALL_METHOD(&_4$$6, this_ptr, "has", NULL, 0, &metaData, &readConnection);
@@ -4968,10 +4968,10 @@ PHP_METHOD(Phalcon_Mvc_Model, refresh)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_2, 985, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_2, 984, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&uniqueKey, &_7$$6);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 986, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 985, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&uniqueParams, &_3);
 	if (UNEXPECTED(Z_TYPE_P(&uniqueParams) != IS_ARRAY)) {
 		ZEPHIR_INIT_VAR(&_8$$8);
@@ -5035,7 +5035,7 @@ PHP_METHOD(Phalcon_Mvc_Model, refresh)
 	zephir_array_update_string(&_16, SL("where"), &uniqueKey, PH_COPY | PH_SEPARATE);
 	ZEPHIR_CALL_METHOD(&tables, &dialect, "select", NULL, 0, &_16);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_4, 987, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_4, 986, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_18, 2);
 	ZEPHIR_CALL_METHOD(&row, &readConnection, "fetchone", NULL, 0, &tables, &_18, &uniqueParams, &_3);
 	zephir_check_call_status();
@@ -5228,7 +5228,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 		if (ZEPHIR_IS_FALSE_IDENTICAL(&_2$$4)) {
 			ZEPHIR_INIT_VAR(&_3$$5);
 			array_init(&_3$$5);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 988, &_3$$5);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 987, &_3$$5);
 			RETURN_MM_BOOL(0);
 		}
 	}
@@ -5249,15 +5249,15 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 	if (zephir_is_true(&exists)) {
 		ZVAL_UNDEF(&_4$$8);
 		ZVAL_LONG(&_4$$8, 2);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 980, &_4$$8);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 979, &_4$$8);
 	} else {
 		ZVAL_UNDEF(&_5$$9);
 		ZVAL_LONG(&_5$$9, 1);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 980, &_5$$9);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 979, &_5$$9);
 	}
 	ZEPHIR_INIT_NVAR(&_1);
 	array_init(&_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 979, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 978, &_1);
 	ZEPHIR_CALL_METHOD(&identityField, &metaData, "getidentityfield", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_6, this_ptr, "presave", NULL, 0, &metaData, &exists, &identityField);
@@ -5270,7 +5270,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 		}
 		ZEPHIR_INIT_VAR(&_8$$10);
 		array_init(&_8$$10);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 988, &_8$$10);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 987, &_8$$10);
 		ZEPHIR_INIT_VAR(&_10$$10);
 		ZVAL_STRING(&_10$$10, "orm.exception_on_failed_save");
 		ZEPHIR_CALL_CE_STATIC(&_9$$10, phalcon_support_settings_ce, "get", NULL, 0, &_10$$10);
@@ -5302,9 +5302,9 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 	}
 	if (_14) {
 		zephir_memory_observe(&savedSnapshot);
-		zephir_read_property_cached(&savedSnapshot, this_ptr, _zephir_prop_3, 977, PH_NOISY_CC);
+		zephir_read_property_cached(&savedSnapshot, this_ptr, _zephir_prop_3, 976, PH_NOISY_CC);
 		zephir_memory_observe(&savedOldSnapshot);
-		zephir_read_property_cached(&savedOldSnapshot, this_ptr, _zephir_prop_4, 984, PH_NOISY_CC);
+		zephir_read_property_cached(&savedOldSnapshot, this_ptr, _zephir_prop_4, 983, PH_NOISY_CC);
 	}
 	if (zephir_is_true(&exists)) {
 		ZEPHIR_CALL_METHOD(&success, this_ptr, "dolowupdate", NULL, 0, &metaData, &writeConnection, &table);
@@ -5316,7 +5316,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&success)) {
 		ZVAL_UNDEF(&_17$$16);
 		ZVAL_LONG(&_17$$16, 0);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 976, &_17$$16);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 975, &_17$$16);
 	}
 	if (hasRelatedToSave) {
 		if (ZEPHIR_IS_FALSE_IDENTICAL(&success)) {
@@ -5351,19 +5351,19 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 			_22$$21 = zephir_is_true(&_23$$21);
 		}
 		if (_22$$21) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 977, &savedSnapshot);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 984, &savedOldSnapshot);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &savedSnapshot);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 983, &savedOldSnapshot);
 		}
 	} else {
 		if (hasRelatedToSave) {
 			ZEPHIR_INIT_VAR(&_25$$24);
 			array_init(&_25$$24);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 974, &_25$$24);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 973, &_25$$24);
 		}
 		ZEPHIR_INIT_VAR(&_26$$23);
 		array_init(&_26$$23);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 975, &_26$$23);
-		zephir_read_property_cached(&_27$$23, this_ptr, _zephir_prop_8, 973, PH_NOISY_CC | PH_READONLY);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 974, &_26$$23);
+		zephir_read_property_cached(&_27$$23, this_ptr, _zephir_prop_8, 972, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_27$$23, "clearreusableobjects", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_28$$23);
@@ -5373,7 +5373,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doSave)
 	}
 	ZEPHIR_INIT_NVAR(&_16);
 	array_init(&_16);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 988, &_16);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 987, &_16);
 	RETURN_CCTOR(&success);
 }
 
@@ -5416,7 +5416,7 @@ PHP_METHOD(Phalcon_Mvc_Model, serialize)
 	ZVAL_BOOL(&_1, 0);
 	ZEPHIR_CALL_METHOD(&attributes, this_ptr, "toarray", NULL, 0, &_0, &_1);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&dirtyState, &_0);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "getmodelsmanager", NULL, 0);
 	zephir_check_call_status();
@@ -5425,16 +5425,16 @@ PHP_METHOD(Phalcon_Mvc_Model, serialize)
 	zephir_check_call_status();
 	_3 = zephir_is_true(&_2);
 	if (_3) {
-		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 976, PH_NOISY_CC | PH_READONLY);
 		_3 = Z_TYPE_P(&_0) != IS_NULL;
 	}
 	_4 = _3;
 	if (_4) {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 976, PH_NOISY_CC | PH_READONLY);
 		_4 = !ZEPHIR_IS_EQUAL(&attributes, &_1);
 	}
 	if (_4) {
-		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$3, this_ptr, _zephir_prop_1, 976, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&snapshot, &_5$$3);
 	}
 	ZEPHIR_INIT_VAR(&_6);
@@ -5528,7 +5528,7 @@ PHP_METHOD(Phalcon_Mvc_Model, unserialize)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 972, &container);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 971, &container);
 		ZEPHIR_INIT_VAR(&_4$$3);
 		ZVAL_STRING(&_4$$3, "modelsManager");
 		ZEPHIR_CALL_METHOD(&_3$$3, &container, "getshared", NULL, 0, &_4$$3);
@@ -5545,7 +5545,7 @@ PHP_METHOD(Phalcon_Mvc_Model, unserialize)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 973, &manager);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 972, &manager);
 		ZEPHIR_CALL_METHOD(NULL, &manager, "initialize", NULL, 0, this_ptr);
 		zephir_check_call_status();
 		if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("onconstruct")) == SUCCESS)) {
@@ -5631,7 +5631,7 @@ PHP_METHOD(Phalcon_Mvc_Model, unserialize)
 		}
 		zephir_memory_observe(&dirtyState);
 		if (zephir_array_isset_string_fetch(&dirtyState, &attributes, SL("dirtyState"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 976, &dirtyState);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 975, &dirtyState);
 		}
 		ZEPHIR_CALL_METHOD(&_3$$3, &manager, "iskeepingsnapshots", NULL, 0, this_ptr);
 		zephir_check_call_status();
@@ -5643,9 +5643,9 @@ PHP_METHOD(Phalcon_Mvc_Model, unserialize)
 				} else {
 					ZEPHIR_CPY_WRT(&_16$$18, &properties);
 				}
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 977, &_16$$18);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &_16$$18);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 977, &properties);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &properties);
 			}
 		}
 	}
@@ -5677,7 +5677,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setConnectionService)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&connectionService_zv);
 	ZVAL_STR_COPY(&connectionService_zv, connectionService);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setconnectionservice", NULL, 0, this_ptr, &connectionService_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -5704,7 +5704,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setDirtyState)
 	zephir_fetch_params_without_memory_grow(1, 0, &dirtyState_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, dirtyState);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 976, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 975, &_0);
 	RETURN_THISW();
 }
 
@@ -5731,7 +5731,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setEventsManager)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &eventsManager);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setcustomeventsmanager", NULL, 0, this_ptr, eventsManager);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -5762,7 +5762,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setReadConnectionService)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&connectionService_zv);
 	ZVAL_STR_COPY(&connectionService_zv, connectionService);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setreadconnectionservice", NULL, 0, this_ptr, &connectionService_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -5962,7 +5962,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setOldSnapshotData)
 	} else {
 		ZEPHIR_CPY_WRT(&snapshot, &data);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 984, &snapshot);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 983, &snapshot);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -6191,7 +6191,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setSnapshotData)
 	} else {
 		ZEPHIR_CPY_WRT(&snapshot, &data);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 977, &snapshot);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 976, &snapshot);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -6371,7 +6371,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setTransaction)
 		Z_PARAM_OBJECT_OF_CLASS(transaction, phalcon_mvc_model_transactioninterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &transaction);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 983, transaction);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 982, transaction);
 	RETURN_THISW();
 }
 
@@ -6598,7 +6598,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setWriteConnectionService)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&connectionService_zv);
 	ZVAL_STR_COPY(&connectionService_zv, connectionService);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setwriteconnectionservice", NULL, 0, this_ptr, &connectionService_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -6625,9 +6625,9 @@ PHP_METHOD(Phalcon_Mvc_Model, skipOperation)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &skip_param);
 	if (skip) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 981, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 980, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 981, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 980, &__$false);
 	}
 }
 
@@ -7031,7 +7031,7 @@ PHP_METHOD(Phalcon_Mvc_Model, update)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 976, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 975, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_CALL_METHOD(&metaData, this_ptr, "getmodelsmetadata", NULL, 0);
 		zephir_check_call_status();
@@ -7059,7 +7059,7 @@ PHP_METHOD(Phalcon_Mvc_Model, update)
 			ZEPHIR_CALL_METHOD(NULL, &_4$$4, "__construct", NULL, 5, &_6$$4, &_7$$4, &_8$$4, &_9$$4, &_5$$4);
 			zephir_check_call_status();
 			zephir_array_fast_append(&_3$$4, &_4$$4);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 979, &_3$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 978, &_3$$4);
 			RETURN_MM_BOOL(0);
 		}
 	}
@@ -7170,7 +7170,7 @@ PHP_METHOD(Phalcon_Mvc_Model, checkForeignKeysRestrict)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_CALL_METHOD(&belongsTo, &manager, "getbelongsto", NULL, 0, this_ptr);
 	zephir_check_call_status();
@@ -7560,7 +7560,7 @@ PHP_METHOD(Phalcon_Mvc_Model, checkForeignKeysReverseCascade)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_CALL_METHOD(&relations, &manager, "gethasoneandhasmany", NULL, 0, this_ptr);
 	zephir_check_call_status();
@@ -7698,7 +7698,7 @@ PHP_METHOD(Phalcon_Mvc_Model, checkForeignKeysReverseRestrict)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_CALL_METHOD(&relations, &manager, "gethasoneandhasmany", NULL, 0, this_ptr);
 	zephir_check_call_status();
@@ -7976,7 +7976,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowInsert)
 	ZEPHIR_SEPARATE_PARAM(table);
 	ZEPHIR_INIT_VAR(&bindSkip);
 	ZVAL_LONG(&bindSkip, 1024);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_INIT_VAR(&fields);
 	array_init(&fields);
@@ -7988,7 +7988,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowInsert)
 	array_init(&bindTypes);
 	ZEPHIR_INIT_VAR(&unsetDefaultValues);
 	array_init(&unsetDefaultValues);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 978, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 977, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&rawValues, &_0);
 	ZEPHIR_CALL_METHOD(&attributes, metaData, "getattributes", NULL, 0, this_ptr);
 	zephir_check_call_status();
@@ -8360,8 +8360,8 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowInsert)
 		}
 		zephir_update_property_zval_zval(this_ptr, &attributeField, &lastInsertedId);
 		zephir_array_update_zval(&snapshot, &attributeField, &lastInsertedId, PH_COPY | PH_SEPARATE);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 985, &__$null);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 986, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 984, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 985, &__$null);
 	}
 	if (zephir_is_true(&success)) {
 		ZEPHIR_CALL_METHOD(NULL, &manager, "registerwrite", NULL, 0, this_ptr);
@@ -8392,7 +8392,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowInsert)
 			_64$$64 = zephir_is_true(&_65$$64);
 		}
 		if (_64$$64) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 977, &snapshot);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 976, &snapshot);
 		}
 	}
 	RETURN_CCTOR(&success);
@@ -8553,14 +8553,14 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowUpdate)
 	array_init(&bindTypes);
 	ZEPHIR_INIT_VAR(&newSnapshot);
 	array_init(&newSnapshot);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 978, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 977, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&rawValues, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_CALL_METHOD(&_1, &manager, "isusingdynamicupdate", NULL, 0, this_ptr);
 	zephir_check_call_status();
 	useDynamicUpdate = zephir_get_boolval(&_1);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 977, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 976, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&snapshot, &_0);
 	ZEPHIR_CALL_METHOD(&dataTypes, metaData, "getdatatypes", NULL, 0, this_ptr);
 	zephir_check_call_status();
@@ -8859,7 +8859,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowUpdate)
 		}
 		ZEPHIR_INIT_NVAR(&field);
 		if (!(zephir_fast_count_int(&fields))) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 984, &snapshot);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 983, &snapshot);
 			RETURN_MM_BOOL(1);
 		}
 	} else {
@@ -9041,9 +9041,9 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowUpdate)
 	if (!(zephir_fast_count_int(&fields))) {
 		RETURN_MM_BOOL(1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 985, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 984, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&uniqueKey, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 986, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 985, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&uniqueParams, &_0);
 	if (Z_TYPE_P(&uniqueParams) != IS_ARRAY) {
 		ZEPHIR_CALL_METHOD(&primaryKeys, metaData, "getprimarykeyattributes", NULL, 0, this_ptr);
@@ -9150,7 +9150,7 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowUpdate)
 	zephir_array_update_string(&_77, SL("conditions"), &uniqueKey, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_77, SL("bind"), &uniqueParams, PH_COPY | PH_SEPARATE);
 	zephir_memory_observe(&_78);
-	zephir_read_property_cached(&_78, this_ptr, _zephir_prop_6, 987, PH_NOISY_CC);
+	zephir_read_property_cached(&_78, this_ptr, _zephir_prop_6, 986, PH_NOISY_CC);
 	zephir_array_update_string(&_77, SL("bindTypes"), &_78, PH_COPY | PH_SEPARATE);
 	ZEPHIR_CALL_METHOD(&success, connection, "update", NULL, 0, table, &fields, &values, &_77, &bindTypes);
 	zephir_check_call_status();
@@ -9174,15 +9174,15 @@ PHP_METHOD(Phalcon_Mvc_Model, doLowUpdate)
 	}
 	if (_81) {
 		if (Z_TYPE_P(&snapshot) == IS_ARRAY) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 984, &snapshot);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 983, &snapshot);
 			ZEPHIR_INIT_VAR(&_83$$96);
 			zephir_fast_array_merge(&_83$$96, &snapshot, &newSnapshot);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 977, &_83$$96);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 976, &_83$$96);
 		} else {
 			ZEPHIR_INIT_VAR(&_84$$97);
 			array_init(&_84$$97);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 984, &_84$$97);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 977, &newSnapshot);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 983, &_84$$97);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 976, &newSnapshot);
 		}
 	}
 	RETURN_CCTOR(&success);
@@ -9274,7 +9274,7 @@ PHP_METHOD(Phalcon_Mvc_Model, has)
 	ZVAL_NULL(&uniqueParams);
 	ZEPHIR_INIT_VAR(&uniqueTypes);
 	ZVAL_NULL(&uniqueTypes);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 985, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 984, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&uniqueKey, &_0);
 	if (Z_TYPE_P(&uniqueKey) == IS_NULL) {
 		ZEPHIR_CALL_METHOD(&primaryKeys, metaData, "getprimarykeyattributes", NULL, 0, this_ptr);
@@ -9436,25 +9436,25 @@ PHP_METHOD(Phalcon_Mvc_Model, has)
 		}
 		ZEPHIR_INIT_VAR(&joinWhere);
 		zephir_fast_join_str(&joinWhere, SL(" AND "), &wherePk);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 985, &joinWhere);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 986, &uniqueParams);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 987, &uniqueTypes);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 984, &joinWhere);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 985, &uniqueParams);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 986, &uniqueTypes);
 		ZEPHIR_CPY_WRT(&uniqueKey, &joinWhere);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 976, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 975, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		RETURN_MM_BOOL(1);
 	}
 	if (Z_TYPE_P(&uniqueKey) == IS_NULL) {
-		zephir_read_property_cached(&_24$$25, this_ptr, _zephir_prop_0, 985, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_24$$25, this_ptr, _zephir_prop_0, 984, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&uniqueKey, &_24$$25);
 	}
 	if (Z_TYPE_P(&uniqueParams) == IS_NULL) {
-		zephir_read_property_cached(&_25$$26, this_ptr, _zephir_prop_1, 986, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_25$$26, this_ptr, _zephir_prop_1, 985, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&uniqueParams, &_25$$26);
 	}
 	if (Z_TYPE_P(&uniqueTypes) == IS_NULL) {
-		zephir_read_property_cached(&_26$$27, this_ptr, _zephir_prop_2, 987, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_26$$27, this_ptr, _zephir_prop_2, 986, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&uniqueTypes, &_26$$27);
 	}
 	ZEPHIR_CALL_METHOD(&schema, this_ptr, "getschema", NULL, 0);
@@ -9480,12 +9480,12 @@ PHP_METHOD(Phalcon_Mvc_Model, has)
 	if (zephir_is_true(&_30)) {
 		ZVAL_UNDEF(&_31$$30);
 		ZVAL_LONG(&_31$$30, 0);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &_31$$30);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 975, &_31$$30);
 		RETURN_MM_BOOL(1);
 	} else {
 		ZVAL_UNDEF(&_32$$31);
 		ZVAL_LONG(&_32$$31, 1);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 976, &_32$$31);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 975, &_32$$31);
 	}
 	RETURN_MM_BOOL(0);
 }
@@ -9541,7 +9541,7 @@ PHP_METHOD(Phalcon_Mvc_Model, getRelatedRecords)
 	zephir_memory_observe(&method_zv);
 	ZVAL_STR_COPY(&method_zv, method);
 	zephir_get_arrval(&arguments, arguments_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_INIT_VAR(&relation);
 	ZVAL_BOOL(&relation, 0);
@@ -10373,9 +10373,9 @@ PHP_METHOD(Phalcon_Mvc_Model, preSave)
 			RETURN_MM_BOOL(0);
 		}
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 981, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 980, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 981, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 980, &__$false);
 		}
 		if (exists) {
 			ZEPHIR_INIT_NVAR(&eventName);
@@ -10389,7 +10389,7 @@ PHP_METHOD(Phalcon_Mvc_Model, preSave)
 		if (ZEPHIR_IS_FALSE_IDENTICAL(&_54$$60)) {
 			RETURN_MM_BOOL(0);
 		}
-		zephir_read_property_cached(&_55$$60, this_ptr, _zephir_prop_0, 981, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_55$$60, this_ptr, _zephir_prop_0, 980, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_IS_TRUE_IDENTICAL(&_55$$60)) {
 			RETURN_MM_BOOL(1);
 		}
@@ -11075,12 +11075,12 @@ PHP_METHOD(Phalcon_Mvc_Model, postSaveRelatedRecords)
 					zephir_check_call_status();
 					doSync = zephir_get_boolval(&_13$$9);
 					ZEPHIR_OBS_NVAR(&override);
-					zephir_read_property_cached(&_15$$9, this_ptr, _zephir_prop_0, 988, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_15$$9, this_ptr, _zephir_prop_0, 987, PH_NOISY_CC | PH_READONLY);
 					if (zephir_array_isset_fetch(&override, &_15$$9, &name, 0)) {
 						doSync = zephir_get_boolval(&override);
 					} else {
 						ZEPHIR_OBS_NVAR(&override);
-						zephir_read_property_cached(&_16$$9, this_ptr, _zephir_prop_0, 988, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_16$$9, this_ptr, _zephir_prop_0, 987, PH_NOISY_CC | PH_READONLY);
 						if (zephir_array_isset_string_fetch(&override, &_16$$9, SL("*"), 0)) {
 							doSync = zephir_get_boolval(&override);
 						}
@@ -12026,12 +12026,12 @@ PHP_METHOD(Phalcon_Mvc_Model, postSaveRelatedRecords)
 						zephir_check_call_status();
 						doSync = zephir_get_boolval(&_201$$91);
 						ZEPHIR_OBS_NVAR(&override);
-						zephir_read_property_cached(&_203$$91, this_ptr, _zephir_prop_0, 988, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_203$$91, this_ptr, _zephir_prop_0, 987, PH_NOISY_CC | PH_READONLY);
 						if (zephir_array_isset_fetch(&override, &_203$$91, &name, 0)) {
 							doSync = zephir_get_boolval(&override);
 						} else {
 							ZEPHIR_OBS_NVAR(&override);
-							zephir_read_property_cached(&_204$$91, this_ptr, _zephir_prop_0, 988, PH_NOISY_CC | PH_READONLY);
+							zephir_read_property_cached(&_204$$91, this_ptr, _zephir_prop_0, 987, PH_NOISY_CC | PH_READONLY);
 							if (zephir_array_isset_string_fetch(&override, &_204$$91, SL("*"), 0)) {
 								doSync = zephir_get_boolval(&override);
 							}
@@ -13003,7 +13003,7 @@ PHP_METHOD(Phalcon_Mvc_Model, cancelOperation)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 980, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 979, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_LONG(&_0, 3)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZVAL_STRING(&_1$$3, "notDeleted");
@@ -13103,7 +13103,7 @@ PHP_METHOD(Phalcon_Mvc_Model, belongsTo)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "addbelongsto", NULL, 0, this_ptr, fields, &referenceModel_zv, referencedFields, &options);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -13283,7 +13283,7 @@ PHP_METHOD(Phalcon_Mvc_Model, hasMany)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "addhasmany", NULL, 0, this_ptr, fields, &referenceModel_zv, referencedFields, &options);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -13395,7 +13395,7 @@ PHP_METHOD(Phalcon_Mvc_Model, hasManyToMany)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "addhasmanytomany", NULL, 0, this_ptr, fields, &intermediateModel_zv, intermediateFields, intermediateReferencedFields, &referenceModel_zv, referencedFields, &options);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -13486,7 +13486,7 @@ PHP_METHOD(Phalcon_Mvc_Model, hasOne)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "addhasone", NULL, 0, this_ptr, fields, &referenceModel_zv, referencedFields, &options);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -13571,7 +13571,7 @@ PHP_METHOD(Phalcon_Mvc_Model, hasOneThrough)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "addhasonethrough", NULL, 0, this_ptr, fields, &intermediateModel_zv, intermediateFields, intermediateReferencedFields, &referenceModel_zv, referencedFields, &options);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -13613,7 +13613,7 @@ PHP_METHOD(Phalcon_Mvc_Model, keepSnapshots)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &keepSnapshot_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	if (keepSnapshot) {
 		ZVAL_BOOL(&_1, 1);
 	} else {
@@ -13649,7 +13649,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setSchema)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&schema_zv);
 	ZVAL_STR_COPY(&schema_zv, schema);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setmodelschema", NULL, 0, this_ptr, &schema_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -13680,7 +13680,7 @@ PHP_METHOD(Phalcon_Mvc_Model, setSource)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&source_zv);
 	ZVAL_STR_COPY(&source_zv, source);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "setmodelsource", NULL, 0, this_ptr, &source_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -13921,7 +13921,7 @@ PHP_METHOD(Phalcon_Mvc_Model, useDynamicUpdate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &dynamicUpdate_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 973, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 972, PH_NOISY_CC | PH_READONLY);
 	if (dynamicUpdate) {
 		ZVAL_BOOL(&_1, 1);
 	} else {
@@ -14064,7 +14064,7 @@ PHP_METHOD(Phalcon_Mvc_Model, validationHasFailed)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("errorMessages", 13, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 979, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 978, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_fast_count_int(&_0) > 0);
 }
 
@@ -14158,14 +14158,14 @@ PHP_METHOD(Phalcon_Mvc_Model, getPrivateProperties)
 		array_init(&privateProperties);
 		ZEPHIR_INIT_VAR(&reflection);
 		object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionclass")));
-		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 239, &className_zv);
+		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 240, &className_zv);
 		zephir_check_call_status();
 		while (1) {
 			if (!(Z_TYPE_P(&reflection) == IS_OBJECT)) {
 				break;
 			}
 			ZVAL_LONG(&_0$$4, 4);
-			ZEPHIR_CALL_METHOD(&reflectionProperties, &reflection, "getproperties", &_1, 347, &_0$$4);
+			ZEPHIR_CALL_METHOD(&reflectionProperties, &reflection, "getproperties", &_1, 349, &_0$$4);
 			zephir_check_call_status();
 			zephir_is_iterable(&reflectionProperties, 0, "phalcon/Mvc/Model.zep", 6522);
 			if (Z_TYPE_P(&reflectionProperties) == IS_ARRAY) {

--- a/ext/phalcon/mvc/model/binder.zep.c
+++ b/ext/phalcon/mvc/model/binder.zep.c
@@ -93,7 +93,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, __construct)
 		cache = &cache_sub;
 		cache = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 989, cache);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 988, cache);
 }
 
 /**
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, bindToHandler)
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 990, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 989, &_0);
 	_1 = !((zephir_is_instance_of(handler, SL("Closure"))));
 	if (_1) {
 		_1 = ZEPHIR_IS_NULL(&methodName_zv);
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, bindToHandler)
 	}
 	ZEPHIR_INIT_VAR(&_3);
 	array_init(&_3);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 991, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 990, &_3);
 	ZEPHIR_CALL_METHOD(&paramsCache, this_ptr, "getparamsfromcache", NULL, 0, &cacheKey_zv);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&paramsCache) == IS_ARRAY) {
@@ -283,7 +283,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, setCache)
 		Z_PARAM_OBJECT_OF_CLASS(cache, phalcon_cache_adapter_adapterinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &cache);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 989, cache);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 988, cache);
 	RETURN_THISW();
 }
 
@@ -352,11 +352,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, getParamsFromCache)
 	zephir_memory_observe(&cacheKey_zv);
 	ZVAL_STR_COPY(&cacheKey_zv, cacheKey);
 	zephir_memory_observe(&internalParams);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 991, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&internalParams, &_0, &cacheKey_zv, 0)) {
 		RETURN_CCTOR(&internalParams);
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 989, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 988, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cache, &_1);
 	_2 = Z_TYPE_P(&cache) == IS_NULL;
 	if (!(_2)) {
@@ -451,12 +451,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Binder, getParamsFromReflection)
 		zephir_check_call_status();
 	} else {
 		object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionfunction")));
-		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 236, handler);
+		ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 237, handler);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 989, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 988, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cache, &_0);
-	ZEPHIR_CALL_METHOD(&methodParams, &reflection, "getparameters", NULL, 237);
+	ZEPHIR_CALL_METHOD(&methodParams, &reflection, "getparameters", NULL, 238);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&paramsKeys);
 	zephir_array_keys(&paramsKeys, &params);

--- a/ext/phalcon/mvc/model/criteria.zep.c
+++ b/ext/phalcon/mvc/model/criteria.zep.c
@@ -121,7 +121,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, andWhere)
 		bindTypes = &__$null;
 	}
 	zephir_memory_observe(&currentConditions);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&currentConditions, &_0, SL("conditions"), 0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZEPHIR_CONCAT_SVSVS(&_1$$3, "(", &currentConditions, ") AND (", &conditions, ")");
@@ -174,7 +174,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, betweenWhere)
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
 	zephir_memory_observe(&hiddenParam);
-	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 994, PH_NOISY_CC);
+	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&nextHiddenParam);
 	ZVAL_LONG(&nextHiddenParam, (zephir_get_numberval(&hiddenParam) + 1));
 	ZEPHIR_INIT_VAR(&minimumKey);
@@ -191,7 +191,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, betweenWhere)
 	zephir_check_call_status();
 	SEPARATE_ZVAL(&nextHiddenParam);
 	zephir_increment(&nextHiddenParam);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 994, &nextHiddenParam);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 993, &nextHiddenParam);
 	RETURN_THIS();
 }
 
@@ -236,7 +236,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, bind)
 		merge = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value_string(&_0, SL("bind")))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		array_init(&_1$$3);
@@ -244,7 +244,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, bind)
 		ZVAL_STRING(&_2$$3, "bind");
 		zephir_update_property_array(this_ptr, SL("params"), &_2$$3, &_1$$3);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&_4);
 	zephir_array_fetch_string(&_4, &_3, SL("bind"), PH_NOISY, "phalcon/Mvc/Model/Criteria.zep", 130);
 	_5 = Z_TYPE_P(&_4) == IS_ARRAY;
@@ -252,7 +252,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, bind)
 		_5 = merge;
 	}
 	if (_5) {
-		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$4, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch_string(&_7$$4, &_6$$4, SL("bind"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Criteria.zep", 131);
 		ZEPHIR_INIT_VAR(&_8$$4);
 		zephir_add_function(&_8$$4, &_7$$4, &bindParams);
@@ -461,10 +461,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, createBuilder)
 	ZEPHIR_CALL_METHOD(&_0, &container, "getshared", NULL, 0, &_1);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&manager, &_0);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&builder, &manager, "createbuilder", NULL, 0, &_2);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 995, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 994, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &builder, "from", NULL, 0, &_3);
 	zephir_check_call_status();
 	RETURN_CCTOR(&builder);
@@ -788,7 +788,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getColumns)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&columns);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&columns, &_0, SL("columns"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -814,7 +814,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getConditions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&conditions);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&conditions, &_0, SL("conditions"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -835,7 +835,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getDI)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("params", 6, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch_string(&_1, &_0, SL("di"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Criteria.zep", 415);
 	RETURN_CTORW(&_1);
 }
@@ -859,7 +859,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getGroupBy)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&group);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&group, &_0, SL("group"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -885,7 +885,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getHaving)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&having);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&having, &_0, SL("having"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -915,7 +915,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getLimit)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&limit);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&limit, &_0, SL("limit"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -950,7 +950,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getOrderBy)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&order);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&order, &_0, SL("order"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -985,7 +985,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, getWhere)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&conditions);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&conditions, &_0, SL("conditions"), 0))) {
 		RETURN_MM_NULL();
 	}
@@ -1093,7 +1093,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, inWhere)
 		RETURN_THIS();
 	}
 	zephir_memory_observe(&hiddenParam);
-	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 994, PH_NOISY_CC);
+	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&bindParams);
 	array_init(&bindParams);
 	ZEPHIR_INIT_VAR(&bindKeys);
@@ -1150,7 +1150,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, inWhere)
 	ZEPHIR_CONCAT_VSVS(&_7, &expr_zv, " IN (", &_6, ")");
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "andwhere", NULL, 0, &_7, &bindParams);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 994, &hiddenParam);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 993, &hiddenParam);
 	RETURN_THIS();
 }
 
@@ -1473,7 +1473,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, notBetweenWhere)
 	zephir_memory_observe(&expr_zv);
 	ZVAL_STR_COPY(&expr_zv, expr);
 	zephir_memory_observe(&hiddenParam);
-	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 994, PH_NOISY_CC);
+	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&nextHiddenParam);
 	ZVAL_LONG(&nextHiddenParam, (zephir_get_numberval(&hiddenParam) + 1));
 	ZEPHIR_INIT_VAR(&_0);
@@ -1492,7 +1492,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, notBetweenWhere)
 	zephir_check_call_status();
 	SEPARATE_ZVAL(&nextHiddenParam);
 	zephir_increment(&nextHiddenParam);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 994, &nextHiddenParam);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 993, &nextHiddenParam);
 	RETURN_THIS();
 }
 
@@ -1544,7 +1544,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, notInWhere)
 	ZVAL_STR_COPY(&expr_zv, expr);
 	zephir_get_arrval(&values, values_param);
 	zephir_memory_observe(&hiddenParam);
-	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 994, PH_NOISY_CC);
+	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&bindParams);
 	array_init(&bindParams);
 	ZEPHIR_INIT_VAR(&bindKeys);
@@ -1601,7 +1601,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, notInWhere)
 	ZEPHIR_CONCAT_VSVS(&_8, &expr_zv, " NOT IN (", &_7, ")");
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "andwhere", NULL, 0, &_8, &bindParams);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 994, &hiddenParam);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 993, &hiddenParam);
 	RETURN_THIS();
 }
 
@@ -1648,7 +1648,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, orWhere)
 		bindTypes = &__$null;
 	}
 	zephir_memory_observe(&currentConditions);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&currentConditions, &_0, SL("conditions"), 0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZEPHIR_CONCAT_SVSVS(&_1$$3, "(", &currentConditions, ") OR (", &conditions, ")");
@@ -1784,7 +1784,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, setModelName)
 		Z_PARAM_STR(modelName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&modelName_zv, modelName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 995, &modelName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 994, &modelName_zv);
 	RETURN_THISW();
 }
 
@@ -1879,7 +1879,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, where)
 	zephir_update_property_array(this_ptr, SL("params"), &_0, &conditions_zv);
 	if (Z_TYPE_P(bindParams) == IS_ARRAY) {
 		zephir_memory_observe(&currentBindParams);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_string_fetch(&currentBindParams, &_1$$3, SL("bind"), 0)) {
 			ZEPHIR_INIT_VAR(&_2$$4);
 			zephir_fast_array_merge(&_2$$4, &currentBindParams, bindParams);
@@ -1894,7 +1894,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, where)
 	}
 	if (Z_TYPE_P(bindTypes) == IS_ARRAY) {
 		zephir_memory_observe(&currentBindTypes);
-		zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_string_fetch(&currentBindTypes, &_5$$6, SL("bindTypes"), 0)) {
 			ZEPHIR_INIT_VAR(&_6$$7);
 			zephir_fast_array_merge(&_6$$7, &currentBindTypes, bindTypes);
@@ -1983,7 +1983,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Criteria, addJoinClause)
 	zephir_array_fast_append(&join, alias);
 	zephir_array_fast_append(&join, type);
 	zephir_memory_observe(&currentJoins);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 993, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 992, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_string_fetch(&currentJoins, &_0, SL("joins"), 0)) {
 		if (Z_TYPE_P(&currentJoins) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_1$$4);

--- a/ext/phalcon/mvc/model/manager.zep.c
+++ b/ext/phalcon/mvc/model/manager.zep.c
@@ -274,7 +274,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addBehavior)
 	zephir_fetch_params(1, 2, 0, &model, &behavior);
 	ZEPHIR_INIT_VAR(&entityName);
 	zephir_get_class(&entityName, model, 1);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_0, &entityName))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		array_init(&_1$$3);
@@ -367,7 +367,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addBelongsTo)
 	ZEPHIR_CONCAT_VSV(&_0, &entityName, "$", &referencedEntity);
 	zephir_get_strval(&keyRelation, &_0);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 997, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&relations, &_1, &keyRelation, 0))) {
 		ZEPHIR_INIT_NVAR(&relations);
 		array_init(&relations);
@@ -414,7 +414,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addBelongsTo)
 	zephir_update_property_array(this_ptr, SL("aliases"), &_7, &relation);
 	zephir_update_property_array(this_ptr, SL("belongsTo"), &keyRelation, &relations);
 	zephir_memory_observe(&singleRelations);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 998, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 997, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&singleRelations, &_4, &entityName, 0))) {
 		ZEPHIR_INIT_NVAR(&singleRelations);
 		array_init(&singleRelations);
@@ -506,7 +506,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasMany)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_VSV(&_0, &entityName, "$", &referencedEntity);
 	zephir_get_strval(&keyRelation, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 999, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 998, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hasMany, &_1);
 	zephir_memory_observe(&relations);
 	if (!(zephir_array_isset_fetch(&relations, &hasMany, &keyRelation, 0))) {
@@ -555,7 +555,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasMany)
 	zephir_update_property_array(this_ptr, SL("aliases"), &_6, &relation);
 	zephir_update_property_array(this_ptr, SL("hasMany"), &keyRelation, &relations);
 	zephir_memory_observe(&singleRelations);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1000, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 999, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&singleRelations, &_1, &entityName, 0))) {
 		ZEPHIR_INIT_NVAR(&singleRelations);
 		array_init(&singleRelations);
@@ -665,7 +665,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasManyToMany)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_VSV(&_0, &entityName, "$", &referencedEntity);
 	zephir_get_strval(&keyRelation, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1001, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1000, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hasManyToMany, &_1);
 	zephir_memory_observe(&relations);
 	if (!(zephir_array_isset_fetch(&relations, &hasManyToMany, &keyRelation, 0))) {
@@ -729,7 +729,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasManyToMany)
 	zephir_update_property_array(this_ptr, SL("aliases"), &_8, &relation);
 	zephir_update_property_array(this_ptr, SL("hasManyToMany"), &keyRelation, &relations);
 	zephir_memory_observe(&singleRelations);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1002, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1001, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&singleRelations, &_1, &entityName, 0))) {
 		ZEPHIR_INIT_NVAR(&singleRelations);
 		array_init(&singleRelations);
@@ -822,7 +822,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasOne)
 	ZEPHIR_CONCAT_VSV(&_0, &entityName, "$", &referencedEntity);
 	zephir_get_strval(&keyRelation, &_0);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1003, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1002, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&relations, &_1, &keyRelation, 0))) {
 		ZEPHIR_INIT_NVAR(&relations);
 		array_init(&relations);
@@ -869,7 +869,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasOne)
 	zephir_update_property_array(this_ptr, SL("aliases"), &_7, &relation);
 	zephir_update_property_array(this_ptr, SL("hasOne"), &keyRelation, &relations);
 	zephir_memory_observe(&singleRelations);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1004, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1003, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&singleRelations, &_4, &entityName, 0))) {
 		ZEPHIR_INIT_NVAR(&singleRelations);
 		array_init(&singleRelations);
@@ -979,7 +979,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasOneThrough)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_VSV(&_0, &entityName, "$", &referencedEntity);
 	zephir_get_strval(&keyRelation, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1005, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1004, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hasOneThrough, &_1);
 	zephir_memory_observe(&relations);
 	if (!(zephir_array_isset_fetch(&relations, &hasOneThrough, &keyRelation, 0))) {
@@ -1043,7 +1043,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, addHasOneThrough)
 	zephir_update_property_array(this_ptr, SL("aliases"), &_8, &relation);
 	zephir_update_property_array(this_ptr, SL("hasOneThrough"), &keyRelation, &relations);
 	zephir_memory_observe(&singleRelations);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1006, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1005, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&singleRelations, &_1, &entityName, 0))) {
 		ZEPHIR_INIT_NVAR(&singleRelations);
 		array_init(&singleRelations);
@@ -1072,7 +1072,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, clearReusableObjects)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1007, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1006, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1118,7 +1118,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, createBuilder)
 		params = &params_sub;
 		params = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1008, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1007, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -1137,7 +1137,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, createBuilder)
 	ZVAL_STRING(&_4, "Phalcon\\Mvc\\Model\\Query\\Builder");
 	ZEPHIR_CALL_METHOD(&_2, &container, "get", NULL, 0, &_4, &_3);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1009, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1008, &_2);
 	RETURN_MM_MEMBER(getThis(), "builder");
 }
 
@@ -1181,7 +1181,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, createQuery)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&phql_zv);
 	ZVAL_STR_COPY(&phql_zv, phql);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1008, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1007, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -1201,7 +1201,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, createQuery)
 	ZEPHIR_CALL_METHOD(&_2, &container, "get", NULL, 0, &_4, &_3);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&query, &_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1010, &query);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1009, &query);
 	RETURN_CCTOR(&query);
 }
 
@@ -1467,7 +1467,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getBelongsTo)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 998, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 997, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&relations, &_0, &_1, 0))) {
@@ -1552,7 +1552,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getBelongsToRecords)
 	ZEPHIR_CONCAT_VSV(&_2, &_0, "$", &_1);
 	zephir_get_strval(&keyRelation, &_2);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 999, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 998, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&relations, &_3, &keyRelation, 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -1639,7 +1639,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getCustomEventsManager)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&eventsManager);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1011, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1010, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (zephir_array_isset_fetch(&eventsManager, &_0, &_1, 0)) {
@@ -1691,7 +1691,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getHasMany)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1000, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 999, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&relations, &_0, &_1, 0))) {
@@ -1768,7 +1768,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getHasManyRecords)
 	ZEPHIR_CONCAT_VSV(&_2, &_0, "$", &_1);
 	zephir_get_strval(&keyRelation, &_2);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 999, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 998, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&relations, &_3, &keyRelation, 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -1803,7 +1803,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getHasManyToMany)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1002, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1001, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&relations, &_0, &_1, 0))) {
@@ -1838,7 +1838,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getHasOne)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1004, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1003, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&relations, &_0, &_1, 0))) {
@@ -1942,7 +1942,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getHasOneRecords)
 	ZEPHIR_CONCAT_VSV(&_2, &_0, "$", &_1);
 	zephir_get_strval(&keyRelation, &_2);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1003, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1002, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&relations, &_3, &keyRelation, 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -1977,7 +1977,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getHasOneThrough)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1006, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1005, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&relations, &_0, &_1, 0))) {
@@ -2039,7 +2039,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getModelSchema)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
 	zephir_memory_observe(&schema);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1012, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1011, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&schema, &_0, &_1, 0))) {
@@ -2083,7 +2083,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getModelSource)
 	zephir_fetch_params(1, 1, 0, &model);
 	ZEPHIR_INIT_VAR(&entityName);
 	zephir_get_class(&entityName, model, 1);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1013, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1012, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_0, &entityName))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZEPHIR_INIT_VAR(&_2$$3);
@@ -2092,8 +2092,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getModelSource)
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setmodelsource", NULL, 0, model, &_1$$3);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 1014, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 1013, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 1013, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 1012, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_5, &_4, &entityName, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Manager.zep", 1294);
 	ZEPHIR_CONCAT_VV(return_value, &_3, &_5);
 	RETURN_MM();
@@ -2139,20 +2139,20 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getReadConnection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1015, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1014, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1016, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1015, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&writeService, this_ptr, "getconnectionservice", NULL, 0, model, &_1$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 1017, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 1016, PH_NOISY_CC | PH_READONLY);
 		if (zephir_array_isset_value(&_2$$3, &writeService)) {
-			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 1016, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_1, 1015, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getconnection", NULL, 0, model, &_3$$4);
 			zephir_check_call_status();
 			RETURN_MM();
 		}
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 1018, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 1017, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getconnection", NULL, 0, model, &_4);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -2181,7 +2181,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getReadConnectionService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1018, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1017, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getconnectionservice", NULL, 0, model, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -2225,7 +2225,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelationByAlias)
 	zephir_memory_observe(&alias_zv);
 	ZVAL_STR_COPY(&alias_zv, alias);
 	zephir_memory_observe(&relation);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1019, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1018, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_INIT_VAR(&_2);
 	ZEPHIR_CONCAT_VSV(&_2, &modelName_zv, "$", &alias_zv);
@@ -2763,7 +2763,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelations)
 	ZEPHIR_INIT_VAR(&allRelations);
 	array_init(&allRelations);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 998, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 997, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_0, &entityName, 0)) {
 		zephir_is_iterable(&relations, 0, "phalcon/Mvc/Model/Manager.zep", 1638);
 		if (Z_TYPE_P(&relations) == IS_ARRAY) {
@@ -2797,7 +2797,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelations)
 		ZEPHIR_INIT_NVAR(&relation);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1000, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 999, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_4, &entityName, 0)) {
 		zephir_is_iterable(&relations, 0, "phalcon/Mvc/Model/Manager.zep", 1647);
 		if (Z_TYPE_P(&relations) == IS_ARRAY) {
@@ -2831,7 +2831,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelations)
 		ZEPHIR_INIT_NVAR(&relation);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_2, 1004, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_2, 1003, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_8, &entityName, 0)) {
 		zephir_is_iterable(&relations, 0, "phalcon/Mvc/Model/Manager.zep", 1656);
 		if (Z_TYPE_P(&relations) == IS_ARRAY) {
@@ -2865,7 +2865,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelations)
 		ZEPHIR_INIT_NVAR(&relation);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_3, 1006, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_12, this_ptr, _zephir_prop_3, 1005, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_12, &entityName, 0)) {
 		zephir_is_iterable(&relations, 0, "phalcon/Mvc/Model/Manager.zep", 1665);
 		if (Z_TYPE_P(&relations) == IS_ARRAY) {
@@ -2899,7 +2899,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelations)
 		ZEPHIR_INIT_NVAR(&relation);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_16, this_ptr, _zephir_prop_4, 1002, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_16, this_ptr, _zephir_prop_4, 1001, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_16, &entityName, 0)) {
 		zephir_is_iterable(&relations, 0, "phalcon/Mvc/Model/Manager.zep", 1674);
 		if (Z_TYPE_P(&relations) == IS_ARRAY) {
@@ -3002,27 +3002,27 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getRelationsBetween)
 	ZEPHIR_CONCAT_VSV(&_2, &_0, "$", &_1);
 	zephir_get_strval(&keyRelation, &_2);
 	zephir_memory_observe(&relations);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 997, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_3, &keyRelation, 0)) {
 		RETURN_CCTOR(&relations);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 999, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 998, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_4, &keyRelation, 0)) {
 		RETURN_CCTOR(&relations);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 1003, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 1002, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_5, &keyRelation, 0)) {
 		RETURN_CCTOR(&relations);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 1005, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_3, 1004, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_6, &keyRelation, 0)) {
 		RETURN_CCTOR(&relations);
 	}
 	ZEPHIR_OBS_NVAR(&relations);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_4, 1001, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_4, 1000, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&relations, &_7, &keyRelation, 0)) {
 		RETURN_CCTOR(&relations);
 	}
@@ -3064,7 +3064,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getReusableRecords)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&records);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1007, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1006, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&records, &_0, &key_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -3098,7 +3098,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getWriteConnection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1016, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1015, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getconnection", NULL, 0, model, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -3131,7 +3131,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getWriteConnectionService)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1016, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1015, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getconnectionservice", NULL, 0, model, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -3360,7 +3360,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, initialize)
 	zephir_fetch_params(1, 1, 0, &model);
 	ZEPHIR_INIT_VAR(&className);
 	zephir_get_class(&className, model, 1);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1020, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1019, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, &className)) {
 		RETURN_MM_BOOL(0);
 	}
@@ -3369,8 +3369,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, initialize)
 		ZEPHIR_CALL_METHOD(NULL, model, "initialize", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1021, model);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1022, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1020, model);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1021, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_1);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_2$$5);
@@ -3378,7 +3378,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, initialize)
 		ZEPHIR_CALL_METHOD(NULL, &eventsManager, "fire", NULL, 0, &_2$$5, this_ptr, model);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1021, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1020, &__$null);
 	RETURN_MM_BOOL(1);
 }
 
@@ -3411,7 +3411,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, isInitialized)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&className_zv);
 	ZVAL_STR_COPY(&className_zv, className);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1020, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1019, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_fast_strtolower(&_1, &className_zv);
 	RETURN_MM_BOOL(zephir_array_isset_value(&_0, &_1));
@@ -3454,7 +3454,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, isKeepingSnapshots)
 	if (zephir_is_true(&_0)) {
 		RETURN_MM_BOOL(1);
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1023, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1022, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&isKeeping, &_2, &_1, 1))) {
@@ -3500,7 +3500,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, isUsingDynamicUpdate)
 	if (zephir_is_true(&_0)) {
 		RETURN_MM_BOOL(1);
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1024, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1023, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_NVAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (!(zephir_array_isset_fetch(&isUsing, &_2, &_1, 1))) {
@@ -3568,16 +3568,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, isVisibleModelProperty)
 	ZVAL_STR_COPY(&property_zv, property);
 	ZEPHIR_INIT_VAR(&className);
 	zephir_get_class(&className, model, 0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1025, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1024, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_0, &className))) {
 		ZEPHIR_INIT_VAR(&publicProperties);
 		array_init(&publicProperties);
 		ZEPHIR_INIT_VAR(&classReflection);
 		object_init_ex(&classReflection, zephir_get_internal_ce(SL("reflectionclass")));
-		ZEPHIR_CALL_METHOD(NULL, &classReflection, "__construct", NULL, 239, &className);
+		ZEPHIR_CALL_METHOD(NULL, &classReflection, "__construct", NULL, 240, &className);
 		zephir_check_call_status();
 		ZVAL_LONG(&_1$$3, 1);
-		ZEPHIR_CALL_METHOD(&reflectionProperties, &classReflection, "getproperties", NULL, 347, &_1$$3);
+		ZEPHIR_CALL_METHOD(&reflectionProperties, &classReflection, "getproperties", NULL, 349, &_1$$3);
 		zephir_check_call_status();
 		zephir_is_iterable(&reflectionProperties, 0, "phalcon/Mvc/Model/Manager.zep", 1986);
 		if (Z_TYPE_P(&reflectionProperties) == IS_ARRAY) {
@@ -3615,7 +3615,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, isVisibleModelProperty)
 		ZEPHIR_INIT_NVAR(&reflectionProperty);
 		zephir_update_property_array(this_ptr, SL("modelVisibility"), &className, &publicProperties);
 	}
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 1025, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 1024, PH_NOISY_CC | PH_READONLY);
 	zephir_memory_observe(&properties);
 	zephir_array_fetch(&properties, &_7, &className, PH_NOISY, "phalcon/Mvc/Model/Manager.zep", 1989);
 	RETURN_MM_BOOL(zephir_array_key_exists(&properties, &property_zv));
@@ -3701,7 +3701,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, load)
 	zephir_create_array(&_1, 3, 0);
 	zephir_array_fast_append(&_1, &__$null);
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1008, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1007, PH_NOISY_CC);
 	zephir_array_fast_append(&_1, &_2);
 	zephir_array_fast_append(&_1, this_ptr);
 	ZEPHIR_INIT_VAR(&model);
@@ -3762,7 +3762,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, missingMethod)
 	zephir_memory_observe(&eventName_zv);
 	ZVAL_STR_COPY(&eventName_zv, eventName);
 	zephir_memory_observe(&modelsBehaviors);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (zephir_array_isset_fetch(&modelsBehaviors, &_0, &_1, 0)) {
@@ -3805,7 +3805,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, missingMethod)
 		}
 		ZEPHIR_INIT_NVAR(&behavior);
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 1022, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 1021, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_5);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_6$$8);
@@ -3874,7 +3874,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, notifyEvent)
 	ZEPHIR_INIT_VAR(&status);
 	ZVAL_BOOL(&status, 1);
 	zephir_memory_observe(&modelsBehaviors);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_get_class(&_1, model, 1);
 	if (zephir_array_isset_fetch(&modelsBehaviors, &_0, &_1, 0)) {
@@ -3917,7 +3917,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, notifyEvent)
 		}
 		ZEPHIR_INIT_NVAR(&behavior);
 	}
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 1022, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 1021, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_5);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_6$$8);
@@ -3929,7 +3929,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, notifyEvent)
 		}
 	}
 	zephir_memory_observe(&customEventsManager);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 1011, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_2, 1010, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_7);
 	zephir_get_class(&_7, model, 1);
 	if (zephir_array_isset_fetch(&customEventsManager, &_5, &_7, 0)) {
@@ -3980,11 +3980,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, registerWrite)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &model);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1015, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1014, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1016, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1015, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getconnectionservice", NULL, 0, model, &_2);
 	zephir_check_call_status();
 	zephir_update_property_array(this_ptr, SL("dirtyWriteServices"), &_1, &__$true);
@@ -4043,9 +4043,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, removeBehavior)
 	ZVAL_STR_COPY(&behaviorClass_zv, behaviorClass);
 	ZEPHIR_INIT_VAR(&entityName);
 	zephir_get_class(&entityName, model, 1);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, &entityName)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, &entityName, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Manager.zep", 2184);
 		zephir_is_iterable(&_2$$3, 0, "phalcon/Mvc/Model/Manager.zep", 2190);
 		if (Z_TYPE_P(&_2$$3) == IS_ARRAY) {
@@ -4062,7 +4062,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, removeBehavior)
 				ZEPHIR_INIT_NVAR(&_6$$4);
 				zephir_get_class(&_6$$4, &behavior, 0);
 				if (ZEPHIR_IS_IDENTICAL(&_6$$4, &behaviorClass_zv)) {
-					zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_7$$5, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 					zephir_array_fetch(&_8$$5, &_7$$5, &entityName, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Manager.zep", 2186);
 					zephir_array_unset(&_8$$5, &key, PH_SEPARATE);
 				}
@@ -4090,7 +4090,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, removeBehavior)
 					ZEPHIR_INIT_NVAR(&_11$$6);
 					zephir_get_class(&_11$$6, &behavior, 0);
 					if (ZEPHIR_IS_IDENTICAL(&_11$$6, &behaviorClass_zv)) {
-						zephir_read_property_cached(&_12$$7, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_12$$7, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 						zephir_array_fetch(&_13$$7, &_12$$7, &entityName, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Manager.zep", 2186);
 						zephir_array_unset(&_13$$7, &key, PH_SEPARATE);
 					}
@@ -4098,7 +4098,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, removeBehavior)
 		}
 		ZEPHIR_INIT_NVAR(&behavior);
 		ZEPHIR_INIT_NVAR(&key);
-		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_0, 996, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_14$$3, this_ptr, _zephir_prop_0, 995, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_15$$3, &_14$$3, &entityName, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Manager.zep", 2190);
 		ZEPHIR_CALL_FUNCTION(&_16$$3, "array_values", NULL, 27, &_15$$3);
 		zephir_check_call_status();
@@ -4130,7 +4130,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, resetConnectionState)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1017, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1016, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -4220,7 +4220,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1008, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1007, container);
 }
 
 /**
@@ -4245,7 +4245,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1022, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1021, eventsManager);
 }
 
 /**
@@ -4290,7 +4290,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, setModelPrefix)
 		Z_PARAM_STR(prefix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&prefix_zv, prefix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1014, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1013, &prefix_zv);
 }
 
 /**
@@ -4448,9 +4448,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, setSticky)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &sticky_param);
 	if (sticky) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1015, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1014, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1015, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1014, &__$false);
 	}
 }
 
@@ -4565,7 +4565,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, getConnection)
 	zephir_get_arrval(&connectionServices, connectionServices_param);
 	ZEPHIR_CALL_METHOD(&service, this_ptr, "getconnectionservice", NULL, 0, model, &connectionServices);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1008, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1007, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -4882,7 +4882,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Manager, checkHasRelationship)
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_CONCAT_VSV(&_1, &entityName, "$", &_0);
 	zephir_get_strval(&keyRelation, &_1);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1020, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1019, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value(&_2, &entityName))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "load", NULL, 0, &modelName_zv);
 		zephir_check_call_status();

--- a/ext/phalcon/mvc/model/metadata/apcu.zep.c
+++ b/ext/phalcon/mvc/model/metadata/apcu.zep.c
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Apcu, __construct)
 	ZVAL_STRING(&_1, "apcu");
 	ZEPHIR_CALL_METHOD(&_5, factory, "newinstance", NULL, 0, &_1, &options);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1026, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1025, &_5);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/mvc/model/metadata/libmemcached.zep.c
+++ b/ext/phalcon/mvc/model/metadata/libmemcached.zep.c
@@ -106,7 +106,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Libmemcached, __construct)
 	ZVAL_STRING(&_1, "libmemcached");
 	ZEPHIR_CALL_METHOD(&_6, factory, "newinstance", NULL, 0, &_1, &options);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1027, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1026, &_6);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -128,7 +128,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Libmemcached, reset)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1027, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1026, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "clear", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_PARENT(NULL, phalcon_mvc_model_metadata_libmemcached_ce, getThis(), "reset", NULL, 0);

--- a/ext/phalcon/mvc/model/metadata/redis.zep.c
+++ b/ext/phalcon/mvc/model/metadata/redis.zep.c
@@ -112,7 +112,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Redis, __construct)
 	ZVAL_STRING(&_1, "redis");
 	ZEPHIR_CALL_METHOD(&_5, factory, "newinstance", NULL, 0, &_1, &options);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1028, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1027, &_5);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -134,7 +134,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Redis, reset)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1028, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1027, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "clear", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_PARENT(NULL, phalcon_mvc_model_metadata_redis_ce, getThis(), "reset", NULL, 0);

--- a/ext/phalcon/mvc/model/metadata/stream.zep.c
+++ b/ext/phalcon/mvc/model/metadata/stream.zep.c
@@ -90,7 +90,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Stream, __construct)
 	}
 	zephir_memory_observe(&metaDataDir);
 	if (zephir_array_isset_string_fetch(&metaDataDir, &options, SL("metaDataDir"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1029, &metaDataDir);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1028, &metaDataDir);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -126,7 +126,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Stream, read)
 	if (Z_TYPE_P(key) == IS_NULL) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1029, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1028, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "_");
@@ -188,7 +188,7 @@ PHP_METHOD(Phalcon_Mvc_Model_MetaData_Stream, write)
 
 	/* try_start_1: */
 
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1029, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1028, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZVAL_STRING(&_3$$3, "_");

--- a/ext/phalcon/mvc/model/query.zep.c
+++ b/ext/phalcon/mvc/model/query.zep.c
@@ -293,7 +293,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1030, &phql_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1029, &phql_zv);
 	if (Z_TYPE_P(container) == IS_OBJECT) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setdi", NULL, 0, container);
 		zephir_check_call_status();
@@ -301,23 +301,23 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, __construct)
 	zephir_memory_observe(&enableImplicitJoins);
 	if (zephir_array_isset_string_fetch(&enableImplicitJoins, &options, SL("enable_implicit_joins"), 0)) {
 		if (ZEPHIR_IS_TRUE(&enableImplicitJoins)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1031, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1030, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1031, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1030, &__$false);
 		}
 	} else {
 		ZEPHIR_INIT_VAR(&_1$$5);
 		ZVAL_STRING(&_1$$5, "orm.enable_implicit_joins");
 		ZEPHIR_CALL_CE_STATIC(&_0$$5, phalcon_support_settings_ce, "get", NULL, 0, &_1$$5);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1031, &_0$$5);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1030, &_0$$5);
 	}
 	ZEPHIR_INIT_VAR(&_2);
 	array_init(&_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1032, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1031, &_2);
 	ZEPHIR_INIT_VAR(&_3);
 	array_init(&_3);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1033, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1032, &_3);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -344,7 +344,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, cache)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &cacheOptions_param);
 	zephir_get_arrval(&cacheOptions, cacheOptions_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1034, &cacheOptions);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1033, &cacheOptions);
 	RETURN_THIS();
 }
 
@@ -458,9 +458,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute)
 	} else {
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1035, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1034, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&uniqueRow, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1034, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1033, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cacheOptions, &_0);
 	if (Z_TYPE_P(&cacheOptions) != IS_NULL) {
 		if (UNEXPECTED(Z_TYPE_P(&cacheOptions) != IS_ARRAY)) {
@@ -487,7 +487,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute)
 			ZEPHIR_INIT_NVAR(&cacheService);
 			ZVAL_STRING(&cacheService, "modelsCache");
 		}
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 1036, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 1035, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&cache, &_3$$3, "getshared", NULL, 0, &cacheService);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&_4$$3);
@@ -540,23 +540,23 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, execute)
 			}
 			RETURN_CCTOR(&preparedResult);
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1037, &cache);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1036, &cache);
 	}
 	ZEPHIR_CALL_METHOD(&intermediate, this_ptr, "parse", NULL, 0);
 	zephir_check_call_status();
 	zephir_memory_observe(&defaultBindParams);
-	zephir_read_property_cached(&defaultBindParams, this_ptr, _zephir_prop_4, 1032, PH_NOISY_CC);
+	zephir_read_property_cached(&defaultBindParams, this_ptr, _zephir_prop_4, 1031, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&mergedParams);
 	zephir_add_function(&mergedParams, &defaultBindParams, &bindParams);
 	zephir_memory_observe(&defaultBindTypes);
-	zephir_read_property_cached(&defaultBindTypes, this_ptr, _zephir_prop_5, 1033, PH_NOISY_CC);
+	zephir_read_property_cached(&defaultBindTypes, this_ptr, _zephir_prop_5, 1032, PH_NOISY_CC);
 	if (Z_TYPE_P(&defaultBindTypes) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&mergedTypes);
 		zephir_add_function(&mergedTypes, &defaultBindTypes, &bindTypes);
 	} else {
 		ZEPHIR_CPY_WRT(&mergedTypes, &bindTypes);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 1038, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 1037, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&type, &_0);
 	do {
 		if (ZEPHIR_IS_LONG(&type, 309)) {
@@ -704,7 +704,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSingleResult)
 	} else {
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1035, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1034, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "execute", NULL, 0, &bindParams, &bindTypes);
 		zephir_check_call_status();
@@ -759,10 +759,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSql)
 
 	ZEPHIR_CALL_METHOD(&intermediate, this_ptr, "parse", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1038, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1037, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_LONG(&_0, 309)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1032, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 1033, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1031, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 1032, PH_NOISY_CC | PH_READONLY);
 		ZVAL_BOOL(&_3$$3, 1);
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "executeselect", NULL, 0, &intermediate, &_1$$3, &_2$$3, &_3$$3);
 		zephir_check_call_status();
@@ -862,12 +862,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, parse)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1039, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1038, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&intermediate, &_0);
 	if (Z_TYPE_P(&intermediate) == IS_ARRAY) {
 		RETURN_CCTOR(&intermediate);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1030, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1029, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&phql, &_0);
 	ZEPHIR_CALL_CE_STATIC(&ast, phalcon_mvc_model_query_lang_ce, "parsephql", NULL, 0, &phql);
 	zephir_check_call_status();
@@ -883,7 +883,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, parse)
 			if (zephir_array_isset_fetch(&irPhql, &_1$$5, &uniqueId, 0)) {
 				if (Z_TYPE_P(&irPhql) == IS_ARRAY) {
 					zephir_array_fetch_string(&_2$$7, &ast, SL("type"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query.zep", 662);
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1038, &_2$$7);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1037, &_2$$7);
 					ZEPHIR_RETURN_CALL_METHOD(this_ptr, "refreshschemasinintermediate", NULL, 0, &irPhql);
 					zephir_check_call_status();
 					RETURN_MM();
@@ -892,8 +892,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, parse)
 		}
 		zephir_memory_observe(&type);
 		if (zephir_array_isset_string_fetch(&type, &ast, SL("type"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1040, &ast);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1038, &type);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1039, &ast);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1037, &type);
 			do {
 				if (ZEPHIR_IS_LONG(&type, 309)) {
 					ZEPHIR_CALL_METHOD(&irPhql, this_ptr, "prepareselect", NULL, 0);
@@ -938,7 +938,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, parse)
 	if (Z_TYPE_P(&uniqueId) == IS_LONG) {
 		zephir_update_static_property_array_multi_ce(phalcon_mvc_model_query_ce, SL("internalPhqlCache"), &irPhql, SL("z"), 1, &uniqueId);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1039, &irPhql);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1038, &irPhql);
 	RETURN_CCTOR(&irPhql);
 }
 
@@ -976,12 +976,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setBindParams)
 		}
 	if (merge) {
 		zephir_memory_observe(&currentBindParams);
-		zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_0, 1032, PH_NOISY_CC);
+		zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_0, 1031, PH_NOISY_CC);
 		ZEPHIR_INIT_VAR(&_0$$3);
 		zephir_add_function(&_0$$3, &currentBindParams, &bindParams);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1032, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1031, &_0$$3);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1032, &bindParams);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1031, &bindParams);
 	}
 	RETURN_THIS();
 }
@@ -1020,16 +1020,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setBindTypes)
 		}
 	if (UNEXPECTED(merge)) {
 		zephir_memory_observe(&currentBindTypes);
-		zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_0, 1033, PH_NOISY_CC);
+		zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_0, 1032, PH_NOISY_CC);
 		if (Z_TYPE_P(&currentBindTypes) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			zephir_add_function(&_0$$4, &currentBindTypes, &bindTypes);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1033, &_0$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1032, &_0$$4);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1033, &bindTypes);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1032, &bindTypes);
 		}
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1033, &bindTypes);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1032, &bindTypes);
 	}
 	RETURN_THIS();
 }
@@ -1095,9 +1095,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setDI)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1041, &manager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1042, &metaData);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1036, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1040, &manager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1041, &metaData);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1035, container);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -1124,7 +1124,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setIntermediate)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &intermediate_param);
 	zephir_get_arrval(&intermediate, intermediate_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1039, &intermediate);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1038, &intermediate);
 	RETURN_THIS();
 }
 
@@ -1154,9 +1154,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setSharedLock)
 	} else {
 		}
 	if (sharedLock) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1043, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1042, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1043, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1042, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1179,7 +1179,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setTransaction)
 		Z_PARAM_OBJECT_OF_CLASS(transaction, phalcon_mvc_model_transactioninterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &transaction);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1044, transaction);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1043, transaction);
 	RETURN_THISW();
 }
 
@@ -1204,7 +1204,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setType)
 	zephir_fetch_params_without_memory_grow(1, 0, &type_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1038, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1037, &_0);
 	RETURN_THISW();
 }
 
@@ -1260,7 +1260,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setResultsetRowClass)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1045, &resultsetRowClass_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1044, &resultsetRowClass_zv);
 	RETURN_THIS();
 }
 
@@ -1286,9 +1286,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, setUniqueRow)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &uniqueRow_param);
 	if (uniqueRow) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1035, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1034, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1035, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1034, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1359,9 +1359,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeDelete)
 	zephir_memory_observe(&modelName);
 	zephir_array_fetch_long(&modelName, &models, 0, PH_NOISY, "phalcon/Mvc/Model/Query.zep", 872);
 	zephir_memory_observe(&model);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1046, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1045, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&model, &_1, &modelName, 0))) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 1041, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 1040, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&model, &_2$$4, "load", NULL, 0, &modelName);
 		zephir_check_call_status();
 	}
@@ -1516,17 +1516,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeInsert)
 	zephir_get_arrval(&bindTypes, bindTypes_param);
 	zephir_memory_observe(&modelName);
 	zephir_array_fetch_string(&modelName, &intermediate, SL("model"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 959);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	zephir_memory_observe(&model);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1046, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1045, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&model, &_0, &modelName, 0))) {
 		ZEPHIR_CALL_METHOD(&model, &manager, "load", NULL, 0, &modelName);
 		zephir_check_call_status();
 	}
 	ZEPHIR_CALL_METHOD(&connection, this_ptr, "getwriteconnection", NULL, 0, &model, &intermediate, &bindParams, &bindTypes);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1042, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1041, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&metaData, &_1);
 	ZEPHIR_CALL_METHOD(&attributes, &metaData, "getattributes", NULL, 0, &model);
 	zephir_check_call_status();
@@ -1926,7 +1926,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 		simulate = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_INIT_VAR(&connectionTypes);
 	array_init(&connectionTypes);
@@ -1939,7 +1939,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 			ZEPHIR_INIT_NVAR(&modelName);
 			ZVAL_COPY(&modelName, _1);
 			ZEPHIR_OBS_NVAR(&model);
-			zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 1046, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 1045, PH_NOISY_CC | PH_READONLY);
 			if (!(zephir_array_isset_fetch(&model, &_2$$3, &modelName, 0))) {
 				ZEPHIR_CALL_METHOD(&model, &manager, "load", &_3, 0, &modelName);
 				zephir_check_call_status();
@@ -1991,7 +1991,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 			ZEPHIR_CALL_METHOD(&modelName, &models, "current", NULL, 0);
 			zephir_check_call_status();
 				ZEPHIR_OBS_NVAR(&model);
-				zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_1, 1046, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_13$$9, this_ptr, _zephir_prop_1, 1045, PH_NOISY_CC | PH_READONLY);
 				if (!(zephir_array_isset_fetch(&model, &_13$$9, &modelName, 0))) {
 					ZEPHIR_CALL_METHOD(&model, &manager, "load", &_14, 0, &modelName);
 					zephir_check_call_status();
@@ -2120,7 +2120,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 	array_init(&selectColumns);
 	ZEPHIR_INIT_VAR(&simpleColumnMap);
 	array_init(&simpleColumnMap);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1042, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1041, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&metaData, &_0);
 	zephir_is_iterable(&columns, 0, "phalcon/Mvc/Model/Query.zep", 1274);
 	if (Z_TYPE_P(&columns) == IS_ARRAY) {
@@ -2141,7 +2141,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 				ZEPHIR_OBS_NVAR(&modelName);
 				zephir_array_fetch_string(&modelName, &column, SL("model"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 1195);
 				ZEPHIR_OBS_NVAR(&instance);
-				zephir_read_property_cached(&_31$$33, this_ptr, _zephir_prop_1, 1046, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_31$$33, this_ptr, _zephir_prop_1, 1045, PH_NOISY_CC | PH_READONLY);
 				if (!(zephir_array_isset_fetch(&instance, &_31$$33, &modelName, 0))) {
 					ZEPHIR_CALL_METHOD(&instance, &manager, "load", &_32, 0, &modelName);
 					zephir_check_call_status();
@@ -2314,7 +2314,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 					ZEPHIR_OBS_NVAR(&modelName);
 					zephir_array_fetch_string(&modelName, &column, SL("model"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 1195);
 					ZEPHIR_OBS_NVAR(&instance);
-					zephir_read_property_cached(&_59$$51, this_ptr, _zephir_prop_1, 1046, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_59$$51, this_ptr, _zephir_prop_1, 1045, PH_NOISY_CC | PH_READONLY);
 					if (!(zephir_array_isset_fetch(&instance, &_59$$51, &modelName, 0))) {
 						ZEPHIR_CALL_METHOD(&instance, &manager, "load", &_60, 0, &modelName);
 						zephir_check_call_status();
@@ -2588,7 +2588,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&sqlSelect, &dialect, "select", NULL, 0, &intermediate);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1043, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1042, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_CALL_METHOD(&_97$$83, &dialect, "sharedlock", NULL, 0, &sqlSelect);
 		zephir_check_call_status();
@@ -2648,13 +2648,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 		ZEPHIR_INIT_NVAR(&resultData);
 		ZVAL_NULL(&resultData);
 	}
-	zephir_read_property_cached(&_110, this_ptr, _zephir_prop_4, 1037, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_110, this_ptr, _zephir_prop_4, 1036, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cache, &_110);
 	if (!(isComplex)) {
 		if (isSimpleStd) {
-			zephir_read_property_cached(&_111$$92, this_ptr, _zephir_prop_5, 1045, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_111$$92, this_ptr, _zephir_prop_5, 1044, PH_NOISY_CC | PH_READONLY);
 			if (!ZEPHIR_IS_STRING_IDENTICAL(&_111$$92, "")) {
-				zephir_read_property_cached(&_112$$93, this_ptr, _zephir_prop_5, 1045, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_112$$93, this_ptr, _zephir_prop_5, 1044, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&resultObject);
 				ZEPHIR_LAST_CALL_STATUS = zephir_create_instance(&resultObject, &_112$$93);
 				zephir_check_call_status();
@@ -2847,7 +2847,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeSelect)
 		RETURN_MM();
 	}
 	object_init_ex(return_value, phalcon_mvc_model_resultset_complex_ce);
-	zephir_read_property_cached(&_110, this_ptr, _zephir_prop_5, 1045, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_110, this_ptr, _zephir_prop_5, 1044, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0, &columns1, &resultData, &cache, &_110);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -3008,9 +3008,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeUpdate)
 	zephir_memory_observe(&modelName);
 	zephir_array_fetch_long(&modelName, &models, 0, PH_NOISY, "phalcon/Mvc/Model/Query.zep", 1500);
 	zephir_memory_observe(&model);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1046, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1045, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&model, &_1, &modelName, 0))) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 1041, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 1040, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&model, &_2$$4, "load", NULL, 0, &modelName);
 		zephir_check_call_status();
 	}
@@ -3096,7 +3096,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeUpdate)
 				zephir_preg_match(&_16$$12, &_17$$12, &sqlExpr, &namedParams, 1, 0 , 0 );
 				if (zephir_is_true(&_16$$12)) {
 					zephir_array_fetch_long(&_18$$13, &namedParams, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query.zep", 1591);
-					ZEPHIR_CALL_FUNCTION(&paramKeys, "array_unique", &_19, 412, &_18$$13);
+					ZEPHIR_CALL_FUNCTION(&paramKeys, "array_unique", &_19, 414, &_18$$13);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&_20$$13);
 					ZEPHIR_INIT_NVAR(&_20$$13);
@@ -3289,7 +3289,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, executeUpdate)
 					zephir_preg_match(&_65$$29, &_66$$29, &sqlExpr, &namedParams, 1, 0 , 0 );
 					if (zephir_is_true(&_65$$29)) {
 						zephir_array_fetch_long(&_67$$30, &namedParams, 1, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query.zep", 1591);
-						ZEPHIR_CALL_FUNCTION(&paramKeys, "array_unique", &_19, 412, &_67$$30);
+						ZEPHIR_CALL_FUNCTION(&paramKeys, "array_unique", &_19, 414, &_67$$30);
 						zephir_check_call_status();
 						ZEPHIR_INIT_NVAR(&_68$$30);
 						ZEPHIR_INIT_NVAR(&_68$$30);
@@ -4230,7 +4230,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getExpression)
 						}
 						if (ZEPHIR_IS_STRING(&bindType, "array") || ZEPHIR_IS_STRING(&bindType, "array-str") || ZEPHIR_IS_STRING(&bindType, "array-int")) {
 							zephir_memory_observe(&bind);
-							zephir_read_property_cached(&_58$$52, this_ptr, _zephir_prop_0, 1032, PH_NOISY_CC | PH_READONLY);
+							zephir_read_property_cached(&_58$$52, this_ptr, _zephir_prop_0, 1031, PH_NOISY_CC | PH_READONLY);
 							if (UNEXPECTED(!(zephir_array_isset_fetch(&bind, &_58$$52, &name, 0)))) {
 								ZEPHIR_INIT_VAR(&_59$$53);
 								object_init_ex(&_59$$53, phalcon_mvc_model_query_exceptions_bindvaluerequired_ce);
@@ -4852,7 +4852,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoinType)
 
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_mvc_model_query_exceptions_unknownjointype_ce);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1030, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1029, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 0, &type, &_2);
 	zephir_check_call_status();
 	zephir_throw_exception_debug(&_1, "phalcon/Mvc/Model/Query.zep", 2562);
@@ -5002,17 +5002,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &select_param);
 	zephir_get_arrval(&select, select_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1047, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1046, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&models, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1048, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1047, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&sqlAliases, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1049, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1048, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&sqlAliasesModels, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1050, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1049, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&sqlModelsAliases, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1051, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1050, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&sqlAliasesModelsInstances, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 1046, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 1045, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&modelsInstances, &_0);
 	ZEPHIR_CPY_WRT(&fromModels, &models);
 	ZEPHIR_INIT_VAR(&sqlJoins);
@@ -5027,7 +5027,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 	array_init(&joinPreCondition);
 	ZEPHIR_INIT_VAR(&joinPrepared);
 	array_init(&joinPrepared);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	zephir_memory_observe(&tables);
 	zephir_array_fetch_string(&tables, &select, SL("tables"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 2598);
@@ -5076,7 +5076,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 				if (UNEXPECTED(zephir_array_isset_value(&joinModels, &alias))) {
 					ZEPHIR_INIT_NVAR(&_4$$9);
 					object_init_ex(&_4$$9, phalcon_mvc_model_query_exceptions_joinaliasalreadyused_ce);
-					zephir_read_property_cached(&_5$$9, this_ptr, _zephir_prop_7, 1030, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_5$$9, this_ptr, _zephir_prop_7, 1029, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_4$$9, "__construct", &_6, 0, &alias, &_5$$9);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_4$$9, "phalcon/Mvc/Model/Query.zep", 2641);
@@ -5097,7 +5097,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 				if (UNEXPECTED(zephir_array_isset_value(&joinModels, &realModelName))) {
 					ZEPHIR_INIT_NVAR(&_7$$11);
 					object_init_ex(&_7$$11, phalcon_mvc_model_query_exceptions_joinaliasalreadyused_ce);
-					zephir_read_property_cached(&_8$$11, this_ptr, _zephir_prop_7, 1030, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_8$$11, this_ptr, _zephir_prop_7, 1029, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_7$$11, "__construct", &_6, 0, &realModelName, &_8$$11);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_7$$11, "phalcon/Mvc/Model/Query.zep", 2698);
@@ -5158,7 +5158,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 					if (UNEXPECTED(zephir_array_isset_value(&joinModels, &alias))) {
 						ZEPHIR_INIT_NVAR(&_12$$14);
 						object_init_ex(&_12$$14, phalcon_mvc_model_query_exceptions_joinaliasalreadyused_ce);
-						zephir_read_property_cached(&_13$$14, this_ptr, _zephir_prop_7, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_13$$14, this_ptr, _zephir_prop_7, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_12$$14, "__construct", &_6, 0, &alias, &_13$$14);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_12$$14, "phalcon/Mvc/Model/Query.zep", 2641);
@@ -5179,7 +5179,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 					if (UNEXPECTED(zephir_array_isset_value(&joinModels, &realModelName))) {
 						ZEPHIR_INIT_NVAR(&_14$$16);
 						object_init_ex(&_14$$16, phalcon_mvc_model_query_exceptions_joinaliasalreadyused_ce);
-						zephir_read_property_cached(&_15$$16, this_ptr, _zephir_prop_7, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_15$$16, this_ptr, _zephir_prop_7, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_14$$16, "__construct", &_6, 0, &realModelName, &_15$$16);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_14$$16, "phalcon/Mvc/Model/Query.zep", 2698);
@@ -5200,12 +5200,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&joinItem);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1047, &models);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1048, &sqlAliases);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1049, &sqlAliasesModels);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1050, &sqlModelsAliases);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1051, &sqlAliasesModelsInstances);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1046, &modelsInstances);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1046, &models);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1047, &sqlAliases);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1048, &sqlAliasesModels);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1049, &sqlModelsAliases);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1050, &sqlAliasesModelsInstances);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1045, &modelsInstances);
 	zephir_is_iterable(&joinPrepared, 0, "phalcon/Mvc/Model/Query.zep", 2773);
 	ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&joinPrepared), _17, _18, _16)
 	{
@@ -5226,7 +5226,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 	} ZEND_HASH_FOREACH_END();
 	ZEPHIR_INIT_NVAR(&joinItem);
 	ZEPHIR_INIT_NVAR(&joinAliasName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_8, 1031, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_8, 1030, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_21$$19);
 		zephir_is_iterable(&joinPrepared, 0, "phalcon/Mvc/Model/Query.zep", 2785);
@@ -5339,7 +5339,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 							if (UNEXPECTED(zephir_fast_count_int(&relations) != 1)) {
 								ZEPHIR_INIT_NVAR(&_43$$28);
 								object_init_ex(&_43$$28, phalcon_mvc_model_query_exceptions_ambiguousjoinrelation_ce);
-								zephir_read_property_cached(&_44$$28, this_ptr, _zephir_prop_7, 1030, PH_NOISY_CC | PH_READONLY);
+								zephir_read_property_cached(&_44$$28, this_ptr, _zephir_prop_7, 1029, PH_NOISY_CC | PH_READONLY);
 								ZEPHIR_CALL_METHOD(NULL, &_43$$28, "__construct", &_45, 0, &fromModelName, &joinModel, &_44$$28);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_43$$28, "phalcon/Mvc/Model/Query.zep", 2843);
@@ -5469,7 +5469,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getJoins)
 								if (UNEXPECTED(zephir_fast_count_int(&relations) != 1)) {
 									ZEPHIR_INIT_NVAR(&_63$$43);
 									object_init_ex(&_63$$43, phalcon_mvc_model_query_exceptions_ambiguousjoinrelation_ce);
-									zephir_read_property_cached(&_64$$43, this_ptr, _zephir_prop_7, 1030, PH_NOISY_CC | PH_READONLY);
+									zephir_read_property_cached(&_64$$43, this_ptr, _zephir_prop_7, 1029, PH_NOISY_CC | PH_READONLY);
 									ZEPHIR_CALL_METHOD(NULL, &_63$$43, "__construct", &_45, 0, &fromModelName, &joinModel, &_64$$43);
 									zephir_check_call_status();
 									zephir_throw_exception_debug(&_63$$43, "phalcon/Mvc/Model/Query.zep", 2843);
@@ -5691,7 +5691,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getMultiJoin)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&intermediateModelName, relation, "getintermediatemodel", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	ZEPHIR_CALL_METHOD(&intermediateModel, &manager, "load", NULL, 0, &intermediateModelName);
 	zephir_check_call_status();
@@ -5723,7 +5723,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getMultiJoin)
 				if (UNEXPECTED(!(zephir_array_isset_value(&referencedFields, &position)))) {
 					ZEPHIR_INIT_NVAR(&_4$$5);
 					object_init_ex(&_4$$5, phalcon_mvc_model_query_exceptions_joinfieldcountmismatch_ce);
-					zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 1030, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 1029, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_4$$5, "__construct", &_6, 0, &modelAlias_zv, &joinAlias_zv, &_5$$5);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_4$$5, "phalcon/Mvc/Model/Query.zep", 3019);
@@ -5776,7 +5776,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getMultiJoin)
 					if (UNEXPECTED(!(zephir_array_isset_value(&referencedFields, &position)))) {
 						ZEPHIR_INIT_NVAR(&_13$$7);
 						object_init_ex(&_13$$7, phalcon_mvc_model_query_exceptions_joinfieldcountmismatch_ce);
-						zephir_read_property_cached(&_14$$7, this_ptr, _zephir_prop_1, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_14$$7, this_ptr, _zephir_prop_1, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_13$$7, "__construct", &_6, 0, &modelAlias_zv, &joinAlias_zv, &_14$$7);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_13$$7, "phalcon/Mvc/Model/Query.zep", 3019);
@@ -6123,11 +6123,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 	zephir_get_arrval(&expr, expr_param);
 	zephir_memory_observe(&columnName);
 	zephir_array_fetch_string(&columnName, &expr, SL("name"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 3175);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1052, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1051, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&nestingLevel, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1053, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1052, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_0, &nestingLevel)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1053, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1052, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, &nestingLevel, PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Query.zep", 3183);
 		ZEPHIR_CPY_WRT(&sqlColumnAliases, &_2$$3);
 	} else {
@@ -6149,17 +6149,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 		zephir_array_update_string(return_value, SL("name"), &columnName, PH_COPY | PH_SEPARATE);
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_2, 1042, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_2, 1041, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&metaData, &_6);
 	zephir_memory_observe(&columnDomain);
 	if (zephir_array_isset_string_fetch(&columnDomain, &expr, SL("domain"), 0)) {
-		zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_3, 1048, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$6, this_ptr, _zephir_prop_3, 1047, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&sqlAliases, &_7$$6);
 		zephir_memory_observe(&source);
 		if (UNEXPECTED(!(zephir_array_isset_fetch(&source, &sqlAliases, &columnDomain, 0)))) {
 			ZEPHIR_INIT_VAR(&_8$$7);
 			object_init_ex(&_8$$7, phalcon_mvc_model_query_exceptions_unknownmodeloralias_ce);
-			zephir_read_property_cached(&_9$$7, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_9$$7, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_10$$7);
 			ZVAL_STRING(&_10$$7, "11");
 			ZEPHIR_CALL_METHOD(NULL, &_8$$7, "__construct", NULL, 0, &columnDomain, &_10$$7, &_9$$7);
@@ -6173,13 +6173,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 		ZEPHIR_CALL_CE_STATIC(&_11$$6, phalcon_support_settings_ce, "get", NULL, 0, &_12$$6);
 		zephir_check_call_status();
 		if (zephir_is_true(&_11$$6)) {
-			zephir_read_property_cached(&_13$$8, this_ptr, _zephir_prop_5, 1051, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_13$$8, this_ptr, _zephir_prop_5, 1050, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&sqlAliasesModelsInstances, &_13$$8);
 			zephir_memory_observe(&model);
 			if (UNEXPECTED(!(zephir_array_isset_fetch(&model, &sqlAliasesModelsInstances, &columnDomain, 0)))) {
 				ZEPHIR_INIT_VAR(&_14$$9);
 				object_init_ex(&_14$$9, phalcon_mvc_model_query_exceptions_nomodelforalias_ce);
-				zephir_read_property_cached(&_15$$9, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_15$$9, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &_14$$9, "__construct", NULL, 0, &columnDomain, &_15$$9);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_14$$9, "phalcon/Mvc/Model/Query.zep", 3224);
@@ -6197,7 +6197,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 			if (UNEXPECTED(!(zephir_array_isset_fetch(&realColumnName, &columnMap, &columnName, 0)))) {
 				ZEPHIR_INIT_VAR(&_16$$12);
 				object_init_ex(&_16$$12, phalcon_mvc_model_query_exceptions_columnnotindomain_ce);
-				zephir_read_property_cached(&_17$$12, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_17$$12, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &_16$$12, "__construct", NULL, 0, &columnName, &columnDomain, &_17$$12);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_16$$12, "phalcon/Mvc/Model/Query.zep", 3234);
@@ -6211,7 +6211,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 		number = 0;
 		ZEPHIR_INIT_VAR(&hasModel);
 		ZVAL_BOOL(&hasModel, 0);
-		zephir_read_property_cached(&_18$$14, this_ptr, _zephir_prop_6, 1046, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_18$$14, this_ptr, _zephir_prop_6, 1045, PH_NOISY_CC | PH_READONLY);
 		zephir_is_iterable(&_18$$14, 0, "phalcon/Mvc/Model/Query.zep", 3266);
 		if (Z_TYPE_P(&_18$$14) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_18$$14), _19$$14)
@@ -6225,7 +6225,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 					if (UNEXPECTED(number > 1)) {
 						ZEPHIR_INIT_NVAR(&_22$$17);
 						object_init_ex(&_22$$17, phalcon_mvc_model_query_exceptions_ambiguouscolumn_ce);
-						zephir_read_property_cached(&_23$$17, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_23$$17, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_22$$17, "__construct", &_24, 0, &columnName, &_23$$17);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_22$$17, "phalcon/Mvc/Model/Query.zep", 3255);
@@ -6260,7 +6260,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 						if (UNEXPECTED(number > 1)) {
 							ZEPHIR_INIT_NVAR(&_29$$20);
 							object_init_ex(&_29$$20, phalcon_mvc_model_query_exceptions_ambiguouscolumn_ce);
-							zephir_read_property_cached(&_30$$20, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+							zephir_read_property_cached(&_30$$20, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 							ZEPHIR_CALL_METHOD(NULL, &_29$$20, "__construct", &_24, 0, &columnName, &_30$$20);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_29$$20, "phalcon/Mvc/Model/Query.zep", 3255);
@@ -6275,7 +6275,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 		if (UNEXPECTED(ZEPHIR_IS_FALSE_IDENTICAL(&hasModel))) {
 			ZEPHIR_INIT_VAR(&_31$$21);
 			object_init_ex(&_31$$21, phalcon_mvc_model_query_exceptions_columnnotinselectedmodels_ce);
-			zephir_read_property_cached(&_32$$21, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_32$$21, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_33$$21);
 			ZVAL_STRING(&_33$$21, "1");
 			ZEPHIR_CALL_METHOD(NULL, &_31$$21, "__construct", NULL, 0, &columnName, &_33$$21, &_32$$21);
@@ -6284,7 +6284,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_34$$14, this_ptr, _zephir_prop_7, 1047, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_34$$14, this_ptr, _zephir_prop_7, 1046, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&models, &_34$$14);
 		if (UNEXPECTED(Z_TYPE_P(&models) != IS_ARRAY)) {
 			ZEPHIR_INIT_VAR(&_35$$22);
@@ -6301,7 +6301,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 		if (UNEXPECTED(!(zephir_array_isset_fetch(&source, &models, &className, 0)))) {
 			ZEPHIR_INIT_VAR(&_36$$23);
 			object_init_ex(&_36$$23, phalcon_mvc_model_query_exceptions_modelsourcenotfound_ce);
-			zephir_read_property_cached(&_37$$23, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_37$$23, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_36$$23, "__construct", NULL, 0, &className, &_37$$23);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_36$$23, "phalcon/Mvc/Model/Query.zep", 3285);
@@ -6324,7 +6324,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getQualified)
 			if (UNEXPECTED(!(zephir_array_isset_fetch(&realColumnName, &columnMap, &columnName, 0)))) {
 				ZEPHIR_INIT_VAR(&_40$$27);
 				object_init_ex(&_40$$27, phalcon_mvc_model_query_exceptions_columnnotinselectedmodels_ce);
-				zephir_read_property_cached(&_41$$27, this_ptr, _zephir_prop_4, 1030, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_41$$27, this_ptr, _zephir_prop_4, 1029, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_42$$27);
 				ZVAL_STRING(&_42$$27, "3");
 				ZEPHIR_CALL_METHOD(NULL, &_40$$27, "__construct", NULL, 0, &columnName, &_42$$27, &_41$$27);
@@ -6401,7 +6401,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getReadConnection)
 	}
 	ZEPHIR_INIT_VAR(&connection);
 	ZVAL_NULL(&connection);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1044, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1043, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&transaction, &_0);
 	_1 = Z_TYPE_P(&transaction) == IS_OBJECT;
 	if (_1) {
@@ -6514,7 +6514,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getRelatedRecords)
 	object_init_ex(&query, phalcon_mvc_model_query_ce);
 	ZEPHIR_CALL_METHOD(NULL, &query, "__construct", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 1036, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_0, 1035, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &query, "setdi", NULL, 0, &_5);
 	zephir_check_call_status();
 	ZVAL_LONG(&_6, 309);
@@ -6621,7 +6621,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSelectColumn)
 	zephir_memory_observe(&eager);
 	zephir_array_isset_string_fetch(&eager, &column, SL("eager"), 0);
 	if (ZEPHIR_IS_LONG(&columnType, 352)) {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_0, 1047, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_0, 1046, PH_NOISY_CC | PH_READONLY);
 		zephir_is_iterable(&_1$$4, 0, "phalcon/Mvc/Model/Query.zep", 3454);
 		if (Z_TYPE_P(&_1$$4) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_1$$4), _3$$4, _4$$4, _2$$4)
@@ -6718,7 +6718,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSelectColumn)
 		return;
 	}
 	if (ZEPHIR_IS_LONG(&columnType, 353)) {
-		zephir_read_property_cached(&_18$$10, this_ptr, _zephir_prop_1, 1048, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_18$$10, this_ptr, _zephir_prop_1, 1047, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&sqlAliases, &_18$$10);
 		zephir_memory_observe(&columnDomain);
 		zephir_array_fetch_string(&columnDomain, &column, SL("column"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 3470);
@@ -6726,7 +6726,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSelectColumn)
 		if (UNEXPECTED(!(zephir_array_isset_fetch(&source, &sqlAliases, &columnDomain, 0)))) {
 			ZEPHIR_INIT_VAR(&_19$$11);
 			object_init_ex(&_19$$11, phalcon_mvc_model_query_exceptions_unknownmodeloralias_ce);
-			zephir_read_property_cached(&_20$$11, this_ptr, _zephir_prop_2, 1030, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_20$$11, this_ptr, _zephir_prop_2, 1029, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_21$$11);
 			ZVAL_STRING(&_21$$11, "2");
 			ZEPHIR_CALL_METHOD(NULL, &_19$$11, "__construct", NULL, 0, &columnDomain, &_21$$11, &_20$$11);
@@ -6738,7 +6738,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSelectColumn)
 		ZEPHIR_CPY_WRT(&sqlColumnAlias, &source);
 		zephir_memory_observe(&preparedAlias);
 		zephir_array_isset_string_fetch(&preparedAlias, &column, SL("balias"), 0);
-		zephir_read_property_cached(&_18$$10, this_ptr, _zephir_prop_3, 1049, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_18$$10, this_ptr, _zephir_prop_3, 1048, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&sqlAliasesModels, &_18$$10);
 		ZEPHIR_OBS_NVAR(&modelName);
 		zephir_array_fetch(&modelName, &sqlAliasesModels, &columnDomain, PH_NOISY, "phalcon/Mvc/Model/Query.zep", 3487);
@@ -6924,7 +6924,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSingleJoin)
 				if (UNEXPECTED(!(zephir_array_isset_fetch(&referencedField, &referencedFields, &position, 0)))) {
 					ZEPHIR_INIT_NVAR(&_8$$6);
 					object_init_ex(&_8$$6, phalcon_mvc_model_query_exceptions_joinfieldcountmismatch_ce);
-					zephir_read_property_cached(&_9$$6, this_ptr, _zephir_prop_0, 1030, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_9$$6, this_ptr, _zephir_prop_0, 1029, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_8$$6, "__construct", &_10, 0, &modelAlias_zv, &joinAlias_zv, &_9$$6);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_8$$6, "phalcon/Mvc/Model/Query.zep", 3608);
@@ -6977,7 +6977,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getSingleJoin)
 					if (UNEXPECTED(!(zephir_array_isset_fetch(&referencedField, &referencedFields, &position, 0)))) {
 						ZEPHIR_INIT_NVAR(&_17$$8);
 						object_init_ex(&_17$$8, phalcon_mvc_model_query_exceptions_joinfieldcountmismatch_ce);
-						zephir_read_property_cached(&_18$$8, this_ptr, _zephir_prop_0, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_18$$8, this_ptr, _zephir_prop_0, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_17$$8, "__construct", &_10, 0, &modelAlias_zv, &joinAlias_zv, &_18$$8);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_17$$8, "phalcon/Mvc/Model/Query.zep", 3608);
@@ -7125,7 +7125,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, getWriteConnection)
 	}
 	ZEPHIR_INIT_VAR(&connection);
 	ZVAL_NULL(&connection);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1044, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1043, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&transaction, &_0);
 	_1 = Z_TYPE_P(&transaction) == IS_OBJECT;
 	if (_1) {
@@ -7229,7 +7229,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareDelete)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1039, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&ast, &_0);
 	zephir_memory_observe(&delete);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&delete, &ast, SL("delete"), 0)))) {
@@ -7270,7 +7270,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareDelete)
 	} else {
 		ZEPHIR_CPY_WRT(&deleteTables, &tables);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	zephir_is_iterable(&deleteTables, 0, "phalcon/Mvc/Model/Query.zep", 3780);
 	if (Z_TYPE_P(&deleteTables) == IS_ARRAY) {
@@ -7377,10 +7377,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareDelete)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&table);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1047, &models);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1046, &modelsInstances);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1048, &sqlAliases);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1051, &sqlAliasesModelsInstances);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1046, &models);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1045, &modelsInstances);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1047, &sqlAliases);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1050, &sqlAliasesModelsInstances);
 	ZEPHIR_INIT_VAR(&sqlDelete);
 	array_init(&sqlDelete);
 	zephir_array_update_string(&sqlDelete, SL("tables"), &sqlTables, PH_COPY | PH_SEPARATE);
@@ -7471,7 +7471,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareInsert)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1039, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&ast, &_0);
 	if (UNEXPECTED(!(zephir_array_isset_value_string(&ast, SL("qualifiedName"))))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -7502,7 +7502,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareInsert)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	zephir_memory_observe(&modelName);
 	zephir_array_fetch_string(&modelName, &qualifiedName, SL("name"), PH_NOISY, "phalcon/Mvc/Model/Query.zep", 3829);
@@ -7583,7 +7583,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareInsert)
 	zephir_create_array(&sqlInsert, 2, 0);
 	zephir_array_update_string(&sqlInsert, SL("model"), &modelName, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&sqlInsert, SL("table"), &source, PH_COPY | PH_SEPARATE);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1042, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1041, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&metaData, &_0);
 	zephir_memory_observe(&fields);
 	if (zephir_array_isset_string_fetch(&fields, &ast, SL("fields"), 0)) {
@@ -7602,7 +7602,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareInsert)
 				if (UNEXPECTED(!zephir_is_true(&_19$$10))) {
 					ZEPHIR_INIT_NVAR(&_21$$11);
 					object_init_ex(&_21$$11, phalcon_mvc_model_query_exceptions_missingmodelattribute_ce);
-					zephir_read_property_cached(&_22$$11, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_22$$11, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_21$$11, "__construct", &_23, 0, &modelName, &name, &_22$$11);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_21$$11, "phalcon/Mvc/Model/Query.zep", 3865);
@@ -7636,7 +7636,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareInsert)
 					if (UNEXPECTED(!zephir_is_true(&_26$$12))) {
 						ZEPHIR_INIT_NVAR(&_28$$13);
 						object_init_ex(&_28$$13, phalcon_mvc_model_query_exceptions_missingmodelattribute_ce);
-						zephir_read_property_cached(&_29$$13, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_29$$13, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_28$$13, "__construct", &_23, 0, &modelName, &name, &_29$$13);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_28$$13, "phalcon/Mvc/Model/Query.zep", 3865);
@@ -7867,7 +7867,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 	} else {
 		}
 	if (ZEPHIR_IS_EMPTY(ast)) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1039, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(ast, &_0$$3);
 	}
 	zephir_memory_observe(&select);
@@ -7927,9 +7927,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 	} else {
 		ZEPHIR_CPY_WRT(&selectColumns, &columns);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_1, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1042, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1041, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&metaData, &_3);
 	if (UNEXPECTED(Z_TYPE_P(&manager) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_4$$11);
@@ -7981,7 +7981,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 				if (UNEXPECTED(zephir_array_isset_value(&sqlAliases, &alias))) {
 					ZEPHIR_INIT_NVAR(&_8$$17);
 					object_init_ex(&_8$$17, phalcon_mvc_model_query_exceptions_duplicatealias_ce);
-					zephir_read_property_cached(&_9$$17, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_9$$17, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_8$$17, "__construct", &_10, 0, &alias, &_9$$17);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_8$$17, "phalcon/Mvc/Model/Query.zep", 4013);
@@ -8050,7 +8050,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 							if (UNEXPECTED(Z_TYPE_P(&relation) != IS_OBJECT)) {
 								ZEPHIR_INIT_NVAR(&_18$$27);
 								object_init_ex(&_18$$27, phalcon_mvc_model_query_exceptions_relationshipnotfound_ce);
-								zephir_read_property_cached(&_19$$27, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+								zephir_read_property_cached(&_19$$27, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 								ZEPHIR_CALL_METHOD(NULL, &_18$$27, "__construct", &_20, 0, &modelName, &relationModel, &_19$$27);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_18$$27, "phalcon/Mvc/Model/Query.zep", 4069);
@@ -8132,7 +8132,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 								if (UNEXPECTED(Z_TYPE_P(&relation) != IS_OBJECT)) {
 									ZEPHIR_INIT_NVAR(&_32$$31);
 									object_init_ex(&_32$$31, phalcon_mvc_model_query_exceptions_relationshipnotfound_ce);
-									zephir_read_property_cached(&_33$$31, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+									zephir_read_property_cached(&_33$$31, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 									ZEPHIR_CALL_METHOD(NULL, &_32$$31, "__construct", &_20, 0, &modelName, &relationModel, &_33$$31);
 									zephir_check_call_status();
 									zephir_throw_exception_debug(&_32$$31, "phalcon/Mvc/Model/Query.zep", 4069);
@@ -8221,7 +8221,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 					if (UNEXPECTED(zephir_array_isset_value(&sqlAliases, &alias))) {
 						ZEPHIR_INIT_NVAR(&_42$$36);
 						object_init_ex(&_42$$36, phalcon_mvc_model_query_exceptions_duplicatealias_ce);
-						zephir_read_property_cached(&_43$$36, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_43$$36, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CALL_METHOD(NULL, &_42$$36, "__construct", &_10, 0, &alias, &_43$$36);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_42$$36, "phalcon/Mvc/Model/Query.zep", 4013);
@@ -8291,7 +8291,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 								if (UNEXPECTED(Z_TYPE_P(&relation) != IS_OBJECT)) {
 									ZEPHIR_INIT_NVAR(&_52$$46);
 									object_init_ex(&_52$$46, phalcon_mvc_model_query_exceptions_relationshipnotfound_ce);
-									zephir_read_property_cached(&_53$$46, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+									zephir_read_property_cached(&_53$$46, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 									ZEPHIR_CALL_METHOD(NULL, &_52$$46, "__construct", &_20, 0, &modelName, &relationModel, &_53$$46);
 									zephir_check_call_status();
 									zephir_throw_exception_debug(&_52$$46, "phalcon/Mvc/Model/Query.zep", 4069);
@@ -8373,7 +8373,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 									if (UNEXPECTED(Z_TYPE_P(&relation) != IS_OBJECT)) {
 										ZEPHIR_INIT_NVAR(&_65$$50);
 										object_init_ex(&_65$$50, phalcon_mvc_model_query_exceptions_relationshipnotfound_ce);
-										zephir_read_property_cached(&_66$$50, this_ptr, _zephir_prop_3, 1030, PH_NOISY_CC | PH_READONLY);
+										zephir_read_property_cached(&_66$$50, this_ptr, _zephir_prop_3, 1029, PH_NOISY_CC | PH_READONLY);
 										ZEPHIR_CALL_METHOD(NULL, &_65$$50, "__construct", &_20, 0, &modelName, &relationModel, &_66$$50);
 										zephir_check_call_status();
 										zephir_throw_exception_debug(&_65$$50, "phalcon/Mvc/Model/Query.zep", 4069);
@@ -8423,25 +8423,25 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 	}
 	ZEPHIR_INIT_NVAR(&selectedModel);
 	if (!(merge)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1047, &models);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1046, &modelsInstances);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1048, &sqlAliases);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1049, &sqlAliasesModels);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1050, &sqlModelsAliases);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1051, &sqlAliasesModelsInstances);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1046, &models);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1045, &modelsInstances);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1047, &sqlAliases);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1048, &sqlAliasesModels);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1049, &sqlModelsAliases);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1050, &sqlAliasesModelsInstances);
 	} else {
 		zephir_memory_observe(&tempModels);
-		zephir_read_property_cached(&tempModels, this_ptr, _zephir_prop_4, 1047, PH_NOISY_CC);
+		zephir_read_property_cached(&tempModels, this_ptr, _zephir_prop_4, 1046, PH_NOISY_CC);
 		zephir_memory_observe(&tempModelsInstances);
-		zephir_read_property_cached(&tempModelsInstances, this_ptr, _zephir_prop_5, 1046, PH_NOISY_CC);
+		zephir_read_property_cached(&tempModelsInstances, this_ptr, _zephir_prop_5, 1045, PH_NOISY_CC);
 		zephir_memory_observe(&tempSqlAliases);
-		zephir_read_property_cached(&tempSqlAliases, this_ptr, _zephir_prop_6, 1048, PH_NOISY_CC);
+		zephir_read_property_cached(&tempSqlAliases, this_ptr, _zephir_prop_6, 1047, PH_NOISY_CC);
 		zephir_memory_observe(&tempSqlAliasesModels);
-		zephir_read_property_cached(&tempSqlAliasesModels, this_ptr, _zephir_prop_7, 1049, PH_NOISY_CC);
+		zephir_read_property_cached(&tempSqlAliasesModels, this_ptr, _zephir_prop_7, 1048, PH_NOISY_CC);
 		zephir_memory_observe(&tempSqlModelsAliases);
-		zephir_read_property_cached(&tempSqlModelsAliases, this_ptr, _zephir_prop_8, 1050, PH_NOISY_CC);
+		zephir_read_property_cached(&tempSqlModelsAliases, this_ptr, _zephir_prop_8, 1049, PH_NOISY_CC);
 		zephir_memory_observe(&tempSqlAliasesModelsInstances);
-		zephir_read_property_cached(&tempSqlAliasesModelsInstances, this_ptr, _zephir_prop_9, 1051, PH_NOISY_CC);
+		zephir_read_property_cached(&tempSqlAliasesModelsInstances, this_ptr, _zephir_prop_9, 1050, PH_NOISY_CC);
 		zephir_is_iterable(&models, 0, "phalcon/Mvc/Model/Query.zep", 4131);
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&models), _72$$52, _73$$52, _71$$52)
 		{
@@ -8746,7 +8746,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 	}
 	ZEPHIR_INIT_NVAR(&column);
 	zephir_memory_observe(&_114);
-	zephir_read_property_cached(&_114, this_ptr, _zephir_prop_10, 1052, PH_NOISY_CC);
+	zephir_read_property_cached(&_114, this_ptr, _zephir_prop_10, 1051, PH_NOISY_CC);
 	zephir_update_property_array(this_ptr, SL("sqlColumnAliases"), &_114, &sqlColumnAliases);
 	ZEPHIR_INIT_VAR(&sqlSelect);
 	zephir_create_array(&sqlSelect, 3, 0);
@@ -8794,12 +8794,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareSelect)
 		zephir_array_update_string(&sqlSelect, SL("forUpdate"), &__$true, PH_COPY | PH_SEPARATE);
 	}
 	if (merge) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1047, &tempModels);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1046, &tempModelsInstances);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1048, &tempSqlAliases);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1049, &tempSqlAliasesModels);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1050, &tempSqlModelsAliases);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1051, &tempSqlAliasesModelsInstances);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1046, &tempModels);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1045, &tempModelsInstances);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1047, &tempSqlAliases);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1048, &tempSqlAliasesModels);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1049, &tempSqlModelsAliases);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1050, &tempSqlAliasesModelsInstances);
 	}
 	RETURN_ON_FAILURE(zephir_property_decr(this_ptr, SL("nestingLevel")));
 	RETURN_CCTOR(&sqlSelect);
@@ -8914,7 +8914,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareUpdate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1039, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&ast, &_0);
 	zephir_memory_observe(&update);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&update, &ast, SL("update"), 0)))) {
@@ -8969,7 +8969,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareUpdate)
 	} else {
 		ZEPHIR_CPY_WRT(&updateTables, &tables);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	zephir_is_iterable(&updateTables, 0, "phalcon/Mvc/Model/Query.zep", 4369);
 	if (Z_TYPE_P(&updateTables) == IS_ARRAY) {
@@ -9084,12 +9084,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, prepareUpdate)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&table);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1047, &models);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1046, &modelsInstances);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1048, &sqlAliases);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1049, &sqlAliasesModels);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1050, &sqlModelsAliases);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1051, &sqlAliasesModelsInstances);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1046, &models);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1045, &modelsInstances);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1047, &sqlAliases);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1048, &sqlAliasesModels);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1049, &sqlModelsAliases);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1050, &sqlAliasesModelsInstances);
 	ZEPHIR_INIT_VAR(&sqlJoins);
 	array_init(&sqlJoins);
 	zephir_memory_observe(&joins);
@@ -9263,7 +9263,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query, refreshSchemasInIntermediate)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &irPhql_param);
 	zephir_get_arrval(&irPhql, irPhql_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1041, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1040, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	if (Z_TYPE_P(&manager) != IS_OBJECT) {
 		RETURN_CTOR(&irPhql);

--- a/ext/phalcon/mvc/model/query/builder.zep.c
+++ b/ext/phalcon/mvc/model/query/builder.zep.c
@@ -267,11 +267,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct)
 	if (Z_TYPE_P(params) == IS_ARRAY) {
 		zephir_memory_observe(&conditions);
 		if (zephir_array_isset_long_fetch(&conditions, params, 0, 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &conditions);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1053, &conditions);
 		} else {
 			ZEPHIR_OBS_NVAR(&conditions);
 			if (zephir_array_isset_string_fetch(&conditions, params, SL("conditions"), 0)) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &conditions);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1053, &conditions);
 			}
 		}
 		if (Z_TYPE_P(&conditions) == IS_ARRAY) {
@@ -353,33 +353,33 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct)
 			ZEPHIR_INIT_NVAR(&singleConditionArray);
 			ZEPHIR_INIT_VAR(&_7$$7);
 			zephir_fast_join_str(&_7$$7, SL(" AND "), &mergedConditions);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &_7$$7);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1055, &mergedParams);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1056, &mergedTypes);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1053, &_7$$7);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1054, &mergedParams);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1055, &mergedTypes);
 		}
 		zephir_memory_observe(&bind);
 		if (zephir_array_isset_string_fetch(&bind, params, SL("bind"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1055, &bind);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1054, &bind);
 		}
 		zephir_memory_observe(&bindTypes);
 		if (zephir_array_isset_string_fetch(&bindTypes, params, SL("bindTypes"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1056, &bindTypes);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1055, &bindTypes);
 		}
 		zephir_memory_observe(&distinct);
 		if (zephir_array_isset_string_fetch(&distinct, params, SL("distinct"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1057, &distinct);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1056, &distinct);
 		}
 		zephir_memory_observe(&fromClause);
 		if (zephir_array_isset_string_fetch(&fromClause, params, SL("models"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1058, &fromClause);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1057, &fromClause);
 		}
 		zephir_memory_observe(&columns);
 		if (zephir_array_isset_string_fetch(&columns, params, SL("columns"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1059, &columns);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1058, &columns);
 		}
 		zephir_memory_observe(&joinsClause);
 		if (zephir_array_isset_string_fetch(&joinsClause, params, SL("joins"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1060, &joinsClause);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1059, &joinsClause);
 		}
 		zephir_memory_observe(&groupClause);
 		if (zephir_array_isset_string_fetch(&groupClause, params, SL("group"), 0)) {
@@ -388,11 +388,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct)
 		}
 		zephir_memory_observe(&havingClause);
 		if (zephir_array_isset_string_fetch(&havingClause, params, SL("having"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1061, &havingClause);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1060, &havingClause);
 		}
 		zephir_memory_observe(&orderClause);
 		if (zephir_array_isset_string_fetch(&orderClause, params, SL("order"), 0)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1062, &orderClause);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1061, &orderClause);
 		}
 		zephir_memory_observe(&limitClause);
 		if (zephir_array_isset_string_fetch(&limitClause, params, SL("limit"), 0)) {
@@ -400,29 +400,29 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct)
 				zephir_memory_observe(&limit);
 				if (zephir_array_isset_long_fetch(&limit, &limitClause, 0, 0)) {
 					if (Z_TYPE_P(&limit) == IS_LONG) {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1063, &limit);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1062, &limit);
 					}
 					zephir_memory_observe(&offset);
 					if (zephir_array_isset_long_fetch(&offset, &limitClause, 1, 0)) {
 						if (Z_TYPE_P(&offset) == IS_LONG) {
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 1064, &offset);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 1063, &offset);
 						}
 					}
 				} else {
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1063, &limitClause);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1062, &limitClause);
 				}
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1063, &limitClause);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1062, &limitClause);
 			}
 		}
 		if (zephir_array_isset_string_fetch(&offsetClause, params, SL("offset"), 1)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 1064, &offsetClause);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 1063, &offsetClause);
 		}
 		if (zephir_array_isset_string_fetch(&forUpdate, params, SL("for_update"), 1)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 1065, &forUpdate);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 1064, &forUpdate);
 		}
 		if (zephir_array_isset_string_fetch(&sharedLock, params, SL("shared_lock"), 1)) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_12, 1066, &sharedLock);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_12, 1065, &sharedLock);
 		}
 	} else {
 		_8$$38 = Z_TYPE_P(params) == IS_STRING;
@@ -430,10 +430,10 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, __construct)
 			_8$$38 = !ZEPHIR_IS_STRING_IDENTICAL(params, "");
 		}
 		if (_8$$38) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, params);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1053, params);
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_13, 1067, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_13, 1066, container);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -488,7 +488,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, addFrom)
 		zephir_memory_observe(&alias_zv);
 	ZVAL_STR_COPY(&alias_zv, alias);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1058, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1057, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&models, &_0);
 	if (Z_TYPE_P(&models) != IS_ARRAY) {
 		if (Z_TYPE_P(&models) != IS_NULL) {
@@ -511,7 +511,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, addFrom)
 	} else {
 		zephir_array_append(&models, &model_zv, PH_SEPARATE, "phalcon/Mvc/Model/Query/Builder.zep", 355);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1058, &models);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1057, &models);
 	RETURN_THIS();
 }
 
@@ -571,7 +571,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, andHaving)
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
 	zephir_memory_observe(&currentConditions);
-	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1061, PH_NOISY_CC);
+	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1060, PH_NOISY_CC);
 	if (zephir_is_true(&currentConditions)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZEPHIR_CONCAT_SVSVS(&_0$$3, "(", &currentConditions, ") AND (", &conditions, ")");
@@ -639,7 +639,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, andWhere)
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
 	zephir_memory_observe(&currentConditions);
-	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1054, PH_NOISY_CC);
+	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1053, PH_NOISY_CC);
 	if (zephir_is_true(&currentConditions)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZEPHIR_CONCAT_SVSVS(&_0$$3, "(", &currentConditions, ") AND (", &conditions, ")");
@@ -845,7 +845,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, columns)
 		Z_PARAM_ZVAL(columns)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &columns);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1059, columns);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1058, columns);
 	RETURN_THISW();
 }
 
@@ -872,7 +872,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, distinct)
 		Z_PARAM_ZVAL(distinct)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &distinct);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1057, distinct);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1056, distinct);
 	RETURN_THISW();
 }
 
@@ -901,9 +901,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, forUpdate)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &forUpdate_param);
 	if (forUpdate) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1065, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1064, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1065, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1064, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -946,7 +946,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, from)
 		Z_PARAM_ZVAL(models)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &models);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1058, models);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1057, models);
 	RETURN_THISW();
 }
 
@@ -1066,7 +1066,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getModels)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1058, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1057, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&models, &_0);
 	_1 = Z_TYPE_P(&models) == IS_ARRAY;
 	if (_1) {
@@ -1309,14 +1309,14 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1067, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1066, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (Z_TYPE_P(&container) != IS_OBJECT) {
 		ZEPHIR_CALL_CE_STATIC(&container, phalcon_di_di_ce, "getdefault", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1067, &container);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1066, &container);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1058, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1057, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&models, &_0);
 	if (Z_TYPE_P(&models) == IS_ARRAY) {
 		if (UNEXPECTED(!(zephir_fast_count_int(&models)))) {
@@ -1339,7 +1339,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 			return;
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1054, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1053, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&conditions, &_0);
 	if (zephir_is_numeric(&conditions)) {
 		if (Z_TYPE_P(&models) == IS_ARRAY) {
@@ -1421,7 +1421,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 			return;
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1057, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1056, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&distinct, &_0);
 	if (((Z_TYPE_P(&distinct) == IS_TRUE || Z_TYPE_P(&distinct) == IS_FALSE) == 1)) {
 		ZEPHIR_INIT_VAR(&phql);
@@ -1434,7 +1434,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 		ZEPHIR_INIT_NVAR(&phql);
 		ZVAL_STRING(&phql, "SELECT ");
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1059, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1058, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&columns, &_0);
 	if (Z_TYPE_P(&columns) != IS_NULL) {
 		if (Z_TYPE_P(&columns) == IS_ARRAY) {
@@ -1651,7 +1651,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 		ZEPHIR_CONCAT_SV(&_46$$49, " FROM ", &_45$$49);
 		zephir_concat_self(&phql, &_46$$49);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 1060, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_5, 1059, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&joins, &_0);
 	if (Z_TYPE_P(&joins) == IS_ARRAY) {
 		zephir_is_iterable(&joins, 0, "phalcon/Mvc/Model/Query/Builder.zep", 921);
@@ -1756,7 +1756,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 			zephir_concat_self(&phql, &_64$$62);
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 1068, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_6, 1067, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&group, &_0);
 	if (!(ZEPHIR_IS_EMPTY(&group))) {
 		ZEPHIR_INIT_VAR(&groupItems);
@@ -1801,7 +1801,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 		ZEPHIR_CONCAT_SV(&_71$$63, " GROUP BY ", &_70$$63);
 		zephir_concat_self(&phql, &_71$$63);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_7, 1061, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_7, 1060, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&having, &_0);
 	if (Z_TYPE_P(&having) != IS_NULL) {
 		if (!(ZEPHIR_IS_EMPTY(&having))) {
@@ -1810,7 +1810,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 			zephir_concat_self(&phql, &_72$$67);
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_8, 1062, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_8, 1061, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&order, &_0);
 	if (Z_TYPE_P(&order) != IS_NULL) {
 		if (Z_TYPE_P(&order) == IS_ARRAY) {
@@ -1963,7 +1963,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 			zephir_concat_self(&phql, &_104$$82);
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_9, 1063, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_9, 1062, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&limit, &_0);
 	if (Z_TYPE_P(&limit) != IS_NULL) {
 		ZEPHIR_INIT_VAR(&number);
@@ -1981,7 +1981,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 		} else {
 			if (zephir_is_numeric(&limit)) {
 				ZEPHIR_CPY_WRT(&number, &limit);
-				zephir_read_property_cached(&_105$$88, this_ptr, _zephir_prop_10, 1064, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_105$$88, this_ptr, _zephir_prop_10, 1063, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CPY_WRT(&offset, &_105$$88);
 				if (Z_TYPE_P(&offset) != IS_NULL) {
 					if (!(zephir_is_numeric(&offset))) {
@@ -2024,7 +2024,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getPhql)
 			}
 		}
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_11, 1065, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_11, 1064, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&forUpdate, &_0);
 	if (((Z_TYPE_P(&forUpdate) == IS_TRUE || Z_TYPE_P(&forUpdate) == IS_FALSE) == 1)) {
 		if (zephir_is_true(&forUpdate)) {
@@ -2084,7 +2084,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getQuery)
 
 	ZEPHIR_CALL_METHOD(&phql, this_ptr, "getphql", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1067, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1066, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -2104,32 +2104,32 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, getQuery)
 	ZEPHIR_CALL_METHOD(&_2, &container, "get", NULL, 0, &_4, &_3);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&query, &_2);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1055, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1054, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&bindParams, &_0);
 	if (Z_TYPE_P(&bindParams) == IS_ARRAY) {
 		ZEPHIR_CALL_METHOD(NULL, &query, "setbindparams", NULL, 0, &bindParams);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1056, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1055, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&bindTypes, &_0);
 	if (Z_TYPE_P(&bindTypes) == IS_ARRAY) {
 		ZEPHIR_CALL_METHOD(NULL, &query, "setbindtypes", NULL, 0, &bindTypes);
 		zephir_check_call_status();
 	}
 	zephir_memory_observe(&_5);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_3, 1066, PH_NOISY_CC);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_3, 1065, PH_NOISY_CC);
 	if (((Z_TYPE_P(&_5) == IS_TRUE || Z_TYPE_P(&_5) == IS_FALSE) == 1)) {
-		zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_3, 1066, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_3, 1065, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &query, "setsharedlock", NULL, 0, &_6$$6);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1069, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1068, PH_NOISY_CC | PH_READONLY);
 	_7 = !ZEPHIR_IS_STRING(&_0, "");
 	if (_7) {
 		_7 = (zephir_method_exists_ex(&query, ZEND_STRL("setresultsetrowclass")) == SUCCESS);
 	}
 	if (_7) {
-		zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_4, 1069, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$7, this_ptr, _zephir_prop_4, 1068, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &query, "setresultsetrowclass", NULL, 0, &_8$$7);
 		zephir_check_call_status();
 	}
@@ -2208,7 +2208,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, groupBy)
 		zephir_fast_explode_str(&_3$$3, SL(","), group, LONG_MAX);
 		ZEPHIR_CPY_WRT(group, &_3$$3);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1068, group);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1067, group);
 	RETURN_THIS();
 }
 
@@ -2282,24 +2282,24 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, having)
 	} else {
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1061, &conditions_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1060, &conditions_zv);
 	zephir_memory_observe(&currentBindParams);
-	zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_1, 1055, PH_NOISY_CC);
+	zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_1, 1054, PH_NOISY_CC);
 	if (Z_TYPE_P(&currentBindParams) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		zephir_add_function(&_0$$3, &currentBindParams, &bindParams);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1055, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1054, &_0$$3);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1055, &bindParams);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1054, &bindParams);
 	}
 	zephir_memory_observe(&currentBindTypes);
-	zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_2, 1056, PH_NOISY_CC);
+	zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_2, 1055, PH_NOISY_CC);
 	if (Z_TYPE_P(&currentBindTypes) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_1$$5);
 		zephir_add_function(&_1$$5, &currentBindTypes, &bindTypes);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1056, &_1$$5);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1055, &_1$$5);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1056, &bindTypes);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1055, &bindTypes);
 	}
 	RETURN_THIS();
 }
@@ -2672,12 +2672,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, limit)
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, limit);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1063, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1062, &_0);
 	if (zephir_is_numeric(offset)) {
 		ZVAL_LONG(&_2$$4, zephir_get_intval(offset));
 		ZEPHIR_CALL_FUNCTION(&_3$$4, "abs", NULL, 0, &_2$$4);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1064, &_3$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1063, &_3$$4);
 	}
 	RETURN_THIS();
 }
@@ -2905,7 +2905,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, offset)
 	zephir_fetch_params_without_memory_grow(1, 0, &offset_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, offset);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1064, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1063, &_0);
 	RETURN_THISW();
 }
 
@@ -2965,7 +2965,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, orHaving)
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
 	zephir_memory_observe(&currentConditions);
-	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1061, PH_NOISY_CC);
+	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1060, PH_NOISY_CC);
 	if (zephir_is_true(&currentConditions)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZEPHIR_CONCAT_SVSVS(&_0$$3, "(", &currentConditions, ") OR (", &conditions, ")");
@@ -3033,7 +3033,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, orWhere)
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
 	zephir_memory_observe(&currentConditions);
-	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1054, PH_NOISY_CC);
+	zephir_read_property_cached(&currentConditions, this_ptr, _zephir_prop_0, 1053, PH_NOISY_CC);
 	if (zephir_is_true(&currentConditions)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		ZEPHIR_CONCAT_SVSVS(&_0$$3, "(", &currentConditions, ") OR (", &conditions, ")");
@@ -3070,7 +3070,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, orderBy)
 		Z_PARAM_ZVAL(orderBy)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &orderBy);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1062, orderBy);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1061, orderBy);
 	RETURN_THISW();
 }
 
@@ -3167,16 +3167,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, setBindParams)
 		}
 	if (merge) {
 		zephir_memory_observe(&currentBindParams);
-		zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_0, 1055, PH_NOISY_CC);
+		zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_0, 1054, PH_NOISY_CC);
 		if (Z_TYPE_P(&currentBindParams) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			zephir_add_function(&_0$$4, &currentBindParams, &bindParams);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1055, &_0$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &_0$$4);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1055, &bindParams);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &bindParams);
 		}
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1055, &bindParams);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &bindParams);
 	}
 	RETURN_THIS();
 }
@@ -3215,16 +3215,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, setBindTypes)
 		}
 	if (UNEXPECTED(merge)) {
 		zephir_memory_observe(&currentBindTypes);
-		zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_0, 1056, PH_NOISY_CC);
+		zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_0, 1055, PH_NOISY_CC);
 		if (Z_TYPE_P(&currentBindTypes) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			zephir_add_function(&_0$$4, &currentBindTypes, &bindTypes);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1056, &_0$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1055, &_0$$4);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1056, &bindTypes);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1055, &bindTypes);
 		}
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1056, &bindTypes);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1055, &bindTypes);
 	}
 	RETURN_THIS();
 }
@@ -3247,7 +3247,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1067, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1066, container);
 }
 
 /**
@@ -3272,7 +3272,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, setResultsetRowClass)
 		Z_PARAM_STR(resultsetRowClass)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&resultsetRowClass_zv, resultsetRowClass);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1069, &resultsetRowClass_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1068, &resultsetRowClass_zv);
 	RETURN_THISW();
 }
 
@@ -3349,26 +3349,26 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, where)
 	} else {
 		zephir_get_arrval(&bindTypes, bindTypes_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1054, &conditions_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1053, &conditions_zv);
 	if (zephir_fast_count_int(&bindParams) > 0) {
 		zephir_memory_observe(&currentBindParams);
-		zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_1, 1055, PH_NOISY_CC);
+		zephir_read_property_cached(&currentBindParams, this_ptr, _zephir_prop_1, 1054, PH_NOISY_CC);
 		if (Z_TYPE_P(&currentBindParams) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			zephir_add_function(&_0$$4, &currentBindParams, &bindParams);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1055, &_0$$4);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1054, &_0$$4);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1055, &bindParams);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1054, &bindParams);
 		}
 	}
 	if (zephir_fast_count_int(&bindTypes) > 0) {
-		zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_2, 1056, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&currentBindTypes, this_ptr, _zephir_prop_2, 1055, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&currentBindTypes) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_1$$7);
 			zephir_add_function(&_1$$7, &currentBindTypes, &bindTypes);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1056, &_1$$7);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1055, &_1$$7);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1056, &bindTypes);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1055, &bindTypes);
 		}
 	}
 	RETURN_THIS();
@@ -3441,7 +3441,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionBetween)
 	ZEPHIR_CONCAT_VV(&_2, &operator_zv, &clause_zv);
 	ZEPHIR_CPY_WRT(&operatorMethod, &_2);
 	zephir_memory_observe(&hiddenParam);
-	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 1070, PH_NOISY_CC);
+	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 1069, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&nextHiddenParam);
 	ZVAL_LONG(&nextHiddenParam, (zephir_get_numberval(&hiddenParam) + 1));
 	ZEPHIR_INIT_VAR(&minimumKey);
@@ -3458,7 +3458,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionBetween)
 	zephir_check_call_status();
 	SEPARATE_ZVAL(&nextHiddenParam);
 	zephir_increment(&nextHiddenParam);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1070, &nextHiddenParam);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1069, &nextHiddenParam);
 	RETURN_THIS();
 }
 
@@ -3543,7 +3543,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn)
 		RETURN_THIS();
 	}
 	zephir_memory_observe(&_4);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 1070, PH_NOISY_CC);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 1069, PH_NOISY_CC);
 	hiddenParam = zephir_get_intval(&_4);
 	ZEPHIR_INIT_VAR(&bindParams);
 	array_init(&bindParams);
@@ -3605,7 +3605,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionIn)
 	zephir_check_call_status();
 	ZVAL_UNDEF(&_14);
 	ZVAL_LONG(&_14, hiddenParam);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1070, &_14);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1069, &_14);
 	RETURN_THIS();
 }
 
@@ -3676,7 +3676,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotBetween)
 	ZEPHIR_CONCAT_VV(&_2, &operator_zv, &clause_zv);
 	ZEPHIR_CPY_WRT(&operatorMethod, &_2);
 	zephir_memory_observe(&hiddenParam);
-	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 1070, PH_NOISY_CC);
+	zephir_read_property_cached(&hiddenParam, this_ptr, _zephir_prop_0, 1069, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&nextHiddenParam);
 	ZVAL_LONG(&nextHiddenParam, (zephir_get_numberval(&hiddenParam) + 1));
 	ZEPHIR_INIT_VAR(&minimumKey);
@@ -3693,7 +3693,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotBetween)
 	zephir_check_call_status();
 	SEPARATE_ZVAL(&nextHiddenParam);
 	zephir_increment(&nextHiddenParam);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1070, &nextHiddenParam);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1069, &nextHiddenParam);
 	RETURN_THIS();
 }
 
@@ -3778,7 +3778,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn)
 		RETURN_THIS();
 	}
 	zephir_memory_observe(&_4);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 1070, PH_NOISY_CC);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_0, 1069, PH_NOISY_CC);
 	hiddenParam = zephir_get_intval(&_4);
 	ZEPHIR_INIT_VAR(&bindParams);
 	array_init(&bindParams);
@@ -3840,7 +3840,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Builder, conditionNotIn)
 	zephir_check_call_status();
 	ZVAL_UNDEF(&_14);
 	ZVAL_LONG(&_14, hiddenParam);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1070, &_14);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1069, &_14);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/mvc/model/query/status.zep.c
+++ b/ext/phalcon/mvc/model/query/status.zep.c
@@ -101,11 +101,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Status, __construct)
 		model = &__$null;
 	}
 	if (success) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1071, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1070, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1071, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1070, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1072, model);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1071, model);
 }
 
 /**
@@ -127,7 +127,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Query_Status, getMessages)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1072, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1071, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&model, &_0);
 	if (Z_TYPE_P(&model) != IS_OBJECT) {
 		array_init(return_value);

--- a/ext/phalcon/mvc/model/relation.zep.c
+++ b/ext/phalcon/mvc/model/relation.zep.c
@@ -182,11 +182,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, __construct)
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1073, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1074, &referencedModel_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1075, fields);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1076, referencedFields);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1077, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1072, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1073, &referencedModel_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1074, fields);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1075, referencedFields);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1076, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -222,7 +222,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, getForeignKey)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1077, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1076, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	zephir_memory_observe(&foreignKey);
 	if (zephir_array_isset_string_fetch(&foreignKey, &options, SL("foreignKey"), 0)) {
@@ -291,7 +291,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, getOption)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&option);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1077, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1076, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&option, &_0, &name_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -329,7 +329,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, getParams)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1077, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1076, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	zephir_memory_observe(&params);
 	if (zephir_array_isset_string_fetch(&params, &options, SL("params"), 0)) {
@@ -393,7 +393,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, isForeignKey)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&foreignKey);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1077, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1076, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_string_fetch(&foreignKey, &_0, SL("foreignKey"), 0))) {
 		RETURN_MM_BOOL(0);
 	}
@@ -419,7 +419,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, isThrough)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1073, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1072, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&type, &_0);
 	_1 = ZEPHIR_IS_LONG(&type, 3);
 	if (!(_1)) {
@@ -447,7 +447,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, isReusable)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1077, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1076, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	zephir_memory_observe(&reusable);
 	if (!(zephir_array_isset_string_fetch(&reusable, &options, SL("reusable"), 0))) {
@@ -493,9 +493,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Relation, setIntermediateRelation)
 	intermediateFields = ZEND_CALL_ARG(execute_data, 1);
 	intermediateReferencedFields = ZEND_CALL_ARG(execute_data, 3);
 	ZVAL_STR(&intermediateModel_zv, intermediateModel);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1078, intermediateFields);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1079, &intermediateModel_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1080, intermediateReferencedFields);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1077, intermediateFields);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1078, &intermediateModel_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1079, intermediateReferencedFields);
 }
 
 zend_object *zephir_init_properties_Phalcon_Mvc_Model_Relation(zend_class_entry *class_type)

--- a/ext/phalcon/mvc/model/resultset/complex.zep.c
+++ b/ext/phalcon/mvc/model/resultset/complex.zep.c
@@ -124,8 +124,8 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, __construct)
 		zephir_memory_observe(&resultsetRowClass_zv);
 	ZVAL_STR_COPY(&resultsetRowClass_zv, resultsetRowClass);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1081, columnTypes);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1082, &resultsetRowClass_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1080, columnTypes);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1081, &resultsetRowClass_zv);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_mvc_model_resultset_complex_ce, getThis(), "__construct", NULL, 0, result, cache);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -160,11 +160,11 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, __serialize)
 
 	ZEPHIR_CALL_METHOD(&records, this_ptr, "toarray", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1083, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1082, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&cache, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1081, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1080, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&columnTypes, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1084, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1083, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hydrateMode, &_0);
 	zephir_create_array(return_value, 4, 0);
 	zephir_array_update_string(return_value, SL("cache"), &cache, PH_COPY | PH_SEPARATE);
@@ -223,22 +223,22 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, __unserialize)
 	zephir_fetch_params(1, 1, 0, &data_param);
 	zephir_get_arrval(&data, data_param);
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1085, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1084, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1085, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1084, &__$false);
 	}
 	zephir_array_fetch_string(&_0, &data, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 111);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1086, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1085, &_0);
 	zephir_array_fetch_string(&_1, &data, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 112);
 	ZVAL_UNDEF(&_2);
 	ZVAL_LONG(&_2, zephir_fast_count_int(&_1));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1087, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1086, &_2);
 	zephir_array_fetch_string(&_3, &data, SL("cache"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 113);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1083, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1082, &_3);
 	zephir_array_fetch_string(&_4, &data, SL("columnTypes"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 114);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1081, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1080, &_4);
 	zephir_array_fetch_string(&_5, &data, SL("hydrateMode"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 115);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1084, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1083, &_5);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -340,33 +340,33 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, current)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1088, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1087, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&activeRow, &_0);
 	if (Z_TYPE_P(&activeRow) != IS_NULL) {
 		RETURN_CCTOR(&activeRow);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1089, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1088, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&row, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1085, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1084, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1088, &row);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1087, &row);
 		RETURN_CCTOR(&row);
 	}
 	if (Z_TYPE_P(&row) != IS_ARRAY) {
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1088, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1087, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1088, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1087, &__$false);
 		}
 		RETURN_MM_BOOL(0);
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 1084, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 1083, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hydrateMode, &_1);
 	do {
 		if (ZEPHIR_IS_LONG(&hydrateMode, 0)) {
-			zephir_read_property_cached(&_2$$6, this_ptr, _zephir_prop_4, 1082, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$6, this_ptr, _zephir_prop_4, 1081, PH_NOISY_CC | PH_READONLY);
 			if (!ZEPHIR_IS_STRING_IDENTICAL(&_2$$6, "")) {
-				zephir_read_property_cached(&_3$$7, this_ptr, _zephir_prop_4, 1082, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_3$$7, this_ptr, _zephir_prop_4, 1081, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_NVAR(&activeRow);
 				ZEPHIR_LAST_CALL_STATUS = zephir_create_instance(&activeRow, &_3$$7);
 				zephir_check_call_status();
@@ -392,7 +392,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, current)
 	} while(0);
 
 	dirtyState = 0;
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_5, 1081, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_5, 1080, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_1, 0, "phalcon/Mvc/Model/Resultset/Complex.zep", 337);
 	if (Z_TYPE_P(&_1) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_1), _5, _6, _4)
@@ -743,7 +743,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, current)
 	}
 	ZEPHIR_INIT_NVAR(&column);
 	ZEPHIR_INIT_NVAR(&alias);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1088, &activeRow);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1087, &activeRow);
 	RETURN_CCTOR(&activeRow);
 }
 
@@ -797,16 +797,16 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, serialize)
 	ZEPHIR_INIT_VAR(&data);
 	zephir_create_array(&data, 4, 0);
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1083, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1082, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("cache"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "toarray", NULL, 0);
 	zephir_check_call_status();
 	zephir_array_update_string(&data, SL("rows"), &_2, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1081, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1080, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("columnTypes"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1084, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1083, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("hydrateMode"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "serializer");
@@ -927,9 +927,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, unserialize)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &data);
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1085, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1084, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1085, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1084, &__$false);
 	}
 	ZEPHIR_CALL_CE_STATIC(&container, phalcon_di_di_ce, "getdefault", NULL, 0);
 	zephir_check_call_status();
@@ -970,17 +970,17 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Complex, unserialize)
 		return;
 	}
 	zephir_array_fetch_string(&_6, &resultset, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 426);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1086, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1085, &_6);
 	zephir_array_fetch_string(&_7, &resultset, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 427);
 	ZVAL_UNDEF(&_8);
 	ZVAL_LONG(&_8, zephir_fast_count_int(&_7));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1087, &_8);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1086, &_8);
 	zephir_array_fetch_string(&_9, &resultset, SL("cache"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 428);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1083, &_9);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1082, &_9);
 	zephir_array_fetch_string(&_10, &resultset, SL("columnTypes"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 429);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1081, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1080, &_10);
 	zephir_array_fetch_string(&_11, &resultset, SL("hydrateMode"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Complex.zep", 430);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1084, &_11);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1083, &_11);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/mvc/model/resultset/simple.zep.c
+++ b/ext/phalcon/mvc/model/resultset/simple.zep.c
@@ -113,12 +113,12 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, __construct)
 		keepSnapshots = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1090, model);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1091, columnMap);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1089, model);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1090, columnMap);
 	if (keepSnapshots) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1092, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1091, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1092, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1091, &__$false);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_mvc_model_resultset_simple_ce, getThis(), "__construct", NULL, 0, result, cache);
 	zephir_check_call_status();
@@ -160,23 +160,23 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, __serialize)
 
 	zephir_create_array(return_value, 6, 0);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1090, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1089, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("model"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1093, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1092, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("cache"), &_0, PH_COPY | PH_SEPARATE);
 	ZVAL_BOOL(&_2, 0);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "toarray", NULL, 0, &_2);
 	zephir_check_call_status();
 	zephir_array_update_string(return_value, SL("rows"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1091, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1090, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("columnMap"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1094, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1093, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("hydrateMode"), &_0, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1092, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_4, 1091, PH_NOISY_CC);
 	zephir_array_update_string(return_value, SL("keepSnapshots"), &_0, PH_COPY | PH_SEPARATE);
 	RETURN_MM();
 }
@@ -234,21 +234,21 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, __unserialize)
 	zephir_fetch_params(1, 1, 0, &data_param);
 	zephir_get_arrval(&data, data_param);
 	zephir_array_fetch_string(&_0, &data, SL("model"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 95);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1090, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1089, &_0);
 	zephir_array_fetch_string(&_1, &data, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 96);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1095, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1094, &_1);
 	zephir_array_fetch_string(&_2, &data, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 97);
 	ZVAL_UNDEF(&_3);
 	ZVAL_LONG(&_3, zephir_fast_count_int(&_2));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1096, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1095, &_3);
 	zephir_array_fetch_string(&_4, &data, SL("cache"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 98);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1093, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1092, &_4);
 	zephir_array_fetch_string(&_5, &data, SL("columnMap"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 99);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1091, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1090, &_5);
 	zephir_array_fetch_string(&_6, &data, SL("hydrateMode"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 100);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1094, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1093, &_6);
 	if (zephir_array_isset_string_fetch(&keepSnapshots, &data, SL("keepSnapshots"), 1)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1092, &keepSnapshots);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1091, &keepSnapshots);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -310,24 +310,24 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, current)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1097, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1096, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&activeRow, &_0);
 	if (Z_TYPE_P(&activeRow) != IS_NULL) {
 		RETURN_CCTOR(&activeRow);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1098, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1097, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&row, &_0);
 	if (Z_TYPE_P(&row) != IS_ARRAY) {
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1097, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1096, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1097, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1096, &__$false);
 		}
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1094, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1093, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hydrateMode, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1091, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_3, 1090, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&columnMap, &_0);
 	do {
 		if (ZEPHIR_IS_LONG(&hydrateMode, 0)) {
@@ -337,24 +337,24 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, current)
 			zephir_check_call_status();
 			if (zephir_is_true(&_1$$5)) {
 				zephir_memory_observe(&_3$$6);
-				zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_4, 1090, PH_NOISY_CC);
+				zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_4, 1089, PH_NOISY_CC);
 				if (zephir_instance_of_ev(&_3$$6, phalcon_mvc_model_ce)) {
-					zephir_read_property_cached(&_4$$7, this_ptr, _zephir_prop_4, 1090, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_4$$7, this_ptr, _zephir_prop_4, 1089, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_INIT_VAR(&modelName);
 					zephir_get_class(&modelName, &_4$$7, 0);
 				} else {
 					ZEPHIR_INIT_NVAR(&modelName);
 					ZVAL_STRING(&modelName, "Phalcon\\Mvc\\Model");
 				}
-				zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_4, 1090, PH_NOISY_CC | PH_READONLY);
-				zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_5, 1092, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_5$$6, this_ptr, _zephir_prop_4, 1089, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_6$$6, this_ptr, _zephir_prop_5, 1091, PH_NOISY_CC | PH_READONLY);
 				ZVAL_LONG(&_7$$6, 0);
 				_8$$6 = zephir_fetch_class(&modelName);
 				ZEPHIR_CALL_CE_STATIC(&activeRow, _8$$6, "cloneresultmap", NULL, 0, &_5$$6, &row, &columnMap, &_7$$6, &_6$$6);
 				zephir_check_call_status();
 			} else {
-				zephir_read_property_cached(&_9$$9, this_ptr, _zephir_prop_4, 1090, PH_NOISY_CC | PH_READONLY);
-				zephir_read_property_cached(&_10$$9, this_ptr, _zephir_prop_5, 1092, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_9$$9, this_ptr, _zephir_prop_4, 1089, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_10$$9, this_ptr, _zephir_prop_5, 1091, PH_NOISY_CC | PH_READONLY);
 				ZVAL_LONG(&_11$$9, 0);
 				ZEPHIR_CALL_CE_STATIC(&activeRow, phalcon_mvc_model_ce, "cloneresultmap", NULL, 0, &_9$$9, &row, &columnMap, &_11$$9, &_10$$9);
 				zephir_check_call_status();
@@ -366,7 +366,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, current)
 		break;
 	} while(0);
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1097, &activeRow);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1096, &activeRow);
 	RETURN_CCTOR(&activeRow);
 }
 
@@ -428,23 +428,23 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, serialize)
 	ZEPHIR_INIT_VAR(&data);
 	zephir_create_array(&data, 6, 0);
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1090, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1089, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("model"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1093, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1092, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("cache"), &_1, PH_COPY | PH_SEPARATE);
 	ZVAL_BOOL(&_3, 0);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "toarray", NULL, 0, &_3);
 	zephir_check_call_status();
 	zephir_array_update_string(&data, SL("rows"), &_2, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1091, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1090, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("columnMap"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 1094, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 1093, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("hydrateMode"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_OBS_NVAR(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_4, 1092, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_4, 1091, PH_NOISY_CC);
 	zephir_array_update_string(&data, SL("keepSnapshots"), &_1, PH_COPY | PH_SEPARATE);
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, "serializer");
@@ -542,28 +542,28 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, toArray)
 	} else {
 		}
 	zephir_memory_observe(&records);
-	zephir_read_property_cached(&records, this_ptr, _zephir_prop_0, 1095, PH_NOISY_CC);
+	zephir_read_property_cached(&records, this_ptr, _zephir_prop_0, 1094, PH_NOISY_CC);
 	if (Z_TYPE_P(&records) != IS_ARRAY) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_1, 1099, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_1, 1098, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&result, &_0$$3);
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_2, 1098, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_2, 1097, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_0$$3) != IS_NULL) {
 			ZEPHIR_CALL_METHOD(NULL, &result, "execute", NULL, 0);
 			zephir_check_call_status();
 		}
 		ZEPHIR_CALL_METHOD(&records, &result, "fetchall", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1098, &__$null);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1095, &records);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1097, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1094, &records);
 	}
 	_1 = renameColumns;
 	if (_1) {
 		zephir_memory_observe(&_2);
-		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_3, 1090, PH_NOISY_CC);
+		zephir_read_property_cached(&_2, this_ptr, _zephir_prop_3, 1089, PH_NOISY_CC);
 		_1 = !(zephir_instance_of_ev(&_2, phalcon_mvc_model_row_ce));
 	}
 	if (_1) {
-		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_4, 1091, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_4, 1090, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&columnMap, &_3$$5);
 		if (Z_TYPE_P(&columnMap) != IS_ARRAY) {
 			RETURN_CCTOR(&records);
@@ -888,21 +888,21 @@ PHP_METHOD(Phalcon_Mvc_Model_Resultset_Simple, unserialize)
 		return;
 	}
 	zephir_array_fetch_string(&_6, &resultset, SL("model"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 343);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1090, &_6);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1089, &_6);
 	zephir_array_fetch_string(&_7, &resultset, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 344);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1095, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1094, &_7);
 	zephir_array_fetch_string(&_8, &resultset, SL("rows"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 345);
 	ZVAL_UNDEF(&_9);
 	ZVAL_LONG(&_9, zephir_fast_count_int(&_8));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1096, &_9);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1095, &_9);
 	zephir_array_fetch_string(&_10, &resultset, SL("cache"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 346);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1093, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1092, &_10);
 	zephir_array_fetch_string(&_11, &resultset, SL("columnMap"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 347);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1091, &_11);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1090, &_11);
 	zephir_array_fetch_string(&_12, &resultset, SL("hydrateMode"), PH_NOISY | PH_READONLY, "phalcon/Mvc/Model/Resultset/Simple.zep", 348);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1094, &_12);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1093, &_12);
 	if (zephir_array_isset_string_fetch(&keepSnapshots, &resultset, SL("keepSnapshots"), 1)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1092, &keepSnapshots);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1091, &keepSnapshots);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/mvc/model/row.zep.c
+++ b/ext/phalcon/mvc/model/row.zep.c
@@ -247,7 +247,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Row, toArray)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_RETURN_CALL_FUNCTION("get_object_vars", NULL, 335, this_ptr);
+	ZEPHIR_RETURN_CALL_FUNCTION("get_object_vars", NULL, 337, this_ptr);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/mvc/model/transaction.zep.c
+++ b/ext/phalcon/mvc/model/transaction.zep.c
@@ -161,7 +161,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, __construct)
 	}
 	ZEPHIR_CALL_METHOD(&connection, container, "get", NULL, 0, &service_zv);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1100, &connection);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1099, &connection);
 	if (autoBegin) {
 		ZEPHIR_CALL_METHOD(NULL, &connection, "begin", NULL, 0);
 		zephir_check_call_status();
@@ -187,7 +187,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, begin)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1100, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1099, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "begin", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -216,13 +216,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, commit)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1101, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1100, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	if (Z_TYPE_P(&manager) == IS_OBJECT) {
 		ZEPHIR_CALL_METHOD(NULL, &manager, "notifycommit", NULL, 0, this_ptr);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1100, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1099, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "commit", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -248,7 +248,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, getConnection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1102, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1101, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_CALL_FUNCTION(&_1$$3, "connection_aborted", NULL, 0);
 		zephir_check_call_status();
@@ -289,7 +289,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, isManaged)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1101, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1100, PH_NOISY_CC);
 	RETURN_MM_BOOL(Z_TYPE_P(&_0) == IS_OBJECT);
 }
 
@@ -311,7 +311,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, isValid)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1100, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1099, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "isundertransaction", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -373,13 +373,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, rollback)
 		rollbackRecord = &rollbackRecord_sub;
 		rollbackRecord = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1101, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1100, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&manager, &_0);
 	if (Z_TYPE_P(&manager) == IS_OBJECT) {
 		ZEPHIR_CALL_METHOD(NULL, &manager, "notifyrollback", NULL, 0, this_ptr);
 		zephir_check_call_status();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1100, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1099, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&connection, &_0);
 	ZEPHIR_CALL_METHOD(&_1, &connection, "rollback", NULL, 0);
 	zephir_check_call_status();
@@ -389,13 +389,13 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, rollback)
 			ZVAL_STRING(&rollbackMessage, "Transaction aborted");
 		}
 		if (Z_TYPE_P(rollbackRecord) == IS_OBJECT) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1103, rollbackRecord);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1102, rollbackRecord);
 		}
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 1104, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 1103, PH_NOISY_CC | PH_READONLY);
 		if (zephir_is_true(&_2$$4)) {
 			ZEPHIR_INIT_VAR(&_3$$7);
 			object_init_ex(&_3$$7, phalcon_mvc_model_transaction_failed_ce);
-			zephir_read_property_cached(&_4$$7, this_ptr, _zephir_prop_2, 1103, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$7, this_ptr, _zephir_prop_2, 1102, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(NULL, &_3$$7, "__construct", NULL, 0, &rollbackMessage, &_4$$7);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_3$$7, "phalcon/Mvc/Model/Transaction.zep", 211);
@@ -427,9 +427,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, setIsNewTransaction)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &isNew_param);
 	if (isNew) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1105, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1104, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1105, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1104, &__$false);
 	}
 }
 
@@ -454,9 +454,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, setRollbackOnAbort)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &rollbackOnAbort_param);
 	if (rollbackOnAbort) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1102, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1101, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1102, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1101, &__$false);
 	}
 }
 
@@ -478,7 +478,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, setRollbackedRecord)
 		Z_PARAM_OBJECT_OF_CLASS(record, phalcon_mvc_modelinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &record);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1103, record);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1102, record);
 }
 
 /**
@@ -499,7 +499,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, setTransactionManager)
 		Z_PARAM_OBJECT_OF_CLASS(manager, phalcon_mvc_model_transaction_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &manager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1101, manager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1100, manager);
 }
 
 /**
@@ -523,9 +523,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction, throwRollbackException)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &status_param);
 	if (status) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1104, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1103, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1104, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1103, &__$false);
 	}
 	RETURN_THISW();
 }

--- a/ext/phalcon/mvc/model/transaction/failed.zep.c
+++ b/ext/phalcon/mvc/model/transaction/failed.zep.c
@@ -81,7 +81,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Failed, __construct)
 		record = &record_sub;
 		record = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1106, record);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1105, record);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_mvc_model_transaction_failed_ce, getThis(), "__construct", NULL, 0, &message_zv);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -119,7 +119,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Failed, getRecordMessages)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1106, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1105, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&record, &_0);
 	if (Z_TYPE_P(&record) != IS_NULL) {
 		ZEPHIR_RETURN_CALL_METHOD(&record, "getmessages", NULL, 0);

--- a/ext/phalcon/mvc/model/transaction/manager.zep.c
+++ b/ext/phalcon/mvc/model/transaction/manager.zep.c
@@ -146,7 +146,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, __construct)
 		ZEPHIR_CALL_CE_STATIC(container, phalcon_di_di_ce, "getdefault", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1107, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1106, container);
 	if (UNEXPECTED(Z_TYPE_P(container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_0$$4);
 		object_init_ex(&_0$$4, phalcon_mvc_model_exceptions_managerormservicesunavailable_ce);
@@ -182,7 +182,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, collectTransactions)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1108, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1107, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&transactions, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_is_iterable(&transactions, 0, "phalcon/Mvc/Model/Transaction/Manager.zep", 128);
@@ -217,7 +217,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, collectTransactions)
 	ZEPHIR_INIT_NVAR(&_1);
 	ZEPHIR_INIT_VAR(&_5);
 	array_init(&_5);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1108, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1107, &_5);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -247,7 +247,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, commit)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1108, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1107, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&transactions, &_0);
 	zephir_is_iterable(&transactions, 0, "phalcon/Mvc/Model/Transaction/Manager.zep", 149);
 	if (Z_TYPE_P(&transactions) == IS_ARRAY) {
@@ -344,9 +344,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, get)
 		autoBegin = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1109, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1108, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1110, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1109, PH_NOISY_CC | PH_READONLY);
 		if (zephir_is_true(&_1$$3)) {
 			ZEPHIR_INIT_VAR(&_2$$4);
 			zephir_create_array(&_2$$4, 2, 0);
@@ -358,9 +358,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, get)
 			zephir_check_call_status();
 		}
 		if (1) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1109, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1108, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1109, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1108, &__$false);
 		}
 	}
 	if (autoBegin) {
@@ -445,7 +445,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction)
 		autoBegin = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1107, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1106, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -456,9 +456,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1111, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1110, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_2, 1108, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_2, 1107, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&transactions, &_2$$4);
 		zephir_is_iterable(&transactions, 0, "phalcon/Mvc/Model/Transaction/Manager.zep", 220);
 		if (Z_TYPE_P(&transactions) == IS_ARRAY) {
@@ -503,7 +503,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, getOrCreateTransaction)
 	}
 	ZEPHIR_INIT_NVAR(&transaction);
 	object_init_ex(&transaction, phalcon_mvc_model_transaction_ce);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_3, 1112, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_3, 1111, PH_NOISY_CC | PH_READONLY);
 	if (autoBegin) {
 		ZVAL_BOOL(&_9, 1);
 	} else {
@@ -541,7 +541,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, has)
 	if (UNEXPECTED(!_zephir_prop_0)) {
 		_zephir_prop_0 = zend_string_init("number", 6, 1);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1111, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1110, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(ZEPHIR_GT_LONG(&_0, 0));
 }
 
@@ -631,7 +631,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, rollback)
 		collect = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1108, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1107, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&transactions, &_0);
 	zephir_is_iterable(&transactions, 0, "phalcon/Mvc/Model/Transaction/Manager.zep", 291);
 	if (Z_TYPE_P(&transactions) == IS_ARRAY) {
@@ -729,7 +729,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, setDbService)
 		Z_PARAM_STR(service)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&service_zv, service);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1112, &service_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1111, &service_zv);
 	RETURN_THISW();
 }
 
@@ -753,7 +753,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1107, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1106, container);
 }
 
 /**
@@ -780,9 +780,9 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, setRollbackPendent)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &rollbackPendent_param);
 	if (rollbackPendent) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1110, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1109, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1110, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1109, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -819,7 +819,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, collectTransaction)
 	zephir_fetch_params(1, 1, 0, &transaction);
 	ZEPHIR_INIT_VAR(&newTransactions);
 	array_init(&newTransactions);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1108, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1107, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Mvc/Model/Transaction/Manager.zep", 356);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)
@@ -858,7 +858,7 @@ PHP_METHOD(Phalcon_Mvc_Model_Transaction_Manager, collectTransaction)
 		}
 	}
 	ZEPHIR_INIT_NVAR(&managedTransaction);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1108, &newTransactions);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1107, &newTransactions);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/mvc/model/validationfailed.zep.c
+++ b/ext/phalcon/mvc/model/validationfailed.zep.c
@@ -94,8 +94,8 @@ PHP_METHOD(Phalcon_Mvc_Model_ValidationFailed, __construct)
 		ZEPHIR_INIT_NVAR(&messageStr);
 		ZVAL_STRING(&messageStr, "Validation failed");
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1113, model);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1114, &validationMessages);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1112, model);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1113, &validationMessages);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_mvc_model_validationfailed_ce, getThis(), "__construct", NULL, 0, &messageStr);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();

--- a/ext/phalcon/mvc/router.zep.c
+++ b/ext/phalcon/mvc/router.zep.c
@@ -337,7 +337,7 @@ PHP_METHOD(Phalcon_Mvc_Router, __construct)
 		add_assoc_long_ex(&_1$$3, SL("controller"), 1);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZVAL_STRING(&_2$$3, "#^/([\\w0-9\\_\\-]+)[/]{0,1}$#u");
-		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 254, &_2$$3, &_1$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 255, &_2$$3, &_1$$3);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "attach", NULL, 0, &_0$$3);
 		zephir_check_call_status();
@@ -350,7 +350,7 @@ PHP_METHOD(Phalcon_Mvc_Router, __construct)
 		add_assoc_long_ex(&_3$$3, SL("params"), 3);
 		ZEPHIR_INIT_VAR(&_4$$3);
 		ZVAL_STRING(&_4$$3, "#^/([\\w0-9\\_\\-]+)/([\\w0-9\\.\\_]+)(/.*)?$#u");
-		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 254, &_4$$3, &_3$$3);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$3, "__construct", NULL, 255, &_4$$3, &_3$$3);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "attach", NULL, 0, &_2$$3);
 		zephir_check_call_status();
@@ -441,7 +441,7 @@ PHP_METHOD(Phalcon_Mvc_Router, add)
 		}
 	ZEPHIR_INIT_VAR(&route);
 	object_init_ex(&route, phalcon_mvc_router_route_ce);
-	ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 254, &pattern_zv, paths, httpMethods);
+	ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 255, &pattern_zv, paths, httpMethods);
 	zephir_check_call_status();
 	ZVAL_LONG(&_0, position);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "attach", NULL, 0, &route, &_0);
@@ -1127,7 +1127,7 @@ PHP_METHOD(Phalcon_Mvc_Router, attach)
 		}
 		ZEPHIR_INIT_VAR(&_3$$5);
 		object_init_ex(&_3$$5, phalcon_mvc_router_exceptions_invalidrouteposition_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_3$$5, "__construct", NULL, 255);
+		ZEPHIR_CALL_METHOD(NULL, &_3$$5, "__construct", NULL, 256);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_3$$5, "phalcon/Mvc/Router.zep", 672);
 		ZEPHIR_MM_RESTORE();
@@ -3237,7 +3237,7 @@ PHP_METHOD(Phalcon_Mvc_Router, dumpDispatcher)
 	zephir_var_export_ex(&_0, &dump);
 	ZEPHIR_INIT_VAR(&php);
 	ZEPHIR_CONCAT_SVS(&php, "<?php\nreturn ", &_0, ";\n");
-	ZEPHIR_CALL_FUNCTION(&_1, "getmypid", NULL, 256);
+	ZEPHIR_CALL_FUNCTION(&_1, "getmypid", NULL, 257);
 	zephir_check_call_status();
 	zephir_cast_to_string(&_2, &_1);
 	ZEPHIR_INIT_VAR(&_3);
@@ -3256,7 +3256,7 @@ PHP_METHOD(Phalcon_Mvc_Router, dumpDispatcher)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	ZEPHIR_CALL_FUNCTION(&_7, "rename", NULL, 257, &tmpPath, &path_zv);
+	ZEPHIR_CALL_FUNCTION(&_7, "rename", NULL, 258, &tmpPath, &path_zv);
 	zephir_check_call_status();
 	if (!(zephir_is_true(&_7))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpunlink", NULL, 0, &tmpPath);
@@ -4212,7 +4212,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 	if (Z_TYPE_P(&container) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_5$$9);
 		object_init_ex(&_5$$9, phalcon_mvc_router_exceptions_requestserviceunavailable_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_5$$9, "__construct", NULL, 258);
+		ZEPHIR_CALL_METHOD(NULL, &_5$$9, "__construct", NULL, 259);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_5$$9, "phalcon/Mvc/Router.zep", 1265);
 		ZEPHIR_MM_RESTORE();
@@ -4334,7 +4334,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 						if (UNEXPECTED(!(zephir_is_callable(&staticBeforeMatch)))) {
 							ZEPHIR_INIT_NVAR(&_33$$27);
 							object_init_ex(&_33$$27, phalcon_mvc_router_exceptions_beforematchnotcallable_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_33$$27, "__construct", &_34, 259);
+							ZEPHIR_CALL_METHOD(NULL, &_33$$27, "__construct", &_34, 260);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_33$$27, "phalcon/Mvc/Router.zep", 1353);
 							ZEPHIR_MM_RESTORE();
@@ -4403,7 +4403,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 							if (UNEXPECTED(!(zephir_is_callable(&staticBeforeMatch)))) {
 								ZEPHIR_INIT_NVAR(&_39$$37);
 								object_init_ex(&_39$$37, phalcon_mvc_router_exceptions_beforematchnotcallable_ce);
-								ZEPHIR_CALL_METHOD(NULL, &_39$$37, "__construct", &_34, 259);
+								ZEPHIR_CALL_METHOD(NULL, &_39$$37, "__construct", &_34, 260);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_39$$37, "phalcon/Mvc/Router.zep", 1353);
 								ZEPHIR_MM_RESTORE();
@@ -4486,7 +4486,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 					if (UNEXPECTED(!(zephir_is_callable(&combinedBeforeMatch)))) {
 						ZEPHIR_INIT_NVAR(&_53$$44);
 						object_init_ex(&_53$$44, phalcon_mvc_router_exceptions_beforematchnotcallable_ce);
-						ZEPHIR_CALL_METHOD(NULL, &_53$$44, "__construct", &_34, 259);
+						ZEPHIR_CALL_METHOD(NULL, &_53$$44, "__construct", &_34, 260);
 						zephir_check_call_status();
 						zephir_throw_exception_debug(&_53$$44, "phalcon/Mvc/Router.zep", 1411);
 						ZEPHIR_MM_RESTORE();
@@ -4523,7 +4523,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 						if (UNEXPECTED(Z_TYPE_P(&combinedPart) != IS_STRING)) {
 							ZEPHIR_INIT_NVAR(&_58$$47);
 							object_init_ex(&_58$$47, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_58$$47, "__construct", &_59, 260, &combinedPart);
+							ZEPHIR_CALL_METHOD(NULL, &_58$$47, "__construct", &_59, 261, &combinedPart);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_58$$47, "phalcon/Mvc/Router.zep", 1429);
 							ZEPHIR_MM_RESTORE();
@@ -4588,7 +4588,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 							if (UNEXPECTED(Z_TYPE_P(&combinedPart) != IS_STRING)) {
 								ZEPHIR_INIT_NVAR(&_67$$55);
 								object_init_ex(&_67$$55, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-								ZEPHIR_CALL_METHOD(NULL, &_67$$55, "__construct", &_59, 260, &combinedPart);
+								ZEPHIR_CALL_METHOD(NULL, &_67$$55, "__construct", &_59, 261, &combinedPart);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_67$$55, "phalcon/Mvc/Router.zep", 1429);
 								ZEPHIR_MM_RESTORE();
@@ -4682,7 +4682,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 						if (UNEXPECTED(!(zephir_is_callable(&combinedBeforeMatch)))) {
 							ZEPHIR_INIT_NVAR(&_79$$66);
 							object_init_ex(&_79$$66, phalcon_mvc_router_exceptions_beforematchnotcallable_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_79$$66, "__construct", &_34, 259);
+							ZEPHIR_CALL_METHOD(NULL, &_79$$66, "__construct", &_34, 260);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_79$$66, "phalcon/Mvc/Router.zep", 1411);
 							ZEPHIR_MM_RESTORE();
@@ -4719,7 +4719,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 							if (UNEXPECTED(Z_TYPE_P(&combinedPart) != IS_STRING)) {
 								ZEPHIR_INIT_NVAR(&_84$$69);
 								object_init_ex(&_84$$69, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-								ZEPHIR_CALL_METHOD(NULL, &_84$$69, "__construct", &_59, 260, &combinedPart);
+								ZEPHIR_CALL_METHOD(NULL, &_84$$69, "__construct", &_59, 261, &combinedPart);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_84$$69, "phalcon/Mvc/Router.zep", 1429);
 								ZEPHIR_MM_RESTORE();
@@ -4784,7 +4784,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 								if (UNEXPECTED(Z_TYPE_P(&combinedPart) != IS_STRING)) {
 									ZEPHIR_INIT_NVAR(&_92$$77);
 									object_init_ex(&_92$$77, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-									ZEPHIR_CALL_METHOD(NULL, &_92$$77, "__construct", &_59, 260, &combinedPart);
+									ZEPHIR_CALL_METHOD(NULL, &_92$$77, "__construct", &_59, 261, &combinedPart);
 									zephir_check_call_status();
 									zephir_throw_exception_debug(&_92$$77, "phalcon/Mvc/Router.zep", 1429);
 									ZEPHIR_MM_RESTORE();
@@ -4836,7 +4836,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 		ZEPHIR_INIT_NVAR(&combinedChunkIdx);
 	}
 	if (!(zephir_is_true(&routeFound))) {
-		ZEPHIR_CALL_FUNCTION(&_98$$84, "array_reverse", NULL, 261, &candidateRoutes, &__$true);
+		ZEPHIR_CALL_FUNCTION(&_98$$84, "array_reverse", NULL, 262, &candidateRoutes, &__$true);
 		zephir_check_call_status();
 		zephir_is_iterable(&_98$$84, 0, "phalcon/Mvc/Router.zep", 1614);
 		if (Z_TYPE_P(&_98$$84) == IS_ARRAY) {
@@ -4912,7 +4912,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 						if (UNEXPECTED(!(zephir_is_callable(&beforeMatch)))) {
 							ZEPHIR_INIT_NVAR(&_111$$98);
 							object_init_ex(&_111$$98, phalcon_mvc_router_exceptions_beforematchnotcallable_ce);
-							ZEPHIR_CALL_METHOD(NULL, &_111$$98, "__construct", &_34, 259);
+							ZEPHIR_CALL_METHOD(NULL, &_111$$98, "__construct", &_34, 260);
 							zephir_check_call_status();
 							zephir_throw_exception_debug(&_111$$98, "phalcon/Mvc/Router.zep", 1531);
 							ZEPHIR_MM_RESTORE();
@@ -4951,7 +4951,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 								if (UNEXPECTED(Z_TYPE_P(&part) != IS_STRING)) {
 									ZEPHIR_INIT_NVAR(&_117$$104);
 									object_init_ex(&_117$$104, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-									ZEPHIR_CALL_METHOD(NULL, &_117$$104, "__construct", &_59, 260, &part);
+									ZEPHIR_CALL_METHOD(NULL, &_117$$104, "__construct", &_59, 261, &part);
 									zephir_check_call_status();
 									zephir_throw_exception_debug(&_117$$104, "phalcon/Mvc/Router.zep", 1564);
 									ZEPHIR_MM_RESTORE();
@@ -5014,7 +5014,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 									if (UNEXPECTED(Z_TYPE_P(&part) != IS_STRING)) {
 										ZEPHIR_INIT_NVAR(&_124$$113);
 										object_init_ex(&_124$$113, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-										ZEPHIR_CALL_METHOD(NULL, &_124$$113, "__construct", &_59, 260, &part);
+										ZEPHIR_CALL_METHOD(NULL, &_124$$113, "__construct", &_59, 261, &part);
 										zephir_check_call_status();
 										zephir_throw_exception_debug(&_124$$113, "phalcon/Mvc/Router.zep", 1564);
 										ZEPHIR_MM_RESTORE();
@@ -5145,7 +5145,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 							if (UNEXPECTED(!(zephir_is_callable(&beforeMatch)))) {
 								ZEPHIR_INIT_NVAR(&_140$$134);
 								object_init_ex(&_140$$134, phalcon_mvc_router_exceptions_beforematchnotcallable_ce);
-								ZEPHIR_CALL_METHOD(NULL, &_140$$134, "__construct", &_34, 259);
+								ZEPHIR_CALL_METHOD(NULL, &_140$$134, "__construct", &_34, 260);
 								zephir_check_call_status();
 								zephir_throw_exception_debug(&_140$$134, "phalcon/Mvc/Router.zep", 1531);
 								ZEPHIR_MM_RESTORE();
@@ -5184,7 +5184,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 									if (UNEXPECTED(Z_TYPE_P(&part) != IS_STRING)) {
 										ZEPHIR_INIT_NVAR(&_146$$140);
 										object_init_ex(&_146$$140, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-										ZEPHIR_CALL_METHOD(NULL, &_146$$140, "__construct", &_59, 260, &part);
+										ZEPHIR_CALL_METHOD(NULL, &_146$$140, "__construct", &_59, 261, &part);
 										zephir_check_call_status();
 										zephir_throw_exception_debug(&_146$$140, "phalcon/Mvc/Router.zep", 1564);
 										ZEPHIR_MM_RESTORE();
@@ -5247,7 +5247,7 @@ PHP_METHOD(Phalcon_Mvc_Router, handle)
 										if (UNEXPECTED(Z_TYPE_P(&part) != IS_STRING)) {
 											ZEPHIR_INIT_NVAR(&_153$$149);
 											object_init_ex(&_153$$149, phalcon_mvc_router_exceptions_wrongpathskey_ce);
-											ZEPHIR_CALL_METHOD(NULL, &_153$$149, "__construct", &_59, 260, &part);
+											ZEPHIR_CALL_METHOD(NULL, &_153$$149, "__construct", &_59, 261, &part);
 											zephir_check_call_status();
 											zephir_throw_exception_debug(&_153$$149, "phalcon/Mvc/Router.zep", 1564);
 											ZEPHIR_MM_RESTORE();
@@ -5463,7 +5463,7 @@ PHP_METHOD(Phalcon_Mvc_Router, loadFromConfig)
 		if (!(zephir_instance_of_ev(config, phalcon_config_configinterface_ce))) {
 			ZEPHIR_INIT_VAR(&_0$$4);
 			object_init_ex(&_0$$4, phalcon_mvc_router_exceptions_invalidconfigsource_ce);
-			ZEPHIR_CALL_METHOD(NULL, &_0$$4, "__construct", NULL, 262);
+			ZEPHIR_CALL_METHOD(NULL, &_0$$4, "__construct", NULL, 263);
 			zephir_check_call_status();
 			zephir_throw_exception_debug(&_0$$4, "phalcon/Mvc/Router.zep", 1751);
 			ZEPHIR_MM_RESTORE();
@@ -5476,7 +5476,7 @@ PHP_METHOD(Phalcon_Mvc_Router, loadFromConfig)
 	if (Z_TYPE_P(config) != IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_2$$5);
 		object_init_ex(&_2$$5, phalcon_mvc_router_exceptions_invalidconfigsource_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$5, "__construct", NULL, 262);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$5, "__construct", NULL, 263);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$5, "phalcon/Mvc/Router.zep", 1757);
 		ZEPHIR_MM_RESTORE();
@@ -5637,7 +5637,7 @@ PHP_METHOD(Phalcon_Mvc_Router, mount)
 	if (UNEXPECTED(!(zephir_fast_count_int(&groupRoutes)))) {
 		ZEPHIR_INIT_VAR(&_2$$4);
 		object_init_ex(&_2$$4, phalcon_mvc_router_exceptions_emptygroupofroutes_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 263);
+		ZEPHIR_CALL_METHOD(NULL, &_2$$4, "__construct", NULL, 264);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_2$$4, "phalcon/Mvc/Router.zep", 1818);
 		ZEPHIR_MM_RESTORE();
@@ -5786,7 +5786,7 @@ PHP_METHOD(Phalcon_Mvc_Router, notFound)
 	if (UNEXPECTED(_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_mvc_router_exceptions_invalidnotfoundpaths_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 264);
+		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 265);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_1$$3, "phalcon/Mvc/Router.zep", 1859);
 		ZEPHIR_MM_RESTORE();
@@ -6227,7 +6227,7 @@ PHP_METHOD(Phalcon_Mvc_Router, addRouteFromConfig)
 		}
 		ZEPHIR_INIT_VAR(&_5$$7);
 		object_init_ex(&_5$$7, phalcon_mvc_router_exceptions_unknownhttpmethod_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_5$$7, "__construct", NULL, 265, &method);
+		ZEPHIR_CALL_METHOD(NULL, &_5$$7, "__construct", NULL, 266, &method);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_5$$7, "phalcon/Mvc/Router.zep", 2089);
 		ZEPHIR_MM_RESTORE();
@@ -6336,20 +6336,20 @@ PHP_METHOD(Phalcon_Mvc_Router, mountGroupFromConfig)
 	}
 	ZEPHIR_INIT_VAR(&group);
 	object_init_ex(&group, phalcon_mvc_router_group_ce);
-	ZEPHIR_CALL_METHOD(NULL, &group, "__construct", NULL, 266, &paths);
+	ZEPHIR_CALL_METHOD(NULL, &group, "__construct", NULL, 267, &paths);
 	zephir_check_call_status();
 	if (zephir_array_isset_value_string(&groupData, SL("prefix"))) {
 		zephir_memory_observe(&_0$$4);
 		zephir_array_fetch_string(&_0$$4, &groupData, SL("prefix"), PH_NOISY, "phalcon/Mvc/Router.zep", 2129);
 		zephir_cast_to_string(&_1$$4, &_0$$4);
-		ZEPHIR_CALL_METHOD(NULL, &group, "setprefix", NULL, 267, &_1$$4);
+		ZEPHIR_CALL_METHOD(NULL, &group, "setprefix", NULL, 268, &_1$$4);
 		zephir_check_call_status();
 	}
 	if (zephir_array_isset_value_string(&groupData, SL("hostname"))) {
 		zephir_memory_observe(&_2$$5);
 		zephir_array_fetch_string(&_2$$5, &groupData, SL("hostname"), PH_NOISY, "phalcon/Mvc/Router.zep", 2133);
 		zephir_cast_to_string(&_3$$5, &_2$$5);
-		ZEPHIR_CALL_METHOD(NULL, &group, "sethostname", NULL, 268, &_3$$5);
+		ZEPHIR_CALL_METHOD(NULL, &group, "sethostname", NULL, 269, &_3$$5);
 		zephir_check_call_status();
 	}
 	zephir_memory_observe(&routes);
@@ -6360,7 +6360,7 @@ PHP_METHOD(Phalcon_Mvc_Router, mountGroupFromConfig)
 	if (Z_TYPE_P(&routes) != IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_4$$7);
 		object_init_ex(&_4$$7, phalcon_mvc_router_exceptions_grouproutesmustbearray_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_4$$7, "__construct", NULL, 269);
+		ZEPHIR_CALL_METHOD(NULL, &_4$$7, "__construct", NULL, 270);
 		zephir_check_call_status();
 		zephir_throw_exception_debug(&_4$$7, "phalcon/Mvc/Router.zep", 2141);
 		ZEPHIR_MM_RESTORE();
@@ -6408,7 +6408,7 @@ PHP_METHOD(Phalcon_Mvc_Router, mountGroupFromConfig)
 				}
 				ZEPHIR_INIT_NVAR(&_11$$13);
 				object_init_ex(&_11$$13, phalcon_mvc_router_exceptions_unknownhttpmethod_ce);
-				ZEPHIR_CALL_METHOD(NULL, &_11$$13, "__construct", &_12, 265, &method);
+				ZEPHIR_CALL_METHOD(NULL, &_11$$13, "__construct", &_12, 266, &method);
 				zephir_check_call_status();
 				zephir_throw_exception_debug(&_11$$13, "phalcon/Mvc/Router.zep", 2173);
 				ZEPHIR_MM_RESTORE();
@@ -6477,7 +6477,7 @@ PHP_METHOD(Phalcon_Mvc_Router, mountGroupFromConfig)
 					}
 					ZEPHIR_INIT_NVAR(&_22$$20);
 					object_init_ex(&_22$$20, phalcon_mvc_router_exceptions_unknownhttpmethod_ce);
-					ZEPHIR_CALL_METHOD(NULL, &_22$$20, "__construct", &_12, 265, &method);
+					ZEPHIR_CALL_METHOD(NULL, &_22$$20, "__construct", &_12, 266, &method);
 					zephir_check_call_status();
 					zephir_throw_exception_debug(&_22$$20, "phalcon/Mvc/Router.zep", 2173);
 					ZEPHIR_MM_RESTORE();
@@ -7695,12 +7695,12 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 			if (ZEPHIR_IS_EMPTY(&combinedAlternatives)) {
 				continue;
 			}
-			ZEPHIR_CALL_FUNCTION(&_141$$92, "array_reverse", &_142, 261, &combinedAlternatives);
+			ZEPHIR_CALL_FUNCTION(&_141$$92, "array_reverse", &_142, 262, &combinedAlternatives);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&combinedAlternatives, &_141$$92);
 			ZEPHIR_INIT_NVAR(&_143$$92);
 			zephir_array_keys(&_143$$92, &combinedMark);
-			ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$92, "array_reverse", &_142, 261, &_143$$92);
+			ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$92, "array_reverse", &_142, 262, &_143$$92);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&reversedMarkIds$$92, &reversedMarkIds$$92);
 			ZEPHIR_INIT_NVAR(&chunkedPatterns$$92);
@@ -7716,11 +7716,11 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 					break;
 				}
 				ZVAL_LONG(&_144$$102, 10);
-				ZEPHIR_CALL_FUNCTION(&chunkSlice$$92, "array_slice", &_145, 270, &combinedAlternatives, &chunkOffset$$92, &_144$$102);
+				ZEPHIR_CALL_FUNCTION(&chunkSlice$$92, "array_slice", &_145, 271, &combinedAlternatives, &chunkOffset$$92, &_144$$102);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&chunkSlice$$92, &chunkSlice$$92);
 				ZVAL_LONG(&_144$$102, 10);
-				ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$92, "array_slice", &_145, 270, &reversedMarkIds$$92, &chunkOffset$$92, &_144$$102);
+				ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$92, "array_slice", &_145, 271, &reversedMarkIds$$92, &chunkOffset$$92, &_144$$102);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&chunkMarkSubset$$92, &chunkMarkSubset$$92);
 				ZEPHIR_INIT_NVAR(&chunkSliceMap$$92);
@@ -7898,12 +7898,12 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 				if (ZEPHIR_IS_EMPTY(&combinedAlternatives)) {
 					continue;
 				}
-				ZEPHIR_CALL_FUNCTION(&_171$$105, "array_reverse", &_142, 261, &combinedAlternatives);
+				ZEPHIR_CALL_FUNCTION(&_171$$105, "array_reverse", &_142, 262, &combinedAlternatives);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&combinedAlternatives, &_171$$105);
 				ZEPHIR_INIT_NVAR(&_172$$105);
 				zephir_array_keys(&_172$$105, &combinedMark);
-				ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$105, "array_reverse", &_142, 261, &_172$$105);
+				ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$105, "array_reverse", &_142, 262, &_172$$105);
 				zephir_check_call_status();
 				ZEPHIR_CPY_WRT(&reversedMarkIds$$105, &reversedMarkIds$$105);
 				ZEPHIR_INIT_NVAR(&chunkedPatterns$$105);
@@ -7919,11 +7919,11 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 						break;
 					}
 					ZVAL_LONG(&_173$$115, 10);
-					ZEPHIR_CALL_FUNCTION(&chunkSlice$$105, "array_slice", &_145, 270, &combinedAlternatives, &chunkOffset$$105, &_173$$115);
+					ZEPHIR_CALL_FUNCTION(&chunkSlice$$105, "array_slice", &_145, 271, &combinedAlternatives, &chunkOffset$$105, &_173$$115);
 					zephir_check_call_status();
 					ZEPHIR_CPY_WRT(&chunkSlice$$105, &chunkSlice$$105);
 					ZVAL_LONG(&_173$$115, 10);
-					ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$105, "array_slice", &_145, 270, &reversedMarkIds$$105, &chunkOffset$$105, &_173$$115);
+					ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$105, "array_slice", &_145, 271, &reversedMarkIds$$105, &chunkOffset$$105, &_173$$115);
 					zephir_check_call_status();
 					ZEPHIR_CPY_WRT(&chunkMarkSubset$$105, &chunkMarkSubset$$105);
 					ZEPHIR_INIT_NVAR(&chunkSliceMap$$105);

--- a/ext/phalcon/mvc/router/annotations.zep.c
+++ b/ext/phalcon/mvc/router/annotations.zep.c
@@ -272,7 +272,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, handle)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&uri_zv);
 	ZVAL_STR_COPY(&uri_zv, uri);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1115, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1114, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_0);
 	if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
@@ -283,9 +283,9 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, handle)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1116, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1115, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&handlers, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1117, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1116, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&controllerSuffix, &_0);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "annotations");
@@ -305,7 +305,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, handle)
 			if (!(ZEPHIR_IS_EMPTY(&prefix))) {
 				ZEPHIR_INIT_NVAR(&route);
 				object_init_ex(&route, phalcon_mvc_router_route_ce);
-				ZEPHIR_CALL_METHOD(NULL, &route, "__construct", &_4, 254, &prefix);
+				ZEPHIR_CALL_METHOD(NULL, &route, "__construct", &_4, 255, &prefix);
 				zephir_check_call_status();
 				ZEPHIR_CALL_METHOD(&_5$$6, &route, "getcompiledpattern", &_6, 0);
 				zephir_check_call_status();
@@ -345,7 +345,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, handle)
 				ZEPHIR_OBS_NVAR(&namespaceName);
 				zephir_fetch_property(&namespaceName, this_ptr, SL("defaultNamespace"), PH_SILENT_CC);
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1118, &__$null);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1117, &__$null);
 			ZEPHIR_OBS_NVAR(&moduleName);
 			zephir_array_isset_long_fetch(&moduleName, &scope, 2, 0);
 			ZEPHIR_INIT_NVAR(&_14$$4);
@@ -553,7 +553,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, handle)
 				if (!(ZEPHIR_IS_EMPTY(&prefix))) {
 					ZEPHIR_INIT_NVAR(&route);
 					object_init_ex(&route, phalcon_mvc_router_route_ce);
-					ZEPHIR_CALL_METHOD(NULL, &route, "__construct", &_4, 254, &prefix);
+					ZEPHIR_CALL_METHOD(NULL, &route, "__construct", &_4, 255, &prefix);
 					zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_37$$30, &route, "getcompiledpattern", &_6, 0);
 					zephir_check_call_status();
@@ -593,7 +593,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, handle)
 					ZEPHIR_OBS_NVAR(&namespaceName);
 					zephir_fetch_property(&namespaceName, this_ptr, SL("defaultNamespace"), PH_SILENT_CC);
 				}
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1118, &__$null);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1117, &__$null);
 				ZEPHIR_OBS_NVAR(&moduleName);
 				zephir_array_isset_long_fetch(&moduleName, &scope, 2, 0);
 				ZEPHIR_INIT_NVAR(&_45$$28);
@@ -878,16 +878,16 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, processActionAnnotation)
 	if (!(isRoute)) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1119, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1118, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "");
 	ZEPHIR_INIT_VAR(&proxyActionName);
 	zephir_fast_str_replace(&proxyActionName, &_0, &_1, &action_zv);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1118, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1117, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&routePrefix, &_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1120, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1119, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_2) != IS_NULL) {
-		zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_2, 1120, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$6, this_ptr, _zephir_prop_2, 1119, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_4$$6, "call_user_func", NULL, 80, &_3$$6, &proxyActionName);
 		zephir_check_call_status();
 		ZEPHIR_CPY_WRT(&proxyActionName, &_4$$6);
@@ -1097,7 +1097,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, processControllerAnnotation)
 		ZVAL_LONG(&_2$$3, 0);
 		ZEPHIR_CALL_METHOD(&_1$$3, annotation, "getargument", NULL, 0, &_2$$3);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1118, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1117, &_1$$3);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -1121,7 +1121,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, setActionSuffix)
 		Z_PARAM_STR(actionSuffix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&actionSuffix_zv, actionSuffix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1119, &actionSuffix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1118, &actionSuffix_zv);
 	RETURN_THISW();
 }
 
@@ -1183,12 +1183,12 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, setActionPreformatCallback)
 		callback = &__$null;
 	}
 	if (EXPECTED(zephir_is_callable(callback))) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1120, callback);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1119, callback);
 	} else if (Z_TYPE_P(callback) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_0$$4);
 		ZEPHIR_INIT_NVAR(&_0$$4);
 		zephir_create_closure_ex(&_0$$4, NULL, phalcon_91__closure_ce, SL("__invoke"));
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1120, &_0$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1119, &_0$$4);
 	} else {
 		ZEPHIR_INIT_VAR(&_1$$5);
 		object_init_ex(&_1$$5, phalcon_mvc_router_exceptions_invalidcallbackparameter_ce);
@@ -1229,7 +1229,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Annotations, setControllerSuffix)
 		Z_PARAM_STR(controllerSuffix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&controllerSuffix_zv, controllerSuffix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1117, &controllerSuffix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1116, &controllerSuffix_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/mvc/router/group.zep.c
+++ b/ext/phalcon/mvc/router/group.zep.c
@@ -141,7 +141,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, __construct)
 		_0 = Z_TYPE_P(paths) == IS_STRING;
 	}
 	if (_0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1121, paths);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1120, paths);
 	}
 	if ((zephir_method_exists_ex(this_ptr, ZEND_STRL("initialize")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "initialize", NULL, 0, paths);
@@ -724,7 +724,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, beforeMatch)
 		Z_PARAM_ZVAL(beforeMatch)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &beforeMatch);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1122, beforeMatch);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1121, beforeMatch);
 	RETURN_THISW();
 }
 
@@ -747,7 +747,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, clear)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1123, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1122, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -819,7 +819,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, setHostname)
 		Z_PARAM_STR(hostname)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&hostname_zv, hostname);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1124, &hostname_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1123, &hostname_zv);
 	RETURN_THISW();
 }
 
@@ -845,7 +845,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, setPaths)
 		Z_PARAM_ZVAL(paths)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &paths);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1121, paths);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1120, paths);
 	RETURN_THISW();
 }
 
@@ -872,7 +872,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, setPrefix)
 		Z_PARAM_STR(prefix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&prefix_zv, prefix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1125, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1124, &prefix_zv);
 	RETURN_THISW();
 }
 
@@ -943,7 +943,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, addRoute)
 		httpMethods = &__$null;
 	}
 	zephir_memory_observe(&defaultPaths);
-	zephir_read_property_cached(&defaultPaths, this_ptr, _zephir_prop_0, 1121, PH_NOISY_CC);
+	zephir_read_property_cached(&defaultPaths, this_ptr, _zephir_prop_0, 1120, PH_NOISY_CC);
 	if (Z_TYPE_P(&defaultPaths) == IS_ARRAY) {
 		if (Z_TYPE_P(paths) == IS_STRING) {
 			ZEPHIR_CALL_CE_STATIC(&processedPaths, phalcon_mvc_router_route_ce, "getroutepaths", NULL, 0, paths);
@@ -962,10 +962,10 @@ PHP_METHOD(Phalcon_Mvc_Router_Group, addRoute)
 	}
 	ZEPHIR_INIT_VAR(&route);
 	object_init_ex(&route, phalcon_mvc_router_route_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1125, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1124, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_CONCAT_VV(&_1, &_0, &pattern_zv);
-	ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 254, &_1, &mergedPaths, httpMethods);
+	ZEPHIR_CALL_METHOD(NULL, &route, "__construct", NULL, 255, &_1, &mergedPaths, httpMethods);
 	zephir_check_call_status();
 	zephir_update_property_array_append(this_ptr, SL("routes"), &route);
 	ZEPHIR_CALL_METHOD(NULL, &route, "setgroup", NULL, 0, this_ptr);

--- a/ext/phalcon/mvc/router/route.zep.c
+++ b/ext/phalcon/mvc/router/route.zep.c
@@ -156,7 +156,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, __construct)
 	zephir_read_static_property_ce(&_0, phalcon_mvc_router_route_ce, SL("uniqueId"), PH_NOISY_CC);
 	ZEPHIR_CPY_WRT(&uniqueId, &_0);
 	zephir_cast_to_string(&_1, &uniqueId);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1126, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1125, &_1);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, (zephir_get_numberval(&uniqueId) + 1));
 	zephir_update_static_property_ce(phalcon_mvc_router_route_ce, ZEND_STRL("uniqueId"), &_0);
@@ -202,7 +202,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, beforeMatch)
 		Z_PARAM_ZVAL(callback)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &callback);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1127, callback);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1126, callback);
 	RETURN_THISW();
 }
 
@@ -606,18 +606,18 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, getCompiledHostName)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1128, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1127, PH_NOISY_CC | PH_READONLY);
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&_0)) {
 		RETURN_MM_MEMBER(getThis(), "compiledHostName");
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1129, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1128, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&hostname, &_1);
 	if (Z_TYPE_P(&hostname) == IS_NULL) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1128, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1127, &__$null);
 		RETURN_MM_NULL();
 	}
 	if (!(zephir_memnstr_str(&hostname, SL("("), "phalcon/Mvc/Router/Route.zep", 375))) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1128, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1127, &__$null);
 		RETURN_MM_NULL();
 	}
 	if (!(zephir_memnstr_str(&hostname, SL("#"), "phalcon/Mvc/Router/Route.zep", 380))) {
@@ -630,7 +630,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, getCompiledHostName)
 	} else {
 		ZEPHIR_CPY_WRT(&regexHostName, &hostname);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1128, &regexHostName);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1127, &regexHostName);
 	RETURN_CCTOR(&regexHostName);
 }
 
@@ -733,8 +733,8 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, getReversedPaths)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1130, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_RETURN_CALL_FUNCTION("array_flip", NULL, 253, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1129, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_RETURN_CALL_FUNCTION("array_flip", NULL, 254, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -885,7 +885,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, match)
 		Z_PARAM_ZVAL(callback)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &callback);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1131, callback);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1130, callback);
 	RETURN_THISW();
 }
 
@@ -959,9 +959,9 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, reConfigure)
 	} else {
 		ZEPHIR_CPY_WRT(&compiledPattern, &pattern_zv);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1132, &pattern_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1133, &compiledPattern);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1130, &routePaths);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1131, &pattern_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1132, &compiledPattern);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1129, &routePaths);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -996,7 +996,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, setGroup)
 		Z_PARAM_OBJECT_OF_CLASS(group, phalcon_mvc_router_groupinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &group);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1134, group);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1133, group);
 	RETURN_THISW();
 }
 
@@ -1029,11 +1029,11 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, setHostname)
 		Z_PARAM_STR(hostname)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&hostname_zv, hostname);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1129, &hostname_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1128, &hostname_zv);
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1128, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1127, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1128, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1127, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -1099,7 +1099,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, setName)
 		Z_PARAM_STR(name)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&name_zv, name);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1135, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1134, &name_zv);
 	RETURN_THISW();
 }
 
@@ -1124,7 +1124,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, setRouteId)
 		Z_PARAM_STR(routeId)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&routeId_zv, routeId);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1126, &routeId_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1125, &routeId_zv);
 	RETURN_THISW();
 }
 
@@ -1157,7 +1157,7 @@ PHP_METHOD(Phalcon_Mvc_Router_Route, via)
 		Z_PARAM_ZVAL(httpMethods)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &httpMethods);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1136, httpMethods);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1135, httpMethods);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/mvc/url.zep.c
+++ b/ext/phalcon/mvc/url.zep.c
@@ -94,7 +94,7 @@ PHP_METHOD(Phalcon_Mvc_Url, __construct)
 		router = &router_sub;
 		router = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1137, router);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1136, router);
 }
 
 /**
@@ -290,10 +290,10 @@ PHP_METHOD(Phalcon_Mvc_Url, get)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
-		zephir_read_property_cached(&_7$$9, this_ptr, _zephir_prop_0, 1137, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$9, this_ptr, _zephir_prop_0, 1136, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&router, &_7$$9);
 		if (UNEXPECTED(!zephir_is_true(&router))) {
-			zephir_read_property_cached(&_8$$11, this_ptr, _zephir_prop_1, 1138, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_8$$11, this_ptr, _zephir_prop_1, 1137, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&container, &_8$$11);
 			if (UNEXPECTED(Z_TYPE_P(&container) != IS_OBJECT)) {
 				ZEPHIR_INIT_VAR(&_9$$12);
@@ -322,7 +322,7 @@ PHP_METHOD(Phalcon_Mvc_Url, get)
 			ZEPHIR_CALL_METHOD(&_13$$11, &container, "getshared", NULL, 0, &_11$$11);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&router, &_13$$11);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1137, &router);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1136, &router);
 		}
 		ZEPHIR_CALL_METHOD(&_14$$9, &router, "getroutebyname", NULL, 0, &routeName);
 		zephir_check_call_status();
@@ -465,7 +465,7 @@ PHP_METHOD(Phalcon_Mvc_Url, getBaseUri)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_get_global(&_SERVER, SL("_SERVER"));
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1139, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1138, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&baseUri, &_0);
 	if (Z_TYPE_P(&baseUri) == IS_NULL) {
 		zephir_memory_observe(&phpSelf);
@@ -482,7 +482,7 @@ PHP_METHOD(Phalcon_Mvc_Url, getBaseUri)
 		} else {
 			ZEPHIR_CONCAT_SVS(&baseUri, "/", &uri, "/");
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1139, &baseUri);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1138, &baseUri);
 	}
 	RETURN_CCTOR(&baseUri);
 }
@@ -557,7 +557,7 @@ PHP_METHOD(Phalcon_Mvc_Url, getStaticBaseUri)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1140, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1139, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
 		RETURN_MM_MEMBER_TYPED(getThis(), "staticBaseUri", IS_STRING);
 	}
@@ -596,7 +596,7 @@ PHP_METHOD(Phalcon_Mvc_Url, path)
 		zephir_memory_observe(&path_zv);
 	ZVAL_STR_COPY(&path_zv, path);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1141, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1140, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VV(return_value, &_0, &path_zv);
 	RETURN_MM();
 }
@@ -624,7 +624,7 @@ PHP_METHOD(Phalcon_Mvc_Url, setBasePath)
 		Z_PARAM_STR(basePath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&basePath_zv, basePath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1141, &basePath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1140, &basePath_zv);
 	RETURN_THISW();
 }
 
@@ -658,10 +658,10 @@ PHP_METHOD(Phalcon_Mvc_Url, setBaseUri)
 		Z_PARAM_STR(baseUri)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&baseUri_zv, baseUri);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1139, &baseUri_zv);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1140, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1138, &baseUri_zv);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1139, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1140, &baseUri_zv);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1139, &baseUri_zv);
 	}
 	RETURN_THISW();
 }
@@ -689,7 +689,7 @@ PHP_METHOD(Phalcon_Mvc_Url, setStaticBaseUri)
 		Z_PARAM_STR(staticBaseUri)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&staticBaseUri_zv, staticBaseUri);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1140, &staticBaseUri_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1139, &staticBaseUri_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/mvc/view.zep.c
+++ b/ext/phalcon/mvc/view.zep.c
@@ -243,13 +243,13 @@ PHP_METHOD(Phalcon_Mvc_View, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1142, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1141, &options);
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1143, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1142, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	array_init(&_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1144, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1143, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -305,7 +305,7 @@ PHP_METHOD(Phalcon_Mvc_View, __isset)
 		Z_PARAM_STR(key)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&key_zv, key);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1144, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1143, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &key_zv));
 }
 
@@ -359,7 +359,7 @@ PHP_METHOD(Phalcon_Mvc_View, cleanTemplateAfter)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1145, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, &_0);
 	RETURN_THIS();
 }
 
@@ -382,7 +382,7 @@ PHP_METHOD(Phalcon_Mvc_View, cleanTemplateBefore)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1145, &_0);
 	RETURN_THIS();
 }
 
@@ -401,9 +401,9 @@ PHP_METHOD(Phalcon_Mvc_View, disable)
 		_zephir_prop_0 = zend_string_init("disabled", 8, 1);
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -435,7 +435,7 @@ PHP_METHOD(Phalcon_Mvc_View, disableLevel)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &level);
 	if (Z_TYPE_P(level) == IS_ARRAY) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1148, level);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, level);
 	} else {
 		zephir_update_property_array(this_ptr, SL("disabledLevels"), level, &__$true);
 	}
@@ -457,9 +457,9 @@ PHP_METHOD(Phalcon_Mvc_View, enable)
 		_zephir_prop_0 = zend_string_init("disabled", 8, 1);
 	}
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -533,7 +533,7 @@ PHP_METHOD(Phalcon_Mvc_View, getActiveRenderPath)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&activeRenderPath);
-	zephir_read_property_cached(&activeRenderPath, this_ptr, _zephir_prop_0, 1149, PH_NOISY_CC);
+	zephir_read_property_cached(&activeRenderPath, this_ptr, _zephir_prop_0, 1148, PH_NOISY_CC);
 	if (Z_TYPE_P(&activeRenderPath) == IS_ARRAY) {
 		if (zephir_fast_count_int(&activeRenderPath) == 1) {
 			zephir_array_fetch_long(&_0$$4, &activeRenderPath, 0, PH_NOISY | PH_READONLY, "phalcon/Mvc/View.zep", 346);
@@ -835,10 +835,10 @@ PHP_METHOD(Phalcon_Mvc_View, has)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&view_zv);
 	ZVAL_STR_COPY(&view_zv, view);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1150, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1149, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&basePath, &_0);
 	zephir_memory_observe(&engines);
-	zephir_read_property_cached(&engines, this_ptr, _zephir_prop_1, 1143, PH_NOISY_CC);
+	zephir_read_property_cached(&engines, this_ptr, _zephir_prop_1, 1142, PH_NOISY_CC);
 	if (ZEPHIR_IS_EMPTY(&engines)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		zephir_create_array(&_1$$3, 1, 0);
@@ -1058,18 +1058,18 @@ PHP_METHOD(Phalcon_Mvc_View, partial)
 		params = &__$null;
 	}
 	if (Z_TYPE_P(params) == IS_ARRAY) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1144, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1143, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&viewParams, &_0$$3);
 		ZEPHIR_INIT_VAR(&_1$$3);
 		zephir_fast_array_merge(&_1$$3, &viewParams, params);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1143, &_1$$3);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZEPHIR_CREATE_SYMBOL_TABLE();
 		
 	}
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "loadtemplateengines", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1151, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1150, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_5);
 	ZEPHIR_CONCAT_VV(&_5, &_4, &partialPath_zv);
 	ZVAL_BOOL(&_6, 0);
@@ -1077,7 +1077,7 @@ PHP_METHOD(Phalcon_Mvc_View, partial)
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "enginerender", NULL, 0, &_3, &_5, &_6, &_7);
 	zephir_check_call_status();
 	if (Z_TYPE_P(params) == IS_ARRAY) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, &viewParams);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1143, &viewParams);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -1141,7 +1141,7 @@ PHP_METHOD(Phalcon_Mvc_View, pick)
 			zephir_array_append(&pickView, &layout, PH_SEPARATE, "phalcon/Mvc/View.zep", 666);
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &pickView);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1151, &pickView);
 	RETURN_THIS();
 }
 
@@ -1291,25 +1291,25 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 		}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1147, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1146, PH_NOISY_CC | PH_READONLY);
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&_0)) {
 		ZEPHIR_CALL_FUNCTION(&_1$$3, "ob_get_contents", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1154, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1153, &_1$$3);
 		RETURN_MM_BOOL(0);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1155, &controllerName_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1156, &actionName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1154, &controllerName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1155, &actionName_zv);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setvars", NULL, 0, &params);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_5, 1157, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_5, 1156, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&layoutsDir, &_2);
 	if (!(zephir_is_true(&layoutsDir))) {
 		ZEPHIR_INIT_NVAR(&layoutsDir);
 		ZVAL_STRING(&layoutsDir, "layouts/");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_6, 1158, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_6, 1157, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&layout, &_2);
 	if (zephir_is_true(&layout)) {
 		ZEPHIR_CPY_WRT(&layoutName, &layout);
@@ -1318,7 +1318,7 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 	}
 	ZEPHIR_CALL_METHOD(&engines, this_ptr, "loadtemplateengines", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_7, 1152, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_7, 1151, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&pickView, &_2);
 	if (Z_TYPE_P(&pickView) == IS_NULL) {
 		ZEPHIR_INIT_VAR(&_3$$7);
@@ -1334,7 +1334,7 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 			}
 		}
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_8, 1159, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_8, 1158, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_2);
 	ZEPHIR_INIT_VAR(&_4);
 	ZEPHIR_CREATE_SYMBOL_TABLE();
@@ -1354,19 +1354,19 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 	}
 	ZEPHIR_CALL_FUNCTION(&_8, "ob_get_contents", NULL, 0);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1154, &_8);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1153, &_8);
 	silence = 1;
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_9, 1148, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_9, 1147, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&disabledLevels, &_2);
 	zephir_memory_observe(&_9);
-	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_10, 1160, PH_NOISY_CC);
+	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_10, 1159, PH_NOISY_CC);
 	renderLevel = zephir_get_intval(&_9);
 	if (renderLevel) {
 		if (renderLevel >= 1) {
 			if (!(zephir_array_isset_value_long(&disabledLevels, 1))) {
 				ZVAL_UNDEF(&_10$$15);
 				ZVAL_LONG(&_10$$15, 1);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_10$$15);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_10$$15);
 				if (silence) {
 					ZVAL_BOOL(&_10$$15, 1);
 				} else {
@@ -1380,8 +1380,8 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 			if (!(zephir_array_isset_value_long(&disabledLevels, 2))) {
 				ZVAL_UNDEF(&_11$$17);
 				ZVAL_LONG(&_11$$17, 2);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_11$$17);
-				zephir_read_property_cached(&_11$$17, this_ptr, _zephir_prop_11, 1146, PH_NOISY_CC | PH_READONLY);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_11$$17);
+				zephir_read_property_cached(&_11$$17, this_ptr, _zephir_prop_11, 1145, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CPY_WRT(&templatesBefore, &_11$$17);
 				silence = 0;
 				zephir_is_iterable(&templatesBefore, 0, "phalcon/Mvc/View.zep", 821);
@@ -1437,7 +1437,7 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 			if (!(zephir_array_isset_value_long(&disabledLevels, 3))) {
 				ZVAL_UNDEF(&_19$$21);
 				ZVAL_LONG(&_19$$21, 3);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_19$$21);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_19$$21);
 				ZEPHIR_INIT_VAR(&_20$$21);
 				ZEPHIR_CONCAT_VV(&_20$$21, &layoutsDir, &layoutName);
 				if (silence) {
@@ -1453,8 +1453,8 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 			if (!(zephir_array_isset_value_long(&disabledLevels, 4))) {
 				ZVAL_UNDEF(&_21$$23);
 				ZVAL_LONG(&_21$$23, 4);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_21$$23);
-				zephir_read_property_cached(&_21$$23, this_ptr, _zephir_prop_12, 1145, PH_NOISY_CC | PH_READONLY);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_21$$23);
+				zephir_read_property_cached(&_21$$23, this_ptr, _zephir_prop_12, 1144, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CPY_WRT(&templatesAfter, &_21$$23);
 				silence = 0;
 				zephir_is_iterable(&templatesAfter, 0, "phalcon/Mvc/View.zep", 857);
@@ -1510,8 +1510,8 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 			if (!(zephir_array_isset_value_long(&disabledLevels, 5))) {
 				ZVAL_UNDEF(&_29$$27);
 				ZVAL_LONG(&_29$$27, 5);
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_29$$27);
-				zephir_read_property_cached(&_29$$27, this_ptr, _zephir_prop_13, 1161, PH_NOISY_CC | PH_READONLY);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_29$$27);
+				zephir_read_property_cached(&_29$$27, this_ptr, _zephir_prop_13, 1160, PH_NOISY_CC | PH_READONLY);
 				if (silence) {
 					ZVAL_BOOL(&_30$$27, 1);
 				} else {
@@ -1523,7 +1523,7 @@ PHP_METHOD(Phalcon_Mvc_View, processRender)
 		}
 		ZVAL_UNDEF(&_31$$13);
 		ZVAL_LONG(&_31$$13, 0);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_31$$13);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1152, &_31$$13);
 	}
 	_32 = fireEvents;
 	if (_32) {
@@ -1571,7 +1571,7 @@ PHP_METHOD(Phalcon_Mvc_View, registerEngines)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &engines_param);
 	zephir_get_arrval(&engines, engines_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1143, &engines);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1142, &engines);
 	RETURN_THIS();
 }
 
@@ -1667,28 +1667,28 @@ PHP_METHOD(Phalcon_Mvc_View, reset)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1147, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &__$false);
 	}
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1162, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1161, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1162, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1161, &__$false);
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 5);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1160, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1159, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1154, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1153, &_1);
 	ZEPHIR_INIT_NVAR(&_1);
 	array_init(&_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1146, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1145, &_1);
 	ZEPHIR_INIT_VAR(&_2);
 	array_init(&_2);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1145, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1144, &_2);
 	RETURN_THIS();
 }
 
@@ -1716,7 +1716,7 @@ PHP_METHOD(Phalcon_Mvc_View, setBasePath)
 		Z_PARAM_STR(basePath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&basePath_zv, basePath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1150, &basePath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1149, &basePath_zv);
 	RETURN_THISW();
 }
 
@@ -1738,7 +1738,7 @@ PHP_METHOD(Phalcon_Mvc_View, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1159, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1158, eventsManager);
 }
 
 /**
@@ -1765,7 +1765,7 @@ PHP_METHOD(Phalcon_Mvc_View, setLayout)
 		Z_PARAM_STR(layout)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&layout_zv, layout);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1158, &layout_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1157, &layout_zv);
 	RETURN_THISW();
 }
 
@@ -1794,7 +1794,7 @@ PHP_METHOD(Phalcon_Mvc_View, setLayoutsDir)
 		Z_PARAM_STR(layoutsDir)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&layoutsDir_zv, layoutsDir);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1157, &layoutsDir_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1156, &layoutsDir_zv);
 	RETURN_THISW();
 }
 
@@ -1823,7 +1823,7 @@ PHP_METHOD(Phalcon_Mvc_View, setMainView)
 		Z_PARAM_STR(viewPath)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&viewPath_zv, viewPath);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1161, &viewPath_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1160, &viewPath_zv);
 	RETURN_THISW();
 }
 
@@ -1877,7 +1877,7 @@ PHP_METHOD(Phalcon_Mvc_View, setPartialsDir)
 		Z_PARAM_STR(partialsDir)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&partialsDir_zv, partialsDir);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1151, &partialsDir_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1150, &partialsDir_zv);
 	RETURN_THISW();
 }
 
@@ -1909,7 +1909,7 @@ PHP_METHOD(Phalcon_Mvc_View, setRenderLevel)
 	zephir_fetch_params_without_memory_grow(1, 0, &level_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, level);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1160, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1159, &_0);
 	RETURN_THISW();
 }
 
@@ -1940,9 +1940,9 @@ PHP_METHOD(Phalcon_Mvc_View, setTemplateAfter)
 		ZEPHIR_INIT_VAR(&_0$$3);
 		zephir_create_array(&_0$$3, 1, 0);
 		zephir_array_fast_append(&_0$$3, templateAfter);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1145, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, &_0$$3);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1145, templateAfter);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, templateAfter);
 	}
 	RETURN_THIS();
 }
@@ -1974,9 +1974,9 @@ PHP_METHOD(Phalcon_Mvc_View, setTemplateBefore)
 		ZEPHIR_INIT_VAR(&_0$$3);
 		zephir_create_array(&_0$$3, 1, 0);
 		zephir_array_fast_append(&_0$$3, templateBefore);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1145, &_0$$3);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1146, templateBefore);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1145, templateBefore);
 	}
 	RETURN_THIS();
 }
@@ -2023,11 +2023,11 @@ PHP_METHOD(Phalcon_Mvc_View, setVars)
 		}
 	if (merge) {
 		ZEPHIR_INIT_VAR(&_0$$3);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1144, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1143, PH_NOISY_CC | PH_READONLY);
 		zephir_fast_array_merge(&_0$$3, &_1$$3, &params);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1143, &_0$$3);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1144, &params);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1143, &params);
 	}
 	RETURN_THIS();
 }
@@ -2085,7 +2085,7 @@ PHP_METHOD(Phalcon_Mvc_View, setViewsDir)
 	if (Z_TYPE_P(viewsDir) == IS_STRING) {
 		ZEPHIR_CALL_METHOD(&_2$$4, this_ptr, "todirseparator", NULL, 0, viewsDir);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1163, &_2$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1162, &_2$$4);
 	} else {
 		ZEPHIR_INIT_VAR(&newViewsDir);
 		array_init(&newViewsDir);
@@ -2150,7 +2150,7 @@ PHP_METHOD(Phalcon_Mvc_View, setViewsDir)
 		}
 		ZEPHIR_INIT_NVAR(&directory);
 		ZEPHIR_INIT_NVAR(&position);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1163, &newViewsDir);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1162, &newViewsDir);
 	}
 	RETURN_THIS();
 }
@@ -2178,7 +2178,7 @@ PHP_METHOD(Phalcon_Mvc_View, start)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1154, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &_0);
 	RETURN_THIS();
 }
 
@@ -2332,11 +2332,11 @@ PHP_METHOD(Phalcon_Mvc_View, engineRender)
 		mustClean = 1;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1150, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1149, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&basePath, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1144, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1143, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&viewParams, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1159, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1158, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	ZEPHIR_INIT_VAR(&viewEnginePaths);
 	array_init(&viewEnginePaths);
@@ -2377,7 +2377,7 @@ PHP_METHOD(Phalcon_Mvc_View, engineRender)
 							ZEPHIR_INIT_NVAR(&_10$$8);
 							zephir_create_array(&_10$$8, 1, 0);
 							zephir_array_fast_append(&_10$$8, &viewEnginePath);
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1149, &_10$$8);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1148, &_10$$8);
 							ZEPHIR_INIT_NVAR(&_12$$8);
 							ZVAL_STRING(&_12$$8, "view:beforeRenderView");
 							ZEPHIR_CALL_METHOD(&_11$$8, &eventsManager, "fire", &_13, 0, &_12$$8, this_ptr, &viewEnginePath);
@@ -2432,7 +2432,7 @@ PHP_METHOD(Phalcon_Mvc_View, engineRender)
 								ZEPHIR_INIT_NVAR(&_20$$13);
 								zephir_create_array(&_20$$13, 1, 0);
 								zephir_array_fast_append(&_20$$13, &viewEnginePath);
-								zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1149, &_20$$13);
+								zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1148, &_20$$13);
 								ZEPHIR_INIT_NVAR(&_22$$13);
 								ZVAL_STRING(&_22$$13, "view:beforeRenderView");
 								ZEPHIR_CALL_METHOD(&_21$$13, &eventsManager, "fire", &_23, 0, &_22$$13, this_ptr, &viewEnginePath);
@@ -2509,7 +2509,7 @@ PHP_METHOD(Phalcon_Mvc_View, engineRender)
 								ZEPHIR_INIT_NVAR(&_34$$21);
 								zephir_create_array(&_34$$21, 1, 0);
 								zephir_array_fast_append(&_34$$21, &viewEnginePath);
-								zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1149, &_34$$21);
+								zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1148, &_34$$21);
 								ZEPHIR_INIT_NVAR(&_36$$21);
 								ZVAL_STRING(&_36$$21, "view:beforeRenderView");
 								ZEPHIR_CALL_METHOD(&_35$$21, &eventsManager, "fire", &_37, 0, &_36$$21, this_ptr, &viewEnginePath);
@@ -2564,7 +2564,7 @@ PHP_METHOD(Phalcon_Mvc_View, engineRender)
 									ZEPHIR_INIT_NVAR(&_44$$26);
 									zephir_create_array(&_44$$26, 1, 0);
 									zephir_array_fast_append(&_44$$26, &viewEnginePath);
-									zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1149, &_44$$26);
+									zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1148, &_44$$26);
 									ZEPHIR_INIT_NVAR(&_46$$26);
 									ZVAL_STRING(&_46$$26, "view:beforeRenderView");
 									ZEPHIR_CALL_METHOD(&_45$$26, &eventsManager, "fire", &_47, 0, &_46$$26, this_ptr, &viewEnginePath);
@@ -2597,7 +2597,7 @@ PHP_METHOD(Phalcon_Mvc_View, engineRender)
 	}
 	ZEPHIR_INIT_NVAR(&viewsDir);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1149, &viewEnginePaths);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1148, &viewEnginePaths);
 		ZEPHIR_INIT_VAR(&_51$$29);
 		ZVAL_STRING(&_51$$29, "view:notFoundView");
 		ZEPHIR_CALL_METHOD(NULL, &eventsManager, "fire", NULL, 0, &_51$$29, this_ptr, &viewEnginePath);
@@ -2634,11 +2634,11 @@ PHP_METHOD(Phalcon_Mvc_View, getViewsDirs)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1163, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1162, PH_NOISY_CC);
 	if (Z_TYPE_P(&_0) == IS_STRING) {
 		zephir_create_array(return_value, 1, 0);
 		zephir_memory_observe(&_1$$3);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1163, PH_NOISY_CC);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1162, PH_NOISY_CC);
 		zephir_array_fast_append(return_value, &_1$$3);
 		RETURN_MM();
 	}
@@ -2738,14 +2738,14 @@ PHP_METHOD(Phalcon_Mvc_View, loadTemplateEngines)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1162, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1161, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&engines, &_0);
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&engines)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1164, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1163, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&di, &_1$$3);
 		ZEPHIR_INIT_NVAR(&engines);
 		array_init(&engines);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_2, 1143, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_2, 1142, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&registeredEngines, &_1$$3);
 		if (ZEPHIR_IS_EMPTY(&registeredEngines)) {
 			ZEPHIR_INIT_VAR(&_2$$4);
@@ -2859,7 +2859,7 @@ PHP_METHOD(Phalcon_Mvc_View, loadTemplateEngines)
 			ZEPHIR_INIT_NVAR(&engineService);
 			ZEPHIR_INIT_NVAR(&extension);
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1162, &engines);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1161, &engines);
 	}
 	RETURN_CCTOR(&engines);
 }
@@ -3366,7 +3366,7 @@ PHP_METHOD(Phalcon_Mvc_View, getParamsToView)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1144, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1143, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -3391,7 +3391,7 @@ PHP_METHOD(Phalcon_Mvc_View, getRegisteredEngines)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1143, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1142, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -3424,7 +3424,7 @@ PHP_METHOD(Phalcon_Mvc_View, getVar)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1144, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1143, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &key_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -3456,7 +3456,7 @@ PHP_METHOD(Phalcon_Mvc_View, setContent)
 		Z_PARAM_STR(content)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&content_zv, content);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1154, &content_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1153, &content_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/mvc/view/engine/php.zep.c
+++ b/ext/phalcon/mvc/view/engine/php.zep.c
@@ -137,7 +137,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Php, render)
 		RETURN_MM_NULL();
 	}
 	if (mustClean) {
-		zephir_read_property_cached(&_7$$7, this_ptr, _zephir_prop_0, 1165, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$7, this_ptr, _zephir_prop_0, 1164, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_8$$7, "ob_get_contents", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_7$$7, "setcontent", NULL, 0, &_8$$7);

--- a/ext/phalcon/mvc/view/engine/volt.zep.c
+++ b/ext/phalcon/mvc/view/engine/volt.zep.c
@@ -106,7 +106,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, callMacro)
 		zephir_get_arrval(&arguments, arguments_param);
 	}
 	zephir_memory_observe(&macro);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1166, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1165, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(!(zephir_array_isset_fetch(&macro, &_0, &name_zv, 0)))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_mvc_view_engine_volt_exceptions_macronotfound_ce);
@@ -208,27 +208,27 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, getCompiler)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1167, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1166, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&compiler, &_0);
 	if (Z_TYPE_P(&compiler) != IS_OBJECT) {
 		ZEPHIR_INIT_NVAR(&compiler);
 		object_init_ex(&compiler, phalcon_mvc_view_engine_volt_compiler_ce);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1168, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1167, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &compiler, "__construct", NULL, 0, &_1$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 1169, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_2, 1168, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&container, &_2$$3);
 		if (Z_TYPE_P(&container) == IS_OBJECT) {
 			ZEPHIR_CALL_METHOD(NULL, &compiler, "setdi", NULL, 0, &container);
 			zephir_check_call_status();
 		}
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_3, 1170, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_3, 1169, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&options, &_2$$3);
 		if (Z_TYPE_P(&options) == IS_ARRAY) {
 			ZEPHIR_CALL_METHOD(NULL, &compiler, "setoptions", NULL, 0, &options);
 			zephir_check_call_status();
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1167, &compiler);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1166, &compiler);
 	}
 	RETURN_CCTOR(&compiler);
 }
@@ -416,7 +416,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, preload)
 	}
 	zephir_memory_observe(&href);
 	zephir_array_isset_long_fetch(&href, &params, 0, 0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1169, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1168, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&container, &_1);
 	ZEPHIR_INIT_VAR(&_3);
 	ZVAL_STRING(&_3, "response");
@@ -537,7 +537,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, render)
 	}
 	ZEPHIR_CALL_METHOD(&compiler, this_ptr, "getcompiler", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1171, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1170, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_2$$4);
@@ -612,7 +612,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, render)
 		RETURN_MM_NULL();
 	}
 	if (mustClean) {
-		zephir_read_property_cached(&_12$$11, this_ptr, _zephir_prop_1, 1168, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$11, this_ptr, _zephir_prop_1, 1167, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_13$$11, "ob_get_contents", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_12$$11, "setcontent", NULL, 0, &_13$$11);
@@ -643,7 +643,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1171, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1170, eventsManager);
 }
 
 /**
@@ -673,7 +673,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1170, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1169, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -763,7 +763,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, slice)
 	}
 	if (Z_TYPE_P(value) == IS_ARRAY) {
 		ZVAL_LONG(&_5$$9, start);
-		ZEPHIR_RETURN_CALL_FUNCTION("array_slice", NULL, 270, value, &_5$$9, &length);
+		ZEPHIR_RETURN_CALL_FUNCTION("array_slice", NULL, 271, value, &_5$$9, &length);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -774,12 +774,12 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, slice)
 	if (zephir_is_true(&_6)) {
 		if (Z_TYPE_P(&length) != IS_NULL) {
 			ZVAL_LONG(&_8$$11, start);
-			ZEPHIR_RETURN_CALL_FUNCTION("mb_substr", NULL, 296, value, &_8$$11, &length);
+			ZEPHIR_RETURN_CALL_FUNCTION("mb_substr", NULL, 297, value, &_8$$11, &length);
 			zephir_check_call_status();
 			RETURN_MM();
 		}
 		ZVAL_LONG(&_9$$10, start);
-		ZEPHIR_RETURN_CALL_FUNCTION("mb_substr", NULL, 296, value, &_9$$10);
+		ZEPHIR_RETURN_CALL_FUNCTION("mb_substr", NULL, 297, value, &_9$$10);
 		zephir_check_call_status();
 		RETURN_MM();
 	}
@@ -842,7 +842,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/mvc/view/engine/volt/compiler.zep.c
+++ b/ext/phalcon/mvc/view/engine/volt/compiler.zep.c
@@ -170,7 +170,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, __construct)
 		view = &view_sub;
 		view = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1172, view);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1171, view);
 }
 
 /**
@@ -326,7 +326,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, attributeReader)
 		zephir_array_fetch_string(&variable, &left, SL("value"), PH_NOISY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 247);
 		if (ZEPHIR_IS_STRING(&variable, "loop")) {
 			zephir_memory_observe(&level);
-			zephir_read_property_cached(&level, this_ptr, _zephir_prop_0, 1173, PH_NOISY_CC);
+			zephir_read_property_cached(&level, this_ptr, _zephir_prop_0, 1172, PH_NOISY_CC);
 			ZEPHIR_CALL_METHOD(&_1$$4, this_ptr, "getuniqueprefix", NULL, 0);
 			zephir_check_call_status();
 			ZEPHIR_INIT_VAR(&_2$$4);
@@ -334,10 +334,10 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, attributeReader)
 			zephir_concat_self(&exprCode, &_2$$4);
 			zephir_update_property_array(this_ptr, SL("loopPointers"), &level, &level);
 		} else {
-			zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_1, 1174, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_1, 1173, PH_NOISY_CC | PH_READONLY);
 			_4$$5 = Z_TYPE_P(&_3$$5) != IS_NULL;
 			if (_4$$5) {
-				zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 1174, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_1, 1173, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&_6$$5, &_5$$5, "has", NULL, 0, &variable);
 				zephir_check_call_status();
 				_4$$5 = zephir_is_true(&_6$$5);
@@ -508,31 +508,31 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compile)
 	} else {
 		}
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1175, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1175, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, &__$false);
 	}
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1176, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1175, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1176, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1175, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1177, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1176, &__$null);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1178, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1177, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1173, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1172, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1179, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1178, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, 0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1180, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1179, &_0);
 	ZEPHIR_INIT_VAR(&compilation);
 	ZVAL_NULL(&compilation);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_7, 1181, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_7, 1180, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	zephir_memory_observe(&compileAlways);
 	if (!(zephir_array_isset_string_fetch(&compileAlways, &options, SL("always"), 0))) {
@@ -751,7 +751,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compile)
 			}
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1182, &compiledTemplatePath);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1181, &compiledTemplatePath);
 	RETURN_CCTOR(&compilation);
 }
 
@@ -803,8 +803,8 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileAutoEscape)
 		return;
 	}
 	zephir_memory_observe(&oldAutoescape);
-	zephir_read_property_cached(&oldAutoescape, this_ptr, _zephir_prop_0, 1183, PH_NOISY_CC);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1183, &autoescape);
+	zephir_read_property_cached(&oldAutoescape, this_ptr, _zephir_prop_0, 1182, PH_NOISY_CC);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1182, &autoescape);
 	zephir_array_fetch_string(&_1, &statement, SL("block_statements"), PH_NOISY | PH_READONLY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 544);
 	if (extendsMode) {
 		ZVAL_BOOL(&_2, 1);
@@ -813,7 +813,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileAutoEscape)
 	}
 	ZEPHIR_CALL_METHOD(&compilation, this_ptr, "statementlist", NULL, 0, &_1, &_2);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1183, &oldAutoescape);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1182, &oldAutoescape);
 	RETURN_CCTOR(&compilation);
 }
 
@@ -1005,7 +1005,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileEcho)
 			}
 		}
 	}
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 1183, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 1182, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_6)) {
 		ZEPHIR_CONCAT_SVS(return_value, "<?= $this->escaper->html(", &exprCode, ") ?>");
 		RETURN_MM();
@@ -1149,7 +1149,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileFile)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1184, &path_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1183, &path_zv);
 	if (extendsMode) {
 		ZVAL_BOOL(&_4, 1);
 	} else {
@@ -1277,7 +1277,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileForeach)
 	ZEPHIR_CALL_METHOD(&prefix, this_ptr, "getuniqueprefix", NULL, 0);
 	zephir_check_call_status();
 	zephir_memory_observe(&level);
-	zephir_read_property_cached(&level, this_ptr, _zephir_prop_0, 1173, PH_NOISY_CC);
+	zephir_read_property_cached(&level, this_ptr, _zephir_prop_0, 1172, PH_NOISY_CC);
 	ZEPHIR_INIT_VAR(&prefixLevel);
 	ZEPHIR_CONCAT_VV(&prefixLevel, &prefix, &level);
 	zephir_memory_observe(&expr);
@@ -1350,7 +1350,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileForeach)
 	ZEPHIR_CALL_METHOD(&code, this_ptr, "statementlist", NULL, 0, &blockStatements, &_6);
 	zephir_check_call_status();
 	zephir_memory_observe(&loopContext);
-	zephir_read_property_cached(&loopContext, this_ptr, _zephir_prop_1, 1185, PH_NOISY_CC);
+	zephir_read_property_cached(&loopContext, this_ptr, _zephir_prop_1, 1184, PH_NOISY_CC);
 	if (zephir_array_isset_value(&loopContext, &level)) {
 		ZEPHIR_INIT_VAR(&_7$$11);
 		ZEPHIR_CONCAT_SVSVS(&_7$$11, "<?php $", &prefixLevel, "iterator = ", &exprCode, "; ");
@@ -1481,13 +1481,13 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileForElse)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&level);
-	zephir_read_property_cached(&level, this_ptr, _zephir_prop_0, 1173, PH_NOISY_CC);
+	zephir_read_property_cached(&level, this_ptr, _zephir_prop_0, 1172, PH_NOISY_CC);
 	zephir_memory_observe(&prefix);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1186, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1185, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&prefix, &_0, &level, 0))) {
 		RETURN_MM_STRING("");
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1185, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_2, 1184, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value(&_1, &level)) {
 		ZEPHIR_CONCAT_SVSVS(return_value, "<?php $", &prefix, "incr++; } if (!$", &prefix, "iterated) { ?>");
 		RETURN_MM();
@@ -1741,7 +1741,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileMacro)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1187, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1186, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(zephir_array_isset_value(&_1, &name))) {
 		ZEPHIR_INIT_VAR(&_2$$4);
 		object_init_ex(&_2$$4, phalcon_mvc_view_engine_volt_exceptions_macroalreadydefined_ce);
@@ -2194,7 +2194,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileString)
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_INIT_NVAR(&_0);
 	ZVAL_STRING(&_0, "eval code");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1184, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1183, &_0);
 	if (extendsMode) {
 		ZVAL_BOOL(&_1, 1);
 	} else {
@@ -2373,7 +2373,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, expression)
 	ZEPHIR_INIT_VAR(&exprCode);
 	ZVAL_NULL(&exprCode);
 	RETURN_ON_FAILURE(zephir_property_incr(this_ptr, SL("exprLevel")));
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1188, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1187, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extensions, &_0);
 	while (1) {
 		if (Z_TYPE_P(&extensions) == IS_ARRAY) {
@@ -2886,7 +2886,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, fireExtensionEvent)
 	} else {
 		zephir_get_arrval(&arguments, arguments_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1188, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1187, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extensions, &_0);
 	zephir_is_iterable(&extensions, 0, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 1761);
 	if (Z_TYPE_P(&extensions) == IS_ARRAY) {
@@ -3088,7 +3088,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, functionCall)
 	if (ZEPHIR_IS_LONG(&nameType, 265)) {
 		zephir_memory_observe(&name);
 		zephir_array_fetch_string(&name, &nameExpr, SL("value"), PH_NOISY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 1798);
-		zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_0, 1188, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_0, 1187, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&extensions, &_1$$5);
 		if (Z_TYPE_P(&extensions) == IS_ARRAY) {
 			ZEPHIR_INIT_VAR(&_2$$6);
@@ -3104,7 +3104,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, functionCall)
 				RETURN_CCTOR(&code);
 			}
 		}
-		zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_1, 1189, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_1, 1188, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&functions, &_1$$5);
 		if (Z_TYPE_P(&functions) == IS_ARRAY) {
 			zephir_memory_observe(&definition);
@@ -3152,14 +3152,14 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, functionCall)
 			RETURN_MM();
 		}
 		if (ZEPHIR_IS_STRING(&name, "super")) {
-			zephir_read_property_cached(&_12$$15, this_ptr, _zephir_prop_2, 1176, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_12$$15, this_ptr, _zephir_prop_2, 1175, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CPY_WRT(&extendedBlocks, &_12$$15);
 			if (Z_TYPE_P(&extendedBlocks) == IS_ARRAY) {
-				zephir_read_property_cached(&_13$$16, this_ptr, _zephir_prop_3, 1190, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_13$$16, this_ptr, _zephir_prop_3, 1189, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CPY_WRT(&currentBlock, &_13$$16);
 				zephir_memory_observe(&block);
 				if (zephir_array_isset_fetch(&block, &extendedBlocks, &currentBlock, 0)) {
-					zephir_read_property_cached(&_14$$17, this_ptr, _zephir_prop_4, 1180, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_14$$17, this_ptr, _zephir_prop_4, 1179, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CPY_WRT(&exprLevel, &_14$$17);
 					if (Z_TYPE_P(&block) == IS_ARRAY) {
 						ZEPHIR_CALL_METHOD(&code, this_ptr, "statementlistorextends", NULL, 0, &block);
@@ -3223,10 +3223,10 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, functionCall)
 			ZEPHIR_CONCAT_SVSVS(return_value, "\\Phalcon\\Tag::", &method, "(", &arguments, ")");
 			RETURN_MM();
 		}
-		zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_5, 1174, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$5, this_ptr, _zephir_prop_5, 1173, PH_NOISY_CC | PH_READONLY);
 		_17$$5 = Z_TYPE_P(&_1$$5) != IS_NULL;
 		if (_17$$5) {
-			zephir_read_property_cached(&_18$$5, this_ptr, _zephir_prop_5, 1174, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_18$$5, this_ptr, _zephir_prop_5, 1173, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_20$$5);
 			ZVAL_STRING(&_20$$5, "tag");
 			ZEPHIR_CALL_METHOD(&_19$$5, &_18$$5, "has", NULL, 0, &_20$$5);
@@ -3234,7 +3234,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, functionCall)
 			_17$$5 = ZEPHIR_IS_TRUE_IDENTICAL(&_19$$5);
 		}
 		if (_17$$5) {
-			zephir_read_property_cached(&_21$$28, this_ptr, _zephir_prop_5, 1174, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_21$$28, this_ptr, _zephir_prop_5, 1173, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_22$$28);
 			ZVAL_STRING(&_22$$28, "tag");
 			ZEPHIR_CALL_METHOD(&tagService, &_21$$28, "get", NULL, 0, &_22$$28);
@@ -3385,7 +3385,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, getOption)
 	zephir_memory_observe(&option_zv);
 	ZVAL_STR_COPY(&option_zv, option);
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1181, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1180, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &option_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -3449,31 +3449,31 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, getUniquePrefix)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1191, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1190, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_is_true(&_0))) {
 		ZEPHIR_INIT_VAR(&_1$$3);
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 1184, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_1, 1183, PH_NOISY_CC | PH_READONLY);
 		zephir_unique_path_key(&_1$$3, &_2$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1191, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1190, &_1$$3);
 	}
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1191, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1190, PH_NOISY_CC);
 	if (Z_TYPE_P(&_3) == IS_OBJECT) {
 		zephir_memory_observe(&_4$$4);
-		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 1191, PH_NOISY_CC);
+		zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 1190, PH_NOISY_CC);
 		if (zephir_is_instance_of(&_4$$4, SL("Closure"))) {
 			ZEPHIR_INIT_VAR(&_5$$5);
-			zephir_read_property_cached(&_6$$5, this_ptr, _zephir_prop_0, 1191, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_6$$5, this_ptr, _zephir_prop_0, 1190, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_INIT_VAR(&_7$$5);
 			zephir_create_array(&_7$$5, 1, 0);
 			zephir_array_fast_append(&_7$$5, this_ptr);
 			ZEPHIR_CALL_USER_FUNC_ARRAY(&_5$$5, &_6$$5, &_7$$5);
 			zephir_check_call_status();
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1191, &_5$$5);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1190, &_5$$5);
 		}
 	}
 	zephir_memory_observe(&_8);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 1191, PH_NOISY_CC);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 1190, PH_NOISY_CC);
 	if (UNEXPECTED(Z_TYPE_P(&_8) != IS_STRING)) {
 		ZEPHIR_INIT_VAR(&_9$$6);
 		object_init_ex(&_9$$6, phalcon_mvc_view_engine_volt_exceptions_invalidcompilationprefix_ce);
@@ -3644,7 +3644,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1173, container);
 }
 
 /**
@@ -3693,7 +3693,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, setOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1181, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1180, &options);
 	RETURN_THIS();
 }
 
@@ -3716,7 +3716,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, setUniquePrefix)
 		Z_PARAM_STR(prefix)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&prefix_zv, prefix);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1191, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1190, &prefix_zv);
 	RETURN_THISW();
 }
 
@@ -3800,9 +3800,9 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSource)
 		extendsMode = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1184, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1183, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&currentPath, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1181, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1180, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	if (Z_TYPE_P(&options) == IS_ARRAY) {
 		zephir_memory_observe(&autoescape);
@@ -3820,7 +3820,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSource)
 				ZEPHIR_MM_RESTORE();
 				return;
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1183, &autoescape);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1182, &autoescape);
 		}
 	}
 	ZEPHIR_INIT_VAR(&intermediate);
@@ -3842,7 +3842,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSource)
 	}
 	ZEPHIR_CALL_METHOD(&compilation, this_ptr, "statementlist", NULL, 0, &intermediate, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_3, 1175, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_3, 1174, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extended, &_5);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&extended)) {
 		ZEPHIR_INIT_VAR(&finalCompilation);
@@ -3851,9 +3851,9 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSource)
 		} else {
 			ZVAL_NULL(&finalCompilation);
 		}
-		zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_4, 1177, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_4, 1176, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&blocks, &_6$$7);
-		zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_5, 1176, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$7, this_ptr, _zephir_prop_5, 1175, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&extendedBlocks, &_6$$7);
 		if (Z_TYPE_P(&blocks) != IS_ARRAY) {
 			ZEPHIR_INIT_NVAR(&blocks);
@@ -3875,7 +3875,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSource)
 					if (zephir_array_key_exists(&blocks, &name)) {
 						ZEPHIR_OBS_NVAR(&localBlock);
 						zephir_array_fetch(&localBlock, &blocks, &name, PH_NOISY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 2336);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1190, &name);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1189, &name);
 						if (Z_TYPE_P(&localBlock) == IS_NULL) {
 							ZEPHIR_INIT_NVAR(&localBlock);
 							array_init(&localBlock);
@@ -3927,7 +3927,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, compileSource)
 						if (zephir_array_key_exists(&blocks, &name)) {
 							ZEPHIR_OBS_NVAR(&localBlock);
 							zephir_array_fetch(&localBlock, &blocks, &name, PH_NOISY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 2336);
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1190, &name);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1189, &name);
 							if (Z_TYPE_P(&localBlock) == IS_NULL) {
 								ZEPHIR_INIT_NVAR(&localBlock);
 								array_init(&localBlock);
@@ -4018,13 +4018,13 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, getFinalPath)
 		_1 = zephir_start_with_str(&path_zv, SL("../"));
 	}
 	if (_1) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 1184, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 1183, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(&_3$$4, "dirname", NULL, 0, &_2$$4);
 		zephir_check_call_status();
 		ZEPHIR_CONCAT_VSV(return_value, &_3$$4, "/", &path_zv);
 		RETURN_MM();
 	}
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1172, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1171, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&view, &_4);
 	if (Z_TYPE_P(&view) == IS_OBJECT) {
 		ZEPHIR_CALL_METHOD(&viewsDirs, &view, "getviewsdir", NULL, 0);
@@ -4230,7 +4230,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, resolveFilter)
 	} else {
 		ZEPHIR_CPY_WRT(&arguments, &left_zv);
 	}
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 1188, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_0, 1187, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extensions, &_7);
 	if (Z_TYPE_P(&extensions) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&_8$$9);
@@ -4246,7 +4246,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, resolveFilter)
 			RETURN_CCTOR(&code);
 		}
 	}
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_1, 1192, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_1, 1191, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&filters, &_7);
 	zephir_memory_observe(&definition);
 	if (zephir_array_isset_fetch(&definition, &filters, &name, 0)) {
@@ -4350,10 +4350,10 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, resolveFilter)
 			RETURN_MM();
 		}
 		if (ZEPHIR_IS_STRING(&name, "lower") || ZEPHIR_IS_STRING(&name, "lowercase")) {
-			zephir_read_property_cached(&_23$$30, this_ptr, _zephir_prop_2, 1174, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_23$$30, this_ptr, _zephir_prop_2, 1173, PH_NOISY_CC | PH_READONLY);
 			_24$$30 = Z_TYPE_P(&_23$$30) != IS_NULL;
 			if (_24$$30) {
-				zephir_read_property_cached(&_25$$30, this_ptr, _zephir_prop_2, 1174, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_25$$30, this_ptr, _zephir_prop_2, 1173, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_27$$30);
 				ZVAL_STRING(&_27$$30, "helper");
 				ZEPHIR_CALL_METHOD(&_26$$30, &_25$$30, "has", NULL, 0, &_27$$30);
@@ -4401,10 +4401,10 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, resolveFilter)
 			RETURN_MM();
 		}
 		if (ZEPHIR_IS_STRING(&name, "upper") || ZEPHIR_IS_STRING(&name, "uppercase")) {
-			zephir_read_property_cached(&_28$$41, this_ptr, _zephir_prop_2, 1174, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_28$$41, this_ptr, _zephir_prop_2, 1173, PH_NOISY_CC | PH_READONLY);
 			_29$$41 = Z_TYPE_P(&_28$$41) != IS_NULL;
 			if (_29$$41) {
-				zephir_read_property_cached(&_30$$41, this_ptr, _zephir_prop_2, 1174, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_30$$41, this_ptr, _zephir_prop_2, 1173, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_INIT_VAR(&_32$$41);
 				ZVAL_STRING(&_32$$41, "helper");
 				ZEPHIR_CALL_METHOD(&_31$$41, &_30$$41, "has", NULL, 0, &_32$$41);
@@ -4596,7 +4596,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 	if (!(zephir_fast_count_int(&statements))) {
 		RETURN_MM_STRING("");
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1175, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1174, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extended, &_0);
 	_1 = zephir_is_true(&extended);
 	if (!(_1)) {
@@ -4610,7 +4610,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 	RETURN_ON_FAILURE(zephir_property_incr(this_ptr, SL("level")));
 	ZEPHIR_INIT_VAR(&compilation);
 	ZVAL_NULL(&compilation);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1188, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1187, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&extensions, &_0);
 	zephir_is_iterable(&statements, 0, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 2903);
 	if (Z_TYPE_P(&statements) == IS_ARRAY) {
@@ -4734,7 +4734,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 					zephir_array_fetch_string(&blockName, &statement, SL("name"), PH_NOISY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 2750);
 					ZEPHIR_OBS_NVAR(&blockStatements);
 					zephir_array_isset_string_fetch(&blockStatements, &statement, SL("block_statements"), 0);
-					zephir_read_property_cached(&_34$$20, this_ptr, _zephir_prop_2, 1177, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_34$$20, this_ptr, _zephir_prop_2, 1176, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CPY_WRT(&blocks, &_34$$20);
 					if (zephir_is_true(&blockMode)) {
 						if (Z_TYPE_P(&blocks) != IS_ARRAY) {
@@ -4747,7 +4747,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 							ZVAL_NULL(&compilation);
 						}
 						zephir_array_update_zval(&blocks, &blockName, &blockStatements, PH_COPY | PH_SEPARATE);
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1177, &blocks);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1176, &blocks);
 					} else {
 						if (Z_TYPE_P(&blockStatements) == IS_ARRAY) {
 							if (extendsMode) {
@@ -4783,11 +4783,11 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 						zephir_check_call_status();
 					}
 					if (1) {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1175, &__$true);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, &__$true);
 					} else {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1175, &__$false);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, &__$false);
 					}
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1176, &tempCompilation);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1175, &tempCompilation);
 					ZEPHIR_CPY_WRT(&blockMode, &extended);
 					break;
 				}
@@ -5010,7 +5010,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 						zephir_array_fetch_string(&blockName, &statement, SL("name"), PH_NOISY, "phalcon/Mvc/View/Engine/Volt/Compiler.zep", 2750);
 						ZEPHIR_OBS_NVAR(&blockStatements);
 						zephir_array_isset_string_fetch(&blockStatements, &statement, SL("block_statements"), 0);
-						zephir_read_property_cached(&_89$$54, this_ptr, _zephir_prop_2, 1177, PH_NOISY_CC | PH_READONLY);
+						zephir_read_property_cached(&_89$$54, this_ptr, _zephir_prop_2, 1176, PH_NOISY_CC | PH_READONLY);
 						ZEPHIR_CPY_WRT(&blocks, &_89$$54);
 						if (zephir_is_true(&blockMode)) {
 							if (Z_TYPE_P(&blocks) != IS_ARRAY) {
@@ -5023,7 +5023,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 								ZVAL_NULL(&compilation);
 							}
 							zephir_array_update_zval(&blocks, &blockName, &blockStatements, PH_COPY | PH_SEPARATE);
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1177, &blocks);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1176, &blocks);
 						} else {
 							if (Z_TYPE_P(&blockStatements) == IS_ARRAY) {
 								if (extendsMode) {
@@ -5059,11 +5059,11 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 							zephir_check_call_status();
 						}
 						if (1) {
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1175, &__$true);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, &__$true);
 						} else {
-							zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1175, &__$false);
+							zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1174, &__$false);
 						}
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1176, &tempCompilation);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1175, &tempCompilation);
 						ZEPHIR_CPY_WRT(&blockMode, &extended);
 						break;
 					}
@@ -5155,7 +5155,7 @@ PHP_METHOD(Phalcon_Mvc_View_Engine_Volt_Compiler, statementList)
 	}
 	ZEPHIR_INIT_NVAR(&statement);
 	if (ZEPHIR_IS_TRUE_IDENTICAL(&blockMode)) {
-		zephir_read_property_cached(&level, this_ptr, _zephir_prop_4, 1179, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&level, this_ptr, _zephir_prop_4, 1178, PH_NOISY_CC | PH_READONLY);
 		if (ZEPHIR_IS_LONG(&level, 1)) {
 			if (Z_TYPE_P(&compilation) != IS_NULL) {
 				zephir_update_property_array_append(this_ptr, SL("blocks"), &compilation);

--- a/ext/phalcon/mvc/view/simple.zep.c
+++ b/ext/phalcon/mvc/view/simple.zep.c
@@ -146,13 +146,13 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1193, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1192, &options);
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1194, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1193, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	array_init(&_1);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1195, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1194, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -188,7 +188,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, __get)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1195, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &key_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -319,7 +319,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, partial)
 	ZEPHIR_CALL_FUNCTION(NULL, "ob_start", NULL, 0);
 	zephir_check_call_status();
 	if (Z_TYPE_P(params) == IS_ARRAY) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1195, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&viewParams, &_0$$3);
 		ZEPHIR_INIT_VAR(&mergedParams);
 		zephir_fast_array_merge(&mergedParams, &viewParams, params);
@@ -332,11 +332,11 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, partial)
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "internalrender", NULL, 0, &partialPath_zv, &mergedParams);
 	zephir_check_call_status();
 	if (Z_TYPE_P(params) == IS_ARRAY) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1195, &viewParams);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1194, &viewParams);
 	}
 	ZEPHIR_CALL_FUNCTION(NULL, "ob_end_clean", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1196, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1195, PH_NOISY_CC | PH_READONLY);
 	zend_print_zval(&_2, 0);
 	ZEPHIR_MM_RESTORE();
 }
@@ -376,7 +376,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, registerEngines)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &engines_param);
 	zephir_get_arrval(&engines, engines_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1194, &engines);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1193, &engines);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -428,7 +428,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, render)
 	
 	ZEPHIR_CALL_FUNCTION(NULL, "ob_start", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1195, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&viewParams, &_1);
 	ZEPHIR_INIT_VAR(&mergedParams);
 	zephir_fast_array_merge(&mergedParams, &viewParams, &params);
@@ -459,7 +459,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, setEventsManager)
 		Z_PARAM_OBJECT_OF_CLASS(eventsManager, phalcon_events_managerinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &eventsManager);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1197, eventsManager);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1196, eventsManager);
 }
 
 /**
@@ -539,11 +539,11 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, setVars)
 		}
 	if (merge) {
 		ZEPHIR_INIT_VAR(&_0$$3);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1195, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC | PH_READONLY);
 		zephir_fast_array_merge(&_0$$3, &_1$$3, &params);
 		ZEPHIR_CPY_WRT(&params, &_0$$3);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1195, &params);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1194, &params);
 	RETURN_THIS();
 }
 
@@ -576,7 +576,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, setViewsDir)
 	ZVAL_STR_COPY(&viewsDir_zv, viewsDir);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "todirseparator", NULL, 0, &viewsDir_zv);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1198, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1197, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -632,14 +632,14 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, loadTemplateEngines)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1199, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1198, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&engines, &_0);
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&engines)) {
 		zephir_memory_observe(&di);
-		zephir_read_property_cached(&di, this_ptr, _zephir_prop_1, 1200, PH_NOISY_CC);
+		zephir_read_property_cached(&di, this_ptr, _zephir_prop_1, 1199, PH_NOISY_CC);
 		ZEPHIR_INIT_NVAR(&engines);
 		array_init(&engines);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_2, 1194, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_2, 1193, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&registeredEngines, &_1$$3);
 		if (ZEPHIR_IS_EMPTY(&registeredEngines)) {
 			ZEPHIR_INIT_VAR(&_2$$4);
@@ -749,9 +749,9 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, loadTemplateEngines)
 			ZEPHIR_INIT_NVAR(&engineService);
 			ZEPHIR_INIT_NVAR(&extension);
 		}
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1199, &engines);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1198, &engines);
 	} else {
-		zephir_read_property_cached(&_20$$19, this_ptr, _zephir_prop_0, 1199, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_20$$19, this_ptr, _zephir_prop_0, 1198, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&engines, &_20$$19);
 	}
 	RETURN_CCTOR(&engines);
@@ -834,10 +834,10 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, internalRender)
 	params = ZEND_CALL_ARG(execute_data, 2);
 	zephir_memory_observe(&path_zv);
 	ZVAL_STR_COPY(&path_zv, path);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1197, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1196, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&eventsManager, &_0);
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1201, &path_zv);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1200, &path_zv);
 	}
 	if (Z_TYPE_P(&eventsManager) == IS_OBJECT) {
 		ZEPHIR_INIT_VAR(&_2$$4);
@@ -850,7 +850,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, internalRender)
 	}
 	notExists = 1;
 	mustClean = 1;
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1198, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_2, 1197, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_3);
 	ZEPHIR_CONCAT_VV(&_3, &_0, &path_zv);
 	zephir_get_strval(&viewsDirPath, &_3);
@@ -1509,7 +1509,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, getParamsToView)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1195, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -1534,7 +1534,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, getRegisteredEngines)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1193, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -1567,7 +1567,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, getVar)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1195, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1194, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &key_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -1599,7 +1599,7 @@ PHP_METHOD(Phalcon_Mvc_View_Simple, setContent)
 		Z_PARAM_STR(content)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&content_zv, content);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1196, &content_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1195, &content_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/mvc/view/traits/viewparamstrait.zep.c
+++ b/ext/phalcon/mvc/view/traits/viewparamstrait.zep.c
@@ -87,7 +87,7 @@ PHP_METHOD(Phalcon_Mvc_View_Traits_ViewParamsTrait, getParamsToView)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1202, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1201, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -112,7 +112,7 @@ PHP_METHOD(Phalcon_Mvc_View_Traits_ViewParamsTrait, getRegisteredEngines)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1203, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1202, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -145,7 +145,7 @@ PHP_METHOD(Phalcon_Mvc_View_Traits_ViewParamsTrait, getVar)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1202, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1201, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &key_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -177,7 +177,7 @@ PHP_METHOD(Phalcon_Mvc_View_Traits_ViewParamsTrait, setContent)
 		Z_PARAM_STR(content)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&content_zv, content);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1204, &content_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1203, &content_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/paginator/adapter/model.zep.c
+++ b/ext/phalcon/paginator/adapter/model.zep.c
@@ -184,12 +184,12 @@ PHP_METHOD(Phalcon_Paginator_Adapter_Model, paginate)
 	ZEPHIR_INIT_VAR(&pageItems);
 	array_init(&pageItems);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1205, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1204, PH_NOISY_CC);
 	limit = zephir_get_intval(&_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1206, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1205, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&config, &_1);
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1207, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1206, PH_NOISY_CC);
 	pageNumber = zephir_get_intval(&_2);
 	zephir_array_fetch_string(&_3, &config, SL("model"), PH_NOISY | PH_READONLY, "phalcon/Paginator/Adapter/Model.zep", 119);
 	ZEPHIR_CPY_WRT(&modelClass, &_3);
@@ -258,7 +258,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_Model, paginate)
 	ZVAL_LONG(&_6, rowcount);
 	zephir_array_update_string(&_13, SL("total_items"), &_6, PH_COPY | PH_SEPARATE);
 	zephir_memory_observe(&_14);
-	zephir_read_property_cached(&_14, this_ptr, _zephir_prop_0, 1205, PH_NOISY_CC);
+	zephir_read_property_cached(&_14, this_ptr, _zephir_prop_0, 1204, PH_NOISY_CC);
 	zephir_array_update_string(&_13, SL("limit"), &_14, PH_COPY | PH_SEPARATE);
 	add_assoc_long_ex(&_13, SL("first"), 1);
 	ZEPHIR_INIT_NVAR(&_6);

--- a/ext/phalcon/paginator/adapter/nativearray.zep.c
+++ b/ext/phalcon/paginator/adapter/nativearray.zep.c
@@ -97,7 +97,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_NativeArray, paginate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1208, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1207, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&config, &_0);
 	zephir_memory_observe(&items);
 	zephir_array_fetch_string(&items, &config, SL("data"), PH_NOISY, "phalcon/Paginator/Adapter/NativeArray.zep", 52);
@@ -111,10 +111,10 @@ PHP_METHOD(Phalcon_Paginator_Adapter_NativeArray, paginate)
 		return;
 	}
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1209, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1208, PH_NOISY_CC);
 	show = zephir_get_intval(&_2);
 	zephir_memory_observe(&_3);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1210, PH_NOISY_CC);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1209, PH_NOISY_CC);
 	pageNumber = zephir_get_intval(&_3);
 	if (pageNumber <= 0) {
 		pageNumber = 1;
@@ -130,7 +130,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_NativeArray, paginate)
 	}
 	ZVAL_LONG(&_0, (show * ((pageNumber - 1))));
 	ZVAL_LONG(&_5, show);
-	ZEPHIR_CALL_FUNCTION(&_6, "array_slice", NULL, 270, &items, &_0, &_5);
+	ZEPHIR_CALL_FUNCTION(&_6, "array_slice", NULL, 271, &items, &_0, &_5);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&items, &_6);
 	if (pageNumber < totalPages) {
@@ -150,7 +150,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_NativeArray, paginate)
 	ZVAL_LONG(&_8, number);
 	zephir_array_update_string(&_7, SL("total_items"), &_8, PH_COPY | PH_SEPARATE);
 	zephir_memory_observe(&_9);
-	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_1, 1209, PH_NOISY_CC);
+	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_1, 1208, PH_NOISY_CC);
 	zephir_array_update_string(&_7, SL("limit"), &_9, PH_COPY | PH_SEPARATE);
 	add_assoc_long_ex(&_7, SL("first"), 1);
 	ZEPHIR_INIT_NVAR(&_8);

--- a/ext/phalcon/paginator/adapter/querybuilder.zep.c
+++ b/ext/phalcon/paginator/adapter/querybuilder.zep.c
@@ -132,7 +132,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, __construct)
 	}
 	zephir_memory_observe(&columns);
 	if (zephir_array_isset_string_fetch(&columns, &config, SL("columns"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1211, &columns);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1210, &columns);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_paginator_adapter_querybuilder_ce, getThis(), "__construct", NULL, 0, &config);
 	zephir_check_call_status();
@@ -261,8 +261,8 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, paginate)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&originalBuilder);
-	zephir_read_property_cached(&originalBuilder, this_ptr, _zephir_prop_0, 1212, PH_NOISY_CC);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1211, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&originalBuilder, this_ptr, _zephir_prop_0, 1211, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1210, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&columns, &_0);
 	hasMultipleGroups = 0;
 	ZEPHIR_INIT_VAR(&builder);
@@ -274,9 +274,9 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, paginate)
 		RETURN_MM();
 	}
 	zephir_memory_observe(&limit);
-	zephir_read_property_cached(&limit, this_ptr, _zephir_prop_2, 1213, PH_NOISY_CC);
+	zephir_read_property_cached(&limit, this_ptr, _zephir_prop_2, 1212, PH_NOISY_CC);
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 1214, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_3, 1213, PH_NOISY_CC);
 	numberPage = zephir_get_intval(&_1);
 	if (!(numberPage)) {
 		numberPage = 1;
@@ -508,7 +508,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, paginate)
 	zephir_array_update_string(&_43, SL("items"), &items, PH_COPY | PH_SEPARATE);
 	zephir_array_update_string(&_43, SL("total_items"), &rowcount, PH_COPY | PH_SEPARATE);
 	zephir_memory_observe(&_44);
-	zephir_read_property_cached(&_44, this_ptr, _zephir_prop_2, 1213, PH_NOISY_CC);
+	zephir_read_property_cached(&_44, this_ptr, _zephir_prop_2, 1212, PH_NOISY_CC);
 	zephir_array_update_string(&_43, SL("limit"), &_44, PH_COPY | PH_SEPARATE);
 	add_assoc_long_ex(&_43, SL("first"), 1);
 	ZEPHIR_INIT_VAR(&_45);
@@ -542,7 +542,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilder, setQueryBuilder)
 		Z_PARAM_OBJECT_OF_CLASS(builder, phalcon_mvc_model_query_builder_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &builder);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1212, builder);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1211, builder);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/paginator/adapter/querybuildercursor.zep.c
+++ b/ext/phalcon/paginator/adapter/querybuildercursor.zep.c
@@ -174,10 +174,10 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1215, &cursorColumn);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1214, &cursorColumn);
 	zephir_memory_observe(&cursor);
 	if (zephir_array_isset_string_fetch(&cursor, &config, SL("cursor"), 0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1216, &cursor);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1215, &cursor);
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_paginator_adapter_querybuildercursor_ce, getThis(), "__construct", NULL, 0, &config);
 	zephir_check_call_status();
@@ -225,12 +225,12 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, getCurrentPage)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1216, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1215, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		RETURN_MM_LONG(0);
 	}
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1216, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1215, PH_NOISY_CC);
 	RETURN_MM_LONG(zephir_get_intval(&_1));
 }
 
@@ -298,24 +298,24 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, paginate)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1217, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1216, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	if (zephir_clone(&_1, &_0) == FAILURE) {
 		RETURN_MM();
 	}
 	ZEPHIR_CPY_WRT(&builder, &_1);
 	zephir_memory_observe(&_2);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1218, PH_NOISY_CC);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1217, PH_NOISY_CC);
 	limit = zephir_get_intval(&_2);
 	zephir_memory_observe(&currentCursor);
-	zephir_read_property_cached(&currentCursor, this_ptr, _zephir_prop_2, 1216, PH_NOISY_CC);
+	zephir_read_property_cached(&currentCursor, this_ptr, _zephir_prop_2, 1215, PH_NOISY_CC);
 	if (Z_TYPE_P(&currentCursor) == IS_NULL) {
 		currentPage = 0;
 	} else {
 		currentPage = zephir_get_intval(&currentCursor);
 	}
 	if (Z_TYPE_P(&currentCursor) != IS_NULL) {
-		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_3, 1215, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$5, this_ptr, _zephir_prop_3, 1214, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_4$$5);
 		ZEPHIR_CONCAT_SVS(&_4$$5, "[", &_3$$5, "] > :cursor:");
 		ZEPHIR_INIT_VAR(&_5$$5);
@@ -341,7 +341,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, paginate)
 		zephir_memory_observe(&lastItem);
 		zephir_array_fetch_long(&lastItem, &items, (zephir_fast_count_int(&items) - 1), PH_NOISY, "phalcon/Paginator/Adapter/QueryBuilderCursor.zep", 220);
 		zephir_memory_observe(&_8$$6);
-		zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_3, 1215, PH_NOISY_CC);
+		zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_3, 1214, PH_NOISY_CC);
 		zephir_array_fetch(&_7$$6, &lastItem, &_8$$6, PH_NOISY | PH_READONLY, "phalcon/Paginator/Adapter/QueryBuilderCursor.zep", 226);
 		if (UNEXPECTED(!(zephir_is_numeric(&_7$$6)))) {
 			ZEPHIR_INIT_VAR(&_9$$7);
@@ -354,7 +354,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, paginate)
 		}
 		zephir_memory_observe(&_10$$6);
 		zephir_memory_observe(&_11$$6);
-		zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_3, 1215, PH_NOISY_CC);
+		zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_3, 1214, PH_NOISY_CC);
 		zephir_array_fetch(&_10$$6, &lastItem, &_11$$6, PH_NOISY, "phalcon/Paginator/Adapter/QueryBuilderCursor.zep", 230);
 		nextCursor = zephir_get_intval(&_10$$6);
 	} else {
@@ -365,7 +365,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, paginate)
 	zephir_array_update_string(&_12, SL("items"), &items, PH_COPY | PH_SEPARATE);
 	add_assoc_long_ex(&_12, SL("total_items"), 0);
 	zephir_memory_observe(&_13);
-	zephir_read_property_cached(&_13, this_ptr, _zephir_prop_1, 1218, PH_NOISY_CC);
+	zephir_read_property_cached(&_13, this_ptr, _zephir_prop_1, 1217, PH_NOISY_CC);
 	zephir_array_update_string(&_12, SL("limit"), &_13, PH_COPY | PH_SEPARATE);
 	add_assoc_long_ex(&_12, SL("first"), 1);
 	add_assoc_long_ex(&_12, SL("previous"), 0);
@@ -402,7 +402,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, setCursor)
 		Z_PARAM_ZVAL(cursor)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &cursor);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1216, cursor);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1215, cursor);
 	RETURN_THISW();
 }
 
@@ -424,7 +424,7 @@ PHP_METHOD(Phalcon_Paginator_Adapter_QueryBuilderCursor, setQueryBuilder)
 		Z_PARAM_OBJECT_OF_CLASS(builder, phalcon_mvc_model_query_builder_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &builder);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1217, builder);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1216, builder);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/paginator/exceptions/missingrequiredparameter.zep.c
+++ b/ext/phalcon/paginator/exceptions/missingrequiredparameter.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Phalcon_Paginator_Exceptions_MissingRequiredParameter, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&parameter_zv);
 	ZVAL_STR_COPY(&parameter_zv, parameter);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1219, &parameter_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1218, &parameter_zv);
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_SVS(&_0, "Parameter '", &parameter_zv, "' is required");
 	ZEPHIR_CALL_PARENT(NULL, phalcon_paginator_exceptions_missingrequiredparameter_ce, getThis(), "__construct", NULL, 0, &_0);

--- a/ext/phalcon/paginator/repository.zep.c
+++ b/ext/phalcon/paginator/repository.zep.c
@@ -323,7 +323,7 @@ PHP_METHOD(Phalcon_Paginator_Repository, setAliases)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &aliases_param);
 	zephir_get_arrval(&aliases, aliases_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1220, &aliases);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1219, &aliases);
 	RETURN_THIS();
 }
 
@@ -350,7 +350,7 @@ PHP_METHOD(Phalcon_Paginator_Repository, setProperties)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &properties_param);
 	zephir_get_arrval(&properties, properties_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1221, &properties);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1220, &properties);
 	RETURN_THIS();
 }
 
@@ -392,7 +392,7 @@ PHP_METHOD(Phalcon_Paginator_Repository, getProperty)
 		defaultValue = &__$null;
 	}
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1221, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1220, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &property_zv, 0))) {
 		ZEPHIR_CPY_WRT(&value, defaultValue);
 	}
@@ -425,7 +425,7 @@ PHP_METHOD(Phalcon_Paginator_Repository, getRealNameProperty)
 	zephir_memory_observe(&property_zv);
 	ZVAL_STR_COPY(&property_zv, property);
 	zephir_memory_observe(&name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1220, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1219, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&name, &_0, &property_zv, 0))) {
 		RETURN_MM_STR(zend_string_copy(property));
 	}

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalkconnection.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalkconnection.zep.c
@@ -148,19 +148,19 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, __construct)
 		persistent = 0;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1222, &host_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1221, &host_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, port);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1223, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1222, &_0);
 	if (persistent) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1224, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1223, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1224, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1223, &__$false);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_create_array(&_1, 1, 0);
 	zephir_array_update_string(&_1, SL("default"), &__$true, PH_COPY | PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1225, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1224, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -244,7 +244,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, connect)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1226, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1225, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&connection, &_0);
 	if (Z_TYPE_P(&connection) == IS_RESOURCE) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "disconnect", NULL, 0);
@@ -253,10 +253,10 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, connect)
 	ZVAL_LONG(&_0, 0);
 	ZEPHIR_CALL_FUNCTION(&errorLevel, "error_reporting", NULL, 0, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1224, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1223, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_2, 1222, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 1223, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_2, 1221, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_3, 1222, PH_NOISY_CC | PH_READONLY);
 		ZVAL_NULL(&_3$$4);
 		ZVAL_NULL(&_4$$4);
 		ZEPHIR_MAKE_REF(&_3$$4);
@@ -266,8 +266,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, connect)
 		ZEPHIR_UNREF(&_4$$4);
 		zephir_check_call_status();
 	} else {
-		zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_2, 1222, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_6$$5, this_ptr, _zephir_prop_3, 1223, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5$$5, this_ptr, _zephir_prop_2, 1221, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$5, this_ptr, _zephir_prop_3, 1222, PH_NOISY_CC | PH_READONLY);
 		ZVAL_NULL(&_7$$5);
 		ZVAL_NULL(&_8$$5);
 		ZEPHIR_MAKE_REF(&_7$$5);
@@ -287,7 +287,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, connect)
 	ZVAL_LONG(&_10, 0);
 	ZEPHIR_CALL_FUNCTION(NULL, "stream_set_timeout", NULL, 0, &connection, &_9, &_10);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1226, &connection);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1225, &connection);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "restoresession", NULL, 0);
 	zephir_check_call_status();
 	RETURN_CCTOR(&connection);
@@ -346,14 +346,14 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, disconnect)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1226, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1225, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&connection, &_0);
 	if (Z_TYPE_P(&connection) != IS_RESOURCE) {
 		RETURN_MM_BOOL(0);
 	}
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfclose", NULL, 0, &connection);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1226, &__$null);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1225, &__$null);
 	RETURN_MM_BOOL(1);
 }
 
@@ -397,7 +397,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, ignoreTube)
 	result = ZEPHIR_IS_STRING(&_2, "WATCHING");
 	if (result) {
 		zephir_unset_property_array(this_ptr, ZEND_STRL("watchedTubes"), &tube_zv);
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 1225, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 1224, PH_NOISY_CC | PH_READONLY);
 		zephir_array_unset(&_3$$3, &tube_zv, PH_SEPARATE);
 	}
 	RETURN_MM_BOOL(result);
@@ -507,7 +507,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, read)
 		length = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1226, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1225, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&connection, &_0);
 	if (Z_TYPE_P(&connection) != IS_RESOURCE) {
 		ZEPHIR_CALL_METHOD(&connection, this_ptr, "connect", NULL, 0);
@@ -811,7 +811,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, useTube)
 	zephir_array_fetch_long(&_2, &_1, 0, PH_NOISY | PH_READONLY, "phalcon/Queue/Adapter/Beanstalk/BeanstalkConnection.zep", 347);
 	result = ZEPHIR_IS_STRING(&_2, "USING");
 	if (result) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1227, &tube_zv);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1226, &tube_zv);
 	}
 	RETURN_MM_BOOL(result);
 }
@@ -884,7 +884,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, write)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&data_zv);
 	ZVAL_STR_COPY(&data_zv, data);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1226, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1225, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&connection, &_0);
 	if (Z_TYPE_P(&connection) != IS_RESOURCE) {
 		ZEPHIR_CALL_METHOD(&connection, this_ptr, "connect", NULL, 0);
@@ -1014,9 +1014,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, restoreSession)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1227, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1226, PH_NOISY_CC | PH_READONLY);
 	if (!ZEPHIR_IS_STRING(&_0, "default")) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1227, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1226, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_2$$3);
 		ZEPHIR_CONCAT_SV(&_2$$3, "use ", &_1$$3);
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "write", NULL, 0, &_2$$3);
@@ -1025,7 +1025,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, restoreSession)
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(&_3);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1225, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1224, PH_NOISY_CC | PH_READONLY);
 	zephir_array_keys(&_3, &_4);
 	zephir_is_iterable(&_3, 0, "phalcon/Queue/Adapter/Beanstalk/BeanstalkConnection.zep", 452);
 	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_3), _5)
@@ -1042,7 +1042,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnection, restoreSession)
 		}
 	} ZEND_HASH_FOREACH_END();
 	ZEPHIR_INIT_NVAR(&tube);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_1, 1225, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_1, 1224, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_value_string(&_7, SL("default")))) {
 		ZEPHIR_INIT_VAR(&_8$$6);
 		ZVAL_STRING(&_8$$6, "ignore default");

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalkconnectionfactory.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalkconnectionfactory.zep.c
@@ -86,7 +86,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnectionFactory, __constru
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1228, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1227, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -114,7 +114,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConnectionFactory, createCon
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1227, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	if (zephir_array_isset_value_string(&options, SL("host"))) {
 		zephir_memory_observe(&host);

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalkconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalkconsumer.zep.c
@@ -89,8 +89,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConsumer, __construct)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &connection, &queue);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1229, connection);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1230, queue);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1228, connection);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1229, queue);
 	ZEPHIR_CALL_METHOD(&tube, queue, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, connection, "watchtube", NULL, 0, &tube);
@@ -125,7 +125,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConsumer, acknowledge)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &message);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1229, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "resolvejobid", NULL, 0, message);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_0, "deletejob", NULL, 0, &_1);
@@ -165,7 +165,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConsumer, receive)
 	} else {
 		ZVAL_LONG(&seconds, (int) (zephir_safe_div_long_long(((timeout + 999)), 1000)));
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1229, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "reserve", NULL, 0, &seconds);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "buildmessage", NULL, 0, &_1);
@@ -190,7 +190,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConsumer, receiveNoWait)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1229, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_2, 0);
 	ZEPHIR_CALL_METHOD(&_1, &_0, "reserve", NULL, 0, &_2);
 	zephir_check_call_status();
@@ -234,13 +234,13 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConsumer, reject)
 	ZEPHIR_CALL_METHOD(&id, this_ptr, "resolvejobid", NULL, 0, message);
 	zephir_check_call_status();
 	if (requeue) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1229, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_1$$3, 100);
 		ZVAL_LONG(&_2$$3, 0);
 		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "releasejob", NULL, 0, &id, &_1$$3, &_2$$3);
 		zephir_check_call_status();
 	} else {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1229, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_4$$4, 100);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$4, "buryjob", NULL, 0, &id, &_4$$4);
 		zephir_check_call_status();
@@ -272,7 +272,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkConsumer, touch)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &message);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1229, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1228, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "resolvejobid", NULL, 0, message);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "touchjob", NULL, 0, &_1);

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalkcontext.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalkcontext.zep.c
@@ -145,21 +145,21 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkContext, __construct)
 		pollInterval = 200;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1231, &host_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1230, &host_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, port);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1232, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1231, &_0);
 	if (persistent) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1233, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1232, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1233, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1232, &__$false);
 	}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, ttr);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1234, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1233, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1235, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1234, &_0);
 }
 
 PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkContext, close)
@@ -179,12 +179,12 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkContext, close)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1236, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1235, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) != IS_NULL) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1236, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1235, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "disconnect", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1236, &__$null);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1235, &__$null);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -298,7 +298,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkContext, createSubscriptionC
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, phalcon_queue_adapter_beanstalk_beanstalksubscriptionconsumer_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1235, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1234, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0, this_ptr, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -477,11 +477,11 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkContext, getConnection)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1236, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1235, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_0) == IS_NULL) {
 		ZEPHIR_CALL_METHOD(&_1$$3, this_ptr, "newconnection", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1236, &_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1235, &_1$$3);
 	}
 	RETURN_MM_MEMBER(getThis(), "connection");
 }
@@ -517,9 +517,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkContext, newConnection)
 
 	ZEPHIR_INIT_VAR(&connection);
 	object_init_ex(&connection, phalcon_queue_adapter_beanstalk_beanstalkconnection_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1231, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1232, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1233, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1230, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1231, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1232, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &connection, "__construct", NULL, 0, &_0, &_1, &_2);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &connection, "connect", NULL, 0);

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalkmessage.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalkmessage.zep.c
@@ -72,6 +72,6 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkMessage, setJobId)
 		Z_PARAM_STR(jobId)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&jobId_zv, jobId);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1237, &jobId_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1236, &jobId_zv);
 }
 

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalkproducer.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalkproducer.zep.c
@@ -86,7 +86,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkProducer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(context, phalcon_queue_adapter_beanstalk_beanstalkcontext_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1238, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1237, context);
 }
 
 PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkProducer, getDeliveryDelay)
@@ -151,32 +151,32 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkProducer, send)
 	ZEPHIR_CALL_CE_STATIC(&payload, phalcon_queue_adapter_messageenvelope_ce, "encode", NULL, 0, message);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_1);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1239, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1238, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_2) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(&_1);
 		ZVAL_LONG(&_1, 100);
 	} else {
 		zephir_memory_observe(&_3);
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1239, PH_NOISY_CC);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1238, PH_NOISY_CC);
 		ZEPHIR_INIT_NVAR(&_1);
 		ZVAL_LONG(&_1, zephir_get_intval(&_3));
 	}
 	priority = zephir_get_numberval(&_1);
 	ZEPHIR_INIT_VAR(&_4);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 1240, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_1, 1239, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_5) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(&_4);
 		ZVAL_LONG(&_4, 0);
 	} else {
-		zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 1240, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6, this_ptr, _zephir_prop_1, 1239, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_4);
 		ZVAL_LONG(&_4, (int) (zephir_safe_div_zval_long(&_6, 1000)));
 	}
 	delay = zephir_get_numberval(&_4);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 1238, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_2, 1237, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_8, destination, "getqueuename", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_2, 1238, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_9, this_ptr, _zephir_prop_2, 1237, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_10, &_9, "getttr", NULL, 0);
 	zephir_check_call_status();
 	ZVAL_LONG(&_11, priority);
@@ -220,7 +220,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkProducer, setDeliveryDelay)
 		ZEPHIR_INIT_NVAR(&_0);
 		ZVAL_LONG(&_0, zephir_get_intval(deliveryDelay));
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1240, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1239, &_0);
 	RETURN_THIS();
 }
 
@@ -258,7 +258,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkProducer, setPriority)
 		ZEPHIR_INIT_NVAR(&_0);
 		ZVAL_LONG(&_0, zephir_get_intval(priority));
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1239, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1238, &_0);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/queue/adapter/beanstalk/beanstalksubscriptionconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/beanstalk/beanstalksubscriptionconsumer.zep.c
@@ -79,9 +79,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Beanstalk_BeanstalkSubscriptionConsumer, __cons
 		pollInterval = 200;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1241, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1240, context);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1242, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1241, &_0);
 }
 

--- a/ext/phalcon/queue/adapter/genericqueue.zep.c
+++ b/ext/phalcon/queue/adapter/genericqueue.zep.c
@@ -68,7 +68,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_GenericQueue, __construct)
 		Z_PARAM_STR(queueName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&queueName_zv, queueName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1243, &queueName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1242, &queueName_zv);
 }
 
 /**

--- a/ext/phalcon/queue/adapter/generictopic.zep.c
+++ b/ext/phalcon/queue/adapter/generictopic.zep.c
@@ -68,7 +68,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_GenericTopic, __construct)
 		Z_PARAM_STR(topicName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&topicName_zv, topicName);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1244, &topicName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1243, &topicName_zv);
 }
 
 /**

--- a/ext/phalcon/queue/adapter/memory/memoryconnectionfactory.zep.c
+++ b/ext/phalcon/queue/adapter/memory/memoryconnectionfactory.zep.c
@@ -81,7 +81,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryConnectionFactory, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1245, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1244, &options);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/queue/adapter/memory/memoryconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/memory/memoryconsumer.zep.c
@@ -74,8 +74,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryConsumer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(queue, phalcon_contracts_queue_queue_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(2, 0, &context, &queue);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1246, context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1247, queue);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1245, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1246, queue);
 }
 
 /**
@@ -116,8 +116,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryConsumer, receiveNoWait)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1246, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1247, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1245, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1246, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "popmessage", NULL, 0, &_2);
@@ -162,8 +162,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryConsumer, reject)
 	} else {
 		}
 	if (requeue) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1246, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1247, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1245, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1246, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_2$$3, &_1$$3, "getqueuename", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "pushmessage", NULL, 0, &_2$$3, message);

--- a/ext/phalcon/queue/adapter/memory/memorycontext.zep.c
+++ b/ext/phalcon/queue/adapter/memory/memorycontext.zep.c
@@ -75,7 +75,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryContext, close)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1248, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1247, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -224,7 +224,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryContext, popMessage)
 	zephir_memory_observe(&queueName_zv);
 	ZVAL_STR_COPY(&queueName_zv, queueName);
 	zephir_memory_observe(&messages);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1248, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1247, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&messages, &_0, &queueName_zv, 0))) {
 		RETURN_MM_NULL();
 	}
@@ -296,7 +296,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryContext, pushMessage)
 	zephir_memory_observe(&queueName_zv);
 	ZVAL_STR_COPY(&queueName_zv, queueName);
 	zephir_memory_observe(&messages);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1248, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1247, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&messages, &_0, &queueName_zv, 0))) {
 		ZEPHIR_INIT_NVAR(&messages);
 		array_init(&messages);

--- a/ext/phalcon/queue/adapter/memory/memoryproducer.zep.c
+++ b/ext/phalcon/queue/adapter/memory/memoryproducer.zep.c
@@ -65,7 +65,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryProducer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(context, phalcon_queue_adapter_memory_memorycontext_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1249, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1248, context);
 }
 
 PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryProducer, send)
@@ -96,7 +96,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemoryProducer, send)
 	ZVAL_STRING(&_0, "send to");
 	ZEPHIR_CALL_CE_STATIC(NULL, phalcon_queue_adapter_queuedestinationguard_ce, "assertqueue", NULL, 0, destination, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1249, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1248, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, destination, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_1, "pushmessage", NULL, 0, &_2, message);

--- a/ext/phalcon/queue/adapter/memory/memorysubscriptionconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/memory/memorysubscriptionconsumer.zep.c
@@ -66,6 +66,6 @@ PHP_METHOD(Phalcon_Queue_Adapter_Memory_MemorySubscriptionConsumer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(context, phalcon_queue_adapter_memory_memorycontext_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1250, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1249, context);
 }
 

--- a/ext/phalcon/queue/adapter/redis/redisconnectionfactory.zep.c
+++ b/ext/phalcon/queue/adapter/redis/redisconnectionfactory.zep.c
@@ -94,7 +94,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConnectionFactory, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1251, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1250, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -129,7 +129,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConnectionFactory, createContext)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1251, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1250, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	if (zephir_array_isset_value_string(&options, SL("prefix"))) {
 		zephir_memory_observe(&prefix);

--- a/ext/phalcon/queue/adapter/redis/redisconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/redis/redisconsumer.zep.c
@@ -73,8 +73,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConsumer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(queue, phalcon_contracts_queue_queue_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(2, 0, &context, &queue);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1252, context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1253, queue);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1251, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1252, queue);
 }
 
 /**
@@ -127,7 +127,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConsumer, receive)
 		timeout = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1252, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&queueName, &_0, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	deadline = 0;
@@ -137,7 +137,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConsumer, receive)
 		deadline = ((zephir_get_numberval(&_1$$3) * 1000) + timeout);
 	}
 	while (1) {
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 1252, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 1251, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_3$$4, 1);
 		ZEPHIR_CALL_METHOD(&message, &_2$$4, "blockingpop", NULL, 0, &queueName, &_3$$4);
 		zephir_check_call_status();
@@ -178,8 +178,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConsumer, receiveNoWait)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1252, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1253, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1251, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1252, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "popmessage", NULL, 0, &_2);
@@ -221,8 +221,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisConsumer, reject)
 	} else {
 		}
 	if (requeue) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1252, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1253, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1251, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1252, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_2$$3, &_1$$3, "getqueuename", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "pushmessage", NULL, 0, &_2$$3, message);

--- a/ext/phalcon/queue/adapter/redis/rediscontext.zep.c
+++ b/ext/phalcon/queue/adapter/redis/rediscontext.zep.c
@@ -119,11 +119,11 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, __construct)
 		pollInterval = 200;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1254, redis);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1255, &prefix_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1253, redis);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1254, &prefix_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1256, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1255, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -165,7 +165,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, blockingPop)
 	ZVAL_STR_COPY(&queueName_zv, queueName);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "promote", NULL, 0, &queueName_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	zephir_create_array(&_1, 1, 0);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "listkey", NULL, 0, &queueName_zv);
@@ -298,7 +298,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, createSubscriptionConsumer)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, phalcon_queue_adapter_redis_redissubscriptionconsumer_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1256, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1255, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0, this_ptr, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -336,7 +336,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, popMessage)
 	ZVAL_STR_COPY(&queueName_zv, queueName);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "promote", NULL, 0, &queueName_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "listkey", NULL, 0, &queueName_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&payload, &_0, "rpop", NULL, 0, &_1);
@@ -379,12 +379,12 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, purgeQueue)
 	zephir_fetch_params(1, 1, 0, &queue);
 	ZEPHIR_CALL_METHOD(&queueName, queue, "getqueuename", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "listkey", NULL, 0, &queueName);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_0, "del", NULL, 0, &_1);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "delayedkey", NULL, 0, &queueName);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_2, "del", NULL, 0, &_3);
@@ -453,7 +453,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, pushMessage)
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&member);
 		ZEPHIR_CONCAT_VSV(&member, &_2$$3, "|", &payload);
-		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_4$$3, this_ptr, "delayedkey", NULL, 0, &queueName_zv);
 		zephir_check_call_status();
 		ZVAL_LONG(&_5$$3, score);
@@ -461,7 +461,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, pushMessage)
 		zephir_check_call_status();
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_7, this_ptr, "listkey", NULL, 0, &queueName_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_6, "lpush", NULL, 0, &_7, &payload);
@@ -519,7 +519,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, delayedKey)
 		Z_PARAM_STR(queueName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&queueName_zv, queueName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1255, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VVS(return_value, &_0, &queueName_zv, ":delayed");
 	return;
 }
@@ -541,7 +541,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, listKey)
 		Z_PARAM_STR(queueName)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&queueName_zv, queueName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1255, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VV(return_value, &_0, &queueName_zv);
 	return;
 }
@@ -612,7 +612,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, promote)
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&listKey, this_ptr, "listkey", NULL, 0, &queueName_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "now", NULL, 0);
 	zephir_check_call_status();
 	ZVAL_LONG(&_2, 0);
@@ -627,7 +627,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, promote)
 		{
 			ZEPHIR_INIT_NVAR(&member);
 			ZVAL_COPY(&member, _3);
-			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&_5$$4, &_4$$4, "zrem", NULL, 0, &delayedKey, &member);
 			zephir_check_call_status();
 			if (ZEPHIR_GT_LONG(&_5$$4, 0)) {
@@ -638,7 +638,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, promote)
 				ZVAL_LONG(&_7$$5, (zephir_get_numberval(&position) + 1));
 				ZEPHIR_INIT_NVAR(&payload);
 				zephir_substr(&payload, &member, zephir_get_intval(&_7$$5), 0, ZEPHIR_SUBSTR_NO_LENGTH);
-				zephir_read_property_cached(&_8$$5, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_8$$5, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(NULL, &_8$$5, "lpush", NULL, 0, &listKey, &payload);
 				zephir_check_call_status();
 			}
@@ -661,7 +661,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, promote)
 			}
 			ZEPHIR_CALL_METHOD(&member, &due, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_11$$6, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_CALL_METHOD(&_12$$6, &_11$$6, "zrem", NULL, 0, &delayedKey, &member);
 				zephir_check_call_status();
 				if (ZEPHIR_GT_LONG(&_12$$6, 0)) {
@@ -672,7 +672,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisContext, promote)
 					ZVAL_LONG(&_14$$7, (zephir_get_numberval(&position) + 1));
 					ZEPHIR_INIT_NVAR(&payload);
 					zephir_substr(&payload, &member, zephir_get_intval(&_14$$7), 0, ZEPHIR_SUBSTR_NO_LENGTH);
-					zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_0, 1254, PH_NOISY_CC | PH_READONLY);
+					zephir_read_property_cached(&_15$$7, this_ptr, _zephir_prop_0, 1253, PH_NOISY_CC | PH_READONLY);
 					ZEPHIR_CALL_METHOD(NULL, &_15$$7, "lpush", NULL, 0, &listKey, &payload);
 					zephir_check_call_status();
 				}

--- a/ext/phalcon/queue/adapter/redis/redisproducer.zep.c
+++ b/ext/phalcon/queue/adapter/redis/redisproducer.zep.c
@@ -72,7 +72,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisProducer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(context, phalcon_queue_adapter_redis_rediscontext_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1257, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1256, context);
 }
 
 PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisProducer, getDeliveryDelay)
@@ -118,18 +118,18 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisProducer, send)
 	ZEPHIR_CALL_CE_STATIC(NULL, phalcon_queue_adapter_queuedestinationguard_ce, "assertqueue", NULL, 0, destination, &_0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_1);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1258, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1257, PH_NOISY_CC | PH_READONLY);
 	if (Z_TYPE_P(&_2) == IS_NULL) {
 		ZEPHIR_INIT_NVAR(&_1);
 		ZVAL_LONG(&_1, 0);
 	} else {
 		zephir_memory_observe(&_3);
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1258, PH_NOISY_CC);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1257, PH_NOISY_CC);
 		ZEPHIR_INIT_NVAR(&_1);
 		ZVAL_LONG(&_1, zephir_get_intval(&_3));
 	}
 	delay = zephir_get_numberval(&_1);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1257, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_1, 1256, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, destination, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZVAL_LONG(&_6, delay);
@@ -172,7 +172,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisProducer, setDeliveryDelay)
 		ZEPHIR_INIT_NVAR(&_0);
 		ZVAL_LONG(&_0, zephir_get_intval(deliveryDelay));
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1258, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1257, &_0);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/queue/adapter/redis/redissubscriptionconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/redis/redissubscriptionconsumer.zep.c
@@ -79,9 +79,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Redis_RedisSubscriptionConsumer, __construct)
 		pollInterval = 200;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1259, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1258, context);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1260, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1259, &_0);
 }
 

--- a/ext/phalcon/queue/adapter/stream/streamconnectionfactory.zep.c
+++ b/ext/phalcon/queue/adapter/stream/streamconnectionfactory.zep.c
@@ -83,7 +83,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamConnectionFactory, __construct)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1261, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1260, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -110,16 +110,16 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamConnectionFactory, createContext)
 
 	ZEPHIR_CALL_FUNCTION(&storageDir, "sys_get_temp_dir", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1261, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1260, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value_string(&_0, SL("storageDir"))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1261, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1260, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_OBS_NVAR(&storageDir);
 		zephir_array_fetch_string(&storageDir, &_1$$3, SL("storageDir"), PH_NOISY, "phalcon/Queue/Adapter/Stream/StreamConnectionFactory.zep", 51);
 	}
 	pollInterval = 200;
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1261, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1260, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_value_string(&_2, SL("pollInterval"))) {
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1261, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1260, PH_NOISY_CC | PH_READONLY);
 		zephir_memory_observe(&_4$$4);
 		zephir_array_fetch_string(&_4$$4, &_3$$4, SL("pollInterval"), PH_NOISY, "phalcon/Queue/Adapter/Stream/StreamConnectionFactory.zep", 57);
 		pollInterval = zephir_get_intval(&_4$$4);

--- a/ext/phalcon/queue/adapter/stream/streamconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/stream/streamconsumer.zep.c
@@ -83,11 +83,11 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamConsumer, __construct)
 		pollInterval = 200;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1262, context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1263, queue);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1261, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1262, queue);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1264, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1263, &_0);
 }
 
 /**
@@ -125,8 +125,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamConsumer, receiveNoWait)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1262, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1263, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1261, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1262, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "popmessage", NULL, 0, &_2);
@@ -168,8 +168,8 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamConsumer, reject)
 	} else {
 		}
 	if (requeue) {
-		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1262, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1263, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_0$$3, this_ptr, _zephir_prop_0, 1261, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 1262, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_2$$3, &_1$$3, "getqueuename", NULL, 0);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "pushmessage", NULL, 0, &_2$$3, message);

--- a/ext/phalcon/queue/adapter/stream/streamcontext.zep.c
+++ b/ext/phalcon/queue/adapter/stream/streamcontext.zep.c
@@ -108,10 +108,10 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, __construct)
 	zephir_fast_trim(&_0, &storageDir_zv, &_1, ZEPHIR_TRIM_RIGHT);
 	ZEPHIR_INIT_VAR(&_2);
 	ZEPHIR_CONCAT_VS(&_2, &_0, "/");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1265, &_2);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1264, &_2);
 	ZVAL_UNDEF(&_3);
 	ZVAL_LONG(&_3, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1266, &_3);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1265, &_3);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -146,7 +146,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, createConsumer)
 	ZEPHIR_CALL_CE_STATIC(NULL, phalcon_queue_adapter_queuedestinationguard_ce, "assertqueue", NULL, 0, destination, &_0);
 	zephir_check_call_status();
 	object_init_ex(return_value, phalcon_queue_adapter_stream_streamconsumer_ce);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1266, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1265, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0, this_ptr, destination, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -233,7 +233,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, createSubscriptionConsume
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, phalcon_queue_adapter_stream_streamsubscriptionconsumer_ce);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1266, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1265, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0, this_ptr, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -294,7 +294,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, popMessage)
 		RETURN_MM_NULL();
 	}
 	ZVAL_LONG(&_2, 2);
-	ZEPHIR_CALL_FUNCTION(&_3, "flock", NULL, 291, &pointer, &_2);
+	ZEPHIR_CALL_FUNCTION(&_3, "flock", NULL, 292, &pointer, &_2);
 	zephir_check_call_status();
 	if (!(zephir_is_true(&_3))) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfclose", NULL, 0, &pointer);
@@ -311,7 +311,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, popMessage)
 	zephir_check_call_status();
 	if (ZEPHIR_IS_EMPTY(&lines)) {
 		ZVAL_LONG(&_5$$6, 3);
-		ZEPHIR_CALL_FUNCTION(NULL, "flock", NULL, 291, &pointer, &_5$$6);
+		ZEPHIR_CALL_FUNCTION(NULL, "flock", NULL, 292, &pointer, &_5$$6);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfclose", NULL, 0, &pointer);
 		zephir_check_call_status();
@@ -341,7 +341,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, popMessage)
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfwrite", NULL, 0, &pointer, &remaining);
 	zephir_check_call_status();
 	ZVAL_LONG(&_2, 3);
-	ZEPHIR_CALL_FUNCTION(NULL, "flock", NULL, 291, &pointer, &_2);
+	ZEPHIR_CALL_FUNCTION(NULL, "flock", NULL, 292, &pointer, &_2);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "phpfclose", NULL, 0, &pointer);
 	zephir_check_call_status();
@@ -457,13 +457,13 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, ensureDir)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1265, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CALL_FUNCTION(&_1, "is_dir", NULL, 294, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1264, PH_NOISY_CC | PH_READONLY);
+	ZEPHIR_CALL_FUNCTION(&_1, "is_dir", NULL, 295, &_0);
 	zephir_check_call_status();
 	if (!(zephir_is_true(&_1))) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 1265, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 1264, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_3$$3, 0777);
-		ZEPHIR_CALL_FUNCTION(NULL, "mkdir", NULL, 295, &_2$$3, &_3$$3, &__$true);
+		ZEPHIR_CALL_FUNCTION(NULL, "mkdir", NULL, 296, &_2$$3, &_3$$3, &__$true);
 		zephir_check_call_status();
 	}
 	ZEPHIR_MM_RESTORE();
@@ -494,7 +494,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamContext, getFilepath)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&queueName_zv);
 	ZVAL_STR_COPY(&queueName_zv, queueName);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1265, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1264, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "/[^a-zA-Z0-9_-]/");
 	ZEPHIR_INIT_VAR(&_2);

--- a/ext/phalcon/queue/adapter/stream/streamproducer.zep.c
+++ b/ext/phalcon/queue/adapter/stream/streamproducer.zep.c
@@ -65,7 +65,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamProducer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(context, phalcon_queue_adapter_stream_streamcontext_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1267, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1266, context);
 }
 
 PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamProducer, send)
@@ -96,7 +96,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamProducer, send)
 	ZVAL_STRING(&_0, "send to");
 	ZEPHIR_CALL_CE_STATIC(NULL, phalcon_queue_adapter_queuedestinationguard_ce, "assertqueue", NULL, 0, destination, &_0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1267, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1266, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, destination, "getqueuename", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_1, "pushmessage", NULL, 0, &_2, message);

--- a/ext/phalcon/queue/adapter/stream/streamsubscriptionconsumer.zep.c
+++ b/ext/phalcon/queue/adapter/stream/streamsubscriptionconsumer.zep.c
@@ -79,9 +79,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Stream_StreamSubscriptionConsumer, __construct)
 		pollInterval = 200;
 	} else {
 		}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1268, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1267, context);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1269, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1268, &_0);
 }
 

--- a/ext/phalcon/queue/adapter/traits/messagetrait.zep.c
+++ b/ext/phalcon/queue/adapter/traits/messagetrait.zep.c
@@ -132,9 +132,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, __construct)
 	} else {
 		zephir_get_arrval(&headers, headers_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1270, &body_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1271, &properties);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1272, &headers);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1269, &body_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1270, &properties);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1271, &headers);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -202,9 +202,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, getHeader)
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1272, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1271, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_key_exists(&_0, &name_zv)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1272, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1271, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Queue/Adapter/Traits/MessageTrait.zep", 88);
 		RETURN_CTORW(&_2$$3);
 	}
@@ -232,7 +232,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, getHeaders)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1272, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1271, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -278,7 +278,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, getProperties)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1271, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1270, PH_NOISY_CC);
 	zephir_get_arrval(&_1, &_0);
 	RETURN_CTOR(&_1);
 }
@@ -317,9 +317,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, getProperty)
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1271, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1270, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_key_exists(&_0, &name_zv)) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1271, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_0, 1270, PH_NOISY_CC | PH_READONLY);
 		zephir_array_fetch(&_2$$3, &_1$$3, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Queue/Adapter/Traits/MessageTrait.zep", 124);
 		RETURN_CTORW(&_2$$3);
 	}
@@ -401,7 +401,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, setBody)
 		Z_PARAM_STR(body)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&body_zv, body);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1270, &body_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1269, &body_zv);
 }
 
 /**
@@ -474,7 +474,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, setHeaders)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &headers_param);
 	zephir_get_arrval(&headers, headers_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1272, &headers);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1271, &headers);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -528,7 +528,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, setProperties)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &properties_param);
 	zephir_get_arrval(&properties, properties_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1271, &properties);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1270, &properties);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -573,9 +573,9 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_MessageTrait, setRedelivered)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &redelivered_param);
 	if (redelivered) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1273, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1272, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1273, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1272, &__$false);
 	}
 }
 

--- a/ext/phalcon/queue/adapter/traits/subscriptionconsumertrait.zep.c
+++ b/ext/phalcon/queue/adapter/traits/subscriptionconsumertrait.zep.c
@@ -114,18 +114,18 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_SubscriptionConsumerTrait, consume)
 		timeout = 0;
 	} else {
 		}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1274, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1273, PH_NOISY_CC | PH_READONLY);
 	if (ZEPHIR_IS_EMPTY(&_0)) {
 		RETURN_MM_NULL();
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1275, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1274, PH_NOISY_CC | PH_READONLY);
 	sleep = (zephir_get_numberval(&_1) * 1000);
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_microtime(&_2, &__$true);
 	startTime = (zephir_get_numberval(&_2) * 1000);
 	while (1) {
 		ZEPHIR_OBS_NVAR(&_3$$4);
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1274, PH_NOISY_CC);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1273, PH_NOISY_CC);
 		zephir_get_arrval(&_4$$4, &_3$$4);
 		zephir_is_iterable(&_4$$4, 0, "phalcon/Queue/Adapter/Traits/SubscriptionConsumerTrait.zep", 79);
 		if (Z_TYPE_P(&_4$$4) == IS_ARRAY) {
@@ -257,7 +257,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_SubscriptionConsumerTrait, unsubscribe)
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "resolvequeuename", NULL, 0, consumer);
 	zephir_check_call_status();
 	zephir_unset_property_array(this_ptr, ZEND_STRL("subscriptions"), &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1274, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1273, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "resolvequeuename", NULL, 0, consumer);
 	zephir_check_call_status();
 	zephir_array_unset(&_1, &_2, PH_SEPARATE);
@@ -283,7 +283,7 @@ PHP_METHOD(Phalcon_Queue_Adapter_Traits_SubscriptionConsumerTrait, unsubscribeAl
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1274, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1273, &_0);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/queue/consumer/boundprocessor.zep.c
+++ b/ext/phalcon/queue/consumer/boundprocessor.zep.c
@@ -82,9 +82,9 @@ PHP_METHOD(Phalcon_Queue_Consumer_BoundProcessor, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(consumer, phalcon_contracts_queue_consumer_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(3, 0, &queue, &processor, &consumer);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1276, queue);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1277, processor);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1278, consumer);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1275, queue);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1276, processor);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1277, consumer);
 }
 
 PHP_METHOD(Phalcon_Queue_Consumer_BoundProcessor, getConsumer)

--- a/ext/phalcon/queue/consumer/queueconsumer.zep.c
+++ b/ext/phalcon/queue/consumer/queueconsumer.zep.c
@@ -89,7 +89,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(context, phalcon_contracts_queue_context_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &context);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1279, context);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1278, context);
 }
 
 /**
@@ -122,7 +122,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, bind)
 	zephir_fetch_params(1, 2, 0, &queue, &processor);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, phalcon_queue_consumer_boundprocessor_ce);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1279, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1278, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "createconsumer", NULL, 0, queue);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 0, queue, processor, &_2);
@@ -178,7 +178,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, consume)
 	while (1) {
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "consumeonce", &_2, 0);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1280, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3$$4, this_ptr, _zephir_prop_0, 1279, PH_NOISY_CC | PH_READONLY);
 		if (zephir_is_true(&_3$$4)) {
 			break;
 		}
@@ -242,7 +242,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, consumeOnce)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	handled = 0;
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1281, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1280, PH_NOISY_CC | PH_READONLY);
 	zephir_is_iterable(&_0, 0, "phalcon/Queue/Consumer/QueueConsumer.zep", 144);
 	if (Z_TYPE_P(&_0) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&_0), _1)
@@ -266,9 +266,9 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, consumeOnce)
 			zephir_check_call_status();
 			if (ZEPHIR_IS_FALSE_IDENTICAL(&_5$$3)) {
 				if (1) {
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1280, &__$true);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1279, &__$true);
 				} else {
-					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1280, &__$false);
+					zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1279, &__$false);
 				}
 				RETURN_MM_BOOL(handled);
 			}
@@ -313,9 +313,9 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, consumeOnce)
 				zephir_check_call_status();
 				if (ZEPHIR_IS_FALSE_IDENTICAL(&_11$$7)) {
 					if (1) {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1280, &__$true);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1279, &__$true);
 					} else {
-						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1280, &__$false);
+						zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1279, &__$false);
 					}
 					RETURN_MM_BOOL(handled);
 				}
@@ -328,7 +328,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, consumeOnce)
 	}
 	ZEPHIR_INIT_NVAR(&binding);
 	if (!(handled)) {
-		zephir_read_property_cached(&_12$$11, this_ptr, _zephir_prop_2, 1282, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$11, this_ptr, _zephir_prop_2, 1281, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_13$$11, (zephir_get_numberval(&_12$$11) * 1000));
 		ZEPHIR_CALL_FUNCTION(NULL, "usleep", NULL, 73, &_13$$11);
 		zephir_check_call_status();
@@ -392,7 +392,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, setPollInterval)
 	zephir_fetch_params_without_memory_grow(1, 0, &pollInterval_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, pollInterval);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1282, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1281, &_0);
 }
 
 /**
@@ -418,9 +418,9 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, start)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1280, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1279, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1280, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1279, &__$false);
 	}
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "queue:beforeStart");
@@ -444,9 +444,9 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, stop)
 		_zephir_prop_0 = zend_string_init("shouldStop", 10, 1);
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1280, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1279, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1280, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1279, &__$false);
 	}
 }
 
@@ -543,7 +543,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_QueueConsumer, process)
 
 	/* try_start_1: */
 
-		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 1279, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_0, 1278, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&result, &processor, "process", NULL, 0, message, &_2$$4);
 		zephir_check_call_status_or_jump(try_end_1);
 		ZEPHIR_CALL_METHOD(NULL, this_ptr, "handleresult", NULL, 0, &consumer, message, &result);

--- a/ext/phalcon/queue/consumer/worker.zep.c
+++ b/ext/phalcon/queue/consumer/worker.zep.c
@@ -99,8 +99,8 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, __construct)
 		ZEPHIR_CALL_METHOD(NULL, options, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1283, consumer);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1284, options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1282, consumer);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1283, options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -126,7 +126,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, handleSignal)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &signal_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1283, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1282, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "stop", NULL, 0);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -175,7 +175,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, run)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1284, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1283, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&options, &_0);
 	processed = 0;
 	ZEPHIR_CALL_METHOD(&_1, &options, "getmaxmessages", NULL, 0);
@@ -190,7 +190,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, run)
 	ZEPHIR_CALL_METHOD(&_4, &options, "getjitter", NULL, 0);
 	zephir_check_call_status();
 	jitter = zephir_get_intval(&_4);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1283, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 1282, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_5, &_0, "start", NULL, 0);
 	zephir_check_call_status();
 	if (!(zephir_is_true(&_5))) {
@@ -212,13 +212,13 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, run)
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "installsignalhandlers", NULL, 0);
 	zephir_check_call_status();
 	while (1) {
-		zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_1, 1283, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_10$$6, this_ptr, _zephir_prop_1, 1282, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_11$$6, &_10$$6, "isstoprequested", NULL, 0);
 		zephir_check_call_status();
 		if (zephir_is_true(&_11$$6)) {
 			break;
 		}
-		zephir_read_property_cached(&_12$$6, this_ptr, _zephir_prop_1, 1283, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_12$$6, this_ptr, _zephir_prop_1, 1282, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_13$$6, &_12$$6, "consumeonce", NULL, 0);
 		zephir_check_call_status();
 		if (zephir_is_true(&_13$$6)) {
@@ -250,7 +250,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, run)
 			break;
 		}
 	}
-	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_1, 1283, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_20, this_ptr, _zephir_prop_1, 1282, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_20, "end", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM_LONG(processed);
@@ -341,7 +341,7 @@ PHP_METHOD(Phalcon_Queue_Consumer_Worker, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/queue/consumer/workeroptions.zep.c
+++ b/ext/phalcon/queue/consumer/workeroptions.zep.c
@@ -120,16 +120,16 @@ PHP_METHOD(Phalcon_Queue_Consumer_WorkerOptions, __construct)
 		}
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, maxMessages);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1285, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1284, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, maxSeconds);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1286, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1285, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, maxMemory);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1287, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1286, &_0);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, jitter);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1288, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1287, &_0);
 }
 
 PHP_METHOD(Phalcon_Queue_Consumer_WorkerOptions, getJitter)

--- a/ext/phalcon/queue/queuefactory.zep.c
+++ b/ext/phalcon/queue/queuefactory.zep.c
@@ -89,7 +89,7 @@ PHP_METHOD(Phalcon_Queue_QueueFactory, __construct)
 		ZEPHIR_CALL_METHOD(NULL, factory, "__construct", NULL, 0);
 		zephir_check_call_status();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1289, factory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1288, factory);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -179,7 +179,7 @@ PHP_METHOD(Phalcon_Queue_QueueFactory, newInstance)
 	} else {
 		zephir_get_arrval(&options, options_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1289, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1288, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&connectionFactory, &_0, "newinstance", NULL, 0, &name_zv, &options);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&connectionFactory, "createcontext", NULL, 0);

--- a/ext/phalcon/session/adapter/libmemcached.zep.c
+++ b/ext/phalcon/session/adapter/libmemcached.zep.c
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Libmemcached, __construct)
 	ZVAL_STRING(&_1, "libmemcached");
 	ZEPHIR_CALL_METHOD(&_5, factory, "newinstance", NULL, 0, &_1, &options);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1290, &_5);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1289, &_5);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/session/adapter/redis.zep.c
+++ b/ext/phalcon/session/adapter/redis.zep.c
@@ -179,16 +179,16 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, __construct)
 	zephir_check_call_status();
 	ZVAL_UNDEF(&_4);
 	ZVAL_LONG(&_4, zephir_get_intval(&_5));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1291, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1290, &_4);
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "lockingEnabled");
 	ZVAL_BOOL(&_4, 0);
 	ZEPHIR_CALL_METHOD(&_6, this_ptr, "getarrval", NULL, 0, &options, &_1, &_4);
 	zephir_check_call_status();
 	if (zephir_get_boolval(&_6)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1292, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1291, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1292, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1291, &__$false);
 	}
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "lockRetries");
@@ -197,7 +197,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, __construct)
 	zephir_check_call_status();
 	ZVAL_UNDEF(&_4);
 	ZVAL_LONG(&_4, zephir_get_intval(&_6));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1293, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1292, &_4);
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "lockWaitTime");
 	ZVAL_LONG(&_4, 50000);
@@ -205,16 +205,16 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, __construct)
 	zephir_check_call_status();
 	ZVAL_UNDEF(&_4);
 	ZVAL_LONG(&_4, zephir_get_intval(&_7));
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1294, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1293, &_4);
 	zephir_memory_observe(&_8);
 	zephir_array_fetch_string(&_8, &options, SL("prefix"), PH_NOISY, "phalcon/Session/Adapter/Redis.zep", 99);
 	zephir_cast_to_string(&_9, &_8);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1295, &_9);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1294, &_9);
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "redis");
 	ZEPHIR_CALL_METHOD(&_10, factory, "newinstance", NULL, 0, &_1, &options);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1296, &_10);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1295, &_10);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -291,7 +291,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, read)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &id);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1292, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1291, PH_NOISY_CC | PH_READONLY);
 	_1 = ZEPHIR_IS_TRUE_IDENTICAL(&_0);
 	if (_1) {
 		ZEPHIR_CALL_METHOD(&_2, this_ptr, "acquirelock", NULL, 0, id);
@@ -301,7 +301,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, read)
 	if (_1) {
 		ZEPHIR_INIT_VAR(&_3$$3);
 		object_init_ex(&_3$$3, phalcon_session_adapter_exceptions_adapterruntimeerror_ce);
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 1297, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_1, 1296, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_5$$3);
 		ZEPHIR_CONCAT_SV(&_5$$3, "Could not acquire the session lock with key: ", &_4$$3);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 8, &_5$$3);
@@ -386,35 +386,35 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, acquireLock)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &id);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1295, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1294, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&lockKey);
 	ZEPHIR_CONCAT_VVS(&lockKey, &_0, id, "-lock");
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1298, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1297, PH_NOISY_CC | PH_READONLY);
 	_2 = ZEPHIR_IS_TRUE_IDENTICAL(&_1);
 	if (_2) {
-		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1297, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1296, PH_NOISY_CC | PH_READONLY);
 		_2 = ZEPHIR_IS_IDENTICAL(&lockKey, &_3);
 	}
 	if (_2) {
 		RETURN_MM_BOOL(1);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1297, &lockKey);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 1296, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1296, &lockKey);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 1295, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&client, &_4, "getadapter", NULL, 0);
 	zephir_check_call_status();
 	ZVAL_LONG(&_5, 16);
-	ZEPHIR_CALL_FUNCTION(&_6, "random_bytes", NULL, 315, &_5);
+	ZEPHIR_CALL_FUNCTION(&_6, "random_bytes", NULL, 317, &_5);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&token, "bin2hex", NULL, 316, &_6);
+	ZEPHIR_CALL_FUNCTION(&token, "bin2hex", NULL, 318, &_6);
 	zephir_check_call_status();
 	attempt = 0;
 	while (1) {
-		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_4, 1293, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_5, this_ptr, _zephir_prop_4, 1292, PH_NOISY_CC | PH_READONLY);
 		if (!(ZEPHIR_GT_LONG(&_5, attempt))) {
 			break;
 		}
-		zephir_read_property_cached(&_7$$4, this_ptr, _zephir_prop_2, 1297, PH_NOISY_CC | PH_READONLY);
-		zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_5, 1291, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_7$$4, this_ptr, _zephir_prop_2, 1296, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$4, this_ptr, _zephir_prop_5, 1290, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_NVAR(&_9$$4);
 		ZVAL_STRING(&_9$$4, "SET");
 		ZEPHIR_INIT_NVAR(&_10$$4);
@@ -425,14 +425,14 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, acquireLock)
 		zephir_check_call_status();
 		if (!ZEPHIR_IS_FALSE_IDENTICAL(&result)) {
 			if (1) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1298, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1297, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1298, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1297, &__$false);
 			}
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1299, &token);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1298, &token);
 			RETURN_MM_BOOL(1);
 		}
-		zephir_read_property_cached(&_13$$4, this_ptr, _zephir_prop_7, 1294, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_13$$4, this_ptr, _zephir_prop_7, 1293, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_FUNCTION(NULL, "usleep", &_14, 73, &_13$$4);
 		zephir_check_call_status();
 		attempt++;
@@ -480,30 +480,30 @@ PHP_METHOD(Phalcon_Session_Adapter_Redis, releaseLock)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1298, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1297, PH_NOISY_CC | PH_READONLY);
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		RETURN_MM_NULL();
 	}
 	ZEPHIR_INIT_VAR(&script);
 	ZVAL_STRING(&script, "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end");
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1296, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1295, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&client, &_1, "getadapter", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1297, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 1299, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1296, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_3, 1298, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_4);
 	ZVAL_STRING(&_4, "EVAL");
 	ZVAL_LONG(&_5, 1);
 	ZEPHIR_CALL_METHOD(NULL, &client, "rawcommand", NULL, 0, &_4, &script, &_5, &_2, &_3);
 	zephir_check_call_status();
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1298, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1297, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1298, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1297, &__$false);
 	}
 	ZEPHIR_INIT_NVAR(&_4);
 	ZVAL_STRING(&_4, "");
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1299, &_4);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1298, &_4);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/session/adapter/stream.zep.c
+++ b/ext/phalcon/session/adapter/stream.zep.c
@@ -139,8 +139,8 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, __construct)
 	ZVAL_STRING(&_2, "");
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getarrval", NULL, 0, &options, &_1, &_2);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1300, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1301, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1299, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1300, &options);
 	ZEPHIR_INIT_NVAR(&_1);
 	ZVAL_STRING(&_1, "session.save_path");
 	ZEPHIR_CALL_METHOD(&_3, this_ptr, "phpiniget", NULL, 0, &_1);
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, __construct)
 	}
 	ZEPHIR_CALL_METHOD(&_7, this_ptr, "todirseparator", NULL, 0, &path);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1302, &_7);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1301, &_7);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -200,7 +200,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, destroy)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &id);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1301, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getprefixedname", NULL, 0, id);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&file);
@@ -209,7 +209,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, destroy)
 	zephir_check_call_status();
 	_3 = zephir_is_true(&_2);
 	if (_3) {
-		ZEPHIR_CALL_FUNCTION(&_4, "is_file", NULL, 438, &file);
+		ZEPHIR_CALL_FUNCTION(&_4, "is_file", NULL, 440, &file);
 		zephir_check_call_status();
 		_3 = zephir_is_true(&_4);
 	}
@@ -267,8 +267,8 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, gc)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &max_lifetime_param);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1300, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1301, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1299, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&pattern);
 	ZEPHIR_CONCAT_VVS(&pattern, &_0, &_1, "*");
 	ZEPHIR_INIT_VAR(&_2);
@@ -306,7 +306,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, gc)
 				zephir_check_call_status();
 				_8$$7 = ZEPHIR_IS_TRUE_IDENTICAL(&_6$$7);
 				if (_8$$7) {
-					ZEPHIR_CALL_FUNCTION(&_9$$7, "is_file", &_10, 438, &file);
+					ZEPHIR_CALL_FUNCTION(&_9$$7, "is_file", &_10, 440, &file);
 					zephir_check_call_status();
 					_8$$7 = ZEPHIR_IS_TRUE_IDENTICAL(&_9$$7);
 				}
@@ -343,7 +343,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, gc)
 					zephir_check_call_status();
 					_17$$9 = ZEPHIR_IS_TRUE_IDENTICAL(&_16$$9);
 					if (_17$$9) {
-						ZEPHIR_CALL_FUNCTION(&_18$$9, "is_file", &_10, 438, &file);
+						ZEPHIR_CALL_FUNCTION(&_18$$9, "is_file", &_10, 440, &file);
 						zephir_check_call_status();
 						_17$$9 = ZEPHIR_IS_TRUE_IDENTICAL(&_18$$9);
 					}
@@ -414,7 +414,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, read)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &id);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1301, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getprefixedname", NULL, 0, id);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&name);
@@ -429,7 +429,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, read)
 		ZEPHIR_CALL_METHOD(&pointer, this_ptr, "phpfopen", NULL, 0, &name, &_3$$3);
 		zephir_check_call_status();
 		ZVAL_LONG(&_4$$3, 1);
-		ZEPHIR_CALL_FUNCTION(&_5$$3, "flock", NULL, 291, &pointer, &_4$$3);
+		ZEPHIR_CALL_FUNCTION(&_5$$3, "flock", NULL, 292, &pointer, &_4$$3);
 		zephir_check_call_status();
 		if (zephir_is_true(&_5$$3)) {
 			ZEPHIR_CALL_METHOD(&data, this_ptr, "phpfilegetcontents", NULL, 0, &name);
@@ -471,7 +471,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, updateTimestamp)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &id, &data);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1301, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getprefixedname", NULL, 0, id);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&name);
@@ -506,7 +506,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, validateId)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &id);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1301, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getprefixedname", NULL, 0, id);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
@@ -542,7 +542,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, write)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 2, 0, &id, &data);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1301, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getprefixedname", NULL, 0, id);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&name);
@@ -617,7 +617,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, getPrefixedName)
 	ZEPHIR_SEPARATE_PARAM(name);
 	zephir_cast_to_string(&_0, name);
 	ZEPHIR_CPY_WRT(name, &_0);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1300, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1299, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CONCAT_VV(return_value, &_1, name);
 	RETURN_MM();
 }
@@ -1191,7 +1191,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, phpIniGet)
 		zephir_memory_observe(&defaultValue_zv);
 	ZVAL_STR_COPY(&defaultValue_zv, defaultValue);
 	}
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_STR(zend_string_copy(defaultValue));
@@ -1238,7 +1238,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, phpIniGetBool)
 	} else {
 		}
 	result = 0;
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_BOOL(defaultValue);
@@ -1290,7 +1290,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, phpIniGetInt)
 		defaultValue = 0;
 	} else {
 		}
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_LONG(defaultValue);
@@ -1346,7 +1346,7 @@ PHP_METHOD(Phalcon_Session_Adapter_Stream, phpParseIniFile)
 		}
 	ZVAL_BOOL(&_0, (processSections ? 1 : 0));
 	ZVAL_LONG(&_1, scannerMode);
-	ZEPHIR_RETURN_CALL_FUNCTION("parse_ini_file", NULL, 437, &filename_zv, &_0, &_1);
+	ZEPHIR_RETURN_CALL_FUNCTION("parse_ini_file", NULL, 439, &filename_zv, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/session/bag.zep.c
+++ b/ext/phalcon/session/bag.zep.c
@@ -106,14 +106,14 @@ PHP_METHOD(Phalcon_Session_Bag, __construct)
 	session = ZEND_CALL_ARG(execute_data, 1);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1303, session);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1304, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1302, session);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1303, &name_zv);
 	if ((zephir_method_exists_ex(session, ZEND_STRL("getdi")) == SUCCESS)) {
 		ZEPHIR_CALL_METHOD(&_0$$3, session, "getdi", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1305, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1304, &_0$$3);
 	}
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1304, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1303, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&data, session, "get", NULL, 0, &_1);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&data) != IS_ARRAY) {
@@ -150,8 +150,8 @@ PHP_METHOD(Phalcon_Session_Bag, clear)
 
 	ZEPHIR_CALL_PARENT(NULL, phalcon_session_bag_ce, getThis(), "clear", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1303, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1304, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1303, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "remove", NULL, 0, &_1);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -204,8 +204,8 @@ PHP_METHOD(Phalcon_Session_Bag, init)
 	}
 	ZEPHIR_CALL_PARENT(NULL, phalcon_session_bag_ce, getThis(), "init", NULL, 0, &data);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1303, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1304, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1303, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &_1, &data);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -248,9 +248,9 @@ PHP_METHOD(Phalcon_Session_Bag, remove)
 	ZVAL_STR_COPY(&element_zv, element);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_session_bag_ce, getThis(), "remove", NULL, 0, &element_zv);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1303, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1304, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1306, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1303, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1305, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &_1, &_2);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -296,9 +296,9 @@ PHP_METHOD(Phalcon_Session_Bag, set)
 	ZVAL_STR_COPY(&element_zv, element);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_session_bag_ce, getThis(), "set", NULL, 0, &element_zv, value);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1303, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1304, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1306, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1302, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1303, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_2, 1305, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "set", NULL, 0, &_1, &_2);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -322,6 +322,6 @@ PHP_METHOD(Phalcon_Session_Bag, setDI)
 		Z_PARAM_OBJECT_OF_CLASS(container, phalcon_di_diinterface_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &container);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1305, container);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1304, container);
 }
 

--- a/ext/phalcon/session/manager.zep.c
+++ b/ext/phalcon/session/manager.zep.c
@@ -368,13 +368,13 @@ PHP_METHOD(Phalcon_Session_Manager, getName)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1307, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1306, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "");
 	if (ZEPHIR_IS_IDENTICAL(&_1, &_0)) {
 		ZEPHIR_CALL_FUNCTION(&_2$$3, "session_name", NULL, 0);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1307, &_2$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1306, &_2$$3);
 	}
 	RETURN_MM_MEMBER_TYPED(getThis(), "name", IS_STRING);
 }
@@ -544,7 +544,7 @@ PHP_METHOD(Phalcon_Session_Manager, setAdapter)
 		Z_PARAM_OBJECT_OF_CLASS(adapter, php_session_iface_entry)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &adapter);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1308, adapter);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1307, adapter);
 	RETURN_THISW();
 }
 
@@ -687,7 +687,7 @@ PHP_METHOD(Phalcon_Session_Manager, setName)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1307, &name_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1306, &name_zv);
 	ZEPHIR_CALL_FUNCTION(NULL, "session_name", NULL, 0, &name_zv);
 	zephir_check_call_status();
 	RETURN_THIS();
@@ -730,8 +730,8 @@ PHP_METHOD(Phalcon_Session_Manager, setOptions)
 	ZVAL_STRING(&_2, "");
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getarrval", NULL, 0, &options, &_1, &_2);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1309, &_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1310, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1308, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1309, &options);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -792,7 +792,7 @@ PHP_METHOD(Phalcon_Session_Manager, start)
 		}
 	}
 	zephir_memory_observe(&_6);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 1308, PH_NOISY_CC);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_0, 1307, PH_NOISY_CC);
 	if (UNEXPECTED(!(zephir_is_instance_of(&_6, SL("SessionHandlerInterface"))))) {
 		ZEPHIR_INIT_VAR(&_7$$7);
 		object_init_ex(&_7$$7, phalcon_session_exceptions_invalidsessionadapter_ce);
@@ -802,7 +802,7 @@ PHP_METHOD(Phalcon_Session_Manager, start)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 1308, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_0, 1307, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_FUNCTION(NULL, "session_set_save_handler", NULL, 0, &_8);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_FUNCTION("session_start", NULL, 0);
@@ -868,9 +868,9 @@ PHP_METHOD(Phalcon_Session_Manager, getUniqueKey)
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1309, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1308, PH_NOISY_CC);
 	if (1 != ZEPHIR_IS_EMPTY(&_0)) {
-		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1309, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1308, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&prefix);
 		ZEPHIR_CONCAT_VS(&prefix, &_1, "#");
 	} else {
@@ -957,7 +957,7 @@ PHP_METHOD(Phalcon_Session_Manager, phpHeadersSent)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_RETURN_CALL_FUNCTION("headers_sent", NULL, 215);
+	ZEPHIR_RETURN_CALL_FUNCTION("headers_sent", NULL, 216);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/storage/adapter/apcu.zep.c
+++ b/ext/phalcon/storage/adapter/apcu.zep.c
@@ -632,7 +632,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, phpApcuDec)
 	} else {
 		}
 	ZVAL_LONG(&_0, step);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_dec", NULL, 271, key, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_dec", NULL, 272, key, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -657,7 +657,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, phpApcuDelete)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_delete", NULL, 272, key);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_delete", NULL, 273, key);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -682,7 +682,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, phpApcuExists)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_exists", NULL, 273, key);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_exists", NULL, 274, key);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -707,7 +707,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, phpApcuFetch)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_fetch", NULL, 274, key);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_fetch", NULL, 275, key);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -741,7 +741,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, phpApcuInc)
 	} else {
 		}
 	ZVAL_LONG(&_0, step);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_inc", NULL, 275, key, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_inc", NULL, 276, key, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -806,7 +806,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Apcu, phpApcuStore)
 	} else {
 		}
 	ZVAL_LONG(&_0, ttl);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_store", NULL, 276, key, payload, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_store", NULL, 277, key, payload, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/storage/adapter/libmemcached.zep.c
+++ b/ext/phalcon/storage/adapter/libmemcached.zep.c
@@ -234,17 +234,17 @@ PHP_METHOD(Phalcon_Storage_Adapter_Libmemcached, getAdapter)
 			add_index_long(&failover, 21, 2);
 			zephir_array_update_long(&failover, 35, &__$true, PH_COPY ZEPHIR_DEBUG_PARAMS_DUMMY);
 			add_index_long(&failover, 15, 1);
-			ZEPHIR_CALL_FUNCTION(&_9$$4, "array_replace", NULL, 277, &failover, &client);
+			ZEPHIR_CALL_FUNCTION(&_9$$4, "array_replace", NULL, 278, &failover, &client);
 			zephir_check_call_status();
 			ZEPHIR_CPY_WRT(&client, &_9$$4);
-			ZEPHIR_CALL_METHOD(&_9$$4, this_ptr, "setoptions", NULL, 278, &connection, &client);
+			ZEPHIR_CALL_METHOD(&_9$$4, this_ptr, "setoptions", NULL, 279, &connection, &client);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&_10$$4, &_9$$4, "setservers", NULL, 279, &connection, &servers);
+			ZEPHIR_CALL_METHOD(&_10$$4, &_9$$4, "setservers", NULL, 280, &connection, &servers);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(NULL, &_10$$4, "setsasl", NULL, 280, &connection, &saslUser, &saslPass);
+			ZEPHIR_CALL_METHOD(NULL, &_10$$4, "setsasl", NULL, 281, &connection, &saslUser, &saslPass);
 			zephir_check_call_status();
 		}
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setserializer", NULL, 281, &connection);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setserializer", NULL, 282, &connection);
 		zephir_check_call_status();
 		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 309, &connection);
 	}

--- a/ext/phalcon/storage/adapter/rediscluster.zep.c
+++ b/ext/phalcon/storage/adapter/rediscluster.zep.c
@@ -336,7 +336,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_RedisCluster, getAdapter)
 		ZVAL_LONG(&_13$$3, 2);
 		ZEPHIR_CALL_METHOD(NULL, &connection, "setoption", NULL, 0, &_13$$3, &_1$$3);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setserializer", NULL, 282, &connection);
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "setserializer", NULL, 283, &connection);
 		zephir_check_call_status();
 		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 315, &connection);
 	}

--- a/ext/phalcon/storage/adapter/stream.zep.c
+++ b/ext/phalcon/storage/adapter/stream.zep.c
@@ -154,14 +154,14 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, clear)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	result = 1;
-	ZEPHIR_CALL_METHOD(&directory, this_ptr, "getdir", NULL, 283);
+	ZEPHIR_CALL_METHOD(&directory, this_ptr, "getdir", NULL, 284);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "phpfileexists", NULL, 0, &directory);
 	zephir_check_call_status();
 	if (UNEXPECTED(!ZEPHIR_IS_TRUE_IDENTICAL(&_0))) {
 		RETURN_MM_BOOL(result);
 	}
-	ZEPHIR_CALL_METHOD(&iterator, this_ptr, "getiterator", NULL, 284, &directory);
+	ZEPHIR_CALL_METHOD(&iterator, this_ptr, "getiterator", NULL, 285, &directory);
 	zephir_check_call_status();
 	zephir_is_iterable(&iterator, 0, "phalcon/Storage/Adapter/Stream.zep", 107);
 	if (Z_TYPE_P(&iterator) == IS_ARRAY) {
@@ -273,7 +273,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getKeys)
 	}
 	ZEPHIR_INIT_VAR(&files);
 	array_init(&files);
-	ZEPHIR_CALL_METHOD(&directory, this_ptr, "getdir", NULL, 283);
+	ZEPHIR_CALL_METHOD(&directory, this_ptr, "getdir", NULL, 284);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "phpfileexists", NULL, 0, &directory);
 	zephir_check_call_status();
@@ -281,7 +281,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getKeys)
 		array_init(return_value);
 		RETURN_MM();
 	}
-	ZEPHIR_CALL_METHOD(&iterator, this_ptr, "getiterator", NULL, 284, &directory);
+	ZEPHIR_CALL_METHOD(&iterator, this_ptr, "getiterator", NULL, 285, &directory);
 	zephir_check_call_status();
 	zephir_is_iterable(&iterator, 0, "phalcon/Storage/Adapter/Stream.zep", 137);
 	if (Z_TYPE_P(&iterator) == IS_ARRAY) {
@@ -377,7 +377,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, setForever)
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getserializeddata", NULL, 0, value);
 	zephir_check_call_status();
 	zephir_array_update_string(&payload, SL("content"), &_1, PH_COPY | PH_SEPARATE);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "storepayload", NULL, 285, &payload, &key_zv);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "storepayload", NULL, 286, &payload, &key_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -466,7 +466,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, doDelete)
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		RETURN_MM_BOOL(0);
 	}
-	ZEPHIR_CALL_METHOD(&filepath, this_ptr, "getfilepath", NULL, 286, &key_zv);
+	ZEPHIR_CALL_METHOD(&filepath, this_ptr, "getfilepath", NULL, 287, &key_zv);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "phpunlink", NULL, 0, &filepath);
 	zephir_check_call_status();
@@ -516,7 +516,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, doGet)
 		defaultValue = &defaultValue_sub;
 		defaultValue = &__$null;
 	}
-	ZEPHIR_CALL_METHOD(&filepath, this_ptr, "getfilepath", NULL, 286, &key_zv);
+	ZEPHIR_CALL_METHOD(&filepath, this_ptr, "getfilepath", NULL, 287, &key_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "phpfileexists", NULL, 0, &filepath);
 	zephir_check_call_status();
@@ -524,11 +524,11 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, doGet)
 		RETVAL_ZVAL(defaultValue, 1, 0);
 		RETURN_MM();
 	}
-	ZEPHIR_CALL_METHOD(&payload, this_ptr, "getpayload", NULL, 287, &filepath);
+	ZEPHIR_CALL_METHOD(&payload, this_ptr, "getpayload", NULL, 288, &filepath);
 	zephir_check_call_status();
 	_1 = ZEPHIR_IS_EMPTY(&payload);
 	if (!(_1)) {
-		ZEPHIR_CALL_METHOD(&_2, this_ptr, "isexpired", NULL, 288, &payload);
+		ZEPHIR_CALL_METHOD(&_2, this_ptr, "isexpired", NULL, 289, &payload);
 		zephir_check_call_status();
 		_1 = zephir_is_true(&_2);
 	}
@@ -572,19 +572,19 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, doHas)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
-	ZEPHIR_CALL_METHOD(&filepath, this_ptr, "getfilepath", NULL, 286, &key_zv);
+	ZEPHIR_CALL_METHOD(&filepath, this_ptr, "getfilepath", NULL, 287, &key_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "phpfileexists", NULL, 0, &filepath);
 	zephir_check_call_status();
 	if (UNEXPECTED(!ZEPHIR_IS_TRUE_IDENTICAL(&_0))) {
 		RETURN_MM_BOOL(0);
 	}
-	ZEPHIR_CALL_METHOD(&payload, this_ptr, "getpayload", NULL, 287, &filepath);
+	ZEPHIR_CALL_METHOD(&payload, this_ptr, "getpayload", NULL, 288, &filepath);
 	zephir_check_call_status();
 	if (UNEXPECTED(ZEPHIR_IS_EMPTY(&payload))) {
 		RETURN_MM_BOOL(0);
 	}
-	ZEPHIR_CALL_METHOD(&_1, this_ptr, "isexpired", NULL, 288, &payload);
+	ZEPHIR_CALL_METHOD(&_1, this_ptr, "isexpired", NULL, 289, &payload);
 	zephir_check_call_status();
 	RETURN_MM_BOOL(!zephir_is_true(&_1));
 }
@@ -712,7 +712,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, doSet)
 	ZEPHIR_CALL_METHOD(&_2, this_ptr, "getserializeddata", NULL, 0, value);
 	zephir_check_call_status();
 	zephir_array_update_string(&payload, SL("content"), &_2, PH_COPY | PH_SEPARATE);
-	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "storepayload", NULL, 285, &payload, &key_zv);
+	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "storepayload", NULL, 286, &payload, &key_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -807,7 +807,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getFilepath)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&key_zv);
 	ZVAL_STR_COPY(&key_zv, key);
-	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getdir", NULL, 283, &key_zv);
+	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getdir", NULL, 284, &key_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getkeywithoutprefix", NULL, 0, &key_zv);
 	zephir_check_call_status();
@@ -843,10 +843,10 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getIterator)
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, spl_ce_RecursiveDirectoryIterator);
 	ZVAL_LONG(&_1, 4096);
-	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 289, &dir_zv, &_1);
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 290, &dir_zv, &_1);
 	zephir_check_call_status();
 	ZVAL_LONG(&_1, 2);
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 290, &_0, &_1);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 291, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -894,7 +894,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getPayload)
 		RETURN_MM();
 	}
 	ZVAL_LONG(&_1, 1);
-	ZEPHIR_CALL_FUNCTION(&_2, "flock", NULL, 291, &pointer, &_1);
+	ZEPHIR_CALL_FUNCTION(&_2, "flock", NULL, 292, &pointer, &_1);
 	zephir_check_call_status();
 	if (EXPECTED(ZEPHIR_IS_TRUE_IDENTICAL(&_2))) {
 		ZEPHIR_CALL_METHOD(&payload, this_ptr, "phpfilegetcontents", NULL, 0, &filepath_zv);
@@ -911,12 +911,12 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, getPayload)
 	ZEPHIR_INIT_NVAR(&_0);
 	zephir_create_closure_ex(&_0, NULL, phalcon_2__closure_ce, SL("__invoke"));
 	ZVAL_LONG(&_1, 8);
-	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 292, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 293, &_0, &_1);
 	zephir_check_call_status();
 	ZEPHIR_CALL_FUNCTION(&_3, "unserialize", NULL, 26, &payload);
 	zephir_check_call_status();
 	ZEPHIR_CPY_WRT(&payload, &_3);
-	ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 293);
+	ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 294);
 	zephir_check_call_status();
 	_4 = ZEPHIR_GLOBAL(warning).enable;
 	if (!(_4)) {
@@ -1021,13 +1021,13 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, storePayload)
 	ZVAL_STR_COPY(&key_zv, key);
 	ZEPHIR_CALL_FUNCTION(&localPayload, "serialize", NULL, 21, &payload);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(&directory, this_ptr, "getdir", NULL, 283, &key_zv);
+	ZEPHIR_CALL_METHOD(&directory, this_ptr, "getdir", NULL, 284, &key_zv);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_0, "is_dir", NULL, 294, &directory);
+	ZEPHIR_CALL_FUNCTION(&_0, "is_dir", NULL, 295, &directory);
 	zephir_check_call_status();
 	if (!(zephir_is_true(&_0))) {
 		ZVAL_LONG(&_1$$3, 0777);
-		ZEPHIR_CALL_FUNCTION(NULL, "mkdir", NULL, 295, &directory, &_1$$3, &__$true);
+		ZEPHIR_CALL_FUNCTION(NULL, "mkdir", NULL, 296, &directory, &_1$$3, &__$true);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(&_3);
@@ -1085,7 +1085,7 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, toDirFromFile)
 	zephir_check_call_status();
 	ZVAL_LONG(&_0, 0);
 	ZVAL_LONG(&_1, -2);
-	ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 296, &name, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 297, &name, &_0, &_1);
 	zephir_check_call_status();
 	_2 = filesystemSafe == 1;
 	if (_2) {
@@ -1103,12 +1103,12 @@ PHP_METHOD(Phalcon_Storage_Adapter_Stream, toDirFromFile)
 	if (!zephir_is_true(&start)) {
 		ZVAL_LONG(&_6$$4, 0);
 		ZVAL_LONG(&_7$$4, 1);
-		ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 296, &name, &_6$$4, &_7$$4);
+		ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 297, &name, &_6$$4, &_7$$4);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(&_8);
 	ZVAL_LONG(&_0, 2);
-	ZEPHIR_CALL_FUNCTION(&_9, "mb_str_split", NULL, 297, &start, &_0);
+	ZEPHIR_CALL_FUNCTION(&_9, "mb_str_split", NULL, 298, &start, &_0);
 	zephir_check_call_status();
 	zephir_fast_join_str(&_8, SL("/"), &_9);
 	ZEPHIR_CONCAT_VS(return_value, &_8, "/");

--- a/ext/phalcon/storage/adapterfactory.zep.c
+++ b/ext/phalcon/storage/adapterfactory.zep.c
@@ -70,7 +70,7 @@ PHP_METHOD(Phalcon_Storage_AdapterFactory, __construct)
 	} else {
 		zephir_get_arrval(&services, services_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1311, factory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1310, factory);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -145,7 +145,7 @@ PHP_METHOD(Phalcon_Storage_AdapterFactory, newInstance)
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_create_array(&_0, 2, 0);
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1311, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1310, PH_NOISY_CC);
 	zephir_array_fast_append(&_0, &_1);
 	zephir_array_fast_append(&_0, &options);
 	ZEPHIR_LAST_CALL_STATUS = zephir_create_instance_params(return_value, &definition, &_0);

--- a/ext/phalcon/storage/serializer/base64.zep.c
+++ b/ext/phalcon/storage/serializer/base64.zep.c
@@ -58,7 +58,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Base64, serialize)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1312, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1311, PH_NOISY_CC);
 	if (Z_TYPE_P(&_0) != IS_STRING) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_storage_serializer_exceptions_invalidserializationinput_ce);
@@ -68,7 +68,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Base64, serialize)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1312, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1311, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "phpbase64encode", NULL, 0, &_2);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -127,20 +127,20 @@ PHP_METHOD(Phalcon_Storage_Serializer_Base64, unserialize)
 	zephir_check_call_status();
 	if (UNEXPECTED(ZEPHIR_IS_FALSE_IDENTICAL(&result))) {
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1313, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1312, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1313, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1312, &__$false);
 		}
 		ZEPHIR_INIT_NVAR(&result);
 		ZVAL_STRING(&result, "");
 	} else {
 		if (1) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1313, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1312, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1313, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1312, &__$false);
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1312, &result);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1311, &result);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/storage/serializer/igbinary.zep.c
+++ b/ext/phalcon/storage/serializer/igbinary.zep.c
@@ -137,11 +137,11 @@ PHP_METHOD(Phalcon_Storage_Serializer_Igbinary, unserialize)
 		ZEPHIR_INIT_NVAR(&_1$$4);
 		zephir_create_closure_ex(&_1$$4, NULL, phalcon_3__closure_ce, SL("__invoke"));
 		ZVAL_LONG(&_2$$4, 2);
-		ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 292, &_1$$4, &_2$$4);
+		ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 293, &_1$$4, &_2$$4);
 		zephir_check_call_status();
 		ZEPHIR_CALL_METHOD(&result, this_ptr, "dounserialize", NULL, 0, data);
 		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 293);
+		ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 294);
 		zephir_check_call_status();
 		_3$$4 = ZEPHIR_GLOBAL(warning).enable;
 		if (!(_3$$4)) {
@@ -239,7 +239,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Igbinary, phpIgbinarySerialize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &value);
-	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_serialize", NULL, 298, value);
+	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_serialize", NULL, 299, value);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -264,7 +264,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Igbinary, phpIgbinaryUnserialize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &value);
-	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_unserialize", NULL, 299, value);
+	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_unserialize", NULL, 300, value);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/storage/serializer/json.zep.c
+++ b/ext/phalcon/storage/serializer/json.zep.c
@@ -85,7 +85,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Json, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1314, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1313, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_support_helper_json_decode_ce);
 	if (zephir_has_constructor(&_1)) {
@@ -93,7 +93,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Json, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1315, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1314, &_1);
 	ZEPHIR_CALL_PARENT(NULL, phalcon_storage_serializer_json_ce, getThis(), "__construct", NULL, 0, data);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -126,14 +126,14 @@ PHP_METHOD(Phalcon_Storage_Serializer_Json, serialize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1316, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1315, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "isserializable", NULL, 0, &_1);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		RETURN_MM_MEMBER(getThis(), "data");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1314, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1316, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_1, 1313, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1315, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_2, "__invoke", NULL, 0, &_3);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -176,12 +176,12 @@ PHP_METHOD(Phalcon_Storage_Serializer_Json, unserialize)
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "isserializable", NULL, 0, data);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1316, data);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1315, data);
 	} else {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_1, 1315, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_1, 1314, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&_2$$4, &_1$$4, "__invoke", NULL, 0, data);
 		zephir_check_call_status();
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1316, &_2$$4);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1315, &_2$$4);
 	}
 	ZEPHIR_MM_RESTORE();
 }

--- a/ext/phalcon/storage/serializer/php.zep.c
+++ b/ext/phalcon/storage/serializer/php.zep.c
@@ -56,13 +56,13 @@ PHP_METHOD(Phalcon_Storage_Serializer_Php, serialize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1317, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1316, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "isserializable", NULL, 0, &_1);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
 		RETURN_MM_MEMBER(getThis(), "data");
 	}
-	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1317, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 1316, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(this_ptr, "phpserialize", NULL, 0, &_2);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Storage_Serializer_Php, unserialize)
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "isserializable", NULL, 0, data);
 	zephir_check_call_status();
 	if (!ZEPHIR_IS_TRUE_IDENTICAL(&_0)) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1317, data);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1316, data);
 		RETURN_MM_NULL();
 	}
 	ZEPHIR_INIT_VAR(&_1);
@@ -128,11 +128,11 @@ PHP_METHOD(Phalcon_Storage_Serializer_Php, unserialize)
 	ZEPHIR_INIT_NVAR(&_3);
 	zephir_create_closure_ex(&_3, NULL, phalcon_92__closure_ce, SL("__invoke"));
 	ZVAL_LONG(&_4, (8 | 2));
-	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 292, &_3, &_4);
+	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 293, &_3, &_4);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&result, this_ptr, "phpunserialize", NULL, 0, data);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 293);
+	ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 294);
 	zephir_check_call_status();
 	_5 = ZEPHIR_GLOBAL(warning).enable;
 	if (!(_5)) {
@@ -140,20 +140,20 @@ PHP_METHOD(Phalcon_Storage_Serializer_Php, unserialize)
 	}
 	if (UNEXPECTED(_5)) {
 		if (0) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1318, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1317, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1318, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1317, &__$false);
 		}
 		ZEPHIR_INIT_NVAR(&result);
 		ZVAL_STRING(&result, "");
 	} else {
 		if (1) {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1318, &__$true);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1317, &__$true);
 		} else {
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1318, &__$false);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1317, &__$false);
 		}
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1317, &result);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1316, &result);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/support/collection/readonlycollection.zep.c
+++ b/ext/phalcon/support/collection/readonlycollection.zep.c
@@ -122,9 +122,9 @@ PHP_METHOD(Phalcon_Support_Collection_ReadOnlyCollection, __construct)
 	ZEPHIR_CALL_PARENT(NULL, phalcon_support_collection_readonlycollection_ce, getThis(), "__construct", NULL, 0, &data, &_0, &_1, &type_zv);
 	zephir_check_call_status();
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -163,9 +163,9 @@ PHP_METHOD(Phalcon_Support_Collection_ReadOnlyCollection, __unserialize)
 	zephir_fetch_params(1, 1, 0, &data_param);
 	zephir_get_arrval(&data, data_param);
 	if (0) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$false);
 	}
 
 	/* try_start_1: */
@@ -183,9 +183,9 @@ PHP_METHOD(Phalcon_Support_Collection_ReadOnlyCollection, __unserialize)
 			zend_clear_exception();
 			ZEPHIR_CPY_WRT(&ex, &_0);
 			if (1) {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$true);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$true);
 			} else {
-				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$false);
+				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$false);
 			}
 			zephir_throw_exception_debug(&ex, "phalcon/Support/Collection/ReadOnlyCollection.zep", 64);
 			ZEPHIR_MM_RESTORE();
@@ -193,9 +193,9 @@ PHP_METHOD(Phalcon_Support_Collection_ReadOnlyCollection, __unserialize)
 		}
 	}
 	if (1) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1318, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -254,7 +254,7 @@ PHP_METHOD(Phalcon_Support_Collection_ReadOnlyCollection, init)
 	} else {
 		zephir_get_arrval(&data, data_param);
 	}
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1319, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1318, PH_NOISY_CC | PH_READONLY);
 	if (zephir_is_true(&_0)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		object_init_ex(&_1$$3, phalcon_support_collection_exceptions_readonlyviolation_ce);

--- a/ext/phalcon/support/debug.zep.c
+++ b/ext/phalcon/support/debug.zep.c
@@ -109,7 +109,7 @@ PHP_METHOD(Phalcon_Support_Debug, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1320, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, &_0);
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, phalcon_support_debug_reportbuilder_ce);
 	if (zephir_has_constructor(&_1)) {
@@ -117,7 +117,7 @@ PHP_METHOD(Phalcon_Support_Debug, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1321, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1320, &_1);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -140,7 +140,7 @@ PHP_METHOD(Phalcon_Support_Debug, clearVars)
 
 	ZEPHIR_INIT_VAR(&_0);
 	array_init(&_0);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1322, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1321, &_0);
 	RETURN_THIS();
 }
 
@@ -203,8 +203,8 @@ PHP_METHOD(Phalcon_Support_Debug, getCssSources)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1320, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1323, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1319, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1322, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getcsssources", NULL, 0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -233,8 +233,8 @@ PHP_METHOD(Phalcon_Support_Debug, getJsSources)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1320, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1323, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1319, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1322, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getjssources", NULL, 0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -267,7 +267,7 @@ PHP_METHOD(Phalcon_Support_Debug, getVersion)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1320, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1319, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "getversion", NULL, 0);
 	zephir_check_call_status();
 	RETURN_MM();
@@ -388,7 +388,7 @@ PHP_METHOD(Phalcon_Support_Debug, listenLowSeverity)
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "onUncaughtLowSeverity");
 	zephir_array_fast_append(&_0, &_1);
-	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 292, &_0);
+	ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 293, &_0);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
 	zephir_create_array(&_2, 2, 0);
@@ -554,14 +554,14 @@ PHP_METHOD(Phalcon_Support_Debug, renderHtml)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &exception);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1320, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1321, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1324, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 1325, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_4, 1326, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_5, 1327, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_6, 1323, PH_NOISY_CC | PH_READONLY);
-	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_7, 1322, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1319, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_1, 1320, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_2, 1323, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_4, this_ptr, _zephir_prop_3, 1324, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_5, this_ptr, _zephir_prop_4, 1325, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_6, this_ptr, _zephir_prop_5, 1326, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_7, this_ptr, _zephir_prop_6, 1322, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_8, this_ptr, _zephir_prop_7, 1321, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CALL_METHOD(&_2, &_1, "build", NULL, 0, exception, &_3, &_4, &_5, &_6, &_7, &_8);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "render", NULL, 0, &_2);
@@ -714,7 +714,7 @@ PHP_METHOD(Phalcon_Support_Debug, setBlacklist)
 	}
 	ZEPHIR_INIT_NVAR(&value);
 	zephir_array_update_string(&result, SL("server"), &subArray, PH_COPY | PH_SEPARATE);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1324, &result);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1323, &result);
 	RETURN_THIS();
 }
 
@@ -738,7 +738,7 @@ PHP_METHOD(Phalcon_Support_Debug, setRenderer)
 		Z_PARAM_OBJECT_OF_CLASS(renderer, phalcon_contracts_support_debug_renderer_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &renderer);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1320, renderer);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1319, renderer);
 	RETURN_THISW();
 }
 
@@ -765,9 +765,9 @@ PHP_METHOD(Phalcon_Support_Debug, setShowBackTrace)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &showBackTrace_param);
 	if (showBackTrace) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1325, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1324, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1325, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1324, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -796,9 +796,9 @@ PHP_METHOD(Phalcon_Support_Debug, setShowFileFragment)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &showFileFragment_param);
 	if (showFileFragment) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1327, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1326, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1327, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1326, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -826,9 +826,9 @@ PHP_METHOD(Phalcon_Support_Debug, setShowFiles)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &showFiles_param);
 	if (showFiles) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1326, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1325, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1326, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1325, &__$false);
 	}
 	RETURN_THISW();
 }
@@ -854,7 +854,7 @@ PHP_METHOD(Phalcon_Support_Debug, setUri)
 		Z_PARAM_STR(uri)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&uri_zv, uri);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1323, &uri_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1322, &uri_zv);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/support/debug/dump.zep.c
+++ b/ext/phalcon/support/debug/dump.zep.c
@@ -133,13 +133,13 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, __construct)
 		zephir_check_call_status();
 	}
 
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1328, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1327, &_0);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "setstyles", NULL, 0, &styles);
 	zephir_check_call_status();
 	if (detailed) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1329, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1328, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1329, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1328, &__$false);
 	}
 	ZEPHIR_MM_RESTORE();
 }
@@ -211,7 +211,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, getTemplate)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&template);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1330, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1329, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&template, &_0, &name_zv, 0)) {
 		RETURN_CCTOR(&template);
 	}
@@ -271,9 +271,9 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, setDetailed)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &flag_param);
 	if (flag) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1329, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1328, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1329, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1328, &__$false);
 	}
 }
 
@@ -323,7 +323,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, setStyles)
 	add_assoc_stringl_ex(&defaultStyles, SL("str"), SL("color:teal"));
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_fast_array_merge(&_0, &defaultStyles, &styles);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1331, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1330, &_0);
 	RETURN_MM_MEMBER_TYPED(getThis(), "styles", IS_ARRAY);
 }
 
@@ -390,7 +390,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, toJson)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &variable);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1328, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1327, PH_NOISY_CC | PH_READONLY);
 	ZVAL_LONG(&_1, (((128 | 64) | 256) | 4194304));
 	ZEPHIR_RETURN_CALL_METHOD(&_0, "__invoke", NULL, 0, variable, &_1);
 	zephir_check_call_status();
@@ -613,7 +613,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, getStyle)
 	zephir_memory_observe(&type_zv);
 	ZVAL_STR_COPY(&type_zv, type);
 	zephir_memory_observe(&style);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1331, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1330, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&style, &_0, &type_zv, 0))) {
 		RETURN_MM_STRING("color:gray");
 	}
@@ -1054,13 +1054,13 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, output)
 			ZEPHIR_CONCAT_VS(&_51$$11, &_50$$11, "[skipped]\n");
 			zephir_concat_self(&output, &_51$$11);
 		} else {
-			zephir_read_property_cached(&_47$$9, this_ptr, _zephir_prop_0, 1329, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_47$$9, this_ptr, _zephir_prop_0, 1328, PH_NOISY_CC | PH_READONLY);
 			_48$$9 = !zephir_is_true(&_47$$9);
 			if (!(_48$$9)) {
 				_48$$9 = zephir_is_instance_of(variable, SL("stdClass"));
 			}
 			if (_48$$9) {
-				ZEPHIR_CALL_FUNCTION(&_52$$12, "get_object_vars", NULL, 335, variable);
+				ZEPHIR_CALL_FUNCTION(&_52$$12, "get_object_vars", NULL, 337, variable);
 				zephir_check_call_status();
 				zephir_is_iterable(&_52$$12, 0, "phalcon/Support/Debug/Dump.zep", 367);
 				if (Z_TYPE_P(&_52$$12) == IS_ARRAY) {
@@ -1160,10 +1160,10 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, output)
 			} else {
 				ZEPHIR_INIT_VAR(&reflect);
 				object_init_ex(&reflect, zephir_get_internal_ce(SL("reflectionclass")));
-				ZEPHIR_CALL_METHOD(NULL, &reflect, "__construct", NULL, 239, variable);
+				ZEPHIR_CALL_METHOD(NULL, &reflect, "__construct", NULL, 240, variable);
 				zephir_check_call_status();
 				ZVAL_LONG(&_76$$15, ((1 | 2) | 4));
-				ZEPHIR_CALL_METHOD(&props, &reflect, "getproperties", NULL, 347, &_76$$15);
+				ZEPHIR_CALL_METHOD(&props, &reflect, "getproperties", NULL, 349, &_76$$15);
 				zephir_check_call_status();
 				zephir_is_iterable(&props, 0, "phalcon/Support/Debug/Dump.zep", 393);
 				if (Z_TYPE_P(&props) == IS_ARRAY) {
@@ -1302,7 +1302,7 @@ PHP_METHOD(Phalcon_Support_Debug_Dump, output)
 		zephir_concat_self(&output, &_112$$9);
 		ZEPHIR_INIT_NVAR(&_39$$9);
 		zephir_get_class(&_39$$9, variable, 0);
-		zephir_read_property_cached(&_107$$9, this_ptr, _zephir_prop_1, 1332, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_107$$9, this_ptr, _zephir_prop_1, 1331, PH_NOISY_CC | PH_READONLY);
 		if (zephir_fast_in_array(&_39$$9, &_107$$9)) {
 			ZVAL_LONG(&_113$$18, tab);
 			ZEPHIR_CALL_FUNCTION(&_114$$18, "str_repeat", &_10, 6, &space, &_113$$18);

--- a/ext/phalcon/support/debug/renderer/htmlrenderer.zep.c
+++ b/ext/phalcon/support/debug/renderer/htmlrenderer.zep.c
@@ -163,7 +163,7 @@ PHP_METHOD(Phalcon_Support_Debug_Renderer_HtmlRenderer, getTemplate)
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
 	zephir_memory_observe(&template);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1333, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1332, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&template, &_0, &name_zv, 0)) {
 		RETURN_CCTOR(&template);
 	}

--- a/ext/phalcon/support/debug/report/backtraceitem.zep.c
+++ b/ext/phalcon/support/debug/report/backtraceitem.zep.c
@@ -233,20 +233,20 @@ PHP_METHOD(Phalcon_Support_Debug_Report_BacktraceItem, __construct)
 		fragment = &fragment_sub;
 		fragment = &__$null;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1334, &functionName_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1335, type);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1336, className);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1337, classLink);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1338, functionLink);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1333, &functionName_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1334, type);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1335, className);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1336, classLink);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1337, functionLink);
 	if (hasArgs) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1339, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1338, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1339, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1338, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1340, &args);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1341, file);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1342, line);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1343, fragment);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 1339, &args);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 1340, file);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 1341, line);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 1342, fragment);
 	ZEPHIR_MM_RESTORE();
 }
 

--- a/ext/phalcon/support/debug/report/exceptionreport.zep.c
+++ b/ext/phalcon/support/debug/report/exceptionreport.zep.c
@@ -152,18 +152,18 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, __construct)
 	ZVAL_STR(&message_zv, message);
 	ZVAL_STR(&file_zv, file);
 	ZVAL_STR(&uri_zv, uri);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1344, &className_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1345, &message_zv);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1346, &file_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1343, &className_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1344, &message_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_2, 1345, &file_zv);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, line);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1347, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_3, 1346, &_0);
 	if (showBackTrace) {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1348, &__$true);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1347, &__$true);
 	} else {
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1348, &__$false);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_4, 1347, &__$false);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1349, &uri_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 1348, &uri_zv);
 }
 
 /**
@@ -292,7 +292,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, hasVariables)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	zephir_memory_observe(&_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1350, PH_NOISY_CC);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1349, PH_NOISY_CC);
 	RETURN_MM_BOOL(!(ZEPHIR_IS_EMPTY(&_0)));
 }
 
@@ -330,7 +330,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setBacktrace)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &backtrace_param);
 	zephir_get_arrval(&backtrace, backtrace_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1351, &backtrace);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1350, &backtrace);
 	RETURN_THIS();
 }
 
@@ -359,7 +359,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setIncludedFiles)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &includedFiles_param);
 	zephir_get_arrval(&includedFiles, includedFiles_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1352, &includedFiles);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1351, &includedFiles);
 	RETURN_THIS();
 }
 
@@ -386,7 +386,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setMemoryUsage)
 	zephir_fetch_params_without_memory_grow(1, 0, &memoryUsage_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, memoryUsage);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1353, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1352, &_0);
 	RETURN_THISW();
 }
 
@@ -413,7 +413,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setPeakMemoryUsage)
 	zephir_fetch_params_without_memory_grow(1, 0, &peakMemoryUsage_param);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, peakMemoryUsage);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1354, &_0);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1353, &_0);
 	RETURN_THISW();
 }
 
@@ -442,7 +442,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setRequest)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &request_param);
 	zephir_get_arrval(&request, request_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1355, &request);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1354, &request);
 	RETURN_THIS();
 }
 
@@ -471,7 +471,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setServer)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &server_param);
 	zephir_get_arrval(&server, server_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1356, &server);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1355, &server);
 	RETURN_THIS();
 }
 
@@ -500,7 +500,7 @@ PHP_METHOD(Phalcon_Support_Debug_Report_ExceptionReport, setVariables)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &variables_param);
 	zephir_get_arrval(&variables, variables_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1350, &variables);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1349, &variables);
 	RETURN_THIS();
 }
 

--- a/ext/phalcon/support/debug/reportbuilder.zep.c
+++ b/ext/phalcon/support/debug/reportbuilder.zep.c
@@ -547,7 +547,7 @@ PHP_METHOD(Phalcon_Support_Debug_ReportBuilder, resolveClassLink)
 	}
 	ZEPHIR_INIT_VAR(&reflection);
 	object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionclass")));
-	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 239, &className_zv);
+	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 240, &className_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_4, &reflection, "isinternal", NULL, 0);
 	zephir_check_call_status();
@@ -601,7 +601,7 @@ PHP_METHOD(Phalcon_Support_Debug_ReportBuilder, resolveFunctionLink)
 	}
 	ZEPHIR_INIT_VAR(&reflection);
 	object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionfunction")));
-	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 236, &functionName_zv);
+	ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 237, &functionName_zv);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, &reflection, "isinternal", NULL, 0);
 	zephir_check_call_status();
@@ -704,7 +704,7 @@ PHP_METHOD(Phalcon_Support_Debug_ReportBuilder, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/support/helper/arr/blacklist.zep.c
+++ b/ext/phalcon/support/helper/arr/blacklist.zep.c
@@ -70,9 +70,9 @@ PHP_METHOD(Phalcon_Support_Helper_Arr_Blacklist, __invoke)
 	zephir_create_closure_ex(&_0, NULL, phalcon_93__closure_ce, SL("__invoke"));
 	ZEPHIR_CALL_METHOD(&blackListed, this_ptr, "tofilter", NULL, 0, &blackList, &_0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_1, "array_flip", NULL, 253, &blackListed);
+	ZEPHIR_CALL_FUNCTION(&_1, "array_flip", NULL, 254, &blackListed);
 	zephir_check_call_status();
-	ZEPHIR_RETURN_CALL_FUNCTION("array_diff_key", NULL, 249, &collection, &_1);
+	ZEPHIR_RETURN_CALL_FUNCTION("array_diff_key", NULL, 250, &collection, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/support/helper/arr/group.zep.c
+++ b/ext/phalcon/support/helper/arr/group.zep.c
@@ -316,7 +316,7 @@ PHP_METHOD(Phalcon_Support_Helper_Arr_Group, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/support/helper/arr/isunique.zep.c
+++ b/ext/phalcon/support/helper/arr/isunique.zep.c
@@ -58,7 +58,7 @@ PHP_METHOD(Phalcon_Support_Helper_Arr_IsUnique, __invoke)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &collection_param);
 	zephir_get_arrval(&collection, collection_param);
-	ZEPHIR_CALL_FUNCTION(&_0, "array_unique", NULL, 412, &collection);
+	ZEPHIR_CALL_FUNCTION(&_0, "array_unique", NULL, 414, &collection);
 	zephir_check_call_status();
 	RETURN_MM_BOOL(zephir_fast_count_int(&collection) == zephir_fast_count_int(&_0));
 }

--- a/ext/phalcon/support/helper/arr/sliceleft.zep.c
+++ b/ext/phalcon/support/helper/arr/sliceleft.zep.c
@@ -67,7 +67,7 @@ PHP_METHOD(Phalcon_Support_Helper_Arr_SliceLeft, __invoke)
 		}
 	ZVAL_LONG(&_0, 0);
 	ZVAL_LONG(&_1, elements);
-	ZEPHIR_RETURN_CALL_FUNCTION("array_slice", NULL, 270, &collection, &_0, &_1);
+	ZEPHIR_RETURN_CALL_FUNCTION("array_slice", NULL, 271, &collection, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/support/helper/arr/sliceright.zep.c
+++ b/ext/phalcon/support/helper/arr/sliceright.zep.c
@@ -65,7 +65,7 @@ PHP_METHOD(Phalcon_Support_Helper_Arr_SliceRight, __invoke)
 	} else {
 		}
 	ZVAL_LONG(&_0, elements);
-	ZEPHIR_RETURN_CALL_FUNCTION("array_slice", NULL, 270, &collection, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("array_slice", NULL, 271, &collection, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/support/helper/arr/whitelist.zep.c
+++ b/ext/phalcon/support/helper/arr/whitelist.zep.c
@@ -70,7 +70,7 @@ PHP_METHOD(Phalcon_Support_Helper_Arr_Whitelist, __invoke)
 	zephir_create_closure_ex(&_0, NULL, phalcon_94__closure_ce, SL("__invoke"));
 	ZEPHIR_CALL_METHOD(&filtered, this_ptr, "tofilter", NULL, 0, &whiteList, &_0);
 	zephir_check_call_status();
-	ZEPHIR_CALL_FUNCTION(&_1, "array_flip", NULL, 253, &filtered);
+	ZEPHIR_CALL_FUNCTION(&_1, "array_flip", NULL, 254, &filtered);
 	zephir_check_call_status();
 	ZEPHIR_RETURN_CALL_FUNCTION("array_intersect_key", NULL, 7, &collection, &_1);
 	zephir_check_call_status();

--- a/ext/phalcon/support/helper/str/decapitalize.zep.c
+++ b/ext/phalcon/support/helper/str/decapitalize.zep.c
@@ -89,7 +89,7 @@ PHP_METHOD(Phalcon_Support_Helper_Str_Decapitalize, __invoke)
 	ZVAL_STR_COPY(&encoding_zv, encoding);
 	}
 	ZVAL_LONG(&_0, 1);
-	ZEPHIR_CALL_FUNCTION(&substr, "mb_substr", NULL, 296, &text_zv, &_0);
+	ZEPHIR_CALL_FUNCTION(&substr, "mb_substr", NULL, 297, &text_zv, &_0);
 	zephir_check_call_status();
 	if (upperRest) {
 		ZEPHIR_CALL_METHOD(&suffix, this_ptr, "toupper", NULL, 0, &substr, &encoding_zv);
@@ -99,7 +99,7 @@ PHP_METHOD(Phalcon_Support_Helper_Str_Decapitalize, __invoke)
 	}
 	ZVAL_LONG(&_0, 0);
 	ZVAL_LONG(&_2, 1);
-	ZEPHIR_CALL_FUNCTION(&_3, "mb_substr", NULL, 296, &text_zv, &_0, &_2);
+	ZEPHIR_CALL_FUNCTION(&_3, "mb_substr", NULL, 297, &text_zv, &_0, &_2);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&_1, this_ptr, "tolower", NULL, 0, &_3, &encoding_zv);
 	zephir_check_call_status();

--- a/ext/phalcon/support/helper/str/dirfromfile.zep.c
+++ b/ext/phalcon/support/helper/str/dirfromfile.zep.c
@@ -112,7 +112,7 @@ PHP_METHOD(Phalcon_Support_Helper_Str_DirFromFile, toDirFromFile)
 	zephir_check_call_status();
 	ZVAL_LONG(&_0, 0);
 	ZVAL_LONG(&_1, -2);
-	ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 296, &name, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 297, &name, &_0, &_1);
 	zephir_check_call_status();
 	_2 = filesystemSafe == 1;
 	if (_2) {
@@ -130,12 +130,12 @@ PHP_METHOD(Phalcon_Support_Helper_Str_DirFromFile, toDirFromFile)
 	if (!zephir_is_true(&start)) {
 		ZVAL_LONG(&_6$$4, 0);
 		ZVAL_LONG(&_7$$4, 1);
-		ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 296, &name, &_6$$4, &_7$$4);
+		ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 297, &name, &_6$$4, &_7$$4);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(&_8);
 	ZVAL_LONG(&_0, 2);
-	ZEPHIR_CALL_FUNCTION(&_9, "mb_str_split", NULL, 297, &start, &_0);
+	ZEPHIR_CALL_FUNCTION(&_9, "mb_str_split", NULL, 298, &start, &_0);
 	zephir_check_call_status();
 	zephir_fast_join_str(&_8, SL("/"), &_9);
 	ZEPHIR_CONCAT_VS(return_value, &_8, "/");

--- a/ext/phalcon/support/helper/str/dynamic.zep.c
+++ b/ext/phalcon/support/helper/str/dynamic.zep.c
@@ -162,7 +162,7 @@ PHP_METHOD(Phalcon_Support_Helper_Str_Dynamic, __invoke)
 			ZEPHIR_INIT_NVAR(&words);
 			zephir_fast_explode(&words, &separator_zv, &_7$$6, LONG_MAX);
 			ZEPHIR_OBS_NVAR(&word);
-			ZEPHIR_CALL_FUNCTION(&_8$$6, "array_rand", &_9, 486, &words);
+			ZEPHIR_CALL_FUNCTION(&_8$$6, "array_rand", &_9, 488, &words);
 			zephir_check_call_status();
 			zephir_array_fetch(&word, &words, &_8$$6, PH_NOISY, "phalcon/Support/Helper/Str/Dynamic.zep", 60);
 			zephir_array_fetch_long(&_10$$6, &match, 0, PH_NOISY | PH_READONLY, "phalcon/Support/Helper/Str/Dynamic.zep", 61);

--- a/ext/phalcon/support/helperfactory.zep.c
+++ b/ext/phalcon/support/helperfactory.zep.c
@@ -205,7 +205,7 @@ PHP_METHOD(Phalcon_Support_HelperFactory, newInstance)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1357, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1356, PH_NOISY_CC | PH_READONLY);
 	if (1 != zephir_array_isset_value(&_0, &name_zv)) {
 		ZEPHIR_INIT_VAR(&_1$$3);
 		ZEPHIR_CALL_METHOD(&_2$$3, this_ptr, "getservice", NULL, 0, &name_zv);
@@ -214,7 +214,7 @@ PHP_METHOD(Phalcon_Support_HelperFactory, newInstance)
 		zephir_check_call_status();
 		zephir_update_property_array(this_ptr, SL("services"), &name_zv, &_1$$3);
 	}
-	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1357, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_3, this_ptr, _zephir_prop_0, 1356, PH_NOISY_CC | PH_READONLY);
 	zephir_array_fetch(&_4, &_3, &name_zv, PH_NOISY | PH_READONLY, "phalcon/Support/HelperFactory.zep", 177);
 	RETURN_CTOR(&_4);
 }

--- a/ext/phalcon/tag.zep.c
+++ b/ext/phalcon/tag.zep.c
@@ -889,7 +889,7 @@ PHP_METHOD(Phalcon_Tag, getTitle)
 		zephir_read_static_property_ce(&_6$$3, phalcon_tag_ce, SL("documentPrependTitle"), PH_NOISY_CC);
 		ZEPHIR_CPY_WRT(&documentPrependTitle, &_6$$3);
 		if (!(ZEPHIR_IS_EMPTY(&documentPrependTitle))) {
-			ZEPHIR_CALL_FUNCTION(&tmp$$5, "array_reverse", NULL, 261, &documentPrependTitle);
+			ZEPHIR_CALL_FUNCTION(&tmp$$5, "array_reverse", NULL, 262, &documentPrependTitle);
 			zephir_check_call_status();
 			zephir_is_iterable(&tmp$$5, 0, "phalcon/Tag.zep", 476);
 			if (Z_TYPE_P(&tmp$$5) == IS_ARRAY) {

--- a/ext/phalcon/time/clock/frozenclock.zep.c
+++ b/ext/phalcon/time/clock/frozenclock.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Phalcon_Time_Clock_FrozenClock, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(now, php_date_get_immutable_ce())
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &now);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1358, now);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1357, now);
 }
 
 /**
@@ -117,7 +117,7 @@ PHP_METHOD(Phalcon_Time_Clock_FrozenClock, adjust)
 
 		/* try_start_1: */
 
-			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 1358, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_4$$4, this_ptr, _zephir_prop_0, 1357, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&modified, &_4$$4, "modify", NULL, 0, &modifier_zv);
 			zephir_check_call_status_or_jump(try_end_1);
 
@@ -147,12 +147,12 @@ PHP_METHOD(Phalcon_Time_Clock_FrozenClock, adjust)
 		ZEPHIR_INIT_NVAR(&_7$$6);
 		zephir_create_closure_ex(&_7$$6, NULL, phalcon_95__closure_ce, SL("__invoke"));
 		ZVAL_LONG(&_8$$6, 2);
-		ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 292, &_7$$6, &_8$$6);
+		ZEPHIR_CALL_FUNCTION(NULL, "set_error_handler", NULL, 293, &_7$$6, &_8$$6);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_0, 1358, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$6, this_ptr, _zephir_prop_0, 1357, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CALL_METHOD(&modified, &_8$$6, "modify", NULL, 0, &modifier_zv);
 		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 293);
+		ZEPHIR_CALL_FUNCTION(NULL, "restore_error_handler", NULL, 294);
 		zephir_check_call_status();
 		failed = ZEPHIR_GLOBAL(warning).enable;
 		ZEPHIR_GLOBAL(warning).enable = zend_is_true(&priorWarning);
@@ -170,7 +170,7 @@ PHP_METHOD(Phalcon_Time_Clock_FrozenClock, adjust)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1358, &modified);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1357, &modified);
 	RETURN_THIS();
 }
 
@@ -195,7 +195,7 @@ PHP_METHOD(Phalcon_Time_Clock_FrozenClock, fromSystemTimezone)
 	object_init_ex(&_0, php_date_get_immutable_ce());
 	ZEPHIR_INIT_VAR(&_1);
 	object_init_ex(&_1, php_date_get_timezone_ce());
-	ZEPHIR_CALL_FUNCTION(&_2, "date_default_timezone_get", NULL, 247);
+	ZEPHIR_CALL_FUNCTION(&_2, "date_default_timezone_get", NULL, 248);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_1, "__construct", NULL, 0, &_2);
 	zephir_check_call_status();
@@ -268,7 +268,7 @@ PHP_METHOD(Phalcon_Time_Clock_FrozenClock, set)
 		Z_PARAM_OBJECT_OF_CLASS(now, php_date_get_immutable_ce())
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &now);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1358, now);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1357, now);
 	RETURN_THISW();
 }
 

--- a/ext/phalcon/time/clock/systemclock.zep.c
+++ b/ext/phalcon/time/clock/systemclock.zep.c
@@ -58,7 +58,7 @@ PHP_METHOD(Phalcon_Time_Clock_SystemClock, __construct)
 		Z_PARAM_OBJECT_OF_CLASS(timezone, php_date_get_timezone_ce())
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &timezone);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1359, timezone);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1358, timezone);
 }
 
 /**
@@ -78,11 +78,11 @@ PHP_METHOD(Phalcon_Time_Clock_SystemClock, fromSystemTimezone)
 	object_init_ex(return_value, phalcon_time_clock_systemclock_ce);
 	ZEPHIR_INIT_VAR(&_0);
 	object_init_ex(&_0, php_date_get_timezone_ce());
-	ZEPHIR_CALL_FUNCTION(&_1, "date_default_timezone_get", NULL, 247);
+	ZEPHIR_CALL_FUNCTION(&_1, "date_default_timezone_get", NULL, 248);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 0, &_1);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 248, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 249, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -108,7 +108,7 @@ PHP_METHOD(Phalcon_Time_Clock_SystemClock, fromUTC)
 	ZVAL_STRING(&_1, "UTC");
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 0, &_1);
 	zephir_check_call_status();
-	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 248, &_0);
+	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 249, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -133,7 +133,7 @@ PHP_METHOD(Phalcon_Time_Clock_SystemClock, now)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
 	object_init_ex(return_value, php_date_get_immutable_ce());
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1359, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1358, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_INIT_VAR(&_1);
 	ZVAL_STRING(&_1, "now");
 	ZEPHIR_CALL_METHOD(NULL, return_value, "__construct", NULL, 0, &_1, &_0);

--- a/ext/phalcon/traits/php/apcutrait.zep.c
+++ b/ext/phalcon/traits/php/apcutrait.zep.c
@@ -65,7 +65,7 @@ PHP_METHOD(Phalcon_Traits_Php_ApcuTrait, phpApcuDec)
 	} else {
 		}
 	ZVAL_LONG(&_0, step);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_dec", NULL, 271, key, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_dec", NULL, 272, key, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -90,7 +90,7 @@ PHP_METHOD(Phalcon_Traits_Php_ApcuTrait, phpApcuDelete)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_delete", NULL, 272, key);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_delete", NULL, 273, key);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -115,7 +115,7 @@ PHP_METHOD(Phalcon_Traits_Php_ApcuTrait, phpApcuExists)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_exists", NULL, 273, key);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_exists", NULL, 274, key);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -140,7 +140,7 @@ PHP_METHOD(Phalcon_Traits_Php_ApcuTrait, phpApcuFetch)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &key);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_fetch", NULL, 274, key);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_fetch", NULL, 275, key);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -174,7 +174,7 @@ PHP_METHOD(Phalcon_Traits_Php_ApcuTrait, phpApcuInc)
 	} else {
 		}
 	ZVAL_LONG(&_0, step);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_inc", NULL, 275, key, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_inc", NULL, 276, key, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -239,7 +239,7 @@ PHP_METHOD(Phalcon_Traits_Php_ApcuTrait, phpApcuStore)
 	} else {
 		}
 	ZVAL_LONG(&_0, ttl);
-	ZEPHIR_RETURN_CALL_FUNCTION("apcu_store", NULL, 276, key, payload, &_0);
+	ZEPHIR_RETURN_CALL_FUNCTION("apcu_store", NULL, 277, key, payload, &_0);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/traits/php/headertrait.zep.c
+++ b/ext/phalcon/traits/php/headertrait.zep.c
@@ -49,7 +49,7 @@ PHP_METHOD(Phalcon_Traits_Php_HeaderTrait, phpHeadersSent)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	ZEPHIR_RETURN_CALL_FUNCTION("headers_sent", NULL, 215);
+	ZEPHIR_RETURN_CALL_FUNCTION("headers_sent", NULL, 216);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/traits/php/igbinarytrait.zep.c
+++ b/ext/phalcon/traits/php/igbinarytrait.zep.c
@@ -55,7 +55,7 @@ PHP_METHOD(Phalcon_Traits_Php_IgbinaryTrait, phpIgbinarySerialize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &value);
-	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_serialize", NULL, 298, value);
+	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_serialize", NULL, 299, value);
 	zephir_check_call_status();
 	RETURN_MM();
 }
@@ -80,7 +80,7 @@ PHP_METHOD(Phalcon_Traits_Php_IgbinaryTrait, phpIgbinaryUnserialize)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &value);
-	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_unserialize", NULL, 299, value);
+	ZEPHIR_RETURN_CALL_FUNCTION("igbinary_unserialize", NULL, 300, value);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/traits/php/infotrait.zep.c
+++ b/ext/phalcon/traits/php/infotrait.zep.c
@@ -59,7 +59,7 @@ PHP_METHOD(Phalcon_Traits_Php_InfoTrait, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/traits/php/initrait.zep.c
+++ b/ext/phalcon/traits/php/initrait.zep.c
@@ -72,7 +72,7 @@ PHP_METHOD(Phalcon_Traits_Php_IniTrait, phpIniGet)
 		zephir_memory_observe(&defaultValue_zv);
 	ZVAL_STR_COPY(&defaultValue_zv, defaultValue);
 	}
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_STR(zend_string_copy(defaultValue));
@@ -119,7 +119,7 @@ PHP_METHOD(Phalcon_Traits_Php_IniTrait, phpIniGetBool)
 	} else {
 		}
 	result = 0;
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_BOOL(defaultValue);
@@ -171,7 +171,7 @@ PHP_METHOD(Phalcon_Traits_Php_IniTrait, phpIniGetInt)
 		defaultValue = 0;
 	} else {
 		}
-	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 436, &input_zv);
+	ZEPHIR_CALL_FUNCTION(&value, "ini_get", NULL, 438, &input_zv);
 	zephir_check_call_status();
 	if (ZEPHIR_IS_FALSE_IDENTICAL(&value)) {
 		RETURN_MM_LONG(defaultValue);
@@ -227,7 +227,7 @@ PHP_METHOD(Phalcon_Traits_Php_IniTrait, phpParseIniFile)
 		}
 	ZVAL_BOOL(&_0, (processSections ? 1 : 0));
 	ZVAL_LONG(&_1, scannerMode);
-	ZEPHIR_RETURN_CALL_FUNCTION("parse_ini_file", NULL, 437, &filename_zv, &_0, &_1);
+	ZEPHIR_RETURN_CALL_FUNCTION("parse_ini_file", NULL, 439, &filename_zv, &_0, &_1);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/traits/php/yamltrait.zep.c
+++ b/ext/phalcon/traits/php/yamltrait.zep.c
@@ -89,7 +89,7 @@ PHP_METHOD(Phalcon_Traits_Php_YamlTrait, phpYamlParseFile)
 	ZVAL_NULL(&ndocs);
 	ZVAL_LONG(&_0, pos);
 	ZEPHIR_MAKE_REF(&ndocs);
-	ZEPHIR_RETURN_CALL_FUNCTION("yaml_parse_file", NULL, 441, &filename_zv, &_0, &ndocs, &callbacks);
+	ZEPHIR_RETURN_CALL_FUNCTION("yaml_parse_file", NULL, 443, &filename_zv, &_0, &ndocs, &callbacks);
 	ZEPHIR_UNREF(&ndocs);
 	zephir_check_call_status();
 	RETURN_MM();

--- a/ext/phalcon/traits/support/helper/str/dirfromfiletrait.zep.c
+++ b/ext/phalcon/traits/support/helper/str/dirfromfiletrait.zep.c
@@ -86,7 +86,7 @@ PHP_METHOD(Phalcon_Traits_Support_Helper_Str_DirFromFileTrait, toDirFromFile)
 	zephir_check_call_status();
 	ZVAL_LONG(&_0, 0);
 	ZVAL_LONG(&_1, -2);
-	ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 296, &name, &_0, &_1);
+	ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 297, &name, &_0, &_1);
 	zephir_check_call_status();
 	_2 = filesystemSafe == 1;
 	if (_2) {
@@ -104,12 +104,12 @@ PHP_METHOD(Phalcon_Traits_Support_Helper_Str_DirFromFileTrait, toDirFromFile)
 	if (!zephir_is_true(&start)) {
 		ZVAL_LONG(&_6$$4, 0);
 		ZVAL_LONG(&_7$$4, 1);
-		ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 296, &name, &_6$$4, &_7$$4);
+		ZEPHIR_CALL_FUNCTION(&start, "mb_substr", NULL, 297, &name, &_6$$4, &_7$$4);
 		zephir_check_call_status();
 	}
 	ZEPHIR_INIT_VAR(&_8);
 	ZVAL_LONG(&_0, 2);
-	ZEPHIR_CALL_FUNCTION(&_9, "mb_str_split", NULL, 297, &start, &_0);
+	ZEPHIR_CALL_FUNCTION(&_9, "mb_str_split", NULL, 298, &start, &_0);
 	zephir_check_call_status();
 	zephir_fast_join_str(&_8, SL("/"), &_9);
 	ZEPHIR_CONCAT_VS(return_value, &_8, "/");

--- a/ext/phalcon/translate/adapter/csv.zep.c
+++ b/ext/phalcon/translate/adapter/csv.zep.c
@@ -168,7 +168,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Csv, has)
 		Z_PARAM_STR(index)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&index_zv, index);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1360, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1359, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &index_zv));
 }
 
@@ -217,7 +217,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Csv, query)
 		zephir_get_arrval(&placeholders, placeholders_param);
 	}
 	zephir_memory_observe(&translation);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1360, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1359, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&translation, &_0, &translateKey_zv, 0))) {
 		ZEPHIR_CALL_METHOD(&translation, this_ptr, "notfound", NULL, 0, &translateKey_zv);
 		zephir_check_call_status();

--- a/ext/phalcon/translate/adapter/gettext.zep.c
+++ b/ext/phalcon/translate/adapter/gettext.zep.c
@@ -388,7 +388,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, setDefaultDomain)
 		Z_PARAM_STR(domain)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&domain_zv, domain);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1361, &domain_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1360, &domain_zv);
 }
 
 /**
@@ -439,7 +439,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, setDirectory)
 	if (ZEPHIR_IS_EMPTY(directory)) {
 		RETURN_MM_NULL();
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1362, directory);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1361, directory);
 	if (Z_TYPE_P(directory) == IS_ARRAY) {
 		zephir_is_iterable(directory, 0, "phalcon/Translate/Adapter/Gettext.zep", 250);
 		if (Z_TYPE_P(directory) == IS_ARRAY) {
@@ -591,28 +591,28 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, setLocale)
 	ZVAL_LONG(&_0, category);
 	ZEPHIR_CALL_FUNCTION(&_1, "setlocale", NULL, 0, &_0, &localeArray);
 	zephir_check_call_status();
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1363, &_1);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1362, &_1);
 	ZVAL_UNDEF(&_0);
 	ZVAL_LONG(&_0, category);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1364, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1363, PH_NOISY_CC | PH_READONLY);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_1, 1363, &_0);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1362, PH_NOISY_CC | PH_READONLY);
 	if (!ZEPHIR_IS_FALSE_IDENTICAL(&_0)) {
-		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 1363, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_2$$3, this_ptr, _zephir_prop_0, 1362, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_3$$3);
 		ZEPHIR_CONCAT_SV(&_3$$3, "LC_ALL=", &_2$$3);
 		ZEPHIR_CALL_FUNCTION(NULL, "putenv", NULL, 0, &_3$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 1363, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_4$$3, this_ptr, _zephir_prop_0, 1362, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_5$$3);
 		ZEPHIR_CONCAT_SV(&_5$$3, "LANG=", &_4$$3);
 		ZEPHIR_CALL_FUNCTION(NULL, "putenv", NULL, 0, &_5$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 1363, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_6$$3, this_ptr, _zephir_prop_0, 1362, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_INIT_VAR(&_7$$3);
 		ZEPHIR_CONCAT_SV(&_7$$3, "LANGUAGE=", &_6$$3);
 		ZEPHIR_CALL_FUNCTION(NULL, "putenv", NULL, 0, &_7$$3);
 		zephir_check_call_status();
-		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 1363, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_8$$3, this_ptr, _zephir_prop_0, 1362, PH_NOISY_CC | PH_READONLY);
 		ZVAL_LONG(&_9$$3, 6);
 		ZEPHIR_CALL_FUNCTION(NULL, "setlocale", NULL, 0, &_9$$3, &_8$$3);
 		zephir_check_call_status();
@@ -718,7 +718,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_Gettext, phpExtensionLoaded)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&name_zv);
 	ZVAL_STR_COPY(&name_zv, name);
-	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 440, &name_zv);
+	ZEPHIR_RETURN_CALL_FUNCTION("extension_loaded", NULL, 442, &name_zv);
 	zephir_check_call_status();
 	RETURN_MM();
 }

--- a/ext/phalcon/translate/adapter/nativearray.zep.c
+++ b/ext/phalcon/translate/adapter/nativearray.zep.c
@@ -104,7 +104,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_NativeArray, __construct)
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1365, &data);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1364, &data);
 	ZEPHIR_MM_RESTORE();
 }
 
@@ -161,7 +161,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_NativeArray, has)
 		Z_PARAM_STR(index)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&index_zv, index);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1365, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1364, PH_NOISY_CC | PH_READONLY);
 	RETURN_BOOL(zephir_array_isset_value(&_0, &index_zv));
 }
 
@@ -210,7 +210,7 @@ PHP_METHOD(Phalcon_Translate_Adapter_NativeArray, query)
 		zephir_get_arrval(&placeholders, placeholders_param);
 	}
 	zephir_memory_observe(&translation);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1365, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 1364, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&translation, &_0, &translateKey_zv, 0))) {
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "notfound", NULL, 0, &translateKey_zv);
 		zephir_check_call_status();

--- a/ext/phalcon/translate/exceptions/missingrequiredparameter.zep.c
+++ b/ext/phalcon/translate/exceptions/missingrequiredparameter.zep.c
@@ -60,7 +60,7 @@ PHP_METHOD(Phalcon_Translate_Exceptions_MissingRequiredParameter, __construct)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_memory_observe(&parameter_zv);
 	ZVAL_STR_COPY(&parameter_zv, parameter);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1366, &parameter_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1365, &parameter_zv);
 	ZEPHIR_INIT_VAR(&_0);
 	ZEPHIR_CONCAT_SVS(&_0, "Parameter '", &parameter_zv, "' is required");
 	ZEPHIR_CALL_PARENT(NULL, phalcon_translate_exceptions_missingrequiredparameter_ce, getThis(), "__construct", NULL, 0, &_0);

--- a/ext/phalcon/translate/translatefactory.zep.c
+++ b/ext/phalcon/translate/translatefactory.zep.c
@@ -87,7 +87,7 @@ PHP_METHOD(Phalcon_Translate_TranslateFactory, __construct)
 	} else {
 		zephir_get_arrval(&services, services_param);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1367, interpolator);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 1366, interpolator);
 	ZEPHIR_CALL_METHOD(NULL, this_ptr, "init", NULL, 0, &services);
 	zephir_check_call_status();
 	ZEPHIR_MM_RESTORE();
@@ -189,7 +189,7 @@ PHP_METHOD(Phalcon_Translate_TranslateFactory, newInstance)
 	ZEPHIR_INIT_VAR(&_0);
 	zephir_create_array(&_0, 2, 0);
 	zephir_memory_observe(&_1);
-	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1367, PH_NOISY_CC);
+	zephir_read_property_cached(&_1, this_ptr, _zephir_prop_0, 1366, PH_NOISY_CC);
 	zephir_array_fast_append(&_0, &_1);
 	zephir_array_fast_append(&_0, &options);
 	ZEPHIR_LAST_CALL_STATUS = zephir_create_instance_params(return_value, &definition, &_0);

--- a/phalcon/ADR/Application.zep
+++ b/phalcon/ADR/Application.zep
@@ -13,8 +13,12 @@
 
 namespace Phalcon\ADR;
 
+use Closure;
+use Phalcon\ADR\Container\AdrProvider;
 use Phalcon\ADR\Events\Event;
 use Phalcon\ADR\Exceptions\RouteNotFound;
+use Phalcon\Container\Container;
+use Phalcon\Container\ContainerFactory;
 use Phalcon\Contracts\ADR\Application as ApplicationInterface;
 use Phalcon\Contracts\ADR\Dispatcher as DispatcherInterface;
 use Phalcon\Contracts\ADR\Router\Router as RouterInterface;
@@ -25,53 +29,125 @@ use Phalcon\Http\Response;
 use Phalcon\Http\ResponseInterface;
 
 /**
- * Routes the request, writes the matched attributes onto it, dispatches the
- * Action and returns the response. A single try/catch routes any error through
- * the error responder; if that itself fails, a bare 500 is returned so nothing
- * escapes uncaught.
+ * ADR composition root. Owns (or accepts) a container, exposes a small
+ * registration surface that hides the container's definition API, configures
+ * the convention router, and handles the request through the ADR flow.
+ *
+ * When no container is supplied one is created with the ADR defaults
+ * (`AdrProvider`) registered. Type-hinted dependencies autowire; only scalar
+ * parameters need to be declared via `define()`.
  */
 final class Application implements ApplicationInterface
 {
     /**
-     * @var DispatcherInterface
+     * @var string
      */
-    protected dispatcher;
+    protected baseNamespace = "";
 
     /**
-     * @var ErrorResponder
+     * @var Container
      */
-    protected errorResponder;
+    protected container;
 
     /**
-     * @var Manager
+     * @var array<string, string[]>
      */
-    protected events;
+    protected middlewareMap = [];
 
-    /**
-     * @var RouterInterface
-     */
-    protected router;
+    public function __construct(<Container> container = null)
+    {
+        if container === null {
+            let container = (new ContainerFactory())
+                ->addProvider(new AdrProvider())
+                ->newContainer();
+        }
 
-    public function __construct(
-        <RouterInterface> router,
-        <DispatcherInterface> dispatcher,
-        <ErrorResponder> errorResponder,
-        <Manager> events
-    ) {
-        let this->router         = router,
-            this->dispatcher     = dispatcher,
-            this->errorResponder = errorResponder,
-            this->events         = events;
+        let this->container = container;
     }
 
+    /**
+     * Bind an interface to a concrete class.
+     */
+    public function bind(string interfaceName, string concrete) -> <static>
+    {
+        this->container->bind(interfaceName, concrete);
+
+        return this;
+    }
+
+    /**
+     * Register a class together with explicit values for its constructor
+     * parameters. Type-hinted dependencies autowire; only the supplied
+     * (usually scalar) parameters are declared. Lazy values (e.g.
+     * `new Phalcon\Container\Resolver\Lazy\Env(...)`) may be passed as values.
+     */
+    public function define(string className, array parameters = []) -> <static>
+    {
+        var definition, param, value;
+
+        let definition = this->container->set(className, className);
+
+        for param, value in parameters {
+            definition->setArgument(param, value);
+        }
+
+        return this;
+    }
+
+    /**
+     * Register a post-build extender (decorator) for a service.
+     */
+    public function extend(string name, <Closure> extender) -> <static>
+    {
+        this->container->extend(name, extender);
+
+        return this;
+    }
+
+    /**
+     * Register a factory closure for a service.
+     */
+    public function factory(string name, <Closure> factory) -> <static>
+    {
+        this->container->set(name, factory);
+
+        return this;
+    }
+
+    /**
+     * Returns the underlying container for definition-level access.
+     */
+    public function getContainer() -> <Container>
+    {
+        return this->container;
+    }
+
+    /**
+     * Routes the request, writes the matched attributes onto it, dispatches
+     * the Action and returns the response. A single try/catch routes any error
+     * through the error responder; if that itself fails, a bare 500 is returned
+     * so nothing escapes uncaught.
+     */
     public function handle(<AttributeRequest> request) -> <ResponseInterface>
     {
-        var match, response, key, value, exception;
+        var router, dispatcher, events, match, response, key, value, exception;
 
-        this->events->fire(Event::APPLICATION_BEFORE_HANDLE, this, request);
+        let router     = this->container->get(RouterInterface::class),
+            dispatcher = this->container->get(DispatcherInterface::class),
+            events     = this->container->get(Manager::class);
+
+        if this->baseNamespace !== "" {
+            router->setBaseNamespace(this->baseNamespace);
+        }
+
+        if count(this->middlewareMap) {
+            router->setMiddlewareMap(this->middlewareMap);
+        }
+
+        events->fire(Event::APPLICATION_BEFORE_HANDLE, this, request);
 
         try {
-            let match = this->router->match(request);
+            let match = router->match(request);
             if match === null {
                 throw new RouteNotFound();
             }
@@ -80,16 +156,16 @@ final class Application implements ApplicationInterface
                 request->getAttributes()->set(key, value);
             }
 
-            let response = this->dispatcher->dispatch(
-                match->getAction(), 
-                request, 
+            let response = dispatcher->dispatch(
+                match->getAction(),
+                request,
                 match->getMiddleware()
             );
         } catch \Throwable, exception {
             try {
-                let response = this->errorResponder->handle(
-                    request, 
-                    new Response(), 
+                let response = this->container->get(ErrorResponder::class)->handle(
+                    request,
+                    new Response(),
                     exception
                 );
             } catch \Throwable {
@@ -99,8 +175,47 @@ final class Application implements ApplicationInterface
             }
         }
 
-        this->events->fire(Event::APPLICATION_AFTER_HANDLE, this, response);
+        events->fire(Event::APPLICATION_AFTER_HANDLE, this, response);
 
         return response;
+    }
+
+    /**
+     * Attach a guard (middleware) to every Action under a namespace prefix.
+     */
+    public function secureWith(string guard, string prefix) -> <static>
+    {
+        var list;
+
+        let list = [];
+
+        if isset this->middlewareMap[prefix] {
+            let list = this->middlewareMap[prefix];
+        }
+
+        let list[] = guard,
+            this->middlewareMap[prefix] = list;
+
+        return this;
+    }
+
+    /**
+     * Register a service with a raw definition (class-string, closure or value).
+     */
+    public function set(string name, var definition) -> <static>
+    {
+        this->container->set(name, definition);
+
+        return this;
+    }
+
+    /**
+     * Set the base namespace the convention router derives Actions from.
+     */
+    public function setBaseNamespace(string baseNamespace) -> <static>
+    {
+        let this->baseNamespace = baseNamespace;
+
+        return this;
     }
 }

--- a/phalcon/ADR/Front/AbstractHttpFront.zep
+++ b/phalcon/ADR/Front/AbstractHttpFront.zep
@@ -16,15 +16,16 @@ namespace Phalcon\ADR\Front;
 use Phalcon\ADR\Application;
 use Phalcon\ADR\Container\AdrProvider;
 use Phalcon\Container\Container;
+use Phalcon\Contracts\ADR\Application as ApplicationInterface;
 use Phalcon\Contracts\ADR\Emitter\Emitter;
 use Phalcon\Contracts\Front\FrontController;
 use Phalcon\Contracts\Http\AttributeRequest;
 
 /**
- * Boots a container, resolves the Application, handles the request and emits the
- * response. Userland front controllers override `loadEnvironment()` /
- * `registerProviders()`; 
- * bootstrap is `exit((new AppFront(dirname(__DIR__)))->run());`.
+ * Boots a container, builds the Application, handles the request and emits the
+ * response. Userland front controllers override `loadEnvironment()`,
+ * `registerProviders()` and optionally `getApplication()`; bootstrap is
+ * `exit((new AppFront(dirname(__DIR__)))->run());`.
  */
 abstract class AbstractHttpFront implements FrontController
 {
@@ -52,7 +53,7 @@ abstract class AbstractHttpFront implements FrontController
             this->registerProviders(container);
 
             let request     = container->get(AttributeRequest::class),
-                application = container->get(Application::class),
+                application = this->getApplication(container),
                 response    = application->handle(request);
 
             container->get(Emitter::class)->emit(response);
@@ -68,6 +69,16 @@ abstract class AbstractHttpFront implements FrontController
     protected function buildContainer() -> <Container>
     {
         return new Container();
+    }
+
+    /**
+     * Builds the Application the front will hand the request to. Override to
+     * configure it (`setBaseNamespace()`/`secureWith()`) or to wire a different
+     * `Phalcon\Contracts\ADR\Application` implementation.
+     */
+    protected function getApplication(<Container> container) -> <ApplicationInterface>
+    {
+        return new Application(container);
     }
 
     protected function handleBootError(<\Throwable> exception) -> int

--- a/tests/unit/ADR/Application/HandleTest.php
+++ b/tests/unit/ADR/Application/HandleTest.php
@@ -14,18 +14,10 @@ declare(strict_types=1);
 namespace Phalcon\Tests\Unit\ADR\Application;
 
 use Phalcon\ADR\Application;
-use Phalcon\ADR\Dispatcher;
-use Phalcon\ADR\ErrorResponder;
-use Phalcon\ADR\Responder\JsonResponder;
-use Phalcon\ADR\Router\Router;
-use Phalcon\Contracts\Container\Ioc\IocContainer;
-use Phalcon\Events\Manager;
+use Phalcon\ADR\Container\AdrProvider;
+use Phalcon\Container\ContainerFactory;
 use Phalcon\Http\Request;
-use Phalcon\Logger\Adapter\Noop;
-use Phalcon\Logger\Logger;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
-use Phalcon\Tests\Support\ADR\Action\Hello\GetHello as HelloAction;
-use stdClass;
 
 final class HandleTest extends AbstractUnitTestCase
 {
@@ -44,16 +36,8 @@ final class HandleTest extends AbstractUnitTestCase
         $_SERVER['REQUEST_URI']    = '/hello/world';
         $_SERVER['REQUEST_METHOD'] = 'GET';
 
-        $action = new HelloAction();
-
-        $router = (new Router())->setBaseNamespace('Phalcon\\Tests\\Support\\ADR\\Action');
-
-        $app = new Application(
-            $router,
-            new Dispatcher($this->containerReturning($action), new Manager()),
-            $this->errorResponder(),
-            new Manager()
-        );
+        $app = $this->application()
+                    ->setBaseNamespace('Phalcon\\Tests\\Support\\ADR\\Action');
 
         $response = $app->handle(new Request());
 
@@ -68,39 +52,20 @@ final class HandleTest extends AbstractUnitTestCase
         $_SERVER['REQUEST_URI']    = '/nope';
         $_SERVER['REQUEST_METHOD'] = 'GET';
 
-        $app = new Application(
-            (new Router())->setBaseNamespace('Phalcon\\Tests\\Support\\ADR\\Action'),
-            new Dispatcher($this->containerReturning(new stdClass()), new Manager()),
-            $this->errorResponder(),
-            new Manager()
-        );
+        $app = $this->application()
+                    ->setBaseNamespace('Phalcon\\Tests\\Support\\ADR\\Action');
 
         $response = $app->handle(new Request());
 
         $this->assertSame(404, $response->getStatusCode());
     }
 
-    private function containerReturning(object $service): IocContainer
+    private function application(): Application
     {
-        return new class ($service) implements IocContainer {
-            public function __construct(private object $service)
-            {
-            }
+        $container = (new ContainerFactory())
+            ->addProvider(new AdrProvider())
+            ->newContainer();
 
-            public function getService(string $serviceName): object
-            {
-                return $this->service;
-            }
-
-            public function hasService(string $serviceName): bool
-            {
-                return true;
-            }
-        };
-    }
-
-    private function errorResponder(): ErrorResponder
-    {
-        return new ErrorResponder(new JsonResponder(), new Logger('adr', ['main' => new Noop()]));
+        return new Application($container);
     }
 }

--- a/tests/unit/ADR/Front/HttpFront/RunTest.php
+++ b/tests/unit/ADR/Front/HttpFront/RunTest.php
@@ -16,6 +16,7 @@ namespace Phalcon\Tests\Unit\ADR\Front\HttpFront;
 use Phalcon\ADR\Front\AbstractHttpFront;
 use Phalcon\ADR\Front\HttpFront;
 use Phalcon\Container\Container;
+use Phalcon\Contracts\ADR\Application as ApplicationInterface;
 use Phalcon\Contracts\ADR\Emitter\Emitter;
 use Phalcon\Contracts\Front\FrontController;
 use Phalcon\Http\Response;
@@ -44,19 +45,20 @@ final class RunTest extends AbstractUnitTestCase
         $front = new class ('/project/root') extends AbstractHttpFront {
             public ?ResponseInterface $emitted = null;
 
+            protected function getApplication(Container $container): ApplicationInterface
+            {
+                return new class implements ApplicationInterface {
+                    public function handle($request): ResponseInterface
+                    {
+                        return (new Response())->setContent('front-body');
+                    }
+                };
+            }
+
             protected function registerProviders(Container $container): void
             {
                 $container->set('Phalcon\\Contracts\\Http\\AttributeRequest', function ($c) {
                     return new stdClass();
-                });
-
-                $container->set('Phalcon\\ADR\\Application', function ($c) {
-                    return new class {
-                        public function handle($request): ResponseInterface
-                        {
-                            return (new Response())->setContent('front-body');
-                        }
-                    };
                 });
 
                 $front = $this;

--- a/tests/unit/Support/Fake/FakeVersion.php
+++ b/tests/unit/Support/Fake/FakeVersion.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Support\Fake;
+
+use Phalcon\Support\Version;
+
+/**
+ * A Version with a fixed release array, so version tests do not depend on the
+ * library's live version. Fixture: 6.0.0 alpha 5 (format ABBCCDE).
+ */
+class FakeVersion extends Version
+{
+    /**
+     * @return int[]
+     */
+    protected function getVersion(): array
+    {
+        return [6, 0, 0, 1, 5];
+    }
+}

--- a/tests/unit/Support/Version/GetPartTest.php
+++ b/tests/unit/Support/Version/GetPartTest.php
@@ -15,6 +15,7 @@ namespace Phalcon\Tests\Unit\Support\Version;
 
 use Phalcon\Support\Version;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Support\Fake\FakeVersion;
 use Phalcon\Tests\Unit\Support\Fake\VersionTrait;
 
 final class GetPartTest extends AbstractUnitTestCase
@@ -32,9 +33,12 @@ final class GetPartTest extends AbstractUnitTestCase
          * where A is the major version, BB is the medium version (2 digits)
          * CC is the minor version (2 digits), D is the release type (see
          * Phalcon\Support\Version) and E is the release number (for example 2 for RC2)
+         *
+         * A fixed FakeVersion is used so this test does not depend on the
+         * library's live version.
          */
 
-        $version = new Version();
+        $version = new FakeVersion();
         $id = $version->getId();
 
         // The major version is the first digit
@@ -57,7 +61,9 @@ final class GetPartTest extends AbstractUnitTestCase
         $actual = $version->getPart(Version::VERSION_SPECIAL);
         $this->assertSame($expected, $actual);
 
-        $special = $this->numberToSpecial((string)$id[6]);
+        // The special number is meaningful only for a special (alpha/beta/RC)
+        // release, which is decided by the release-type digit ($id[5]).
+        $special = $this->numberToSpecial((string)$id[5]);
         $expected = (string)(($special) ? $id[6] : 0);
         $actual = $version->getPart(Version::VERSION_SPECIAL_NUMBER);
         $this->assertSame($expected, $actual);


### PR DESCRIPTION
Hello!

* Type: new feature 
* Link to issue: #17389 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\ADR\Application` into a self-contained composition root: it owns (or accepts) a `Phalcon\Container\Container` and exposes a small registration surface - `bind()`, `define()`, `factory()`, `set()`, `extend()` and `getContainer()` - plus `setBaseNamespace()` and `secureWith()` for convention-router and namespace-prefix guard configuration. `Phalcon\ADR\Front\AbstractHttpFront` gained a protected `getApplication()` hook returning `Phalcon\Contracts\ADR\Application`, so a front controller can configure the application or wire a different implementation. 

Thanks

