### PR TITLE
CP-17427 compilation warning

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -14,7 +14,7 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 
 ### Fixed
 
-- Removed a stray "!" in `Phalcon\Db\Adapter\Pdo\Mysql::unquoteDefault()` to remove the compilation warning [#17428](https://github.com/phalcon/cphalcon/issues/17428)
+- Removed a stray "!" in `Phalcon\Db\Adapter\Pdo\Mysql::unquoteDefault()` to remove the compilation warning [#17427](https://github.com/phalcon/cphalcon/issues/17427)
 
 ### Removed
 

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -14,6 +14,8 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 
 ### Fixed
 
+- Removed a stray "!" in `Phalcon\Db\Adapter\Pdo\Mysql::unquoteDefault()` to remove the compilation warning [#17428](https://github.com/phalcon/cphalcon/issues/17428)
+
 ### Removed
 
 

--- a/phalcon/Db/Adapter/Pdo/Mysql.zep
+++ b/phalcon/Db/Adapter/Pdo/Mysql.zep
@@ -807,7 +807,7 @@ class Mysql extends PdoAdapter
      * defaults it has supported since 10.2. Expression defaults arrive
      * unquoted, so an unmatched pair leaves the value untouched.
      */
-    private function unquoteDefault(string! value) -> string
+    private function unquoteDefault(string value) -> string
     {
         if strlen(value) < 2 ||
            substr(value, 0, 1) !== "'" ||


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17427 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Removed a stray "!" in `Phalcon\Db\Adapter\Pdo\Mysql::unquoteDefault()` to remove the compilation warning 

Thanks

