### PR TITLE
CP-17499 callback closure bind

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -10,9 +10,13 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 
 ### Changed
 
+- Changed `Phalcon\Filter\Validation\Validator\Callback` to stop binding the callback closure to the validator; to set the message from inside the callback ([#17255](https://github.com/phalcon/cphalcon/issues/17255)), declare a second parameter and call `$validator->setTemplate()` instead of `$this->setTemplate()` [#17499](https://github.com/phalcon/cphalcon/issues/17499) [[doc]](https://docs.phalcon.io/5.18/filter-validation/)
+
 ### Added
 
 ### Fixed
+
+- Fixed `Phalcon\Filter\Validation\Validator\Callback` rebinding `$this` in callback closures; the validator is now passed as a second argument to closures that declare one [#17499](https://github.com/phalcon/cphalcon/issues/17499) [[doc]](https://docs.phalcon.io/5.18/filter-validation/)
 
 ### Removed
 

--- a/ext/phalcon/filter/validation/validator/callback.zep.c
+++ b/ext/phalcon/filter/validation/validator/callback.zep.c
@@ -16,6 +16,7 @@
 #include "kernel/memory.h"
 #include "kernel/operators.h"
 #include "kernel/object.h"
+#include "kernel/array.h"
 #include "Zend/zend_closures.h"
 #include "kernel/exception.h"
 
@@ -120,25 +121,26 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, __construct)
  */
 PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, validate)
 {
-	zend_bool _3$$3, _5$$3;
-	zend_class_entry *_2$$5;
+	zend_bool _2$$3, _4$$3;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, callback, returnedValue, data, savedTemplate, savedChanged, savedTemplates, _0, _1$$5, _6$$3, _4$$6;
+	zval *validation, validation_sub, *field, field_sub, arguments, callback, returnedValue, data, reflection, savedTemplate, savedChanged, savedTemplates, _0, _1$$5, _5$$3, _3$$7;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
 	ZVAL_UNDEF(&field_sub);
+	ZVAL_UNDEF(&arguments);
 	ZVAL_UNDEF(&callback);
 	ZVAL_UNDEF(&returnedValue);
 	ZVAL_UNDEF(&data);
+	ZVAL_UNDEF(&reflection);
 	ZVAL_UNDEF(&savedTemplate);
 	ZVAL_UNDEF(&savedChanged);
 	ZVAL_UNDEF(&savedTemplates);
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_1$$5);
-	ZVAL_UNDEF(&_6$$3);
-	ZVAL_UNDEF(&_4$$6);
+	ZVAL_UNDEF(&_5$$3);
+	ZVAL_UNDEF(&_3$$7);
 	static zend_string *_zephir_prop_0 = NULL;
 	static zend_string *_zephir_prop_1 = NULL;
 	static zend_string *_zephir_prop_2 = NULL;
@@ -176,22 +178,31 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, validate)
 		zephir_read_property_cached(&savedChanged, this_ptr, _zephir_prop_1, 755, PH_NOISY_CC);
 		zephir_memory_observe(&savedTemplates);
 		zephir_read_property_cached(&savedTemplates, this_ptr, _zephir_prop_2, 756, PH_NOISY_CC);
+		ZEPHIR_INIT_VAR(&arguments);
+		zephir_create_array(&arguments, 1, 0);
+		zephir_array_fast_append(&arguments, &data);
 		if (zephir_is_instance_of(&callback, SL("Closure"))) {
-			_2$$5 = zephir_fetch_class_str_ex(SL("Closure"), ZEND_FETCH_CLASS_AUTO);
-			ZEPHIR_CALL_CE_STATIC(&_1$$5, _2$$5, "bind", NULL, 0, &callback, this_ptr);
+			ZEPHIR_INIT_VAR(&reflection);
+			object_init_ex(&reflection, zephir_get_internal_ce(SL("reflectionfunction")));
+			ZEPHIR_CALL_METHOD(NULL, &reflection, "__construct", NULL, 242, &callback);
 			zephir_check_call_status();
-			ZEPHIR_CPY_WRT(&callback, &_1$$5);
+			ZEPHIR_CALL_METHOD(&_1$$5, &reflection, "getnumberofparameters", NULL, 0);
+			zephir_check_call_status();
+			if (ZEPHIR_GT_LONG(&_1$$5, 1)) {
+				zephir_array_append(&arguments, this_ptr, PH_SEPARATE, "phalcon/Filter/Validation/Validator/Callback.zep", 121);
+			}
 		}
-		ZEPHIR_CALL_FUNCTION(&returnedValue, "call_user_func", NULL, 81, &callback, &data);
+		ZEPHIR_INIT_VAR(&returnedValue);
+		ZEPHIR_CALL_USER_FUNC_ARRAY(&returnedValue, &callback, &arguments);
 		zephir_check_call_status();
-		_3$$3 = ((Z_TYPE_P(&returnedValue) == IS_TRUE || Z_TYPE_P(&returnedValue) == IS_FALSE) == 1);
-		if (_3$$3) {
-			_3$$3 = !zephir_is_true(&returnedValue);
+		_2$$3 = ((Z_TYPE_P(&returnedValue) == IS_TRUE || Z_TYPE_P(&returnedValue) == IS_FALSE) == 1);
+		if (_2$$3) {
+			_2$$3 = !zephir_is_true(&returnedValue);
 		}
-		if (_3$$3) {
-			ZEPHIR_CALL_METHOD(&_4$$6, this_ptr, "messagefactory", NULL, 0, validation, field);
+		if (_2$$3) {
+			ZEPHIR_CALL_METHOD(&_3$$7, this_ptr, "messagefactory", NULL, 0, validation, field);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_4$$6);
+			ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_3$$7);
 			zephir_check_call_status();
 		}
 		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 754, &savedTemplate);
@@ -200,20 +211,20 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_Callback, validate)
 		if (((Z_TYPE_P(&returnedValue) == IS_TRUE || Z_TYPE_P(&returnedValue) == IS_FALSE) == 1)) {
 			RETURN_CCTOR(&returnedValue);
 		}
-		_5$$3 = Z_TYPE_P(&returnedValue) == IS_OBJECT;
-		if (_5$$3) {
-			_5$$3 = zephir_instance_of_ev(&returnedValue, phalcon_filter_validation_validatorinterface_ce);
+		_4$$3 = Z_TYPE_P(&returnedValue) == IS_OBJECT;
+		if (_4$$3) {
+			_4$$3 = zephir_instance_of_ev(&returnedValue, phalcon_filter_validation_validatorinterface_ce);
 		}
-		if (_5$$3) {
+		if (_4$$3) {
 			ZEPHIR_RETURN_CALL_METHOD(&returnedValue, "validate", NULL, 0, validation, field);
 			zephir_check_call_status();
 			RETURN_MM();
 		}
-		ZEPHIR_INIT_VAR(&_6$$3);
-		object_init_ex(&_6$$3, phalcon_filter_validation_exceptions_invalidcallbackreturn_ce);
-		ZEPHIR_CALL_METHOD(NULL, &_6$$3, "__construct", NULL, 0);
+		ZEPHIR_INIT_VAR(&_5$$3);
+		object_init_ex(&_5$$3, phalcon_filter_validation_exceptions_invalidcallbackreturn_ce);
+		ZEPHIR_CALL_METHOD(NULL, &_5$$3, "__construct", NULL, 0);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_6$$3, "phalcon/Filter/Validation/Validator/Callback.zep", 131);
+		zephir_throw_exception_debug(&_5$$3, "phalcon/Filter/Validation/Validator/Callback.zep", 145);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}

--- a/phalcon/Filter/Validation/Validator/Callback.zep
+++ b/phalcon/Filter/Validation/Validator/Callback.zep
@@ -15,6 +15,7 @@ use Phalcon\Filter\Validation\AbstractValidator;
 use Phalcon\Filter\Validation\Exceptions\InvalidCallbackReturn;
 use Phalcon\Filter\Validation\ValidatorInterface;
 use Phalcon\Messages\Message;
+use ReflectionFunction;
 
 /**
  * Calls user function for validation
@@ -83,7 +84,8 @@ class Callback extends AbstractValidator
      */
     public function validate(<Validation> validation, var field) -> bool
     {
-        var callback, returnedValue, data, savedTemplate, savedChanged, savedTemplates;
+        var arguments, callback, returnedValue, data, reflection, savedTemplate,
+            savedChanged, savedTemplates;
 
         let callback = this->getOption("callback");
 
@@ -96,19 +98,31 @@ class Callback extends AbstractValidator
 
             /**
              * Snapshot the message state so a setTemplate()/setTemplates()
-             * call inside the bound closure cannot leak into later
-             * validations that reuse this validator instance. Restored below
-             * once the failure message (if any) has been built.
+             * call inside the callback cannot leak into later validations
+             * that reuse this validator instance. Restored below once the
+             * failure message (if any) has been built.
              */
             let savedTemplate  = this->template,
                 savedChanged   = this->templateChanged,
                 savedTemplates = this->templates;
 
+            /**
+             * Send this validator to the closure as a second argument, but
+             * only if the closure accepts it. The `$this` of the closure does
+             * not change. Thus a closure that you write in a class keeps the
+             * object that made it.
+             */
+            let arguments = [data];
+
             if callback instanceof \Closure {
-                let callback = \Closure::bind(callback, this);
+                let reflection = new ReflectionFunction(callback);
+
+                if reflection->getNumberOfParameters() > 1 {
+                    let arguments[] = this;
+                }
             }
 
-            let returnedValue = call_user_func(callback, data);
+            let returnedValue = call_user_func_array(callback, arguments);
 
             if typeof returnedValue == "boolean" && !returnedValue {
                 validation->appendMessage(

--- a/tests/unit/Filter/Validation/Validator/Callback/ValidateTest.php
+++ b/tests/unit/Filter/Validation/Validator/Callback/ValidateTest.php
@@ -25,32 +25,32 @@ use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 
 final class ValidateTest extends AbstractUnitTestCase
 {
+    private array $allowedStatuses = ['pending', 'confirmed'];
+
     /**
+     * A closure that is created in a class keeps the object that made it as
+     * its `$this`. The validator must not replace it.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17499
+     *
      * @author Phalcon Team <team@phalcon.io>
-     * @since  2026-07-06
+     * @since  2026-08-15
      */
-    public function testFilterValidationValidatorCallbackValidateBoundClosure(): void
+    public function testFilterValidationValidatorCallbackValidateClosureKeepsOwnThis(): void
     {
         $validation = new Validation();
 
         $validation->add(
-            'title',
+            'status',
             new Callback(
                 [
+                    'message'  => 'Invalid status.',
                     'callback' => function ($data) {
-                        if (!is_string($data['title'])) {
-                            $this->setTemplate('Title is not a string');
-
-                            return false;
-                        }
-
-                        if (strlen($data['title']) > 10) {
-                            $this->setTemplate('Title too long');
-
-                            return false;
-                        }
-
-                        return true;
+                        return in_array(
+                            $data['status'],
+                            $this->allowedStatuses,
+                            true
+                        );
                     },
                 ]
             )
@@ -59,107 +59,24 @@ final class ValidateTest extends AbstractUnitTestCase
 
         $messages = $validation->validate(
             [
-                'title' => 123,
-            ]
-        );
-
-        $this->assertCount(1, $messages);
-        $this->assertSame(
-            'Title is not a string',
-            $messages[0]->getMessage()
-        );
-
-
-        $messages = $validation->validate(
-            [
-                'title' => 'This title is way too long',
-            ]
-        );
-
-        $this->assertCount(1, $messages);
-        $this->assertSame(
-            'Title too long',
-            $messages[0]->getMessage()
-        );
-
-
-        $messages = $validation->validate(
-            [
-                'title' => 'Short',
+                'status' => 'confirmed',
             ]
         );
 
         $this->assertCount(0, $messages);
-    }
-
-    /**
-     * @author Phalcon Team <team@phalcon.io>
-     * @since  2026-07-06
-     */
-    public function testFilterValidationValidatorCallbackValidateBoundClosureTemplateIsolation(): void
-    {
-        $validation = new Validation();
-
-        $validation->add(
-            'amount',
-            new Callback(
-                [
-                    'message'  => 'DEFAULT failure message',
-                    'callback' => function ($data) {
-                        if ($data['amount'] > 100) {
-                            $this->setTemplate('Amount too big');
-
-                            return false;
-                        }
-
-                        return $data['amount'] >= 0;
-                    },
-                ]
-            )
-        );
 
 
-        /**
-         * The branch that calls setTemplate() must use that template.
-         */
         $messages = $validation->validate(
             [
-                'amount' => 200,
+                'status' => 'unknown',
             ]
         );
 
         $this->assertCount(1, $messages);
         $this->assertSame(
-            'Amount too big',
+            'Invalid status.',
             $messages[0]->getMessage()
         );
-
-
-        /**
-         * A later branch that does NOT call setTemplate() must fall back to
-         * the configured 'message' option, not leak the template set on the
-         * previous call.
-         */
-        $messages = $validation->validate(
-            [
-                'amount' => -5,
-            ]
-        );
-
-        $this->assertCount(1, $messages);
-        $this->assertSame(
-            'DEFAULT failure message',
-            $messages[0]->getMessage()
-        );
-
-
-        $messages = $validation->validate(
-            [
-                'amount' => 50,
-            ]
-        );
-
-        $this->assertCount(0, $messages);
     }
 
     /**
@@ -545,5 +462,201 @@ final class ValidateTest extends AbstractUnitTestCase
         );
 
         $this->assertEquals($expected, $messages);
+    }
+
+    /**
+     * A static closure cannot take a `$this`. It must still run, and it must
+     * still get the validator as a second argument.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17499
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-15
+     */
+    public function testFilterValidationValidatorCallbackValidateStaticClosure(): void
+    {
+        $validation = new Validation();
+
+        $validation->add(
+            'amount',
+            new Callback(
+                [
+                    'message'  => 'DEFAULT failure message',
+                    'callback' => static function ($data, $validator) {
+                        if ($data['amount'] > 100) {
+                            $validator->setTemplate('Amount too big');
+
+                            return false;
+                        }
+
+                        return true;
+                    },
+                ]
+            )
+        );
+
+
+        $messages = $validation->validate(
+            [
+                'amount' => 200,
+            ]
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertSame(
+            'Amount too big',
+            $messages[0]->getMessage()
+        );
+
+
+        $messages = $validation->validate(
+            [
+                'amount' => 50,
+            ]
+        );
+
+        $this->assertCount(0, $messages);
+    }
+
+    /**
+     * A closure that declares a second parameter gets the validator, so it can
+     * change the message from inside the callback.
+     *
+     * @issue  https://github.com/phalcon/cphalcon/issues/17255
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-07-06
+     */
+    public function testFilterValidationValidatorCallbackValidateValidatorArgument(): void
+    {
+        $validation = new Validation();
+
+        $validation->add(
+            'title',
+            new Callback(
+                [
+                    'callback' => function ($data, $validator) {
+                        if (!is_string($data['title'])) {
+                            $validator->setTemplate('Title is not a string');
+
+                            return false;
+                        }
+
+                        if (strlen($data['title']) > 10) {
+                            $validator->setTemplate('Title too long');
+
+                            return false;
+                        }
+
+                        return true;
+                    },
+                ]
+            )
+        );
+
+
+        $messages = $validation->validate(
+            [
+                'title' => 123,
+            ]
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertSame(
+            'Title is not a string',
+            $messages[0]->getMessage()
+        );
+
+
+        $messages = $validation->validate(
+            [
+                'title' => 'This title is way too long',
+            ]
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertSame(
+            'Title too long',
+            $messages[0]->getMessage()
+        );
+
+
+        $messages = $validation->validate(
+            [
+                'title' => 'Short',
+            ]
+        );
+
+        $this->assertCount(0, $messages);
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-07-06
+     */
+    public function testFilterValidationValidatorCallbackValidateValidatorArgumentTemplateIsolation(): void
+    {
+        $validation = new Validation();
+
+        $validation->add(
+            'amount',
+            new Callback(
+                [
+                    'message'  => 'DEFAULT failure message',
+                    'callback' => function ($data, $validator) {
+                        if ($data['amount'] > 100) {
+                            $validator->setTemplate('Amount too big');
+
+                            return false;
+                        }
+
+                        return $data['amount'] >= 0;
+                    },
+                ]
+            )
+        );
+
+
+        /**
+         * The branch that calls setTemplate() must use that template.
+         */
+        $messages = $validation->validate(
+            [
+                'amount' => 200,
+            ]
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertSame(
+            'Amount too big',
+            $messages[0]->getMessage()
+        );
+
+
+        /**
+         * A later branch that does NOT call setTemplate() must fall back to
+         * the configured 'message' option, not leak the template set on the
+         * previous call.
+         */
+        $messages = $validation->validate(
+            [
+                'amount' => -5,
+            ]
+        );
+
+        $this->assertCount(1, $messages);
+        $this->assertSame(
+            'DEFAULT failure message',
+            $messages[0]->getMessage()
+        );
+
+
+        $messages = $validation->validate(
+            [
+                'amount' => 50,
+            ]
+        );
+
+        $this->assertCount(0, $messages);
     }
 }


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17499 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

Changed `Phalcon\Filter\Validation\Validator\Callback` to stop binding the callback closure to the validator; to set the message from inside the callback ([#17255](https://github.com/phalcon/cphalcon/issues/17255)), declare a second parameter and call `$validator->setTemplate()` instead of `$this->setTemplate()` 

Fixed `Phalcon\Filter\Validation\Validator\Callback` rebinding `$this` in callback closures; the validator is now passed as a second argument to closures that declare one 


Thanks

