### PR TITLE
CP-17409 call to undefined method getpreparedquery

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -48,6 +48,7 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 - Fixed `Phalcon\Mvc\Model` inserting a literal `null` for a column the database can supply a value for, instead of the `DEFAULT` keyword (or omitting the column on an adapter without `DEFAULT` support, such as SQLite). This restores inserts against a MySQL `GENERATED ALWAYS AS (...) STORED` column, which rejects an explicit `null` with `SQLSTATE[HY000]: General error: 3105` but accepts `DEFAULT`. [#17382](https://github.com/phalcon/cphalcon/issues/17382) [[doc]](https://docs.phalcon.io/5.18/db-models/)
 
 - Fixed `Phalcon\ADR\Router\Router` treating `-` and `_` as the same delimiter, so `/forgot-password` and `/forgot_password` resolved to the same Action and the path-to-class map had no inverse. A single separator now applies in both directions, default `-` and settable with `setWordSeparator()`; `_` is literal. [#17405](https://github.com/phalcon/cphalcon/issues/17405) [[doc]](https://docs.phalcon.io/5.18/adr/)
+- Fixed `Phalcon\Mvc\Model::find()` and `Phalcon\Mvc\Model::findFirst()` raising an error `Call to undefined method static::getpreparedquery()`. Using `self` vs. 'static` for the internal calls. [#17409](https://github.com/phalcon/cphalcon/issues/17409) [[doc]](https://docs.phalcon.io/5.18/db-models/)
 
 ### Removed
 

--- a/ext/phalcon/mvc/model.zep.c
+++ b/ext/phalcon/mvc/model.zep.c
@@ -3384,7 +3384,7 @@ PHP_METHOD(Phalcon_Mvc_Model, find)
 	} else {
 		ZEPHIR_CPY_WRT(&params, parameters);
 	}
-	ZEPHIR_CALL_STATIC(&query, "getpreparedquery", &_0, 0, &params);
+	ZEPHIR_CALL_SELF(&query, "getpreparedquery", &_0, 0, &params);
 	zephir_check_call_status();
 	ZEPHIR_CALL_METHOD(&resultset, &query, "execute", NULL, 0);
 	zephir_check_call_status();
@@ -3396,7 +3396,7 @@ PHP_METHOD(Phalcon_Mvc_Model, find)
 		}
 		zephir_memory_observe(&eager);
 		if (zephir_array_isset_string_fetch(&eager, &params, SL("eager"), 0)) {
-			ZEPHIR_CALL_STATIC(NULL, "loadeager", &_1, 0, &resultset, &eager, &params);
+			ZEPHIR_CALL_SELF(NULL, "loadeager", &_1, 0, &resultset, &eager, &params);
 			zephir_check_call_status();
 		}
 	}
@@ -3545,7 +3545,7 @@ PHP_METHOD(Phalcon_Mvc_Model, findFirst)
 		}
 	}
 	ZVAL_LONG(&_5, 1);
-	ZEPHIR_CALL_STATIC(&query, "getpreparedquery", &_4, 0, &params, &_5);
+	ZEPHIR_CALL_SELF(&query, "getpreparedquery", &_4, 0, &params, &_5);
 	zephir_check_call_status();
 	ZVAL_BOOL(&_5, 1);
 	ZEPHIR_CALL_METHOD(NULL, &query, "setuniquerow", NULL, 0, &_5);

--- a/phalcon/Mvc/Model.zep
+++ b/phalcon/Mvc/Model.zep
@@ -1869,7 +1869,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             let params = parameters;
         }
 
-        let query = static::getPreparedQuery(params);
+        let query = self::getPreparedQuery(params);
 
         /**
          * Execute the query passing the bind-params and casting-types
@@ -1890,7 +1890,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
              * cursor has not been advanced, so materializing it is free.
              */
             if fetch eager, params["eager"] {
-                static::loadEager(resultset, eager, params);
+                self::loadEager(resultset, eager, params);
             }
         }
 
@@ -1997,7 +1997,7 @@ abstract class Model extends AbstractInjectionAware implements EntityInterface, 
             throw new InvalidFindParameters(get_called_class());
         }
 
-        let query = static::getPreparedQuery(params, 1);
+        let query = self::getPreparedQuery(params, 1);
 
         /**
          * Return only the first row


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17409 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Fixed `Phalcon\Mvc\Model::find()` and `Phalcon\Mvc\Model::findFirst()` raising an error `Call to undefined method static::getpreparedquery()`. Using `self` vs. 'static` for the internal calls. 


Thanks

