### PR TITLE
CP-17527 router notices

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,23 @@
 
 All notable changes are documented here. The format is based on [Keep a Changelog][keep_a_changelog] and this project adheres to [Semantic Versioning][semantic_versioning].
 
+## [5.20.2](https://github.com/phalcon/cphalcon/releases/tag/v5.20.2) (2026-08-25)
+
+### Tools
+
+- Zephir 1.2.0 (32d04d5)
+
+### Changed
+
+- The PHPUnit configuration now fails the run on notices, deprecations and PHPUnit deprecations, and prints the details of every triggering test.
+- Added regression tests for the hardening changes released in 5.20.0 and 5.20.1 that had no failing-on-revert coverage.
+
+### Added
+
+### Fixed
+
+- `Undefined index` notice emitted for every literal route when `Phalcon\Mvc\Router` rebuilds its per-method index. [#17527](https://github.com/phalcon/cphalcon/issues/17527)
+
 ## [5.20.1](https://github.com/phalcon/cphalcon/releases/tag/v5.20.1) (2026-08-24)
 
 ### Tools

--- a/composer.lock
+++ b/composer.lock
@@ -2461,16 +2461,16 @@
         },
         {
             "name": "phalcon/ide-stubs",
-            "version": "v5.20.0",
+            "version": "v5.20.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phalcon/ide-stubs.git",
-                "reference": "771147b738a34a6c72a103f021a512014a0fb5dc"
+                "reference": "4cb649aa15e767cd08a476fdd697a94fe2198e1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phalcon/ide-stubs/zipball/771147b738a34a6c72a103f021a512014a0fb5dc",
-                "reference": "771147b738a34a6c72a103f021a512014a0fb5dc",
+                "url": "https://api.github.com/repos/phalcon/ide-stubs/zipball/4cb649aa15e767cd08a476fdd697a94fe2198e1c",
+                "reference": "4cb649aa15e767cd08a476fdd697a94fe2198e1c",
                 "shasum": ""
             },
             "require": {
@@ -2526,7 +2526,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2026-08-23T02:38:27+00:00"
+            "time": "2026-08-25T02:12:31+00:00"
         },
         {
             "name": "phalcon/quill",
@@ -2681,12 +2681,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/zephir-lang/zephir.git",
-                "reference": "0dd0f2a41e80c41c3fd34dc3b2a7b2ab215a58f1"
+                "reference": "47f31e1c6e249067b12df101aeea0fecdafd77e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/0dd0f2a41e80c41c3fd34dc3b2a7b2ab215a58f1",
-                "reference": "0dd0f2a41e80c41c3fd34dc3b2a7b2ab215a58f1",
+                "url": "https://api.github.com/repos/zephir-lang/zephir/zipball/47f31e1c6e249067b12df101aeea0fecdafd77e9",
+                "reference": "47f31e1c6e249067b12df101aeea0fecdafd77e9",
                 "shasum": ""
             },
             "require": {
@@ -2763,7 +2763,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-23T21:54:38+00:00"
+            "time": "2026-08-25T13:09:06+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -7943,23 +7943,23 @@
         },
         {
             "name": "vlucas/phpdotenv",
-            "version": "v5.6.4",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vlucas/phpdotenv.git",
-                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b"
+                "reference": "301c07936b16d88628b126b01d082ba153cf4c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/416df702837983f8d5ff48c9c3fee4f5f57b980b",
-                "reference": "416df702837983f8d5ff48c9c3fee4f5f57b980b",
+                "url": "https://api.github.com/repos/vlucas/phpdotenv/zipball/301c07936b16d88628b126b01d082ba153cf4c40",
+                "reference": "301c07936b16d88628b126b01d082ba153cf4c40",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
-                "graham-campbell/result-type": "^1.1.4",
+                "graham-campbell/result-type": "^1.2",
                 "php": "^7.2.5 || ^8.0",
-                "phpoption/phpoption": "^1.9.5",
+                "phpoption/phpoption": "^1.10",
                 "symfony/polyfill-ctype": "^1.26",
                 "symfony/polyfill-mbstring": "^1.26",
                 "symfony/polyfill-php80": "^1.26"
@@ -8003,7 +8003,7 @@
                     "homepage": "https://github.com/vlucas"
                 }
             ],
-            "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
+            "description": "Loads environment variables from `.env` to `$_ENV` and `$_SERVER` automagically, and optionally to `getenv()`.",
             "keywords": [
                 "dotenv",
                 "env",
@@ -8011,7 +8011,7 @@
             ],
             "support": {
                 "issues": "https://github.com/vlucas/phpdotenv/issues",
-                "source": "https://github.com/vlucas/phpdotenv/tree/v5.6.4"
+                "source": "https://github.com/vlucas/phpdotenv/tree/v5.7.0"
             },
             "funding": [
                 {
@@ -8023,7 +8023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-06T19:11:50+00:00"
+            "time": "2026-08-24T18:07:49+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/ext/phalcon/cli/router.zep.c
+++ b/ext/phalcon/cli/router.zep.c
@@ -438,15 +438,15 @@ PHP_METHOD(Phalcon_Cli_Router, getTaskName)
  */
 PHP_METHOD(Phalcon_Cli_Router, handle)
 {
-	zval _44$$55;
-	zend_string *_11$$12, *_29$$32;
-	zend_ulong _10$$12, _28$$32;
-	zval _8$$9, _13$$15, _15$$18, _19$$21, _21$$24, _26$$29, _31$$35, _33$$38, _37$$41, _39$$44;
-	zend_bool _0$$3, _23$$3, _17$$12, _35$$32;
+	zval _44$$56;
+	zend_string *_11$$13, *_29$$33;
+	zend_ulong _10$$13, _28$$33;
+	zval _8$$10, _13$$16, _15$$19, _19$$22, _21$$25, _26$$30, _31$$36, _33$$39, _37$$42, _39$$45;
+	zend_bool _0$$3, _23$$3, _17$$13, _35$$33;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zephir_fcall_cache_entry *_7 = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *arguments = NULL, arguments_sub, __$true, __$false, __$null, moduleName, taskName, actionName, params, route, parts, pattern, routeFound, matches, paths, beforeMatch, converters, converter, part, position, matchPosition, strParams, _3$$3, *_4$$3, _22$$3, _1$$4, _2$$4, _5$$10, _6$$10, *_9$$12, _16$$12, _12$$15, _14$$18, _18$$21, _20$$24, _24$$30, _25$$30, *_27$$32, _34$$32, _30$$35, _32$$38, _36$$41, _38$$44, _40$$46, _41$$46, _42$$46, _43$$46, _45$$55, _46$$56, _47$$58;
+	zval *arguments = NULL, arguments_sub, __$true, __$false, __$null, moduleName, taskName, actionName, params, route, parts, pattern, routeFound, matches, paths, beforeMatch, converters, converter, part, position, matchPosition, strParams, _3$$3, *_4$$3, _22$$3, _1$$4, _2$$4, _5$$11, _6$$11, *_9$$13, _16$$13, _12$$16, _14$$19, _18$$22, _20$$25, _24$$31, _25$$31, *_27$$33, _34$$33, _30$$36, _32$$39, _36$$42, _38$$45, _40$$47, _41$$47, _42$$47, _43$$47, _45$$56, _46$$57, _47$$59;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&arguments_sub);
@@ -474,38 +474,38 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 	ZVAL_UNDEF(&_22$$3);
 	ZVAL_UNDEF(&_1$$4);
 	ZVAL_UNDEF(&_2$$4);
-	ZVAL_UNDEF(&_5$$10);
-	ZVAL_UNDEF(&_6$$10);
-	ZVAL_UNDEF(&_16$$12);
-	ZVAL_UNDEF(&_12$$15);
-	ZVAL_UNDEF(&_14$$18);
-	ZVAL_UNDEF(&_18$$21);
-	ZVAL_UNDEF(&_20$$24);
-	ZVAL_UNDEF(&_24$$30);
-	ZVAL_UNDEF(&_25$$30);
-	ZVAL_UNDEF(&_34$$32);
-	ZVAL_UNDEF(&_30$$35);
-	ZVAL_UNDEF(&_32$$38);
-	ZVAL_UNDEF(&_36$$41);
-	ZVAL_UNDEF(&_38$$44);
-	ZVAL_UNDEF(&_40$$46);
-	ZVAL_UNDEF(&_41$$46);
-	ZVAL_UNDEF(&_42$$46);
-	ZVAL_UNDEF(&_43$$46);
-	ZVAL_UNDEF(&_45$$55);
-	ZVAL_UNDEF(&_46$$56);
-	ZVAL_UNDEF(&_47$$58);
-	ZVAL_UNDEF(&_8$$9);
-	ZVAL_UNDEF(&_13$$15);
-	ZVAL_UNDEF(&_15$$18);
-	ZVAL_UNDEF(&_19$$21);
-	ZVAL_UNDEF(&_21$$24);
-	ZVAL_UNDEF(&_26$$29);
-	ZVAL_UNDEF(&_31$$35);
-	ZVAL_UNDEF(&_33$$38);
-	ZVAL_UNDEF(&_37$$41);
-	ZVAL_UNDEF(&_39$$44);
-	ZVAL_UNDEF(&_44$$55);
+	ZVAL_UNDEF(&_5$$11);
+	ZVAL_UNDEF(&_6$$11);
+	ZVAL_UNDEF(&_16$$13);
+	ZVAL_UNDEF(&_12$$16);
+	ZVAL_UNDEF(&_14$$19);
+	ZVAL_UNDEF(&_18$$22);
+	ZVAL_UNDEF(&_20$$25);
+	ZVAL_UNDEF(&_24$$31);
+	ZVAL_UNDEF(&_25$$31);
+	ZVAL_UNDEF(&_34$$33);
+	ZVAL_UNDEF(&_30$$36);
+	ZVAL_UNDEF(&_32$$39);
+	ZVAL_UNDEF(&_36$$42);
+	ZVAL_UNDEF(&_38$$45);
+	ZVAL_UNDEF(&_40$$47);
+	ZVAL_UNDEF(&_41$$47);
+	ZVAL_UNDEF(&_42$$47);
+	ZVAL_UNDEF(&_43$$47);
+	ZVAL_UNDEF(&_45$$56);
+	ZVAL_UNDEF(&_46$$57);
+	ZVAL_UNDEF(&_47$$59);
+	ZVAL_UNDEF(&_8$$10);
+	ZVAL_UNDEF(&_13$$16);
+	ZVAL_UNDEF(&_15$$19);
+	ZVAL_UNDEF(&_19$$22);
+	ZVAL_UNDEF(&_21$$25);
+	ZVAL_UNDEF(&_26$$30);
+	ZVAL_UNDEF(&_31$$36);
+	ZVAL_UNDEF(&_33$$39);
+	ZVAL_UNDEF(&_37$$42);
+	ZVAL_UNDEF(&_39$$45);
+	ZVAL_UNDEF(&_44$$56);
 	static zend_string *_zephir_prop_0 = NULL;
 	static zend_string *_zephir_prop_1 = NULL;
 	static zend_string *_zephir_prop_2 = NULL;
@@ -565,7 +565,9 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 	zephir_fetch_params(1, 0, 1, &arguments);
 	if (!arguments) {
 		arguments = &arguments_sub;
-		arguments = &__$null;
+		ZEPHIR_CPY_WRT(arguments, &__$null);
+	} else {
+		ZEPHIR_SEPARATE_PARAM(arguments);
 	}
 	ZEPHIR_INIT_VAR(&routeFound);
 	ZVAL_BOOL(&routeFound, 0);
@@ -597,8 +599,12 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 			ZEPHIR_MM_RESTORE();
 			return;
 		}
+		if (Z_TYPE_P(arguments) == IS_NULL) {
+			ZEPHIR_INIT_NVAR(arguments);
+			ZVAL_STRING(arguments, "");
+		}
 		zephir_read_property_cached(&_3$$3, this_ptr, _zephir_prop_2, 499, PH_NOISY_CC | PH_READONLY);
-		zephir_is_iterable(&_3$$3, 0, "phalcon/Cli/Router.zep", 343);
+		zephir_is_iterable(&_3$$3, 0, "phalcon/Cli/Router.zep", 351);
 		if (Z_TYPE_P(&_3$$3) == IS_ARRAY) {
 			ZEND_HASH_REVERSE_FOREACH_VAL(Z_ARRVAL_P(&_3$$3), _4$$3)
 			{
@@ -606,7 +612,7 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 				ZVAL_COPY(&route, _4$$3);
 				ZEPHIR_CALL_METHOD(&pattern, &route, "getcompiledpattern", NULL, 0);
 				zephir_check_call_status();
-				if (zephir_memnstr_str(&pattern, SL("^"), "phalcon/Cli/Router.zep", 248)) {
+				if (zephir_memnstr_str(&pattern, SL("^"), "phalcon/Cli/Router.zep", 256)) {
 					ZEPHIR_INIT_NVAR(&routeFound);
 					zephir_preg_match(&routeFound, &pattern, arguments, &matches, 0, 0 , 0 );
 				} else {
@@ -618,23 +624,23 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 					zephir_check_call_status();
 					if (Z_TYPE_P(&beforeMatch) != IS_NULL) {
 						if (UNEXPECTED(!(zephir_is_callable(&beforeMatch)))) {
-							ZEPHIR_INIT_NVAR(&_5$$10);
-							object_init_ex(&_5$$10, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
-							ZEPHIR_CALL_METHOD(&_6$$10, &route, "getpattern", NULL, 0);
+							ZEPHIR_INIT_NVAR(&_5$$11);
+							object_init_ex(&_5$$11, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
+							ZEPHIR_CALL_METHOD(&_6$$11, &route, "getpattern", NULL, 0);
 							zephir_check_call_status();
-							ZEPHIR_CALL_METHOD(NULL, &_5$$10, "__construct", &_7, 454, &_6$$10);
+							ZEPHIR_CALL_METHOD(NULL, &_5$$11, "__construct", &_7, 454, &_6$$11);
 							zephir_check_call_status();
-							zephir_throw_exception_debug(&_5$$10, "phalcon/Cli/Router.zep", 265);
+							zephir_throw_exception_debug(&_5$$11, "phalcon/Cli/Router.zep", 273);
 							ZEPHIR_MM_RESTORE();
 							return;
 						}
-						ZEPHIR_INIT_NVAR(&_8$$9);
-						zephir_create_array(&_8$$9, 3, 0);
-						zephir_array_fast_append(&_8$$9, arguments);
-						zephir_array_fast_append(&_8$$9, &route);
-						zephir_array_fast_append(&_8$$9, this_ptr);
+						ZEPHIR_INIT_NVAR(&_8$$10);
+						zephir_create_array(&_8$$10, 3, 0);
+						zephir_array_fast_append(&_8$$10, arguments);
+						zephir_array_fast_append(&_8$$10, &route);
+						zephir_array_fast_append(&_8$$10, this_ptr);
 						ZEPHIR_INIT_NVAR(&routeFound);
-						ZEPHIR_CALL_USER_FUNC_ARRAY(&routeFound, &beforeMatch, &_8$$9);
+						ZEPHIR_CALL_USER_FUNC_ARRAY(&routeFound, &beforeMatch, &_8$$10);
 						zephir_check_call_status();
 					}
 				}
@@ -645,59 +651,59 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 					if (Z_TYPE_P(&matches) == IS_ARRAY) {
 						ZEPHIR_CALL_METHOD(&converters, &route, "getconverters", NULL, 0);
 						zephir_check_call_status();
-						zephir_is_iterable(&paths, 0, "phalcon/Cli/Router.zep", 330);
+						zephir_is_iterable(&paths, 0, "phalcon/Cli/Router.zep", 338);
 						if (Z_TYPE_P(&paths) == IS_ARRAY) {
-							ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&paths), _10$$12, _11$$12, _9$$12)
+							ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&paths), _10$$13, _11$$13, _9$$13)
 							{
 								ZEPHIR_INIT_NVAR(&part);
-								if (_11$$12 != NULL) { 
-									ZVAL_STR_COPY(&part, _11$$12);
+								if (_11$$13 != NULL) { 
+									ZVAL_STR_COPY(&part, _11$$13);
 								} else {
-									ZVAL_LONG(&part, _10$$12);
+									ZVAL_LONG(&part, _10$$13);
 								}
 								ZEPHIR_INIT_NVAR(&position);
-								ZVAL_COPY(&position, _9$$12);
+								ZVAL_COPY(&position, _9$$13);
 								ZEPHIR_OBS_NVAR(&matchPosition);
 								if (zephir_array_isset_fetch(&matchPosition, &matches, &position, 0)) {
 									ZEPHIR_OBS_NVAR(&converter);
 									if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-										ZEPHIR_INIT_NVAR(&_12$$15);
-										ZEPHIR_INIT_NVAR(&_13$$15);
-										zephir_create_array(&_13$$15, 1, 0);
-										zephir_array_fast_append(&_13$$15, &matchPosition);
-										ZEPHIR_CALL_USER_FUNC_ARRAY(&_12$$15, &converter, &_13$$15);
+										ZEPHIR_INIT_NVAR(&_12$$16);
+										ZEPHIR_INIT_NVAR(&_13$$16);
+										zephir_create_array(&_13$$16, 1, 0);
+										zephir_array_fast_append(&_13$$16, &matchPosition);
+										ZEPHIR_CALL_USER_FUNC_ARRAY(&_12$$16, &converter, &_13$$16);
 										zephir_check_call_status();
-										zephir_array_update_zval(&parts, &part, &_12$$15, PH_COPY | PH_SEPARATE);
+										zephir_array_update_zval(&parts, &part, &_12$$16, PH_COPY | PH_SEPARATE);
 									} else {
 										zephir_array_update_zval(&parts, &part, &matchPosition, PH_COPY | PH_SEPARATE);
 									}
 								} else {
 									ZEPHIR_OBS_NVAR(&converter);
 									if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-										ZEPHIR_INIT_NVAR(&_14$$18);
-										ZEPHIR_INIT_NVAR(&_15$$18);
-										zephir_create_array(&_15$$18, 1, 0);
-										zephir_array_fast_append(&_15$$18, &position);
-										ZEPHIR_CALL_USER_FUNC_ARRAY(&_14$$18, &converter, &_15$$18);
+										ZEPHIR_INIT_NVAR(&_14$$19);
+										ZEPHIR_INIT_NVAR(&_15$$19);
+										zephir_create_array(&_15$$19, 1, 0);
+										zephir_array_fast_append(&_15$$19, &position);
+										ZEPHIR_CALL_USER_FUNC_ARRAY(&_14$$19, &converter, &_15$$19);
 										zephir_check_call_status();
-										zephir_array_update_zval(&parts, &part, &_14$$18, PH_COPY | PH_SEPARATE);
+										zephir_array_update_zval(&parts, &part, &_14$$19, PH_COPY | PH_SEPARATE);
 									}
 								}
 							} ZEND_HASH_FOREACH_END();
 						} else {
 							ZEPHIR_CALL_METHOD(NULL, &paths, "rewind", NULL, 0);
 							zephir_check_call_status();
-							_17$$12 = 1;
+							_17$$13 = 1;
 							while (1) {
-								if (_17$$12) {
-									_17$$12 = 0;
+								if (_17$$13) {
+									_17$$13 = 0;
 								} else {
 									ZEPHIR_CALL_METHOD(NULL, &paths, "next", NULL, 0);
 									zephir_check_call_status();
 								}
-								ZEPHIR_CALL_METHOD(&_16$$12, &paths, "valid", NULL, 0);
+								ZEPHIR_CALL_METHOD(&_16$$13, &paths, "valid", NULL, 0);
 								zephir_check_call_status();
-								if (!zend_is_true(&_16$$12)) {
+								if (!zend_is_true(&_16$$13)) {
 									break;
 								}
 								ZEPHIR_CALL_METHOD(&part, &paths, "key", NULL, 0);
@@ -708,26 +714,26 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 									if (zephir_array_isset_fetch(&matchPosition, &matches, &position, 0)) {
 										ZEPHIR_OBS_NVAR(&converter);
 										if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-											ZEPHIR_INIT_NVAR(&_18$$21);
-											ZEPHIR_INIT_NVAR(&_19$$21);
-											zephir_create_array(&_19$$21, 1, 0);
-											zephir_array_fast_append(&_19$$21, &matchPosition);
-											ZEPHIR_CALL_USER_FUNC_ARRAY(&_18$$21, &converter, &_19$$21);
+											ZEPHIR_INIT_NVAR(&_18$$22);
+											ZEPHIR_INIT_NVAR(&_19$$22);
+											zephir_create_array(&_19$$22, 1, 0);
+											zephir_array_fast_append(&_19$$22, &matchPosition);
+											ZEPHIR_CALL_USER_FUNC_ARRAY(&_18$$22, &converter, &_19$$22);
 											zephir_check_call_status();
-											zephir_array_update_zval(&parts, &part, &_18$$21, PH_COPY | PH_SEPARATE);
+											zephir_array_update_zval(&parts, &part, &_18$$22, PH_COPY | PH_SEPARATE);
 										} else {
 											zephir_array_update_zval(&parts, &part, &matchPosition, PH_COPY | PH_SEPARATE);
 										}
 									} else {
 										ZEPHIR_OBS_NVAR(&converter);
 										if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-											ZEPHIR_INIT_NVAR(&_20$$24);
-											ZEPHIR_INIT_NVAR(&_21$$24);
-											zephir_create_array(&_21$$24, 1, 0);
-											zephir_array_fast_append(&_21$$24, &position);
-											ZEPHIR_CALL_USER_FUNC_ARRAY(&_20$$24, &converter, &_21$$24);
+											ZEPHIR_INIT_NVAR(&_20$$25);
+											ZEPHIR_INIT_NVAR(&_21$$25);
+											zephir_create_array(&_21$$25, 1, 0);
+											zephir_array_fast_append(&_21$$25, &position);
+											ZEPHIR_CALL_USER_FUNC_ARRAY(&_20$$25, &converter, &_21$$25);
 											zephir_check_call_status();
-											zephir_array_update_zval(&parts, &part, &_20$$24, PH_COPY | PH_SEPARATE);
+											zephir_array_update_zval(&parts, &part, &_20$$25, PH_COPY | PH_SEPARATE);
 										}
 									}
 							}
@@ -760,7 +766,7 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 				zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&pattern, &route, "getcompiledpattern", NULL, 0);
 					zephir_check_call_status();
-					if (zephir_memnstr_str(&pattern, SL("^"), "phalcon/Cli/Router.zep", 248)) {
+					if (zephir_memnstr_str(&pattern, SL("^"), "phalcon/Cli/Router.zep", 256)) {
 						ZEPHIR_INIT_NVAR(&routeFound);
 						zephir_preg_match(&routeFound, &pattern, arguments, &matches, 0, 0 , 0 );
 					} else {
@@ -772,23 +778,23 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 						zephir_check_call_status();
 						if (Z_TYPE_P(&beforeMatch) != IS_NULL) {
 							if (UNEXPECTED(!(zephir_is_callable(&beforeMatch)))) {
-								ZEPHIR_INIT_NVAR(&_24$$30);
-								object_init_ex(&_24$$30, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
-								ZEPHIR_CALL_METHOD(&_25$$30, &route, "getpattern", NULL, 0);
+								ZEPHIR_INIT_NVAR(&_24$$31);
+								object_init_ex(&_24$$31, phalcon_cli_router_exceptions_beforematchnotcallable_ce);
+								ZEPHIR_CALL_METHOD(&_25$$31, &route, "getpattern", NULL, 0);
 								zephir_check_call_status();
-								ZEPHIR_CALL_METHOD(NULL, &_24$$30, "__construct", &_7, 454, &_25$$30);
+								ZEPHIR_CALL_METHOD(NULL, &_24$$31, "__construct", &_7, 454, &_25$$31);
 								zephir_check_call_status();
-								zephir_throw_exception_debug(&_24$$30, "phalcon/Cli/Router.zep", 265);
+								zephir_throw_exception_debug(&_24$$31, "phalcon/Cli/Router.zep", 273);
 								ZEPHIR_MM_RESTORE();
 								return;
 							}
-							ZEPHIR_INIT_NVAR(&_26$$29);
-							zephir_create_array(&_26$$29, 3, 0);
-							zephir_array_fast_append(&_26$$29, arguments);
-							zephir_array_fast_append(&_26$$29, &route);
-							zephir_array_fast_append(&_26$$29, this_ptr);
+							ZEPHIR_INIT_NVAR(&_26$$30);
+							zephir_create_array(&_26$$30, 3, 0);
+							zephir_array_fast_append(&_26$$30, arguments);
+							zephir_array_fast_append(&_26$$30, &route);
+							zephir_array_fast_append(&_26$$30, this_ptr);
 							ZEPHIR_INIT_NVAR(&routeFound);
-							ZEPHIR_CALL_USER_FUNC_ARRAY(&routeFound, &beforeMatch, &_26$$29);
+							ZEPHIR_CALL_USER_FUNC_ARRAY(&routeFound, &beforeMatch, &_26$$30);
 							zephir_check_call_status();
 						}
 					}
@@ -799,59 +805,59 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 						if (Z_TYPE_P(&matches) == IS_ARRAY) {
 							ZEPHIR_CALL_METHOD(&converters, &route, "getconverters", NULL, 0);
 							zephir_check_call_status();
-							zephir_is_iterable(&paths, 0, "phalcon/Cli/Router.zep", 330);
+							zephir_is_iterable(&paths, 0, "phalcon/Cli/Router.zep", 338);
 							if (Z_TYPE_P(&paths) == IS_ARRAY) {
-								ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&paths), _28$$32, _29$$32, _27$$32)
+								ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&paths), _28$$33, _29$$33, _27$$33)
 								{
 									ZEPHIR_INIT_NVAR(&part);
-									if (_29$$32 != NULL) { 
-										ZVAL_STR_COPY(&part, _29$$32);
+									if (_29$$33 != NULL) { 
+										ZVAL_STR_COPY(&part, _29$$33);
 									} else {
-										ZVAL_LONG(&part, _28$$32);
+										ZVAL_LONG(&part, _28$$33);
 									}
 									ZEPHIR_INIT_NVAR(&position);
-									ZVAL_COPY(&position, _27$$32);
+									ZVAL_COPY(&position, _27$$33);
 									ZEPHIR_OBS_NVAR(&matchPosition);
 									if (zephir_array_isset_fetch(&matchPosition, &matches, &position, 0)) {
 										ZEPHIR_OBS_NVAR(&converter);
 										if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-											ZEPHIR_INIT_NVAR(&_30$$35);
-											ZEPHIR_INIT_NVAR(&_31$$35);
-											zephir_create_array(&_31$$35, 1, 0);
-											zephir_array_fast_append(&_31$$35, &matchPosition);
-											ZEPHIR_CALL_USER_FUNC_ARRAY(&_30$$35, &converter, &_31$$35);
+											ZEPHIR_INIT_NVAR(&_30$$36);
+											ZEPHIR_INIT_NVAR(&_31$$36);
+											zephir_create_array(&_31$$36, 1, 0);
+											zephir_array_fast_append(&_31$$36, &matchPosition);
+											ZEPHIR_CALL_USER_FUNC_ARRAY(&_30$$36, &converter, &_31$$36);
 											zephir_check_call_status();
-											zephir_array_update_zval(&parts, &part, &_30$$35, PH_COPY | PH_SEPARATE);
+											zephir_array_update_zval(&parts, &part, &_30$$36, PH_COPY | PH_SEPARATE);
 										} else {
 											zephir_array_update_zval(&parts, &part, &matchPosition, PH_COPY | PH_SEPARATE);
 										}
 									} else {
 										ZEPHIR_OBS_NVAR(&converter);
 										if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-											ZEPHIR_INIT_NVAR(&_32$$38);
-											ZEPHIR_INIT_NVAR(&_33$$38);
-											zephir_create_array(&_33$$38, 1, 0);
-											zephir_array_fast_append(&_33$$38, &position);
-											ZEPHIR_CALL_USER_FUNC_ARRAY(&_32$$38, &converter, &_33$$38);
+											ZEPHIR_INIT_NVAR(&_32$$39);
+											ZEPHIR_INIT_NVAR(&_33$$39);
+											zephir_create_array(&_33$$39, 1, 0);
+											zephir_array_fast_append(&_33$$39, &position);
+											ZEPHIR_CALL_USER_FUNC_ARRAY(&_32$$39, &converter, &_33$$39);
 											zephir_check_call_status();
-											zephir_array_update_zval(&parts, &part, &_32$$38, PH_COPY | PH_SEPARATE);
+											zephir_array_update_zval(&parts, &part, &_32$$39, PH_COPY | PH_SEPARATE);
 										}
 									}
 								} ZEND_HASH_FOREACH_END();
 							} else {
 								ZEPHIR_CALL_METHOD(NULL, &paths, "rewind", NULL, 0);
 								zephir_check_call_status();
-								_35$$32 = 1;
+								_35$$33 = 1;
 								while (1) {
-									if (_35$$32) {
-										_35$$32 = 0;
+									if (_35$$33) {
+										_35$$33 = 0;
 									} else {
 										ZEPHIR_CALL_METHOD(NULL, &paths, "next", NULL, 0);
 										zephir_check_call_status();
 									}
-									ZEPHIR_CALL_METHOD(&_34$$32, &paths, "valid", NULL, 0);
+									ZEPHIR_CALL_METHOD(&_34$$33, &paths, "valid", NULL, 0);
 									zephir_check_call_status();
-									if (!zend_is_true(&_34$$32)) {
+									if (!zend_is_true(&_34$$33)) {
 										break;
 									}
 									ZEPHIR_CALL_METHOD(&part, &paths, "key", NULL, 0);
@@ -862,26 +868,26 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 										if (zephir_array_isset_fetch(&matchPosition, &matches, &position, 0)) {
 											ZEPHIR_OBS_NVAR(&converter);
 											if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-												ZEPHIR_INIT_NVAR(&_36$$41);
-												ZEPHIR_INIT_NVAR(&_37$$41);
-												zephir_create_array(&_37$$41, 1, 0);
-												zephir_array_fast_append(&_37$$41, &matchPosition);
-												ZEPHIR_CALL_USER_FUNC_ARRAY(&_36$$41, &converter, &_37$$41);
+												ZEPHIR_INIT_NVAR(&_36$$42);
+												ZEPHIR_INIT_NVAR(&_37$$42);
+												zephir_create_array(&_37$$42, 1, 0);
+												zephir_array_fast_append(&_37$$42, &matchPosition);
+												ZEPHIR_CALL_USER_FUNC_ARRAY(&_36$$42, &converter, &_37$$42);
 												zephir_check_call_status();
-												zephir_array_update_zval(&parts, &part, &_36$$41, PH_COPY | PH_SEPARATE);
+												zephir_array_update_zval(&parts, &part, &_36$$42, PH_COPY | PH_SEPARATE);
 											} else {
 												zephir_array_update_zval(&parts, &part, &matchPosition, PH_COPY | PH_SEPARATE);
 											}
 										} else {
 											ZEPHIR_OBS_NVAR(&converter);
 											if (zephir_array_isset_fetch(&converter, &converters, &part, 0)) {
-												ZEPHIR_INIT_NVAR(&_38$$44);
-												ZEPHIR_INIT_NVAR(&_39$$44);
-												zephir_create_array(&_39$$44, 1, 0);
-												zephir_array_fast_append(&_39$$44, &position);
-												ZEPHIR_CALL_USER_FUNC_ARRAY(&_38$$44, &converter, &_39$$44);
+												ZEPHIR_INIT_NVAR(&_38$$45);
+												ZEPHIR_INIT_NVAR(&_39$$45);
+												zephir_create_array(&_39$$45, 1, 0);
+												zephir_array_fast_append(&_39$$45, &position);
+												ZEPHIR_CALL_USER_FUNC_ARRAY(&_38$$45, &converter, &_39$$45);
 												zephir_check_call_status();
-												zephir_array_update_zval(&parts, &part, &_38$$44, PH_COPY | PH_SEPARATE);
+												zephir_array_update_zval(&parts, &part, &_38$$45, PH_COPY | PH_SEPARATE);
 											}
 										}
 								}
@@ -908,14 +914,14 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 			} else {
 				zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 500, &__$false);
 			}
-			zephir_read_property_cached(&_40$$46, this_ptr, _zephir_prop_4, 503, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 504, &_40$$46);
-			zephir_read_property_cached(&_41$$46, this_ptr, _zephir_prop_6, 505, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 506, &_41$$46);
-			zephir_read_property_cached(&_42$$46, this_ptr, _zephir_prop_8, 507, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 508, &_42$$46);
-			zephir_read_property_cached(&_43$$46, this_ptr, _zephir_prop_10, 509, PH_NOISY_CC | PH_READONLY);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 510, &_43$$46);
+			zephir_read_property_cached(&_40$$47, this_ptr, _zephir_prop_4, 503, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_5, 504, &_40$$47);
+			zephir_read_property_cached(&_41$$47, this_ptr, _zephir_prop_6, 505, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 506, &_41$$47);
+			zephir_read_property_cached(&_42$$47, this_ptr, _zephir_prop_8, 507, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 508, &_42$$47);
+			zephir_read_property_cached(&_43$$47, this_ptr, _zephir_prop_10, 509, PH_NOISY_CC | PH_READONLY);
+			zephir_update_property_zval_cached(this_ptr, _zephir_prop_11, 510, &_43$$47);
 			RETURN_THIS();
 		}
 	} else {
@@ -951,15 +957,15 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 	ZEPHIR_OBS_NVAR(&params);
 	if (zephir_array_isset_string_fetch(&params, &parts, SL("params"), 0)) {
 		if (Z_TYPE_P(&params) != IS_ARRAY) {
-			zephir_cast_to_string(&_44$$55, &params);
-			ZVAL_LONG(&_45$$55, 1);
+			zephir_cast_to_string(&_44$$56, &params);
+			ZVAL_LONG(&_45$$56, 1);
 			ZEPHIR_INIT_VAR(&strParams);
-			zephir_substr(&strParams, &_44$$55, 1 , 0, ZEPHIR_SUBSTR_NO_LENGTH);
+			zephir_substr(&strParams, &_44$$56, 1 , 0, ZEPHIR_SUBSTR_NO_LENGTH);
 			if (zephir_is_true(&strParams)) {
-				ZEPHIR_CALL_CE_STATIC(&_46$$56, phalcon_cli_router_route_ce, "getdelimiter", NULL, 0);
+				ZEPHIR_CALL_CE_STATIC(&_46$$57, phalcon_cli_router_route_ce, "getdelimiter", NULL, 0);
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&params);
-				zephir_fast_explode(&params, &_46$$56, &strParams, LONG_MAX);
+				zephir_fast_explode(&params, &_46$$57, &strParams, LONG_MAX);
 			} else {
 				ZEPHIR_INIT_NVAR(&params);
 				array_init(&params);
@@ -968,9 +974,9 @@ PHP_METHOD(Phalcon_Cli_Router, handle)
 		zephir_array_unset_string(&parts, SL("params"), PH_SEPARATE);
 	}
 	if (!(ZEPHIR_IS_EMPTY(&params))) {
-		ZEPHIR_INIT_VAR(&_47$$58);
-		zephir_fast_array_merge(&_47$$58, &params, &parts);
-		ZEPHIR_CPY_WRT(&params, &_47$$58);
+		ZEPHIR_INIT_VAR(&_47$$59);
+		zephir_fast_array_merge(&_47$$59, &params, &parts);
+		ZEPHIR_CPY_WRT(&params, &_47$$59);
 	} else {
 		ZEPHIR_CPY_WRT(&params, &parts);
 	}

--- a/ext/phalcon/db/dialect.zep.c
+++ b/ext/phalcon/db/dialect.zep.c
@@ -889,9 +889,10 @@ PHP_METHOD(Phalcon_Db_Dialect, limit)
 PHP_METHOD(Phalcon_Db_Dialect, getLimitValue)
 {
 	zval _9;
+	zend_long _8;
 	zend_bool _0, _4;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-	zval *value, value_sub, _1, _2, _3, _5, _6, _7, _8;
+	zval *value = NULL, value_sub, _1, _2, _3, _5, _6, _7;
 
 	ZVAL_UNDEF(&value_sub);
 	ZVAL_UNDEF(&_1);
@@ -900,7 +901,6 @@ PHP_METHOD(Phalcon_Db_Dialect, getLimitValue)
 	ZVAL_UNDEF(&_5);
 	ZVAL_UNDEF(&_6);
 	ZVAL_UNDEF(&_7);
-	ZVAL_UNDEF(&_8);
 	ZVAL_UNDEF(&_9);
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_ZVAL(value)
@@ -908,6 +908,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getLimitValue)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &value);
+	ZEPHIR_SEPARATE_PARAM(value);
 	_0 = Z_TYPE_P(value) == IS_STRING;
 	if (_0) {
 		ZVAL_LONG(&_1, 0);
@@ -928,9 +929,10 @@ PHP_METHOD(Phalcon_Db_Dialect, getLimitValue)
 		RETVAL_ZVAL(value, 1, 0);
 		RETURN_MM();
 	}
-	ZEPHIR_INIT_VAR(&_8);
-	ZVAL_LONG(&_8, zephir_get_intval(value));
-	zephir_cast_to_string(&_9, &_8);
+	_8 = zephir_get_intval(value);
+	ZEPHIR_INIT_NVAR(value);
+	ZVAL_LONG(value, _8);
+	zephir_cast_to_string(&_9, value);
 	RETURN_CTOR(&_9);
 }
 
@@ -995,7 +997,7 @@ PHP_METHOD(Phalcon_Db_Dialect, createMaterializedView)
 	object_init_ex(&_0, phalcon_db_exceptions_materializedviewsnotsupported_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 116);
 	zephir_check_call_status();
-	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 542);
+	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 544);
 	ZEPHIR_MM_RESTORE();
 	return;
 }
@@ -1042,7 +1044,7 @@ PHP_METHOD(Phalcon_Db_Dialect, dropMaterializedView)
 	object_init_ex(&_0, phalcon_db_exceptions_materializedviewsnotsupported_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 116);
 	zephir_check_call_status();
-	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 550);
+	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 552);
 	ZEPHIR_MM_RESTORE();
 	return;
 }
@@ -1092,7 +1094,7 @@ PHP_METHOD(Phalcon_Db_Dialect, refreshMaterializedView)
 	object_init_ex(&_0, phalcon_db_exceptions_materializedviewsnotsupported_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 116);
 	zephir_check_call_status();
-	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 561);
+	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 563);
 	ZEPHIR_MM_RESTORE();
 	return;
 }
@@ -1154,7 +1156,7 @@ PHP_METHOD(Phalcon_Db_Dialect, onConflictUpdate)
 		object_init_ex(&_0$$3, phalcon_db_exceptions_conflicttargetcolumnrequired_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_0$$3, "__construct", NULL, 117);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_0$$3, "phalcon/Db/Dialect.zep", 577);
+		zephir_throw_exception_debug(&_0$$3, "phalcon/Db/Dialect.zep", 579);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -1163,13 +1165,13 @@ PHP_METHOD(Phalcon_Db_Dialect, onConflictUpdate)
 		object_init_ex(&_1$$4, phalcon_db_exceptions_conflictupdatecolumnrequired_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 118);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$4, "phalcon/Db/Dialect.zep", 581);
+		zephir_throw_exception_debug(&_1$$4, "phalcon/Db/Dialect.zep", 583);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
 	ZEPHIR_INIT_VAR(&assignments);
 	array_init(&assignments);
-	zephir_is_iterable(&updateColumns, 0, "phalcon/Db/Dialect.zep", 590);
+	zephir_is_iterable(&updateColumns, 0, "phalcon/Db/Dialect.zep", 592);
 	if (Z_TYPE_P(&updateColumns) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&updateColumns), _2)
 		{
@@ -1183,7 +1185,7 @@ PHP_METHOD(Phalcon_Db_Dialect, onConflictUpdate)
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(&_8$$5);
 			ZEPHIR_CONCAT_VSV(&_8$$5, &_3$$5, " = excluded.", &_6$$5);
-			zephir_array_append(&assignments, &_8$$5, PH_SEPARATE, "phalcon/Db/Dialect.zep", 587);
+			zephir_array_append(&assignments, &_8$$5, PH_SEPARATE, "phalcon/Db/Dialect.zep", 589);
 		} ZEND_HASH_FOREACH_END();
 	} else {
 		ZEPHIR_CALL_METHOD(NULL, &updateColumns, "rewind", NULL, 0);
@@ -1211,7 +1213,7 @@ PHP_METHOD(Phalcon_Db_Dialect, onConflictUpdate)
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_15$$6);
 				ZEPHIR_CONCAT_VSV(&_15$$6, &_11$$6, " = excluded.", &_13$$6);
-				zephir_array_append(&assignments, &_15$$6, PH_SEPARATE, "phalcon/Db/Dialect.zep", 587);
+				zephir_array_append(&assignments, &_15$$6, PH_SEPARATE, "phalcon/Db/Dialect.zep", 589);
 		}
 	}
 	ZEPHIR_INIT_NVAR(&col);
@@ -1255,7 +1257,7 @@ PHP_METHOD(Phalcon_Db_Dialect, returning)
 	object_init_ex(&_0, phalcon_db_exceptions_returningnotsupported_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 120);
 	zephir_check_call_status();
-	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 604);
+	zephir_throw_exception_debug(&_0, "phalcon/Db/Dialect.zep", 606);
 	ZEPHIR_MM_RESTORE();
 	return;
 }
@@ -1344,12 +1346,12 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 	zephir_get_arrval(&definition, definition_param);
 	zephir_memory_observe(&tables);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&tables, &definition, SL("tables"), 0)))) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "tables", "phalcon/Db/Dialect.zep", 633);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "tables", "phalcon/Db/Dialect.zep", 635);
 		return;
 	}
 	zephir_memory_observe(&columns);
 	if (UNEXPECTED(!(zephir_array_isset_string_fetch(&columns, &definition, SL("columns"), 0)))) {
-		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "columns", "phalcon/Db/Dialect.zep", 637);
+		ZEPHIR_THROW_EXCEPTION_DEBUG_STR(phalcon_db_exceptions_missingdefinitionkey_ce, "columns", "phalcon/Db/Dialect.zep", 639);
 		return;
 	}
 	zephir_memory_observe(&distinct);
@@ -1387,10 +1389,10 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 		_2 = zephir_is_true(&joins);
 	}
 	if (_2) {
-		zephir_array_fetch_string(&_4$$10, &definition, SL("joins"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 670);
+		zephir_array_fetch_string(&_4$$10, &definition, SL("joins"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 672);
 		ZEPHIR_CALL_METHOD(&_3$$10, this_ptr, "getsqlexpressionjoins", NULL, 122, &_4$$10, &escapeChar, &bindCounts);
 		zephir_check_call_status();
-		zephir_array_append(&parts, &_3$$10, PH_SEPARATE, "phalcon/Db/Dialect.zep", 670);
+		zephir_array_append(&parts, &_3$$10, PH_SEPARATE, "phalcon/Db/Dialect.zep", 672);
 	}
 	zephir_memory_observe(&where);
 	_5 = zephir_array_isset_string_fetch(&where, &definition, SL("where"), 0);
@@ -1400,7 +1402,7 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 	if (_5) {
 		ZEPHIR_CALL_METHOD(&_6$$11, this_ptr, "getsqlexpressionwhere", NULL, 123, &where, &escapeChar, &bindCounts);
 		zephir_check_call_status();
-		zephir_array_append(&parts, &_6$$11, PH_SEPARATE, "phalcon/Db/Dialect.zep", 674);
+		zephir_array_append(&parts, &_6$$11, PH_SEPARATE, "phalcon/Db/Dialect.zep", 676);
 	}
 	zephir_memory_observe(&groupBy);
 	_7 = zephir_array_isset_string_fetch(&groupBy, &definition, SL("group"), 0);
@@ -1410,7 +1412,7 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 	if (_7) {
 		ZEPHIR_CALL_METHOD(&_8$$12, this_ptr, "getsqlexpressiongroupby", NULL, 124, &groupBy, &escapeChar);
 		zephir_check_call_status();
-		zephir_array_append(&parts, &_8$$12, PH_SEPARATE, "phalcon/Db/Dialect.zep", 678);
+		zephir_array_append(&parts, &_8$$12, PH_SEPARATE, "phalcon/Db/Dialect.zep", 680);
 	}
 	zephir_memory_observe(&having);
 	_9 = zephir_array_isset_string_fetch(&having, &definition, SL("having"), 0);
@@ -1420,7 +1422,7 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 	if (_9) {
 		ZEPHIR_CALL_METHOD(&_10$$13, this_ptr, "getsqlexpressionhaving", NULL, 125, &having, &escapeChar, &bindCounts);
 		zephir_check_call_status();
-		zephir_array_append(&parts, &_10$$13, PH_SEPARATE, "phalcon/Db/Dialect.zep", 682);
+		zephir_array_append(&parts, &_10$$13, PH_SEPARATE, "phalcon/Db/Dialect.zep", 684);
 	}
 	zephir_memory_observe(&orderBy);
 	_11 = zephir_array_isset_string_fetch(&orderBy, &definition, SL("order"), 0);
@@ -1430,7 +1432,7 @@ PHP_METHOD(Phalcon_Db_Dialect, select)
 	if (_11) {
 		ZEPHIR_CALL_METHOD(&_12$$14, this_ptr, "getsqlexpressionorderby", NULL, 126, &orderBy, &escapeChar, &bindCounts);
 		zephir_check_call_status();
-		zephir_array_append(&parts, &_12$$14, PH_SEPARATE, "phalcon/Db/Dialect.zep", 686);
+		zephir_array_append(&parts, &_12$$14, PH_SEPARATE, "phalcon/Db/Dialect.zep", 688);
 	}
 	ZEPHIR_INIT_NVAR(&sql);
 	zephir_fast_join_str(&sql, SL(" "), &parts);
@@ -1765,7 +1767,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getIndexColumnList)
 	ZEPHIR_CALL_METHOD(&directions, index, "getdirections", NULL, 0);
 	zephir_check_call_status();
 	hasExpression = 0;
-	zephir_is_iterable(&columns, 0, "phalcon/Db/Dialect.zep", 873);
+	zephir_is_iterable(&columns, 0, "phalcon/Db/Dialect.zep", 875);
 	if (Z_TYPE_P(&columns) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&columns), _0)
 		{
@@ -1821,7 +1823,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getIndexColumnList)
 	ZEPHIR_INIT_VAR(&parts);
 	array_init(&parts);
 	i = 0;
-	zephir_is_iterable(&columns, 0, "phalcon/Db/Dialect.zep", 909);
+	zephir_is_iterable(&columns, 0, "phalcon/Db/Dialect.zep", 911);
 	if (Z_TYPE_P(&columns) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&columns), _6)
 		{
@@ -1860,7 +1862,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getIndexColumnList)
 					zephir_concat_self_str(&rendered, SL(" ASC"));
 				}
 			}
-			zephir_array_append(&parts, &rendered, PH_SEPARATE, "phalcon/Db/Dialect.zep", 905);
+			zephir_array_append(&parts, &rendered, PH_SEPARATE, "phalcon/Db/Dialect.zep", 907);
 			i = (i + 1);
 		} ZEND_HASH_FOREACH_END();
 	} else {
@@ -1914,7 +1916,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getIndexColumnList)
 						zephir_concat_self_str(&rendered, SL(" ASC"));
 					}
 				}
-				zephir_array_append(&parts, &rendered, PH_SEPARATE, "phalcon/Db/Dialect.zep", 905);
+				zephir_array_append(&parts, &rendered, PH_SEPARATE, "phalcon/Db/Dialect.zep", 907);
 				i = (i + 1);
 		}
 	}
@@ -2086,7 +2088,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionBinaryOperations)
 		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_memory_observe(&operator);
-	zephir_array_fetch_string(&operator, &expression, SL("op"), PH_NOISY, "phalcon/Db/Dialect.zep", 964);
+	zephir_array_fetch_string(&operator, &expression, SL("op"), PH_NOISY, "phalcon/Db/Dialect.zep", 966);
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 113, PH_NOISY_CC | PH_READONLY);
 	_1 = zephir_fast_in_array(&operator, &_0);
 	if (_1) {
@@ -2098,14 +2100,14 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionBinaryOperations)
 		object_init_ex(&_3$$3, phalcon_db_exceptions_unsupportedoperator_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 128, &operator);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_3$$3, "phalcon/Db/Dialect.zep", 967);
+		zephir_throw_exception_debug(&_3$$3, "phalcon/Db/Dialect.zep", 969);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
-	zephir_array_fetch_string(&_4, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 971);
+	zephir_array_fetch_string(&_4, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 973);
 	ZEPHIR_CALL_METHOD(&left, this_ptr, "getsqlexpression", NULL, 0, &_4, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
-	zephir_array_fetch_string(&_5, &expression, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 977);
+	zephir_array_fetch_string(&_5, &expression, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 979);
 	ZEPHIR_CALL_METHOD(&right, this_ptr, "getsqlexpression", NULL, 107, &_5, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
 	ZEPHIR_CONCAT_VSVSV(return_value, &left, " ", &operator, " ", &right);
@@ -2187,34 +2189,34 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCase)
 	} else {
 		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
-	zephir_array_fetch_string(&_1, &expression, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 999);
+	zephir_array_fetch_string(&_1, &expression, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1001);
 	ZEPHIR_CALL_METHOD(&_0, this_ptr, "getsqlexpression", NULL, 0, &_1, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
 	ZEPHIR_INIT_VAR(&_2);
 	ZEPHIR_CONCAT_SV(&_2, "CASE ", &_0);
 	zephir_get_strval(&sql, &_2);
-	zephir_array_fetch_string(&_3, &expression, SL("when-clauses"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1001);
+	zephir_array_fetch_string(&_3, &expression, SL("when-clauses"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1003);
 	ZEPHIR_CALL_FUNCTION(&whenClauses, "array_values", NULL, 28, &_3);
 	zephir_check_call_status();
-	zephir_is_iterable(&whenClauses, 0, "phalcon/Db/Dialect.zep", 1014);
+	zephir_is_iterable(&whenClauses, 0, "phalcon/Db/Dialect.zep", 1016);
 	if (Z_TYPE_P(&whenClauses) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&whenClauses), _4)
 		{
 			ZEPHIR_INIT_NVAR(&whenClause);
 			ZVAL_COPY(&whenClause, _4);
-			zephir_array_fetch_string(&_5$$3, &whenClause, SL("type"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1004);
+			zephir_array_fetch_string(&_5$$3, &whenClause, SL("type"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1006);
 			if (ZEPHIR_IS_STRING(&_5$$3, "when")) {
-				zephir_array_fetch_string(&_7$$4, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1006);
+				zephir_array_fetch_string(&_7$$4, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1008);
 				ZEPHIR_CALL_METHOD(&_6$$4, this_ptr, "getsqlexpression", NULL, 107, &_7$$4, &escapeChar_zv, &bindCounts);
 				zephir_check_call_status();
-				zephir_array_fetch_string(&_9$$4, &whenClause, SL("then"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1008);
+				zephir_array_fetch_string(&_9$$4, &whenClause, SL("then"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1010);
 				ZEPHIR_CALL_METHOD(&_8$$4, this_ptr, "getsqlexpression", NULL, 107, &_9$$4, &escapeChar_zv, &bindCounts);
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_10$$4);
 				ZEPHIR_CONCAT_SVSV(&_10$$4, " WHEN ", &_6$$4, " THEN ", &_8$$4);
 				zephir_concat_self(&sql, &_10$$4);
 			} else {
-				zephir_array_fetch_string(&_12$$5, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1010);
+				zephir_array_fetch_string(&_12$$5, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1012);
 				ZEPHIR_CALL_METHOD(&_11$$5, this_ptr, "getsqlexpression", NULL, 107, &_12$$5, &escapeChar_zv, &bindCounts);
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_13$$5);
@@ -2240,19 +2242,19 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCase)
 			}
 			ZEPHIR_CALL_METHOD(&whenClause, &whenClauses, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_array_fetch_string(&_16$$6, &whenClause, SL("type"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1004);
+				zephir_array_fetch_string(&_16$$6, &whenClause, SL("type"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1006);
 				if (ZEPHIR_IS_STRING(&_16$$6, "when")) {
-					zephir_array_fetch_string(&_18$$7, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1006);
+					zephir_array_fetch_string(&_18$$7, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1008);
 					ZEPHIR_CALL_METHOD(&_17$$7, this_ptr, "getsqlexpression", NULL, 107, &_18$$7, &escapeChar_zv, &bindCounts);
 					zephir_check_call_status();
-					zephir_array_fetch_string(&_20$$7, &whenClause, SL("then"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1008);
+					zephir_array_fetch_string(&_20$$7, &whenClause, SL("then"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1010);
 					ZEPHIR_CALL_METHOD(&_19$$7, this_ptr, "getsqlexpression", NULL, 107, &_20$$7, &escapeChar_zv, &bindCounts);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&_21$$7);
 					ZEPHIR_CONCAT_SVSV(&_21$$7, " WHEN ", &_17$$7, " THEN ", &_19$$7);
 					zephir_concat_self(&sql, &_21$$7);
 				} else {
-					zephir_array_fetch_string(&_23$$8, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1010);
+					zephir_array_fetch_string(&_23$$8, &whenClause, SL("expr"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1012);
 					ZEPHIR_CALL_METHOD(&_22$$8, this_ptr, "getsqlexpression", NULL, 107, &_23$$8, &escapeChar_zv, &bindCounts);
 					zephir_check_call_status();
 					ZEPHIR_INIT_NVAR(&_24$$8);
@@ -2317,10 +2319,10 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionCastValue)
 	} else {
 		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
-	zephir_array_fetch_string(&_0, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1031);
+	zephir_array_fetch_string(&_0, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1033);
 	ZEPHIR_CALL_METHOD(&left, this_ptr, "getsqlexpression", NULL, 0, &_0, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
-	zephir_array_fetch_string(&_1, &expression, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1037);
+	zephir_array_fetch_string(&_1, &expression, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1039);
 	ZEPHIR_CALL_METHOD(&right, this_ptr, "getsqlexpression", NULL, 107, &_1, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
 	ZEPHIR_CONCAT_SVSVS(return_value, "CAST(", &left, " AS ", &right, ")");
@@ -2378,10 +2380,10 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionConvertValue)
 	} else {
 		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
-	zephir_array_fetch_string(&_0, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1059);
+	zephir_array_fetch_string(&_0, &expression, SL("left"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1061);
 	ZEPHIR_CALL_METHOD(&left, this_ptr, "getsqlexpression", NULL, 0, &_0, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
-	zephir_array_fetch_string(&_1, &expression, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1065);
+	zephir_array_fetch_string(&_1, &expression, SL("right"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1067);
 	ZEPHIR_CALL_METHOD(&right, this_ptr, "getsqlexpression", NULL, 107, &_1, &escapeChar_zv, &bindCounts);
 	zephir_check_call_status();
 	ZEPHIR_CONCAT_SVSVS(return_value, "CONVERT(", &left, " USING ", &right, ")");
@@ -2427,7 +2429,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFrom)
 	if (Z_TYPE_P(expression) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&tables);
 		array_init(&tables);
-		zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1087);
+		zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1089);
 		if (Z_TYPE_P(expression) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(expression), _0$$3)
 			{
@@ -2435,7 +2437,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFrom)
 				ZVAL_COPY(&table, _0$$3);
 				ZEPHIR_CALL_METHOD(&_1$$4, this_ptr, "getsqltable", &_2, 129, &table, &escapeChar_zv);
 				zephir_check_call_status();
-				zephir_array_append(&tables, &_1$$4, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1084);
+				zephir_array_append(&tables, &_1$$4, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1086);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, expression, "rewind", NULL, 0);
@@ -2457,7 +2459,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFrom)
 				zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_5$$5, this_ptr, "getsqltable", &_2, 129, &table, &escapeChar_zv);
 					zephir_check_call_status();
-					zephir_array_append(&tables, &_5$$5, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1084);
+					zephir_array_append(&tables, &_5$$5, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1086);
 			}
 		}
 		ZEPHIR_INIT_NVAR(&table);
@@ -2532,7 +2534,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFunctionCall)
 		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	zephir_memory_observe(&name);
-	zephir_array_fetch_string(&name, &expression, SL("name"), PH_NOISY, "phalcon/Db/Dialect.zep", 1108);
+	zephir_array_fetch_string(&name, &expression, SL("name"), PH_NOISY, "phalcon/Db/Dialect.zep", 1110);
 	zephir_memory_observe(&customFunction);
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 115, PH_NOISY_CC | PH_READONLY);
 	if (zephir_array_isset_fetch(&customFunction, &_0, &name, 0)) {
@@ -2555,7 +2557,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionFunctionCall)
 		zephir_check_call_status();
 		_3$$4 = zephir_array_isset_value_string(&expression, SL("distinct"));
 		if (_3$$4) {
-			zephir_array_fetch_string(&_4$$4, &expression, SL("distinct"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1125);
+			zephir_array_fetch_string(&_4$$4, &expression, SL("distinct"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1127);
 			_3$$4 = zephir_is_true(&_4$$4);
 		}
 		if (_3$$4) {
@@ -2628,7 +2630,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionGroupBy)
 	if (Z_TYPE_P(expression) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&fields);
 		array_init(&fields);
-		zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1163);
+		zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1165);
 		if (Z_TYPE_P(expression) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(expression), _0$$3)
 			{
@@ -2639,13 +2641,13 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionGroupBy)
 					object_init_ex(&_1$$5, phalcon_db_exceptions_invalidgroupbyexpression_ce);
 					ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", &_2, 130);
 					zephir_check_call_status();
-					zephir_throw_exception_debug(&_1$$5, "phalcon/Db/Dialect.zep", 1153);
+					zephir_throw_exception_debug(&_1$$5, "phalcon/Db/Dialect.zep", 1155);
 					ZEPHIR_MM_RESTORE();
 					return;
 				}
 				ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "getsqlexpression", &_4, 0, &field, &escapeChar_zv, &bindCounts);
 				zephir_check_call_status();
-				zephir_array_append(&fields, &_3$$4, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1160);
+				zephir_array_append(&fields, &_3$$4, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1162);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, expression, "rewind", NULL, 0);
@@ -2670,13 +2672,13 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionGroupBy)
 						object_init_ex(&_7$$7, phalcon_db_exceptions_invalidgroupbyexpression_ce);
 						ZEPHIR_CALL_METHOD(NULL, &_7$$7, "__construct", &_2, 130);
 						zephir_check_call_status();
-						zephir_throw_exception_debug(&_7$$7, "phalcon/Db/Dialect.zep", 1153);
+						zephir_throw_exception_debug(&_7$$7, "phalcon/Db/Dialect.zep", 1155);
 						ZEPHIR_MM_RESTORE();
 						return;
 					}
 					ZEPHIR_CALL_METHOD(&_8$$6, this_ptr, "getsqlexpression", &_4, 107, &field, &escapeChar_zv, &bindCounts);
 					zephir_check_call_status();
-					zephir_array_append(&fields, &_8$$6, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1160);
+					zephir_array_append(&fields, &_8$$6, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1162);
 			}
 		}
 		ZEPHIR_INIT_NVAR(&field);
@@ -2817,7 +2819,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 	ZVAL_STRING(&joinType, "");
 	ZEPHIR_INIT_VAR(&sql);
 	ZVAL_STRING(&sql, "");
-	zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1237);
+	zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1239);
 	if (Z_TYPE_P(expression) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(expression), _0)
 		{
@@ -2835,7 +2837,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 				} else {
 					ZEPHIR_INIT_NVAR(&joinCondition);
 					array_init(&joinCondition);
-					zephir_is_iterable(&joinConditionsArray, 0, "phalcon/Db/Dialect.zep", 1222);
+					zephir_is_iterable(&joinConditionsArray, 0, "phalcon/Db/Dialect.zep", 1224);
 					if (Z_TYPE_P(&joinConditionsArray) == IS_ARRAY) {
 						ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&joinConditionsArray), _3$$6)
 						{
@@ -2843,7 +2845,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 							ZVAL_COPY(&condition, _3$$6);
 							ZEPHIR_CALL_METHOD(&_4$$7, this_ptr, "getsqlexpression", &_2, 107, &condition, &escapeChar_zv, &bindCounts);
 							zephir_check_call_status();
-							zephir_array_append(&joinCondition, &_4$$7, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1219);
+							zephir_array_append(&joinCondition, &_4$$7, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1221);
 						} ZEND_HASH_FOREACH_END();
 					} else {
 						ZEPHIR_CALL_METHOD(NULL, &joinConditionsArray, "rewind", NULL, 0);
@@ -2865,7 +2867,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 							zephir_check_call_status();
 								ZEPHIR_CALL_METHOD(&_7$$8, this_ptr, "getsqlexpression", &_2, 107, &condition, &escapeChar_zv, &bindCounts);
 								zephir_check_call_status();
-								zephir_array_append(&joinCondition, &_7$$8, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1219);
+								zephir_array_append(&joinCondition, &_7$$8, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1221);
 						}
 					}
 					ZEPHIR_INIT_NVAR(&condition);
@@ -2885,7 +2887,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 			if (_9$$3) {
 				zephir_concat_self_str(&joinType, SL(" "));
 			}
-			zephir_array_fetch_string(&_10$$3, &join, SL("source"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1232);
+			zephir_array_fetch_string(&_10$$3, &join, SL("source"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1234);
 			ZEPHIR_CALL_METHOD(&joinTable, this_ptr, "getsqltable", &_11, 129, &_10$$3, &escapeChar_zv);
 			zephir_check_call_status();
 			ZEPHIR_INIT_NVAR(&_12$$3);
@@ -2922,7 +2924,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 					} else {
 						ZEPHIR_INIT_NVAR(&joinCondition);
 						array_init(&joinCondition);
-						zephir_is_iterable(&joinConditionsArray, 0, "phalcon/Db/Dialect.zep", 1222);
+						zephir_is_iterable(&joinConditionsArray, 0, "phalcon/Db/Dialect.zep", 1224);
 						if (Z_TYPE_P(&joinConditionsArray) == IS_ARRAY) {
 							ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&joinConditionsArray), _16$$14)
 							{
@@ -2930,7 +2932,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 								ZVAL_COPY(&condition, _16$$14);
 								ZEPHIR_CALL_METHOD(&_17$$15, this_ptr, "getsqlexpression", &_2, 107, &condition, &escapeChar_zv, &bindCounts);
 								zephir_check_call_status();
-								zephir_array_append(&joinCondition, &_17$$15, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1219);
+								zephir_array_append(&joinCondition, &_17$$15, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1221);
 							} ZEND_HASH_FOREACH_END();
 						} else {
 							ZEPHIR_CALL_METHOD(NULL, &joinConditionsArray, "rewind", NULL, 0);
@@ -2952,7 +2954,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 								zephir_check_call_status();
 									ZEPHIR_CALL_METHOD(&_20$$16, this_ptr, "getsqlexpression", &_2, 107, &condition, &escapeChar_zv, &bindCounts);
 									zephir_check_call_status();
-									zephir_array_append(&joinCondition, &_20$$16, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1219);
+									zephir_array_append(&joinCondition, &_20$$16, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1221);
 							}
 						}
 						ZEPHIR_INIT_NVAR(&condition);
@@ -2972,7 +2974,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionJoins)
 				if (_22$$11) {
 					zephir_concat_self_str(&joinType, SL(" "));
 				}
-				zephir_array_fetch_string(&_23$$11, &join, SL("source"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1232);
+				zephir_array_fetch_string(&_23$$11, &join, SL("source"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1234);
 				ZEPHIR_CALL_METHOD(&joinTable, this_ptr, "getsqltable", &_11, 129, &_23$$11, &escapeChar_zv);
 				zephir_check_call_status();
 				ZEPHIR_INIT_NVAR(&_24$$11);
@@ -3044,21 +3046,21 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionLimit)
 	ZEPHIR_INIT_VAR(&offset);
 	ZVAL_NULL(&offset);
 	zephir_memory_observe(&value);
-	zephir_array_fetch_string(&value, expression, SL("value"), PH_NOISY, "phalcon/Db/Dialect.zep", 1253);
+	zephir_array_fetch_string(&value, expression, SL("value"), PH_NOISY, "phalcon/Db/Dialect.zep", 1255);
 	if (zephir_array_isset_value_string(expression, SL("sql"))) {
 		ZEPHIR_OBS_NVAR(&sql);
-		zephir_array_fetch_string(&sql, expression, SL("sql"), PH_NOISY, "phalcon/Db/Dialect.zep", 1256);
+		zephir_array_fetch_string(&sql, expression, SL("sql"), PH_NOISY, "phalcon/Db/Dialect.zep", 1258);
 	}
 	if (Z_TYPE_P(&value) == IS_ARRAY) {
 		zephir_memory_observe(&_0$$4);
-		zephir_array_fetch_string(&_0$$4, &value, SL("number"), PH_NOISY, "phalcon/Db/Dialect.zep", 1260);
+		zephir_array_fetch_string(&_0$$4, &value, SL("number"), PH_NOISY, "phalcon/Db/Dialect.zep", 1262);
 		if (Z_TYPE_P(&_0$$4) == IS_ARRAY) {
-			zephir_array_fetch_string(&_1$$5, &value, SL("number"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1262);
+			zephir_array_fetch_string(&_1$$5, &value, SL("number"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1264);
 			ZEPHIR_CALL_METHOD(&limit, this_ptr, "getsqlexpression", NULL, 0, &_1$$5, &escapeChar_zv, &bindCounts);
 			zephir_check_call_status();
 		} else {
 			ZEPHIR_OBS_NVAR(&limit);
-			zephir_array_fetch_string(&limit, &value, SL("number"), PH_NOISY, "phalcon/Db/Dialect.zep", 1267);
+			zephir_array_fetch_string(&limit, &value, SL("number"), PH_NOISY, "phalcon/Db/Dialect.zep", 1269);
 		}
 		ZEPHIR_OBS_NVAR(&offset);
 		_2$$4 = zephir_array_isset_string_fetch(&offset, &value, SL("offset"), 0);
@@ -3147,7 +3149,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 	ZVAL_STRING(&separator, ", ");
 	if (zephir_array_isset_value_string(&expression, SL("separator"))) {
 		ZEPHIR_OBS_NVAR(&separator);
-		zephir_array_fetch_string(&separator, &expression, SL("separator"), PH_NOISY, "phalcon/Db/Dialect.zep", 1306);
+		zephir_array_fetch_string(&separator, &expression, SL("separator"), PH_NOISY, "phalcon/Db/Dialect.zep", 1308);
 	}
 	zephir_memory_observe(&values);
 	_0 = zephir_array_isset_long_fetch(&values, &expression, 0, 0);
@@ -3160,7 +3162,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 		_1 = Z_TYPE_P(&values) == IS_ARRAY;
 	}
 	if (_1) {
-		zephir_is_iterable(&values, 0, "phalcon/Db/Dialect.zep", 1315);
+		zephir_is_iterable(&values, 0, "phalcon/Db/Dialect.zep", 1317);
 		if (Z_TYPE_P(&values) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&values), _2$$4)
 			{
@@ -3168,7 +3170,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 				ZVAL_COPY(&item, _2$$4);
 				ZEPHIR_CALL_METHOD(&_3$$5, this_ptr, "getsqlexpression", &_4, 0, &item, &escapeChar_zv, &bindCounts);
 				zephir_check_call_status();
-				zephir_array_append(&items, &_3$$5, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1312);
+				zephir_array_append(&items, &_3$$5, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1314);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, &values, "rewind", NULL, 0);
@@ -3190,13 +3192,13 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 				zephir_check_call_status();
 					ZEPHIR_CALL_METHOD(&_7$$6, this_ptr, "getsqlexpression", &_4, 107, &item, &escapeChar_zv, &bindCounts);
 					zephir_check_call_status();
-					zephir_array_append(&items, &_7$$6, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1312);
+					zephir_array_append(&items, &_7$$6, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1314);
 			}
 		}
 		ZEPHIR_INIT_NVAR(&item);
 		_8$$4 = zephir_array_isset_value_string(&expression, SL("parentheses"));
 		if (_8$$4) {
-			zephir_array_fetch_string(&_9$$4, &expression, SL("parentheses"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1315);
+			zephir_array_fetch_string(&_9$$4, &expression, SL("parentheses"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1317);
 			_8$$4 = ZEPHIR_IS_FALSE_IDENTICAL(&_9$$4);
 		}
 		if (_8$$4) {
@@ -3212,7 +3214,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionList)
 	object_init_ex(&_11, phalcon_db_exceptions_invalidlistexpression_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_11, "__construct", NULL, 131);
 	zephir_check_call_status();
-	zephir_throw_exception_debug(&_11, "phalcon/Db/Dialect.zep", 1322);
+	zephir_throw_exception_debug(&_11, "phalcon/Db/Dialect.zep", 1324);
 	ZEPHIR_MM_RESTORE();
 	return;
 }
@@ -3355,7 +3357,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionOrderBy)
 	if (Z_TYPE_P(expression) == IS_ARRAY) {
 		ZEPHIR_INIT_VAR(&fields);
 		array_init(&fields);
-		zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1387);
+		zephir_is_iterable(expression, 0, "phalcon/Db/Dialect.zep", 1389);
 		if (Z_TYPE_P(expression) == IS_ARRAY) {
 			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(expression), _0$$3)
 			{
@@ -3366,11 +3368,11 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionOrderBy)
 					object_init_ex(&_1$$5, phalcon_db_exceptions_invalidorderbyexpression_ce);
 					ZEPHIR_CALL_METHOD(NULL, &_1$$5, "__construct", &_2, 132);
 					zephir_check_call_status();
-					zephir_throw_exception_debug(&_1$$5, "phalcon/Db/Dialect.zep", 1368);
+					zephir_throw_exception_debug(&_1$$5, "phalcon/Db/Dialect.zep", 1370);
 					ZEPHIR_MM_RESTORE();
 					return;
 				}
-				zephir_array_fetch_long(&_3$$4, &field, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1372);
+				zephir_array_fetch_long(&_3$$4, &field, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1374);
 				ZEPHIR_CALL_METHOD(&fieldSql, this_ptr, "getsqlexpression", &_4, 0, &_3$$4, &escapeChar_zv, &bindCounts);
 				zephir_check_call_status();
 				ZEPHIR_OBS_NVAR(&type);
@@ -3383,7 +3385,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionOrderBy)
 					ZEPHIR_CONCAT_SV(&_6$$6, " ", &type);
 					zephir_concat_self(&fieldSql, &_6$$6);
 				}
-				zephir_array_append(&fields, &fieldSql, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1384);
+				zephir_array_append(&fields, &fieldSql, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1386);
 			} ZEND_HASH_FOREACH_END();
 		} else {
 			ZEPHIR_CALL_METHOD(NULL, expression, "rewind", NULL, 0);
@@ -3408,11 +3410,11 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionOrderBy)
 						object_init_ex(&_9$$8, phalcon_db_exceptions_invalidorderbyexpression_ce);
 						ZEPHIR_CALL_METHOD(NULL, &_9$$8, "__construct", &_2, 132);
 						zephir_check_call_status();
-						zephir_throw_exception_debug(&_9$$8, "phalcon/Db/Dialect.zep", 1368);
+						zephir_throw_exception_debug(&_9$$8, "phalcon/Db/Dialect.zep", 1370);
 						ZEPHIR_MM_RESTORE();
 						return;
 					}
-					zephir_array_fetch_long(&_10$$7, &field, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1372);
+					zephir_array_fetch_long(&_10$$7, &field, 0, PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1374);
 					ZEPHIR_CALL_METHOD(&fieldSql, this_ptr, "getsqlexpression", &_4, 107, &_10$$7, &escapeChar_zv, &bindCounts);
 					zephir_check_call_status();
 					ZEPHIR_OBS_NVAR(&type);
@@ -3425,7 +3427,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionOrderBy)
 						ZEPHIR_CONCAT_SV(&_12$$9, " ", &type);
 						zephir_concat_self(&fieldSql, &_12$$9);
 					}
-					zephir_array_append(&fields, &fieldSql, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1384);
+					zephir_array_append(&fields, &fieldSql, PH_SEPARATE, "phalcon/Db/Dialect.zep", 1386);
 			}
 		}
 		ZEPHIR_INIT_NVAR(&field);
@@ -3472,7 +3474,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionQualified)
 	ZVAL_STR_COPY(&escapeChar_zv, escapeChar);
 	}
 	zephir_memory_observe(&column);
-	zephir_array_fetch_string(&column, &expression, SL("name"), PH_NOISY, "phalcon/Db/Dialect.zep", 1402);
+	zephir_array_fetch_string(&column, &expression, SL("name"), PH_NOISY, "phalcon/Db/Dialect.zep", 1404);
 	zephir_memory_observe(&domain);
 	if (!(zephir_array_isset_string_fetch(&domain, &expression, SL("domain"), 0))) {
 		ZEPHIR_INIT_NVAR(&domain);
@@ -3532,7 +3534,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionScalar)
 		zephir_get_arrval(&bindCounts, bindCounts_param);
 	}
 	if (zephir_array_isset_value_string(&expression, SL("column"))) {
-		zephir_array_fetch_string(&_0$$3, &expression, SL("column"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1426);
+		zephir_array_fetch_string(&_0$$3, &expression, SL("column"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1428);
 		ZEPHIR_RETURN_CALL_METHOD(this_ptr, "getsqlcolumn", NULL, 100, &_0$$3);
 		zephir_check_call_status();
 		RETURN_MM();
@@ -3543,7 +3545,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionScalar)
 		object_init_ex(&_1$$4, phalcon_db_exceptions_invalidsqlexpression_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$4, "__construct", NULL, 101);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$4, "phalcon/Db/Dialect.zep", 1430);
+		zephir_throw_exception_debug(&_1$$4, "phalcon/Db/Dialect.zep", 1432);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -3613,13 +3615,13 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionUnaryOperations)
 	if (zephir_array_isset_string_fetch(&left, &expression, SL("left"), 0)) {
 		ZEPHIR_CALL_METHOD(&_0$$3, this_ptr, "getsqlexpression", NULL, 0, &left, &escapeChar_zv, &bindCounts);
 		zephir_check_call_status();
-		zephir_array_fetch_string(&_1$$3, &expression, SL("op"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1457);
+		zephir_array_fetch_string(&_1$$3, &expression, SL("op"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1459);
 		ZEPHIR_CONCAT_VSV(return_value, &_0$$3, " ", &_1$$3);
 		RETURN_MM();
 	}
 	zephir_memory_observe(&right);
 	if (zephir_array_isset_string_fetch(&right, &expression, SL("right"), 0)) {
-		zephir_array_fetch_string(&_2$$4, &expression, SL("op"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1464);
+		zephir_array_fetch_string(&_2$$4, &expression, SL("op"), PH_NOISY | PH_READONLY, "phalcon/Db/Dialect.zep", 1466);
 		ZEPHIR_CALL_METHOD(&_3$$4, this_ptr, "getsqlexpression", NULL, 107, &right, &escapeChar_zv, &bindCounts);
 		zephir_check_call_status();
 		ZEPHIR_CONCAT_VSV(return_value, &_2$$4, " ", &_3$$4);
@@ -3629,7 +3631,7 @@ PHP_METHOD(Phalcon_Db_Dialect, getSqlExpressionUnaryOperations)
 	object_init_ex(&_4, phalcon_db_exceptions_invalidunaryexpression_ce);
 	ZEPHIR_CALL_METHOD(NULL, &_4, "__construct", NULL, 133);
 	zephir_check_call_status();
-	zephir_throw_exception_debug(&_4, "phalcon/Db/Dialect.zep", 1467);
+	zephir_throw_exception_debug(&_4, "phalcon/Db/Dialect.zep", 1469);
 	ZEPHIR_MM_RESTORE();
 	return;
 }

--- a/ext/phalcon/mvc/router.zep.c
+++ b/ext/phalcon/mvc/router.zep.c
@@ -6505,14 +6505,14 @@ PHP_METHOD(Phalcon_Mvc_Router, mountGroupFromConfig)
  */
 PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 {
-	zval _141$$94, _147$$97, _171$$107, _177$$110;
+	zval _149$$98, _155$$101, _179$$111, _185$$114;
 	zval _37$$40, _42$$42;
-	zend_string *_19, *_48, *_110, *_133, *_55$$48, *_69$$56, *_84$$65, *_98$$73, *_115$$78, *_124$$85, *_137$$92, *_167$$105;
-	zend_ulong _18, _47, _109, _132, _54$$48, _68$$56, _83$$65, _97$$73, _114$$78, _123$$85, _136$$92, _166$$105;
-	zend_bool isRegex = 0, _11, _27, _41, _77, _119, _163, _9$$6, _14$$12, _25$$16, _33$$28, _63$$44, _59$$48, _73$$56, _92$$61, _88$$65, _102$$73, _117$$78, _126$$85, _143$$92, _157$$102, _173$$105, _185$$115;
+	zend_string *_19, *_48, *_118, *_141, *_57$$49, *_73$$58, *_90$$68, *_106$$77, *_123$$82, *_132$$89, *_145$$96, *_175$$109;
+	zend_ulong _18, _47, _117, _140, _56$$49, _72$$58, _89$$68, _105$$77, _122$$82, _131$$89, _144$$96, _174$$109;
+	zend_bool isRegex = 0, _11, _27, _41, _81, _127, _171, _9$$6, _14$$12, _25$$16, _33$$28, _65$$44, _61$$49, _77$$58, _98$$63, _94$$68, _110$$77, _125$$82, _134$$89, _151$$96, _165$$106, _181$$109, _193$$119;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-	zephir_fcall_cache_entry *_150 = NULL, *_153 = NULL;
-	zval __$true, __$false, route, methods, method, methodSpecific, starRoutes, candidates, candidateRoute, candidatePattern, bucketRoute, bucketPattern, staticUri, staticBucket, staticRoutesList, _0, _1, _2, _3, _4, _5, *_6, _10, _15, _16, *_17, _26, _34, _35, *_36, _40, _45, *_46, _76, bucketIdx, bucketHostname, _105, _106, _107, *_108, _118, combinedAlternatives, combinedMark, combinedBody, combinedBodyMatch, combinedShape, hostnameBucketRef, _127, _128, _129, _130, *_131, _162, *_7$$6, _8$$6, *_12$$12, _13$$12, _20$$17, _21$$16, _22$$16, *_23$$16, _24$$16, _28$$29, _29$$28, _30$$28, *_31$$28, _32$$28, _38$$40, _39$$40, _43$$42, _44$$42, *_49$$44, _62$$44, _50$$46, _51$$46, _52$$47, *_53$$48, _58$$48, _56$$49, _57$$49, _60$$51, _61$$51, _64$$54, _65$$54, _66$$55, *_67$$56, _72$$56, _70$$57, _71$$57, _74$$59, _75$$59, *_78$$61, _91$$61, _79$$63, _80$$63, _81$$64, *_82$$65, _87$$65, _85$$66, _86$$66, _89$$68, _90$$68, _93$$71, _94$$71, _95$$72, *_96$$73, _101$$73, _99$$74, _100$$74, _103$$76, _104$$76, _111$$78, _112$$78, *_113$$78, _116$$78, _120$$85, _121$$85, *_122$$85, _125$$85, _134$$92, *_135$$92, _142$$92, _148$$92, chunkedPatterns$$92, chunkedMarkMaps$$92, chunkOffset$$92, chunkSlice$$92, chunkSliceMap$$92, chunkMarkSubset$$92, reversedMarkIds$$92, chunkMarkId$$92, _149$$92, _151$$92, _138$$94, _139$$94, _140$$94, _144$$97, _145$$97, _146$$97, _152$$102, *_154$$102, _156$$102, _159$$102, _160$$102, _161$$102, _155$$103, _158$$104, _164$$105, *_165$$105, _172$$105, _178$$105, chunkedPatterns$$105, chunkedMarkMaps$$105, chunkOffset$$105, chunkSlice$$105, chunkSliceMap$$105, chunkMarkSubset$$105, reversedMarkIds$$105, chunkMarkId$$105, _179$$105, _180$$105, _168$$107, _169$$107, _170$$107, _174$$110, _175$$110, _176$$110, _181$$115, *_182$$115, _184$$115, _187$$115, _188$$115, _189$$115, _183$$116, _186$$117;
+	zephir_fcall_cache_entry *_158 = NULL, *_161 = NULL;
+	zval __$true, __$false, route, methods, method, methodSpecific, starRoutes, candidates, candidateRoute, candidatePattern, bucketRoute, bucketPattern, staticUri, staticBucket, staticRoutesList, _0, _1, _2, _3, _4, _5, *_6, _10, _15, _16, *_17, _26, _34, _35, *_36, _40, _45, *_46, _80, bucketIdx, bucketHostname, _113, _114, _115, *_116, _126, combinedAlternatives, combinedMark, combinedBody, combinedBodyMatch, combinedShape, hostnameBucketRef, _135, _136, _137, _138, *_139, _170, *_7$$6, _8$$6, *_12$$12, _13$$12, _20$$17, _21$$16, _22$$16, *_23$$16, _24$$16, _28$$29, _29$$28, _30$$28, *_31$$28, _32$$28, _38$$40, _39$$40, _43$$42, _44$$42, *_49$$44, _64$$44, _50$$46, _51$$46, _52$$47, _53$$47, _54$$48, *_55$$49, _60$$49, _58$$50, _59$$50, _62$$52, _63$$52, _66$$55, _67$$55, _68$$56, _69$$56, _70$$57, *_71$$58, _76$$58, _74$$59, _75$$59, _78$$61, _79$$61, *_82$$63, _97$$63, _83$$65, _84$$65, _85$$66, _86$$66, _87$$67, *_88$$68, _93$$68, _91$$69, _92$$69, _95$$71, _96$$71, _99$$74, _100$$74, _101$$75, _102$$75, _103$$76, *_104$$77, _109$$77, _107$$78, _108$$78, _111$$80, _112$$80, _119$$82, _120$$82, *_121$$82, _124$$82, _128$$89, _129$$89, *_130$$89, _133$$89, _142$$96, *_143$$96, _150$$96, _156$$96, chunkedPatterns$$96, chunkedMarkMaps$$96, chunkOffset$$96, chunkSlice$$96, chunkSliceMap$$96, chunkMarkSubset$$96, reversedMarkIds$$96, chunkMarkId$$96, _157$$96, _159$$96, _146$$98, _147$$98, _148$$98, _152$$101, _153$$101, _154$$101, _160$$106, *_162$$106, _164$$106, _167$$106, _168$$106, _169$$106, _163$$107, _166$$108, _172$$109, *_173$$109, _180$$109, _186$$109, chunkedPatterns$$109, chunkedMarkMaps$$109, chunkOffset$$109, chunkSlice$$109, chunkSliceMap$$109, chunkMarkSubset$$109, reversedMarkIds$$109, chunkMarkId$$109, _187$$109, _188$$109, _176$$111, _177$$111, _178$$111, _182$$114, _183$$114, _184$$114, _189$$119, *_190$$119, _192$$119, _195$$119, _196$$119, _197$$119, _191$$120, _194$$121;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
 	zval *this_ptr = getThis();
 
@@ -6545,24 +6545,24 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 	ZVAL_UNDEF(&_35);
 	ZVAL_UNDEF(&_40);
 	ZVAL_UNDEF(&_45);
-	ZVAL_UNDEF(&_76);
+	ZVAL_UNDEF(&_80);
 	ZVAL_UNDEF(&bucketIdx);
 	ZVAL_UNDEF(&bucketHostname);
-	ZVAL_UNDEF(&_105);
-	ZVAL_UNDEF(&_106);
-	ZVAL_UNDEF(&_107);
-	ZVAL_UNDEF(&_118);
+	ZVAL_UNDEF(&_113);
+	ZVAL_UNDEF(&_114);
+	ZVAL_UNDEF(&_115);
+	ZVAL_UNDEF(&_126);
 	ZVAL_UNDEF(&combinedAlternatives);
 	ZVAL_UNDEF(&combinedMark);
 	ZVAL_UNDEF(&combinedBody);
 	ZVAL_UNDEF(&combinedBodyMatch);
 	ZVAL_UNDEF(&combinedShape);
 	ZVAL_UNDEF(&hostnameBucketRef);
-	ZVAL_UNDEF(&_127);
-	ZVAL_UNDEF(&_128);
-	ZVAL_UNDEF(&_129);
-	ZVAL_UNDEF(&_130);
-	ZVAL_UNDEF(&_162);
+	ZVAL_UNDEF(&_135);
+	ZVAL_UNDEF(&_136);
+	ZVAL_UNDEF(&_137);
+	ZVAL_UNDEF(&_138);
+	ZVAL_UNDEF(&_170);
 	ZVAL_UNDEF(&_8$$6);
 	ZVAL_UNDEF(&_13$$12);
 	ZVAL_UNDEF(&_20$$17);
@@ -6577,104 +6577,112 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 	ZVAL_UNDEF(&_39$$40);
 	ZVAL_UNDEF(&_43$$42);
 	ZVAL_UNDEF(&_44$$42);
-	ZVAL_UNDEF(&_62$$44);
+	ZVAL_UNDEF(&_64$$44);
 	ZVAL_UNDEF(&_50$$46);
 	ZVAL_UNDEF(&_51$$46);
 	ZVAL_UNDEF(&_52$$47);
-	ZVAL_UNDEF(&_58$$48);
-	ZVAL_UNDEF(&_56$$49);
-	ZVAL_UNDEF(&_57$$49);
-	ZVAL_UNDEF(&_60$$51);
-	ZVAL_UNDEF(&_61$$51);
-	ZVAL_UNDEF(&_64$$54);
-	ZVAL_UNDEF(&_65$$54);
+	ZVAL_UNDEF(&_53$$47);
+	ZVAL_UNDEF(&_54$$48);
+	ZVAL_UNDEF(&_60$$49);
+	ZVAL_UNDEF(&_58$$50);
+	ZVAL_UNDEF(&_59$$50);
+	ZVAL_UNDEF(&_62$$52);
+	ZVAL_UNDEF(&_63$$52);
 	ZVAL_UNDEF(&_66$$55);
-	ZVAL_UNDEF(&_72$$56);
+	ZVAL_UNDEF(&_67$$55);
+	ZVAL_UNDEF(&_68$$56);
+	ZVAL_UNDEF(&_69$$56);
 	ZVAL_UNDEF(&_70$$57);
-	ZVAL_UNDEF(&_71$$57);
+	ZVAL_UNDEF(&_76$$58);
 	ZVAL_UNDEF(&_74$$59);
 	ZVAL_UNDEF(&_75$$59);
-	ZVAL_UNDEF(&_91$$61);
-	ZVAL_UNDEF(&_79$$63);
-	ZVAL_UNDEF(&_80$$63);
-	ZVAL_UNDEF(&_81$$64);
-	ZVAL_UNDEF(&_87$$65);
+	ZVAL_UNDEF(&_78$$61);
+	ZVAL_UNDEF(&_79$$61);
+	ZVAL_UNDEF(&_97$$63);
+	ZVAL_UNDEF(&_83$$65);
+	ZVAL_UNDEF(&_84$$65);
 	ZVAL_UNDEF(&_85$$66);
 	ZVAL_UNDEF(&_86$$66);
-	ZVAL_UNDEF(&_89$$68);
-	ZVAL_UNDEF(&_90$$68);
-	ZVAL_UNDEF(&_93$$71);
-	ZVAL_UNDEF(&_94$$71);
-	ZVAL_UNDEF(&_95$$72);
-	ZVAL_UNDEF(&_101$$73);
+	ZVAL_UNDEF(&_87$$67);
+	ZVAL_UNDEF(&_93$$68);
+	ZVAL_UNDEF(&_91$$69);
+	ZVAL_UNDEF(&_92$$69);
+	ZVAL_UNDEF(&_95$$71);
+	ZVAL_UNDEF(&_96$$71);
 	ZVAL_UNDEF(&_99$$74);
 	ZVAL_UNDEF(&_100$$74);
+	ZVAL_UNDEF(&_101$$75);
+	ZVAL_UNDEF(&_102$$75);
 	ZVAL_UNDEF(&_103$$76);
-	ZVAL_UNDEF(&_104$$76);
-	ZVAL_UNDEF(&_111$$78);
-	ZVAL_UNDEF(&_112$$78);
-	ZVAL_UNDEF(&_116$$78);
-	ZVAL_UNDEF(&_120$$85);
-	ZVAL_UNDEF(&_121$$85);
-	ZVAL_UNDEF(&_125$$85);
-	ZVAL_UNDEF(&_134$$92);
-	ZVAL_UNDEF(&_142$$92);
-	ZVAL_UNDEF(&_148$$92);
-	ZVAL_UNDEF(&chunkedPatterns$$92);
-	ZVAL_UNDEF(&chunkedMarkMaps$$92);
-	ZVAL_UNDEF(&chunkOffset$$92);
-	ZVAL_UNDEF(&chunkSlice$$92);
-	ZVAL_UNDEF(&chunkSliceMap$$92);
-	ZVAL_UNDEF(&chunkMarkSubset$$92);
-	ZVAL_UNDEF(&reversedMarkIds$$92);
-	ZVAL_UNDEF(&chunkMarkId$$92);
-	ZVAL_UNDEF(&_149$$92);
-	ZVAL_UNDEF(&_151$$92);
-	ZVAL_UNDEF(&_138$$94);
-	ZVAL_UNDEF(&_139$$94);
-	ZVAL_UNDEF(&_140$$94);
-	ZVAL_UNDEF(&_144$$97);
-	ZVAL_UNDEF(&_145$$97);
-	ZVAL_UNDEF(&_146$$97);
-	ZVAL_UNDEF(&_152$$102);
-	ZVAL_UNDEF(&_156$$102);
-	ZVAL_UNDEF(&_159$$102);
-	ZVAL_UNDEF(&_160$$102);
-	ZVAL_UNDEF(&_161$$102);
-	ZVAL_UNDEF(&_155$$103);
-	ZVAL_UNDEF(&_158$$104);
-	ZVAL_UNDEF(&_164$$105);
-	ZVAL_UNDEF(&_172$$105);
-	ZVAL_UNDEF(&_178$$105);
-	ZVAL_UNDEF(&chunkedPatterns$$105);
-	ZVAL_UNDEF(&chunkedMarkMaps$$105);
-	ZVAL_UNDEF(&chunkOffset$$105);
-	ZVAL_UNDEF(&chunkSlice$$105);
-	ZVAL_UNDEF(&chunkSliceMap$$105);
-	ZVAL_UNDEF(&chunkMarkSubset$$105);
-	ZVAL_UNDEF(&reversedMarkIds$$105);
-	ZVAL_UNDEF(&chunkMarkId$$105);
-	ZVAL_UNDEF(&_179$$105);
-	ZVAL_UNDEF(&_180$$105);
-	ZVAL_UNDEF(&_168$$107);
-	ZVAL_UNDEF(&_169$$107);
-	ZVAL_UNDEF(&_170$$107);
-	ZVAL_UNDEF(&_174$$110);
-	ZVAL_UNDEF(&_175$$110);
-	ZVAL_UNDEF(&_176$$110);
-	ZVAL_UNDEF(&_181$$115);
-	ZVAL_UNDEF(&_184$$115);
-	ZVAL_UNDEF(&_187$$115);
-	ZVAL_UNDEF(&_188$$115);
-	ZVAL_UNDEF(&_189$$115);
-	ZVAL_UNDEF(&_183$$116);
-	ZVAL_UNDEF(&_186$$117);
+	ZVAL_UNDEF(&_109$$77);
+	ZVAL_UNDEF(&_107$$78);
+	ZVAL_UNDEF(&_108$$78);
+	ZVAL_UNDEF(&_111$$80);
+	ZVAL_UNDEF(&_112$$80);
+	ZVAL_UNDEF(&_119$$82);
+	ZVAL_UNDEF(&_120$$82);
+	ZVAL_UNDEF(&_124$$82);
+	ZVAL_UNDEF(&_128$$89);
+	ZVAL_UNDEF(&_129$$89);
+	ZVAL_UNDEF(&_133$$89);
+	ZVAL_UNDEF(&_142$$96);
+	ZVAL_UNDEF(&_150$$96);
+	ZVAL_UNDEF(&_156$$96);
+	ZVAL_UNDEF(&chunkedPatterns$$96);
+	ZVAL_UNDEF(&chunkedMarkMaps$$96);
+	ZVAL_UNDEF(&chunkOffset$$96);
+	ZVAL_UNDEF(&chunkSlice$$96);
+	ZVAL_UNDEF(&chunkSliceMap$$96);
+	ZVAL_UNDEF(&chunkMarkSubset$$96);
+	ZVAL_UNDEF(&reversedMarkIds$$96);
+	ZVAL_UNDEF(&chunkMarkId$$96);
+	ZVAL_UNDEF(&_157$$96);
+	ZVAL_UNDEF(&_159$$96);
+	ZVAL_UNDEF(&_146$$98);
+	ZVAL_UNDEF(&_147$$98);
+	ZVAL_UNDEF(&_148$$98);
+	ZVAL_UNDEF(&_152$$101);
+	ZVAL_UNDEF(&_153$$101);
+	ZVAL_UNDEF(&_154$$101);
+	ZVAL_UNDEF(&_160$$106);
+	ZVAL_UNDEF(&_164$$106);
+	ZVAL_UNDEF(&_167$$106);
+	ZVAL_UNDEF(&_168$$106);
+	ZVAL_UNDEF(&_169$$106);
+	ZVAL_UNDEF(&_163$$107);
+	ZVAL_UNDEF(&_166$$108);
+	ZVAL_UNDEF(&_172$$109);
+	ZVAL_UNDEF(&_180$$109);
+	ZVAL_UNDEF(&_186$$109);
+	ZVAL_UNDEF(&chunkedPatterns$$109);
+	ZVAL_UNDEF(&chunkedMarkMaps$$109);
+	ZVAL_UNDEF(&chunkOffset$$109);
+	ZVAL_UNDEF(&chunkSlice$$109);
+	ZVAL_UNDEF(&chunkSliceMap$$109);
+	ZVAL_UNDEF(&chunkMarkSubset$$109);
+	ZVAL_UNDEF(&reversedMarkIds$$109);
+	ZVAL_UNDEF(&chunkMarkId$$109);
+	ZVAL_UNDEF(&_187$$109);
+	ZVAL_UNDEF(&_188$$109);
+	ZVAL_UNDEF(&_176$$111);
+	ZVAL_UNDEF(&_177$$111);
+	ZVAL_UNDEF(&_178$$111);
+	ZVAL_UNDEF(&_182$$114);
+	ZVAL_UNDEF(&_183$$114);
+	ZVAL_UNDEF(&_184$$114);
+	ZVAL_UNDEF(&_189$$119);
+	ZVAL_UNDEF(&_192$$119);
+	ZVAL_UNDEF(&_195$$119);
+	ZVAL_UNDEF(&_196$$119);
+	ZVAL_UNDEF(&_197$$119);
+	ZVAL_UNDEF(&_191$$120);
+	ZVAL_UNDEF(&_194$$121);
 	ZVAL_UNDEF(&_37$$40);
 	ZVAL_UNDEF(&_42$$42);
-	ZVAL_UNDEF(&_141$$94);
-	ZVAL_UNDEF(&_147$$97);
-	ZVAL_UNDEF(&_171$$107);
-	ZVAL_UNDEF(&_177$$110);
+	ZVAL_UNDEF(&_149$$98);
+	ZVAL_UNDEF(&_155$$101);
+	ZVAL_UNDEF(&_179$$111);
+	ZVAL_UNDEF(&_185$$114);
 	static zend_string *_zephir_prop_0 = NULL;
 	static zend_string *_zephir_prop_1 = NULL;
 	static zend_string *_zephir_prop_2 = NULL;
@@ -7091,7 +7099,7 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 	}
 	ZEPHIR_INIT_NVAR(&candidateRoute);
 	zephir_read_property_cached(&_45, this_ptr, _zephir_prop_1, 285, PH_NOISY_CC | PH_READONLY);
-	zephir_is_iterable(&_45, 0, "phalcon/Mvc/Router.zep", 2311);
+	zephir_is_iterable(&_45, 0, "phalcon/Mvc/Router.zep", 2313);
 	if (Z_TYPE_P(&_45) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_45), _47, _48, _46)
 		{
@@ -7103,7 +7111,7 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 			}
 			ZEPHIR_INIT_NVAR(&candidates);
 			ZVAL_COPY(&candidates, _46);
-			zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2304);
+			zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2306);
 			if (Z_TYPE_P(&candidates) == IS_ARRAY) {
 				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&candidates), _49$$44)
 				{
@@ -7114,55 +7122,59 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 					if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2285))) {
 						zephir_update_property_array_multi(this_ptr, SL("staticByMethod"), &bucketRoute, SL("zza"), 3, &method, &bucketPattern);
 						zephir_read_property_cached(&_50$$46, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
-						zephir_array_fetch(&_51$$46, &_50$$46, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
-						zephir_array_unset(&_51$$46, &bucketPattern, PH_SEPARATE);
+						zephir_array_fetch(&_51$$46, &_50$$46, &method, PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
+						if (zephir_array_isset_value(&_51$$46, &bucketPattern)) {
+							zephir_read_property_cached(&_52$$47, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+							zephir_array_fetch(&_53$$47, &_52$$47, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2294);
+							zephir_array_unset(&_53$$47, &bucketPattern, PH_SEPARATE);
+						}
 					} else {
 						ZEPHIR_OBS_NVAR(&staticBucket);
-						zephir_read_property_cached(&_52$$47, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
-						if (zephir_array_isset_fetch(&staticBucket, &_52$$47, &method, 0)) {
-							zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2301);
+						zephir_read_property_cached(&_54$$48, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
+						if (zephir_array_isset_fetch(&staticBucket, &_54$$48, &method, 0)) {
+							zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2303);
 							if (Z_TYPE_P(&staticBucket) == IS_ARRAY) {
-								ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _54$$48, _55$$48, _53$$48)
+								ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _56$$49, _57$$49, _55$$49)
 								{
 									ZEPHIR_INIT_NVAR(&staticUri);
-									if (_55$$48 != NULL) { 
-										ZVAL_STR_COPY(&staticUri, _55$$48);
+									if (_57$$49 != NULL) { 
+										ZVAL_STR_COPY(&staticUri, _57$$49);
 									} else {
-										ZVAL_LONG(&staticUri, _54$$48);
+										ZVAL_LONG(&staticUri, _56$$49);
 									}
 									ZEPHIR_INIT_NVAR(&staticRoutesList);
-									ZVAL_COPY(&staticRoutesList, _53$$48);
-									ZEPHIR_INIT_NVAR(&_56$$49);
-									ZEPHIR_INIT_NVAR(&_57$$49);
-									zephir_preg_match(&_57$$49, &bucketPattern, &staticUri, &_56$$49, 0, 0 , 0 );
-									if (zephir_is_true(&_57$$49)) {
+									ZVAL_COPY(&staticRoutesList, _55$$49);
+									ZEPHIR_INIT_NVAR(&_58$$50);
+									ZEPHIR_INIT_NVAR(&_59$$50);
+									zephir_preg_match(&_59$$50, &bucketPattern, &staticUri, &_58$$50, 0, 0 , 0 );
+									if (zephir_is_true(&_59$$50)) {
 										zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 									}
 								} ZEND_HASH_FOREACH_END();
 							} else {
 								ZEPHIR_CALL_METHOD(NULL, &staticBucket, "rewind", NULL, 0);
 								zephir_check_call_status();
-								_59$$48 = 1;
+								_61$$49 = 1;
 								while (1) {
-									if (_59$$48) {
-										_59$$48 = 0;
+									if (_61$$49) {
+										_61$$49 = 0;
 									} else {
 										ZEPHIR_CALL_METHOD(NULL, &staticBucket, "next", NULL, 0);
 										zephir_check_call_status();
 									}
-									ZEPHIR_CALL_METHOD(&_58$$48, &staticBucket, "valid", NULL, 0);
+									ZEPHIR_CALL_METHOD(&_60$$49, &staticBucket, "valid", NULL, 0);
 									zephir_check_call_status();
-									if (!zend_is_true(&_58$$48)) {
+									if (!zend_is_true(&_60$$49)) {
 										break;
 									}
 									ZEPHIR_CALL_METHOD(&staticUri, &staticBucket, "key", NULL, 0);
 									zephir_check_call_status();
 									ZEPHIR_CALL_METHOD(&staticRoutesList, &staticBucket, "current", NULL, 0);
 									zephir_check_call_status();
-										ZEPHIR_INIT_NVAR(&_60$$51);
-										ZEPHIR_INIT_NVAR(&_61$$51);
-										zephir_preg_match(&_61$$51, &bucketPattern, &staticUri, &_60$$51, 0, 0 , 0 );
-										if (zephir_is_true(&_61$$51)) {
+										ZEPHIR_INIT_NVAR(&_62$$52);
+										ZEPHIR_INIT_NVAR(&_63$$52);
+										zephir_preg_match(&_63$$52, &bucketPattern, &staticUri, &_62$$52, 0, 0 , 0 );
+										if (zephir_is_true(&_63$$52)) {
 											zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 										}
 								}
@@ -7175,17 +7187,17 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &candidates, "rewind", NULL, 0);
 				zephir_check_call_status();
-				_63$$44 = 1;
+				_65$$44 = 1;
 				while (1) {
-					if (_63$$44) {
-						_63$$44 = 0;
+					if (_65$$44) {
+						_65$$44 = 0;
 					} else {
 						ZEPHIR_CALL_METHOD(NULL, &candidates, "next", NULL, 0);
 						zephir_check_call_status();
 					}
-					ZEPHIR_CALL_METHOD(&_62$$44, &candidates, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_64$$44, &candidates, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_62$$44)) {
+					if (!zend_is_true(&_64$$44)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&bucketRoute, &candidates, "current", NULL, 0);
@@ -7194,56 +7206,60 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 						zephir_check_call_status();
 						if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2285))) {
 							zephir_update_property_array_multi(this_ptr, SL("staticByMethod"), &bucketRoute, SL("zza"), 3, &method, &bucketPattern);
-							zephir_read_property_cached(&_64$$54, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
-							zephir_array_fetch(&_65$$54, &_64$$54, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
-							zephir_array_unset(&_65$$54, &bucketPattern, PH_SEPARATE);
+							zephir_read_property_cached(&_66$$55, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+							zephir_array_fetch(&_67$$55, &_66$$55, &method, PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
+							if (zephir_array_isset_value(&_67$$55, &bucketPattern)) {
+								zephir_read_property_cached(&_68$$56, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+								zephir_array_fetch(&_69$$56, &_68$$56, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2294);
+								zephir_array_unset(&_69$$56, &bucketPattern, PH_SEPARATE);
+							}
 						} else {
 							ZEPHIR_OBS_NVAR(&staticBucket);
-							zephir_read_property_cached(&_66$$55, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
-							if (zephir_array_isset_fetch(&staticBucket, &_66$$55, &method, 0)) {
-								zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2301);
+							zephir_read_property_cached(&_70$$57, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
+							if (zephir_array_isset_fetch(&staticBucket, &_70$$57, &method, 0)) {
+								zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2303);
 								if (Z_TYPE_P(&staticBucket) == IS_ARRAY) {
-									ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _68$$56, _69$$56, _67$$56)
+									ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _72$$58, _73$$58, _71$$58)
 									{
 										ZEPHIR_INIT_NVAR(&staticUri);
-										if (_69$$56 != NULL) { 
-											ZVAL_STR_COPY(&staticUri, _69$$56);
+										if (_73$$58 != NULL) { 
+											ZVAL_STR_COPY(&staticUri, _73$$58);
 										} else {
-											ZVAL_LONG(&staticUri, _68$$56);
+											ZVAL_LONG(&staticUri, _72$$58);
 										}
 										ZEPHIR_INIT_NVAR(&staticRoutesList);
-										ZVAL_COPY(&staticRoutesList, _67$$56);
-										ZEPHIR_INIT_NVAR(&_70$$57);
-										ZEPHIR_INIT_NVAR(&_71$$57);
-										zephir_preg_match(&_71$$57, &bucketPattern, &staticUri, &_70$$57, 0, 0 , 0 );
-										if (zephir_is_true(&_71$$57)) {
+										ZVAL_COPY(&staticRoutesList, _71$$58);
+										ZEPHIR_INIT_NVAR(&_74$$59);
+										ZEPHIR_INIT_NVAR(&_75$$59);
+										zephir_preg_match(&_75$$59, &bucketPattern, &staticUri, &_74$$59, 0, 0 , 0 );
+										if (zephir_is_true(&_75$$59)) {
 											zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 										}
 									} ZEND_HASH_FOREACH_END();
 								} else {
 									ZEPHIR_CALL_METHOD(NULL, &staticBucket, "rewind", NULL, 0);
 									zephir_check_call_status();
-									_73$$56 = 1;
+									_77$$58 = 1;
 									while (1) {
-										if (_73$$56) {
-											_73$$56 = 0;
+										if (_77$$58) {
+											_77$$58 = 0;
 										} else {
 											ZEPHIR_CALL_METHOD(NULL, &staticBucket, "next", NULL, 0);
 											zephir_check_call_status();
 										}
-										ZEPHIR_CALL_METHOD(&_72$$56, &staticBucket, "valid", NULL, 0);
+										ZEPHIR_CALL_METHOD(&_76$$58, &staticBucket, "valid", NULL, 0);
 										zephir_check_call_status();
-										if (!zend_is_true(&_72$$56)) {
+										if (!zend_is_true(&_76$$58)) {
 											break;
 										}
 										ZEPHIR_CALL_METHOD(&staticUri, &staticBucket, "key", NULL, 0);
 										zephir_check_call_status();
 										ZEPHIR_CALL_METHOD(&staticRoutesList, &staticBucket, "current", NULL, 0);
 										zephir_check_call_status();
-											ZEPHIR_INIT_NVAR(&_74$$59);
-											ZEPHIR_INIT_NVAR(&_75$$59);
-											zephir_preg_match(&_75$$59, &bucketPattern, &staticUri, &_74$$59, 0, 0 , 0 );
-											if (zephir_is_true(&_75$$59)) {
+											ZEPHIR_INIT_NVAR(&_78$$61);
+											ZEPHIR_INIT_NVAR(&_79$$61);
+											zephir_preg_match(&_79$$61, &bucketPattern, &staticUri, &_78$$61, 0, 0 , 0 );
+											if (zephir_is_true(&_79$$61)) {
 												zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 											}
 									}
@@ -7259,83 +7275,87 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 	} else {
 		ZEPHIR_CALL_METHOD(NULL, &_45, "rewind", NULL, 0);
 		zephir_check_call_status();
-		_77 = 1;
+		_81 = 1;
 		while (1) {
-			if (_77) {
-				_77 = 0;
+			if (_81) {
+				_81 = 0;
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &_45, "next", NULL, 0);
 				zephir_check_call_status();
 			}
-			ZEPHIR_CALL_METHOD(&_76, &_45, "valid", NULL, 0);
+			ZEPHIR_CALL_METHOD(&_80, &_45, "valid", NULL, 0);
 			zephir_check_call_status();
-			if (!zend_is_true(&_76)) {
+			if (!zend_is_true(&_80)) {
 				break;
 			}
 			ZEPHIR_CALL_METHOD(&method, &_45, "key", NULL, 0);
 			zephir_check_call_status();
 			ZEPHIR_CALL_METHOD(&candidates, &_45, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2304);
+				zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2306);
 				if (Z_TYPE_P(&candidates) == IS_ARRAY) {
-					ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&candidates), _78$$61)
+					ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&candidates), _82$$63)
 					{
 						ZEPHIR_INIT_NVAR(&bucketRoute);
-						ZVAL_COPY(&bucketRoute, _78$$61);
+						ZVAL_COPY(&bucketRoute, _82$$63);
 						ZEPHIR_CALL_METHOD(&bucketPattern, &bucketRoute, "getcompiledpattern", NULL, 0);
 						zephir_check_call_status();
 						if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2285))) {
 							zephir_update_property_array_multi(this_ptr, SL("staticByMethod"), &bucketRoute, SL("zza"), 3, &method, &bucketPattern);
-							zephir_read_property_cached(&_79$$63, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
-							zephir_array_fetch(&_80$$63, &_79$$63, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
-							zephir_array_unset(&_80$$63, &bucketPattern, PH_SEPARATE);
+							zephir_read_property_cached(&_83$$65, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+							zephir_array_fetch(&_84$$65, &_83$$65, &method, PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
+							if (zephir_array_isset_value(&_84$$65, &bucketPattern)) {
+								zephir_read_property_cached(&_85$$66, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+								zephir_array_fetch(&_86$$66, &_85$$66, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2294);
+								zephir_array_unset(&_86$$66, &bucketPattern, PH_SEPARATE);
+							}
 						} else {
 							ZEPHIR_OBS_NVAR(&staticBucket);
-							zephir_read_property_cached(&_81$$64, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
-							if (zephir_array_isset_fetch(&staticBucket, &_81$$64, &method, 0)) {
-								zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2301);
+							zephir_read_property_cached(&_87$$67, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
+							if (zephir_array_isset_fetch(&staticBucket, &_87$$67, &method, 0)) {
+								zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2303);
 								if (Z_TYPE_P(&staticBucket) == IS_ARRAY) {
-									ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _83$$65, _84$$65, _82$$65)
+									ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _89$$68, _90$$68, _88$$68)
 									{
 										ZEPHIR_INIT_NVAR(&staticUri);
-										if (_84$$65 != NULL) { 
-											ZVAL_STR_COPY(&staticUri, _84$$65);
+										if (_90$$68 != NULL) { 
+											ZVAL_STR_COPY(&staticUri, _90$$68);
 										} else {
-											ZVAL_LONG(&staticUri, _83$$65);
+											ZVAL_LONG(&staticUri, _89$$68);
 										}
 										ZEPHIR_INIT_NVAR(&staticRoutesList);
-										ZVAL_COPY(&staticRoutesList, _82$$65);
-										ZEPHIR_INIT_NVAR(&_85$$66);
-										ZEPHIR_INIT_NVAR(&_86$$66);
-										zephir_preg_match(&_86$$66, &bucketPattern, &staticUri, &_85$$66, 0, 0 , 0 );
-										if (zephir_is_true(&_86$$66)) {
+										ZVAL_COPY(&staticRoutesList, _88$$68);
+										ZEPHIR_INIT_NVAR(&_91$$69);
+										ZEPHIR_INIT_NVAR(&_92$$69);
+										zephir_preg_match(&_92$$69, &bucketPattern, &staticUri, &_91$$69, 0, 0 , 0 );
+										if (zephir_is_true(&_92$$69)) {
 											zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 										}
 									} ZEND_HASH_FOREACH_END();
 								} else {
 									ZEPHIR_CALL_METHOD(NULL, &staticBucket, "rewind", NULL, 0);
 									zephir_check_call_status();
-									_88$$65 = 1;
+									_94$$68 = 1;
 									while (1) {
-										if (_88$$65) {
-											_88$$65 = 0;
+										if (_94$$68) {
+											_94$$68 = 0;
 										} else {
 											ZEPHIR_CALL_METHOD(NULL, &staticBucket, "next", NULL, 0);
 											zephir_check_call_status();
 										}
-										ZEPHIR_CALL_METHOD(&_87$$65, &staticBucket, "valid", NULL, 0);
+										ZEPHIR_CALL_METHOD(&_93$$68, &staticBucket, "valid", NULL, 0);
 										zephir_check_call_status();
-										if (!zend_is_true(&_87$$65)) {
+										if (!zend_is_true(&_93$$68)) {
 											break;
 										}
 										ZEPHIR_CALL_METHOD(&staticUri, &staticBucket, "key", NULL, 0);
 										zephir_check_call_status();
 										ZEPHIR_CALL_METHOD(&staticRoutesList, &staticBucket, "current", NULL, 0);
 										zephir_check_call_status();
-											ZEPHIR_INIT_NVAR(&_89$$68);
-											ZEPHIR_INIT_NVAR(&_90$$68);
-											zephir_preg_match(&_90$$68, &bucketPattern, &staticUri, &_89$$68, 0, 0 , 0 );
-											if (zephir_is_true(&_90$$68)) {
+											ZEPHIR_INIT_NVAR(&_95$$71);
+											ZEPHIR_INIT_NVAR(&_96$$71);
+											zephir_preg_match(&_96$$71, &bucketPattern, &staticUri, &_95$$71, 0, 0 , 0 );
+											if (zephir_is_true(&_96$$71)) {
 												zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 											}
 									}
@@ -7348,17 +7368,17 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 				} else {
 					ZEPHIR_CALL_METHOD(NULL, &candidates, "rewind", NULL, 0);
 					zephir_check_call_status();
-					_92$$61 = 1;
+					_98$$63 = 1;
 					while (1) {
-						if (_92$$61) {
-							_92$$61 = 0;
+						if (_98$$63) {
+							_98$$63 = 0;
 						} else {
 							ZEPHIR_CALL_METHOD(NULL, &candidates, "next", NULL, 0);
 							zephir_check_call_status();
 						}
-						ZEPHIR_CALL_METHOD(&_91$$61, &candidates, "valid", NULL, 0);
+						ZEPHIR_CALL_METHOD(&_97$$63, &candidates, "valid", NULL, 0);
 						zephir_check_call_status();
-						if (!zend_is_true(&_91$$61)) {
+						if (!zend_is_true(&_97$$63)) {
 							break;
 						}
 						ZEPHIR_CALL_METHOD(&bucketRoute, &candidates, "current", NULL, 0);
@@ -7367,56 +7387,60 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 							zephir_check_call_status();
 							if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2285))) {
 								zephir_update_property_array_multi(this_ptr, SL("staticByMethod"), &bucketRoute, SL("zza"), 3, &method, &bucketPattern);
-								zephir_read_property_cached(&_93$$71, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
-								zephir_array_fetch(&_94$$71, &_93$$71, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
-								zephir_array_unset(&_94$$71, &bucketPattern, PH_SEPARATE);
+								zephir_read_property_cached(&_99$$74, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+								zephir_array_fetch(&_100$$74, &_99$$74, &method, PH_READONLY, "phalcon/Mvc/Router.zep", 2293);
+								if (zephir_array_isset_value(&_100$$74, &bucketPattern)) {
+									zephir_read_property_cached(&_101$$75, this_ptr, _zephir_prop_4, 288, PH_NOISY_CC | PH_READONLY);
+									zephir_array_fetch(&_102$$75, &_101$$75, &method, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2294);
+									zephir_array_unset(&_102$$75, &bucketPattern, PH_SEPARATE);
+								}
 							} else {
 								ZEPHIR_OBS_NVAR(&staticBucket);
-								zephir_read_property_cached(&_95$$72, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
-								if (zephir_array_isset_fetch(&staticBucket, &_95$$72, &method, 0)) {
-									zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2301);
+								zephir_read_property_cached(&_103$$76, this_ptr, _zephir_prop_3, 287, PH_NOISY_CC | PH_READONLY);
+								if (zephir_array_isset_fetch(&staticBucket, &_103$$76, &method, 0)) {
+									zephir_is_iterable(&staticBucket, 0, "phalcon/Mvc/Router.zep", 2303);
 									if (Z_TYPE_P(&staticBucket) == IS_ARRAY) {
-										ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _97$$73, _98$$73, _96$$73)
+										ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&staticBucket), _105$$77, _106$$77, _104$$77)
 										{
 											ZEPHIR_INIT_NVAR(&staticUri);
-											if (_98$$73 != NULL) { 
-												ZVAL_STR_COPY(&staticUri, _98$$73);
+											if (_106$$77 != NULL) { 
+												ZVAL_STR_COPY(&staticUri, _106$$77);
 											} else {
-												ZVAL_LONG(&staticUri, _97$$73);
+												ZVAL_LONG(&staticUri, _105$$77);
 											}
 											ZEPHIR_INIT_NVAR(&staticRoutesList);
-											ZVAL_COPY(&staticRoutesList, _96$$73);
-											ZEPHIR_INIT_NVAR(&_99$$74);
-											ZEPHIR_INIT_NVAR(&_100$$74);
-											zephir_preg_match(&_100$$74, &bucketPattern, &staticUri, &_99$$74, 0, 0 , 0 );
-											if (zephir_is_true(&_100$$74)) {
+											ZVAL_COPY(&staticRoutesList, _104$$77);
+											ZEPHIR_INIT_NVAR(&_107$$78);
+											ZEPHIR_INIT_NVAR(&_108$$78);
+											zephir_preg_match(&_108$$78, &bucketPattern, &staticUri, &_107$$78, 0, 0 , 0 );
+											if (zephir_is_true(&_108$$78)) {
 												zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 											}
 										} ZEND_HASH_FOREACH_END();
 									} else {
 										ZEPHIR_CALL_METHOD(NULL, &staticBucket, "rewind", NULL, 0);
 										zephir_check_call_status();
-										_102$$73 = 1;
+										_110$$77 = 1;
 										while (1) {
-											if (_102$$73) {
-												_102$$73 = 0;
+											if (_110$$77) {
+												_110$$77 = 0;
 											} else {
 												ZEPHIR_CALL_METHOD(NULL, &staticBucket, "next", NULL, 0);
 												zephir_check_call_status();
 											}
-											ZEPHIR_CALL_METHOD(&_101$$73, &staticBucket, "valid", NULL, 0);
+											ZEPHIR_CALL_METHOD(&_109$$77, &staticBucket, "valid", NULL, 0);
 											zephir_check_call_status();
-											if (!zend_is_true(&_101$$73)) {
+											if (!zend_is_true(&_109$$77)) {
 												break;
 											}
 											ZEPHIR_CALL_METHOD(&staticUri, &staticBucket, "key", NULL, 0);
 											zephir_check_call_status();
 											ZEPHIR_CALL_METHOD(&staticRoutesList, &staticBucket, "current", NULL, 0);
 											zephir_check_call_status();
-												ZEPHIR_INIT_NVAR(&_103$$76);
-												ZEPHIR_INIT_NVAR(&_104$$76);
-												zephir_preg_match(&_104$$76, &bucketPattern, &staticUri, &_103$$76, 0, 0 , 0 );
-												if (zephir_is_true(&_104$$76)) {
+												ZEPHIR_INIT_NVAR(&_111$$80);
+												ZEPHIR_INIT_NVAR(&_112$$80);
+												zephir_preg_match(&_112$$80, &bucketPattern, &staticUri, &_111$$80, 0, 0 , 0 );
+												if (zephir_is_true(&_112$$80)) {
 													zephir_update_property_array_multi(this_ptr, SL("staticShadowedByMethod"), &__$true, SL("zz"), 2, &method, &staticUri);
 												}
 										}
@@ -7432,43 +7456,43 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 	}
 	ZEPHIR_INIT_NVAR(&candidates);
 	ZEPHIR_INIT_NVAR(&method);
-	ZEPHIR_INIT_VAR(&_105);
-	array_init(&_105);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 289, &_105);
-	ZEPHIR_INIT_VAR(&_106);
-	array_init(&_106);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 290, &_106);
-	zephir_read_property_cached(&_107, this_ptr, _zephir_prop_1, 285, PH_NOISY_CC | PH_READONLY);
-	zephir_is_iterable(&_107, 0, "phalcon/Mvc/Router.zep", 2338);
-	if (Z_TYPE_P(&_107) == IS_ARRAY) {
-		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_107), _109, _110, _108)
+	ZEPHIR_INIT_VAR(&_113);
+	array_init(&_113);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_6, 289, &_113);
+	ZEPHIR_INIT_VAR(&_114);
+	array_init(&_114);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_7, 290, &_114);
+	zephir_read_property_cached(&_115, this_ptr, _zephir_prop_1, 285, PH_NOISY_CC | PH_READONLY);
+	zephir_is_iterable(&_115, 0, "phalcon/Mvc/Router.zep", 2340);
+	if (Z_TYPE_P(&_115) == IS_ARRAY) {
+		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_115), _117, _118, _116)
 		{
 			ZEPHIR_INIT_NVAR(&method);
-			if (_110 != NULL) { 
-				ZVAL_STR_COPY(&method, _110);
+			if (_118 != NULL) { 
+				ZVAL_STR_COPY(&method, _118);
 			} else {
-				ZVAL_LONG(&method, _109);
+				ZVAL_LONG(&method, _117);
 			}
 			ZEPHIR_INIT_NVAR(&candidates);
-			ZVAL_COPY(&candidates, _108);
-			ZEPHIR_INIT_NVAR(&_111$$78);
-			array_init(&_111$$78);
-			zephir_update_property_array(this_ptr, SL("hostnameByMethod"), &method, &_111$$78);
-			ZEPHIR_INIT_NVAR(&_112$$78);
-			array_init(&_112$$78);
-			zephir_update_property_array(this_ptr, SL("hostnameLessByMethod"), &method, &_112$$78);
-			zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2329);
+			ZVAL_COPY(&candidates, _116);
+			ZEPHIR_INIT_NVAR(&_119$$82);
+			array_init(&_119$$82);
+			zephir_update_property_array(this_ptr, SL("hostnameByMethod"), &method, &_119$$82);
+			ZEPHIR_INIT_NVAR(&_120$$82);
+			array_init(&_120$$82);
+			zephir_update_property_array(this_ptr, SL("hostnameLessByMethod"), &method, &_120$$82);
+			zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2331);
 			if (Z_TYPE_P(&candidates) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _114$$78, _115$$78, _113$$78)
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _122$$82, _123$$82, _121$$82)
 				{
 					ZEPHIR_INIT_NVAR(&bucketIdx);
-					if (_115$$78 != NULL) { 
-						ZVAL_STR_COPY(&bucketIdx, _115$$78);
+					if (_123$$82 != NULL) { 
+						ZVAL_STR_COPY(&bucketIdx, _123$$82);
 					} else {
-						ZVAL_LONG(&bucketIdx, _114$$78);
+						ZVAL_LONG(&bucketIdx, _122$$82);
 					}
 					ZEPHIR_INIT_NVAR(&bucketRoute);
-					ZVAL_COPY(&bucketRoute, _113$$78);
+					ZVAL_COPY(&bucketRoute, _121$$82);
 					ZEPHIR_CALL_METHOD(&bucketHostname, &bucketRoute, "gethostname", NULL, 0);
 					zephir_check_call_status();
 					if (Z_TYPE_P(&bucketHostname) == IS_NULL) {
@@ -7480,17 +7504,17 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &candidates, "rewind", NULL, 0);
 				zephir_check_call_status();
-				_117$$78 = 1;
+				_125$$82 = 1;
 				while (1) {
-					if (_117$$78) {
-						_117$$78 = 0;
+					if (_125$$82) {
+						_125$$82 = 0;
 					} else {
 						ZEPHIR_CALL_METHOD(NULL, &candidates, "next", NULL, 0);
 						zephir_check_call_status();
 					}
-					ZEPHIR_CALL_METHOD(&_116$$78, &candidates, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_124$$82, &candidates, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_116$$78)) {
+					if (!zend_is_true(&_124$$82)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&bucketIdx, &candidates, "key", NULL, 0);
@@ -7510,43 +7534,43 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 			ZEPHIR_INIT_NVAR(&bucketIdx);
 		} ZEND_HASH_FOREACH_END();
 	} else {
-		ZEPHIR_CALL_METHOD(NULL, &_107, "rewind", NULL, 0);
+		ZEPHIR_CALL_METHOD(NULL, &_115, "rewind", NULL, 0);
 		zephir_check_call_status();
-		_119 = 1;
+		_127 = 1;
 		while (1) {
-			if (_119) {
-				_119 = 0;
+			if (_127) {
+				_127 = 0;
 			} else {
-				ZEPHIR_CALL_METHOD(NULL, &_107, "next", NULL, 0);
+				ZEPHIR_CALL_METHOD(NULL, &_115, "next", NULL, 0);
 				zephir_check_call_status();
 			}
-			ZEPHIR_CALL_METHOD(&_118, &_107, "valid", NULL, 0);
+			ZEPHIR_CALL_METHOD(&_126, &_115, "valid", NULL, 0);
 			zephir_check_call_status();
-			if (!zend_is_true(&_118)) {
+			if (!zend_is_true(&_126)) {
 				break;
 			}
-			ZEPHIR_CALL_METHOD(&method, &_107, "key", NULL, 0);
+			ZEPHIR_CALL_METHOD(&method, &_115, "key", NULL, 0);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&candidates, &_107, "current", NULL, 0);
+			ZEPHIR_CALL_METHOD(&candidates, &_115, "current", NULL, 0);
 			zephir_check_call_status();
-				ZEPHIR_INIT_NVAR(&_120$$85);
-				array_init(&_120$$85);
-				zephir_update_property_array(this_ptr, SL("hostnameByMethod"), &method, &_120$$85);
-				ZEPHIR_INIT_NVAR(&_121$$85);
-				array_init(&_121$$85);
-				zephir_update_property_array(this_ptr, SL("hostnameLessByMethod"), &method, &_121$$85);
-				zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2329);
+				ZEPHIR_INIT_NVAR(&_128$$89);
+				array_init(&_128$$89);
+				zephir_update_property_array(this_ptr, SL("hostnameByMethod"), &method, &_128$$89);
+				ZEPHIR_INIT_NVAR(&_129$$89);
+				array_init(&_129$$89);
+				zephir_update_property_array(this_ptr, SL("hostnameLessByMethod"), &method, &_129$$89);
+				zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2331);
 				if (Z_TYPE_P(&candidates) == IS_ARRAY) {
-					ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _123$$85, _124$$85, _122$$85)
+					ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _131$$89, _132$$89, _130$$89)
 					{
 						ZEPHIR_INIT_NVAR(&bucketIdx);
-						if (_124$$85 != NULL) { 
-							ZVAL_STR_COPY(&bucketIdx, _124$$85);
+						if (_132$$89 != NULL) { 
+							ZVAL_STR_COPY(&bucketIdx, _132$$89);
 						} else {
-							ZVAL_LONG(&bucketIdx, _123$$85);
+							ZVAL_LONG(&bucketIdx, _131$$89);
 						}
 						ZEPHIR_INIT_NVAR(&bucketRoute);
-						ZVAL_COPY(&bucketRoute, _122$$85);
+						ZVAL_COPY(&bucketRoute, _130$$89);
 						ZEPHIR_CALL_METHOD(&bucketHostname, &bucketRoute, "gethostname", NULL, 0);
 						zephir_check_call_status();
 						if (Z_TYPE_P(&bucketHostname) == IS_NULL) {
@@ -7558,17 +7582,17 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 				} else {
 					ZEPHIR_CALL_METHOD(NULL, &candidates, "rewind", NULL, 0);
 					zephir_check_call_status();
-					_126$$85 = 1;
+					_134$$89 = 1;
 					while (1) {
-						if (_126$$85) {
-							_126$$85 = 0;
+						if (_134$$89) {
+							_134$$89 = 0;
 						} else {
 							ZEPHIR_CALL_METHOD(NULL, &candidates, "next", NULL, 0);
 							zephir_check_call_status();
 						}
-						ZEPHIR_CALL_METHOD(&_125$$85, &candidates, "valid", NULL, 0);
+						ZEPHIR_CALL_METHOD(&_133$$89, &candidates, "valid", NULL, 0);
 						zephir_check_call_status();
-						if (!zend_is_true(&_125$$85)) {
+						if (!zend_is_true(&_133$$89)) {
 							break;
 						}
 						ZEPHIR_CALL_METHOD(&bucketIdx, &candidates, "key", NULL, 0);
@@ -7590,31 +7614,31 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 	}
 	ZEPHIR_INIT_NVAR(&candidates);
 	ZEPHIR_INIT_NVAR(&method);
-	ZEPHIR_INIT_VAR(&_127);
-	array_init(&_127);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 291, &_127);
-	ZEPHIR_INIT_VAR(&_128);
-	array_init(&_128);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 293, &_128);
-	ZEPHIR_INIT_VAR(&_129);
-	array_init(&_129);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 292, &_129);
-	zephir_read_property_cached(&_130, this_ptr, _zephir_prop_1, 285, PH_NOISY_CC | PH_READONLY);
-	zephir_is_iterable(&_130, 0, "phalcon/Mvc/Router.zep", 2420);
-	if (Z_TYPE_P(&_130) == IS_ARRAY) {
-		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_130), _132, _133, _131)
+	ZEPHIR_INIT_VAR(&_135);
+	array_init(&_135);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_8, 291, &_135);
+	ZEPHIR_INIT_VAR(&_136);
+	array_init(&_136);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_9, 293, &_136);
+	ZEPHIR_INIT_VAR(&_137);
+	array_init(&_137);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_10, 292, &_137);
+	zephir_read_property_cached(&_138, this_ptr, _zephir_prop_1, 285, PH_NOISY_CC | PH_READONLY);
+	zephir_is_iterable(&_138, 0, "phalcon/Mvc/Router.zep", 2422);
+	if (Z_TYPE_P(&_138) == IS_ARRAY) {
+		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&_138), _140, _141, _139)
 		{
 			ZEPHIR_INIT_NVAR(&method);
-			if (_133 != NULL) { 
-				ZVAL_STR_COPY(&method, _133);
+			if (_141 != NULL) { 
+				ZVAL_STR_COPY(&method, _141);
 			} else {
-				ZVAL_LONG(&method, _132);
+				ZVAL_LONG(&method, _140);
 			}
 			ZEPHIR_INIT_NVAR(&candidates);
-			ZVAL_COPY(&candidates, _131);
-			zephir_read_property_cached(&_134$$92, this_ptr, _zephir_prop_6, 289, PH_NOISY_CC | PH_READONLY);
+			ZVAL_COPY(&candidates, _139);
+			zephir_read_property_cached(&_142$$96, this_ptr, _zephir_prop_6, 289, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_OBS_NVAR(&hostnameBucketRef);
-			zephir_array_fetch(&hostnameBucketRef, &_134$$92, &method, PH_NOISY, "phalcon/Mvc/Router.zep", 2346);
+			zephir_array_fetch(&hostnameBucketRef, &_142$$96, &method, PH_NOISY, "phalcon/Mvc/Router.zep", 2348);
 			if (!(ZEPHIR_IS_EMPTY(&hostnameBucketRef))) {
 				zephir_update_property_array(this_ptr, SL("combinedRegexDisabled"), &method, &__$true);
 				continue;
@@ -7623,31 +7647,31 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 			array_init(&combinedAlternatives);
 			ZEPHIR_INIT_NVAR(&combinedMark);
 			array_init(&combinedMark);
-			zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2377);
+			zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2379);
 			if (Z_TYPE_P(&candidates) == IS_ARRAY) {
-				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _136$$92, _137$$92, _135$$92)
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _144$$96, _145$$96, _143$$96)
 				{
 					ZEPHIR_INIT_NVAR(&bucketIdx);
-					if (_137$$92 != NULL) { 
-						ZVAL_STR_COPY(&bucketIdx, _137$$92);
+					if (_145$$96 != NULL) { 
+						ZVAL_STR_COPY(&bucketIdx, _145$$96);
 					} else {
-						ZVAL_LONG(&bucketIdx, _136$$92);
+						ZVAL_LONG(&bucketIdx, _144$$96);
 					}
 					ZEPHIR_INIT_NVAR(&bucketRoute);
-					ZVAL_COPY(&bucketRoute, _135$$92);
+					ZVAL_COPY(&bucketRoute, _143$$96);
 					ZEPHIR_CALL_METHOD(&bucketPattern, &bucketRoute, "getcompiledpattern", NULL, 0);
 					zephir_check_call_status();
-					if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2359))) {
+					if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2361))) {
 						continue;
 					}
 					ZEPHIR_INIT_NVAR(&combinedBodyMatch);
 					array_init(&combinedBodyMatch);
-					ZEPHIR_INIT_NVAR(&_138$$94);
-					ZVAL_STRING(&_138$$94, "/^#\\^(.+)\\$#u$/");
-					ZEPHIR_INIT_NVAR(&_139$$94);
-					ZVAL_STRING(&_139$$94, "/^#\\^(.+)\\$#u$/");
+					ZEPHIR_INIT_NVAR(&_146$$98);
+					ZVAL_STRING(&_146$$98, "/^#\\^(.+)\\$#u$/");
+					ZEPHIR_INIT_NVAR(&_147$$98);
+					ZVAL_STRING(&_147$$98, "/^#\\^(.+)\\$#u$/");
 					ZEPHIR_INIT_NVAR(&combinedShape);
-					zephir_preg_match(&combinedShape, &_139$$94, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
+					zephir_preg_match(&combinedShape, &_147$$98, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
 					if (!(zephir_is_true(&combinedShape))) {
 						zephir_update_property_array(this_ptr, SL("combinedRegexDisabled"), &method, &__$true);
 						ZEPHIR_INIT_NVAR(&combinedAlternatives);
@@ -7655,27 +7679,27 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 						break;
 					}
 					ZEPHIR_OBS_NVAR(&combinedBody);
-					zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2372);
-					ZEPHIR_INIT_NVAR(&_140$$94);
-					ZEPHIR_CONCAT_VSVS(&_140$$94, &combinedBody, "(*:", &bucketIdx, ")");
-					zephir_array_append(&combinedAlternatives, &_140$$94, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2373);
-					zephir_cast_to_string(&_141$$94, &bucketIdx);
-					zephir_array_update_zval(&combinedMark, &_141$$94, &bucketIdx, PH_COPY | PH_SEPARATE);
+					zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2374);
+					ZEPHIR_INIT_NVAR(&_148$$98);
+					ZEPHIR_CONCAT_VSVS(&_148$$98, &combinedBody, "(*:", &bucketIdx, ")");
+					zephir_array_append(&combinedAlternatives, &_148$$98, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2375);
+					zephir_cast_to_string(&_149$$98, &bucketIdx);
+					zephir_array_update_zval(&combinedMark, &_149$$98, &bucketIdx, PH_COPY | PH_SEPARATE);
 				} ZEND_HASH_FOREACH_END();
 			} else {
 				ZEPHIR_CALL_METHOD(NULL, &candidates, "rewind", NULL, 0);
 				zephir_check_call_status();
-				_143$$92 = 1;
+				_151$$96 = 1;
 				while (1) {
-					if (_143$$92) {
-						_143$$92 = 0;
+					if (_151$$96) {
+						_151$$96 = 0;
 					} else {
 						ZEPHIR_CALL_METHOD(NULL, &candidates, "next", NULL, 0);
 						zephir_check_call_status();
 					}
-					ZEPHIR_CALL_METHOD(&_142$$92, &candidates, "valid", NULL, 0);
+					ZEPHIR_CALL_METHOD(&_150$$96, &candidates, "valid", NULL, 0);
 					zephir_check_call_status();
-					if (!zend_is_true(&_142$$92)) {
+					if (!zend_is_true(&_150$$96)) {
 						break;
 					}
 					ZEPHIR_CALL_METHOD(&bucketIdx, &candidates, "key", NULL, 0);
@@ -7684,17 +7708,17 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 					zephir_check_call_status();
 						ZEPHIR_CALL_METHOD(&bucketPattern, &bucketRoute, "getcompiledpattern", NULL, 0);
 						zephir_check_call_status();
-						if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2359))) {
+						if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2361))) {
 							continue;
 						}
 						ZEPHIR_INIT_NVAR(&combinedBodyMatch);
 						array_init(&combinedBodyMatch);
-						ZEPHIR_INIT_NVAR(&_144$$97);
-						ZVAL_STRING(&_144$$97, "/^#\\^(.+)\\$#u$/");
-						ZEPHIR_INIT_NVAR(&_145$$97);
-						ZVAL_STRING(&_145$$97, "/^#\\^(.+)\\$#u$/");
+						ZEPHIR_INIT_NVAR(&_152$$101);
+						ZVAL_STRING(&_152$$101, "/^#\\^(.+)\\$#u$/");
+						ZEPHIR_INIT_NVAR(&_153$$101);
+						ZVAL_STRING(&_153$$101, "/^#\\^(.+)\\$#u$/");
 						ZEPHIR_INIT_NVAR(&combinedShape);
-						zephir_preg_match(&combinedShape, &_145$$97, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
+						zephir_preg_match(&combinedShape, &_153$$101, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
 						if (!(zephir_is_true(&combinedShape))) {
 							zephir_update_property_array(this_ptr, SL("combinedRegexDisabled"), &method, &__$true);
 							ZEPHIR_INIT_NVAR(&combinedAlternatives);
@@ -7702,122 +7726,122 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 							break;
 						}
 						ZEPHIR_OBS_NVAR(&combinedBody);
-						zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2372);
-						ZEPHIR_INIT_NVAR(&_146$$97);
-						ZEPHIR_CONCAT_VSVS(&_146$$97, &combinedBody, "(*:", &bucketIdx, ")");
-						zephir_array_append(&combinedAlternatives, &_146$$97, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2373);
-						zephir_cast_to_string(&_147$$97, &bucketIdx);
-						zephir_array_update_zval(&combinedMark, &_147$$97, &bucketIdx, PH_COPY | PH_SEPARATE);
+						zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2374);
+						ZEPHIR_INIT_NVAR(&_154$$101);
+						ZEPHIR_CONCAT_VSVS(&_154$$101, &combinedBody, "(*:", &bucketIdx, ")");
+						zephir_array_append(&combinedAlternatives, &_154$$101, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2375);
+						zephir_cast_to_string(&_155$$101, &bucketIdx);
+						zephir_array_update_zval(&combinedMark, &_155$$101, &bucketIdx, PH_COPY | PH_SEPARATE);
 				}
 			}
 			ZEPHIR_INIT_NVAR(&bucketRoute);
 			ZEPHIR_INIT_NVAR(&bucketIdx);
-			zephir_read_property_cached(&_148$$92, this_ptr, _zephir_prop_10, 292, PH_NOISY_CC | PH_READONLY);
-			if (zephir_array_isset_value(&_148$$92, &method)) {
+			zephir_read_property_cached(&_156$$96, this_ptr, _zephir_prop_10, 292, PH_NOISY_CC | PH_READONLY);
+			if (zephir_array_isset_value(&_156$$96, &method)) {
 				continue;
 			}
 			if (ZEPHIR_IS_EMPTY(&combinedAlternatives)) {
 				continue;
 			}
-			ZEPHIR_CALL_FUNCTION(&_149$$92, "array_reverse", &_150, 270, &combinedAlternatives);
+			ZEPHIR_CALL_FUNCTION(&_157$$96, "array_reverse", &_158, 270, &combinedAlternatives);
 			zephir_check_call_status();
-			ZEPHIR_CPY_WRT(&combinedAlternatives, &_149$$92);
-			ZEPHIR_INIT_NVAR(&_151$$92);
-			zephir_array_keys(&_151$$92, &combinedMark);
-			ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$92, "array_reverse", &_150, 270, &_151$$92);
+			ZEPHIR_CPY_WRT(&combinedAlternatives, &_157$$96);
+			ZEPHIR_INIT_NVAR(&_159$$96);
+			zephir_array_keys(&_159$$96, &combinedMark);
+			ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$96, "array_reverse", &_158, 270, &_159$$96);
 			zephir_check_call_status();
-			ZEPHIR_CPY_WRT(&reversedMarkIds$$92, &reversedMarkIds$$92);
-			ZEPHIR_INIT_NVAR(&chunkedPatterns$$92);
-			array_init(&chunkedPatterns$$92);
-			ZEPHIR_CPY_WRT(&chunkedPatterns$$92, &chunkedPatterns$$92);
-			ZEPHIR_INIT_NVAR(&chunkedMarkMaps$$92);
-			array_init(&chunkedMarkMaps$$92);
-			ZEPHIR_CPY_WRT(&chunkedMarkMaps$$92, &chunkedMarkMaps$$92);
-			ZEPHIR_INIT_NVAR(&chunkOffset$$92);
-			ZVAL_LONG(&chunkOffset$$92, 0);
+			ZEPHIR_CPY_WRT(&reversedMarkIds$$96, &reversedMarkIds$$96);
+			ZEPHIR_INIT_NVAR(&chunkedPatterns$$96);
+			array_init(&chunkedPatterns$$96);
+			ZEPHIR_CPY_WRT(&chunkedPatterns$$96, &chunkedPatterns$$96);
+			ZEPHIR_INIT_NVAR(&chunkedMarkMaps$$96);
+			array_init(&chunkedMarkMaps$$96);
+			ZEPHIR_CPY_WRT(&chunkedMarkMaps$$96, &chunkedMarkMaps$$96);
+			ZEPHIR_INIT_NVAR(&chunkOffset$$96);
+			ZVAL_LONG(&chunkOffset$$96, 0);
 			while (1) {
-				if (!(ZEPHIR_LT_LONG(&chunkOffset$$92, zephir_fast_count_int(&combinedAlternatives)))) {
+				if (!(ZEPHIR_LT_LONG(&chunkOffset$$96, zephir_fast_count_int(&combinedAlternatives)))) {
 					break;
 				}
-				ZVAL_LONG(&_152$$102, 10);
-				ZEPHIR_CALL_FUNCTION(&chunkSlice$$92, "array_slice", &_153, 279, &combinedAlternatives, &chunkOffset$$92, &_152$$102);
+				ZVAL_LONG(&_160$$106, 10);
+				ZEPHIR_CALL_FUNCTION(&chunkSlice$$96, "array_slice", &_161, 279, &combinedAlternatives, &chunkOffset$$96, &_160$$106);
 				zephir_check_call_status();
-				ZEPHIR_CPY_WRT(&chunkSlice$$92, &chunkSlice$$92);
-				ZVAL_LONG(&_152$$102, 10);
-				ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$92, "array_slice", &_153, 279, &reversedMarkIds$$92, &chunkOffset$$92, &_152$$102);
+				ZEPHIR_CPY_WRT(&chunkSlice$$96, &chunkSlice$$96);
+				ZVAL_LONG(&_160$$106, 10);
+				ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$96, "array_slice", &_161, 279, &reversedMarkIds$$96, &chunkOffset$$96, &_160$$106);
 				zephir_check_call_status();
-				ZEPHIR_CPY_WRT(&chunkMarkSubset$$92, &chunkMarkSubset$$92);
-				ZEPHIR_INIT_NVAR(&chunkSliceMap$$92);
-				array_init(&chunkSliceMap$$92);
-				ZEPHIR_CPY_WRT(&chunkSliceMap$$92, &chunkSliceMap$$92);
-				zephir_is_iterable(&chunkMarkSubset$$92, 0, "phalcon/Mvc/Router.zep", 2411);
-				if (Z_TYPE_P(&chunkMarkSubset$$92) == IS_ARRAY) {
-					ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&chunkMarkSubset$$92), _154$$102)
+				ZEPHIR_CPY_WRT(&chunkMarkSubset$$96, &chunkMarkSubset$$96);
+				ZEPHIR_INIT_NVAR(&chunkSliceMap$$96);
+				array_init(&chunkSliceMap$$96);
+				ZEPHIR_CPY_WRT(&chunkSliceMap$$96, &chunkSliceMap$$96);
+				zephir_is_iterable(&chunkMarkSubset$$96, 0, "phalcon/Mvc/Router.zep", 2413);
+				if (Z_TYPE_P(&chunkMarkSubset$$96) == IS_ARRAY) {
+					ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&chunkMarkSubset$$96), _162$$106)
 					{
-						ZEPHIR_INIT_NVAR(&chunkMarkId$$92);
-						ZVAL_COPY(&chunkMarkId$$92, _154$$102);
-						zephir_array_fetch(&_155$$103, &combinedMark, &chunkMarkId$$92, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2408);
-						zephir_array_update_zval(&chunkSliceMap$$92, &chunkMarkId$$92, &_155$$103, PH_COPY | PH_SEPARATE);
+						ZEPHIR_INIT_NVAR(&chunkMarkId$$96);
+						ZVAL_COPY(&chunkMarkId$$96, _162$$106);
+						zephir_array_fetch(&_163$$107, &combinedMark, &chunkMarkId$$96, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2410);
+						zephir_array_update_zval(&chunkSliceMap$$96, &chunkMarkId$$96, &_163$$107, PH_COPY | PH_SEPARATE);
 					} ZEND_HASH_FOREACH_END();
 				} else {
-					ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$92, "rewind", NULL, 0);
+					ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$96, "rewind", NULL, 0);
 					zephir_check_call_status();
-					_157$$102 = 1;
+					_165$$106 = 1;
 					while (1) {
-						if (_157$$102) {
-							_157$$102 = 0;
+						if (_165$$106) {
+							_165$$106 = 0;
 						} else {
-							ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$92, "next", NULL, 0);
+							ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$96, "next", NULL, 0);
 							zephir_check_call_status();
 						}
-						ZEPHIR_CALL_METHOD(&_156$$102, &chunkMarkSubset$$92, "valid", NULL, 0);
+						ZEPHIR_CALL_METHOD(&_164$$106, &chunkMarkSubset$$96, "valid", NULL, 0);
 						zephir_check_call_status();
-						if (!zend_is_true(&_156$$102)) {
+						if (!zend_is_true(&_164$$106)) {
 							break;
 						}
-						ZEPHIR_CALL_METHOD(&chunkMarkId$$92, &chunkMarkSubset$$92, "current", NULL, 0);
+						ZEPHIR_CALL_METHOD(&chunkMarkId$$96, &chunkMarkSubset$$96, "current", NULL, 0);
 						zephir_check_call_status();
-							zephir_array_fetch(&_158$$104, &combinedMark, &chunkMarkId$$92, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2408);
-							zephir_array_update_zval(&chunkSliceMap$$92, &chunkMarkId$$92, &_158$$104, PH_COPY | PH_SEPARATE);
+							zephir_array_fetch(&_166$$108, &combinedMark, &chunkMarkId$$96, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2410);
+							zephir_array_update_zval(&chunkSliceMap$$96, &chunkMarkId$$96, &_166$$108, PH_COPY | PH_SEPARATE);
 					}
 				}
-				ZEPHIR_INIT_NVAR(&chunkMarkId$$92);
-				ZEPHIR_INIT_NVAR(&_159$$102);
-				zephir_fast_join_str(&_159$$102, SL("|"), &chunkSlice$$92);
-				ZEPHIR_INIT_NVAR(&_160$$102);
-				ZEPHIR_CONCAT_SVS(&_160$$102, "#^(?|", &_159$$102, ")$#u");
-				zephir_array_append(&chunkedPatterns$$92, &_160$$102, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2411);
-				zephir_array_append(&chunkedMarkMaps$$92, &chunkSliceMap$$92, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2412);
-				ZEPHIR_INIT_NVAR(&_161$$102);
-				ZVAL_LONG(&_161$$102, 10);
-				ZEPHIR_ADD_ASSIGN(&chunkOffset$$92, &_161$$102);
+				ZEPHIR_INIT_NVAR(&chunkMarkId$$96);
+				ZEPHIR_INIT_NVAR(&_167$$106);
+				zephir_fast_join_str(&_167$$106, SL("|"), &chunkSlice$$96);
+				ZEPHIR_INIT_NVAR(&_168$$106);
+				ZEPHIR_CONCAT_SVS(&_168$$106, "#^(?|", &_167$$106, ")$#u");
+				zephir_array_append(&chunkedPatterns$$96, &_168$$106, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2413);
+				zephir_array_append(&chunkedMarkMaps$$96, &chunkSliceMap$$96, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2414);
+				ZEPHIR_INIT_NVAR(&_169$$106);
+				ZVAL_LONG(&_169$$106, 10);
+				ZEPHIR_ADD_ASSIGN(&chunkOffset$$96, &_169$$106);
 			}
-			zephir_update_property_array(this_ptr, SL("combinedRegexByMethod"), &method, &chunkedPatterns$$92);
-			zephir_update_property_array(this_ptr, SL("combinedRegexMarkMap"), &method, &chunkedMarkMaps$$92);
+			zephir_update_property_array(this_ptr, SL("combinedRegexByMethod"), &method, &chunkedPatterns$$96);
+			zephir_update_property_array(this_ptr, SL("combinedRegexMarkMap"), &method, &chunkedMarkMaps$$96);
 		} ZEND_HASH_FOREACH_END();
 	} else {
-		ZEPHIR_CALL_METHOD(NULL, &_130, "rewind", NULL, 0);
+		ZEPHIR_CALL_METHOD(NULL, &_138, "rewind", NULL, 0);
 		zephir_check_call_status();
-		_163 = 1;
+		_171 = 1;
 		while (1) {
-			if (_163) {
-				_163 = 0;
+			if (_171) {
+				_171 = 0;
 			} else {
-				ZEPHIR_CALL_METHOD(NULL, &_130, "next", NULL, 0);
+				ZEPHIR_CALL_METHOD(NULL, &_138, "next", NULL, 0);
 				zephir_check_call_status();
 			}
-			ZEPHIR_CALL_METHOD(&_162, &_130, "valid", NULL, 0);
+			ZEPHIR_CALL_METHOD(&_170, &_138, "valid", NULL, 0);
 			zephir_check_call_status();
-			if (!zend_is_true(&_162)) {
+			if (!zend_is_true(&_170)) {
 				break;
 			}
-			ZEPHIR_CALL_METHOD(&method, &_130, "key", NULL, 0);
+			ZEPHIR_CALL_METHOD(&method, &_138, "key", NULL, 0);
 			zephir_check_call_status();
-			ZEPHIR_CALL_METHOD(&candidates, &_130, "current", NULL, 0);
+			ZEPHIR_CALL_METHOD(&candidates, &_138, "current", NULL, 0);
 			zephir_check_call_status();
-				zephir_read_property_cached(&_164$$105, this_ptr, _zephir_prop_6, 289, PH_NOISY_CC | PH_READONLY);
+				zephir_read_property_cached(&_172$$109, this_ptr, _zephir_prop_6, 289, PH_NOISY_CC | PH_READONLY);
 				ZEPHIR_OBS_NVAR(&hostnameBucketRef);
-				zephir_array_fetch(&hostnameBucketRef, &_164$$105, &method, PH_NOISY, "phalcon/Mvc/Router.zep", 2346);
+				zephir_array_fetch(&hostnameBucketRef, &_172$$109, &method, PH_NOISY, "phalcon/Mvc/Router.zep", 2348);
 				if (!(ZEPHIR_IS_EMPTY(&hostnameBucketRef))) {
 					zephir_update_property_array(this_ptr, SL("combinedRegexDisabled"), &method, &__$true);
 					continue;
@@ -7826,31 +7850,31 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 				array_init(&combinedAlternatives);
 				ZEPHIR_INIT_NVAR(&combinedMark);
 				array_init(&combinedMark);
-				zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2377);
+				zephir_is_iterable(&candidates, 0, "phalcon/Mvc/Router.zep", 2379);
 				if (Z_TYPE_P(&candidates) == IS_ARRAY) {
-					ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _166$$105, _167$$105, _165$$105)
+					ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&candidates), _174$$109, _175$$109, _173$$109)
 					{
 						ZEPHIR_INIT_NVAR(&bucketIdx);
-						if (_167$$105 != NULL) { 
-							ZVAL_STR_COPY(&bucketIdx, _167$$105);
+						if (_175$$109 != NULL) { 
+							ZVAL_STR_COPY(&bucketIdx, _175$$109);
 						} else {
-							ZVAL_LONG(&bucketIdx, _166$$105);
+							ZVAL_LONG(&bucketIdx, _174$$109);
 						}
 						ZEPHIR_INIT_NVAR(&bucketRoute);
-						ZVAL_COPY(&bucketRoute, _165$$105);
+						ZVAL_COPY(&bucketRoute, _173$$109);
 						ZEPHIR_CALL_METHOD(&bucketPattern, &bucketRoute, "getcompiledpattern", NULL, 0);
 						zephir_check_call_status();
-						if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2359))) {
+						if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2361))) {
 							continue;
 						}
 						ZEPHIR_INIT_NVAR(&combinedBodyMatch);
 						array_init(&combinedBodyMatch);
-						ZEPHIR_INIT_NVAR(&_168$$107);
-						ZVAL_STRING(&_168$$107, "/^#\\^(.+)\\$#u$/");
-						ZEPHIR_INIT_NVAR(&_169$$107);
-						ZVAL_STRING(&_169$$107, "/^#\\^(.+)\\$#u$/");
+						ZEPHIR_INIT_NVAR(&_176$$111);
+						ZVAL_STRING(&_176$$111, "/^#\\^(.+)\\$#u$/");
+						ZEPHIR_INIT_NVAR(&_177$$111);
+						ZVAL_STRING(&_177$$111, "/^#\\^(.+)\\$#u$/");
 						ZEPHIR_INIT_NVAR(&combinedShape);
-						zephir_preg_match(&combinedShape, &_169$$107, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
+						zephir_preg_match(&combinedShape, &_177$$111, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
 						if (!(zephir_is_true(&combinedShape))) {
 							zephir_update_property_array(this_ptr, SL("combinedRegexDisabled"), &method, &__$true);
 							ZEPHIR_INIT_NVAR(&combinedAlternatives);
@@ -7858,27 +7882,27 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 							break;
 						}
 						ZEPHIR_OBS_NVAR(&combinedBody);
-						zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2372);
-						ZEPHIR_INIT_NVAR(&_170$$107);
-						ZEPHIR_CONCAT_VSVS(&_170$$107, &combinedBody, "(*:", &bucketIdx, ")");
-						zephir_array_append(&combinedAlternatives, &_170$$107, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2373);
-						zephir_cast_to_string(&_171$$107, &bucketIdx);
-						zephir_array_update_zval(&combinedMark, &_171$$107, &bucketIdx, PH_COPY | PH_SEPARATE);
+						zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2374);
+						ZEPHIR_INIT_NVAR(&_178$$111);
+						ZEPHIR_CONCAT_VSVS(&_178$$111, &combinedBody, "(*:", &bucketIdx, ")");
+						zephir_array_append(&combinedAlternatives, &_178$$111, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2375);
+						zephir_cast_to_string(&_179$$111, &bucketIdx);
+						zephir_array_update_zval(&combinedMark, &_179$$111, &bucketIdx, PH_COPY | PH_SEPARATE);
 					} ZEND_HASH_FOREACH_END();
 				} else {
 					ZEPHIR_CALL_METHOD(NULL, &candidates, "rewind", NULL, 0);
 					zephir_check_call_status();
-					_173$$105 = 1;
+					_181$$109 = 1;
 					while (1) {
-						if (_173$$105) {
-							_173$$105 = 0;
+						if (_181$$109) {
+							_181$$109 = 0;
 						} else {
 							ZEPHIR_CALL_METHOD(NULL, &candidates, "next", NULL, 0);
 							zephir_check_call_status();
 						}
-						ZEPHIR_CALL_METHOD(&_172$$105, &candidates, "valid", NULL, 0);
+						ZEPHIR_CALL_METHOD(&_180$$109, &candidates, "valid", NULL, 0);
 						zephir_check_call_status();
-						if (!zend_is_true(&_172$$105)) {
+						if (!zend_is_true(&_180$$109)) {
 							break;
 						}
 						ZEPHIR_CALL_METHOD(&bucketIdx, &candidates, "key", NULL, 0);
@@ -7887,17 +7911,17 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 						zephir_check_call_status();
 							ZEPHIR_CALL_METHOD(&bucketPattern, &bucketRoute, "getcompiledpattern", NULL, 0);
 							zephir_check_call_status();
-							if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2359))) {
+							if (!(zephir_memnstr_str(&bucketPattern, SL("^"), "phalcon/Mvc/Router.zep", 2361))) {
 								continue;
 							}
 							ZEPHIR_INIT_NVAR(&combinedBodyMatch);
 							array_init(&combinedBodyMatch);
-							ZEPHIR_INIT_NVAR(&_174$$110);
-							ZVAL_STRING(&_174$$110, "/^#\\^(.+)\\$#u$/");
-							ZEPHIR_INIT_NVAR(&_175$$110);
-							ZVAL_STRING(&_175$$110, "/^#\\^(.+)\\$#u$/");
+							ZEPHIR_INIT_NVAR(&_182$$114);
+							ZVAL_STRING(&_182$$114, "/^#\\^(.+)\\$#u$/");
+							ZEPHIR_INIT_NVAR(&_183$$114);
+							ZVAL_STRING(&_183$$114, "/^#\\^(.+)\\$#u$/");
 							ZEPHIR_INIT_NVAR(&combinedShape);
-							zephir_preg_match(&combinedShape, &_175$$110, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
+							zephir_preg_match(&combinedShape, &_183$$114, &bucketPattern, &combinedBodyMatch, 0, 0 , 0 );
 							if (!(zephir_is_true(&combinedShape))) {
 								zephir_update_property_array(this_ptr, SL("combinedRegexDisabled"), &method, &__$true);
 								ZEPHIR_INIT_NVAR(&combinedAlternatives);
@@ -7905,98 +7929,98 @@ PHP_METHOD(Phalcon_Mvc_Router, rebuildMethodIndex)
 								break;
 							}
 							ZEPHIR_OBS_NVAR(&combinedBody);
-							zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2372);
-							ZEPHIR_INIT_NVAR(&_176$$110);
-							ZEPHIR_CONCAT_VSVS(&_176$$110, &combinedBody, "(*:", &bucketIdx, ")");
-							zephir_array_append(&combinedAlternatives, &_176$$110, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2373);
-							zephir_cast_to_string(&_177$$110, &bucketIdx);
-							zephir_array_update_zval(&combinedMark, &_177$$110, &bucketIdx, PH_COPY | PH_SEPARATE);
+							zephir_array_fetch_long(&combinedBody, &combinedBodyMatch, 1, PH_NOISY, "phalcon/Mvc/Router.zep", 2374);
+							ZEPHIR_INIT_NVAR(&_184$$114);
+							ZEPHIR_CONCAT_VSVS(&_184$$114, &combinedBody, "(*:", &bucketIdx, ")");
+							zephir_array_append(&combinedAlternatives, &_184$$114, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2375);
+							zephir_cast_to_string(&_185$$114, &bucketIdx);
+							zephir_array_update_zval(&combinedMark, &_185$$114, &bucketIdx, PH_COPY | PH_SEPARATE);
 					}
 				}
 				ZEPHIR_INIT_NVAR(&bucketRoute);
 				ZEPHIR_INIT_NVAR(&bucketIdx);
-				zephir_read_property_cached(&_178$$105, this_ptr, _zephir_prop_10, 292, PH_NOISY_CC | PH_READONLY);
-				if (zephir_array_isset_value(&_178$$105, &method)) {
+				zephir_read_property_cached(&_186$$109, this_ptr, _zephir_prop_10, 292, PH_NOISY_CC | PH_READONLY);
+				if (zephir_array_isset_value(&_186$$109, &method)) {
 					continue;
 				}
 				if (ZEPHIR_IS_EMPTY(&combinedAlternatives)) {
 					continue;
 				}
-				ZEPHIR_CALL_FUNCTION(&_179$$105, "array_reverse", &_150, 270, &combinedAlternatives);
+				ZEPHIR_CALL_FUNCTION(&_187$$109, "array_reverse", &_158, 270, &combinedAlternatives);
 				zephir_check_call_status();
-				ZEPHIR_CPY_WRT(&combinedAlternatives, &_179$$105);
-				ZEPHIR_INIT_NVAR(&_180$$105);
-				zephir_array_keys(&_180$$105, &combinedMark);
-				ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$105, "array_reverse", &_150, 270, &_180$$105);
+				ZEPHIR_CPY_WRT(&combinedAlternatives, &_187$$109);
+				ZEPHIR_INIT_NVAR(&_188$$109);
+				zephir_array_keys(&_188$$109, &combinedMark);
+				ZEPHIR_CALL_FUNCTION(&reversedMarkIds$$109, "array_reverse", &_158, 270, &_188$$109);
 				zephir_check_call_status();
-				ZEPHIR_CPY_WRT(&reversedMarkIds$$105, &reversedMarkIds$$105);
-				ZEPHIR_INIT_NVAR(&chunkedPatterns$$105);
-				array_init(&chunkedPatterns$$105);
-				ZEPHIR_CPY_WRT(&chunkedPatterns$$105, &chunkedPatterns$$105);
-				ZEPHIR_INIT_NVAR(&chunkedMarkMaps$$105);
-				array_init(&chunkedMarkMaps$$105);
-				ZEPHIR_CPY_WRT(&chunkedMarkMaps$$105, &chunkedMarkMaps$$105);
-				ZEPHIR_INIT_NVAR(&chunkOffset$$105);
-				ZVAL_LONG(&chunkOffset$$105, 0);
+				ZEPHIR_CPY_WRT(&reversedMarkIds$$109, &reversedMarkIds$$109);
+				ZEPHIR_INIT_NVAR(&chunkedPatterns$$109);
+				array_init(&chunkedPatterns$$109);
+				ZEPHIR_CPY_WRT(&chunkedPatterns$$109, &chunkedPatterns$$109);
+				ZEPHIR_INIT_NVAR(&chunkedMarkMaps$$109);
+				array_init(&chunkedMarkMaps$$109);
+				ZEPHIR_CPY_WRT(&chunkedMarkMaps$$109, &chunkedMarkMaps$$109);
+				ZEPHIR_INIT_NVAR(&chunkOffset$$109);
+				ZVAL_LONG(&chunkOffset$$109, 0);
 				while (1) {
-					if (!(ZEPHIR_LT_LONG(&chunkOffset$$105, zephir_fast_count_int(&combinedAlternatives)))) {
+					if (!(ZEPHIR_LT_LONG(&chunkOffset$$109, zephir_fast_count_int(&combinedAlternatives)))) {
 						break;
 					}
-					ZVAL_LONG(&_181$$115, 10);
-					ZEPHIR_CALL_FUNCTION(&chunkSlice$$105, "array_slice", &_153, 279, &combinedAlternatives, &chunkOffset$$105, &_181$$115);
+					ZVAL_LONG(&_189$$119, 10);
+					ZEPHIR_CALL_FUNCTION(&chunkSlice$$109, "array_slice", &_161, 279, &combinedAlternatives, &chunkOffset$$109, &_189$$119);
 					zephir_check_call_status();
-					ZEPHIR_CPY_WRT(&chunkSlice$$105, &chunkSlice$$105);
-					ZVAL_LONG(&_181$$115, 10);
-					ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$105, "array_slice", &_153, 279, &reversedMarkIds$$105, &chunkOffset$$105, &_181$$115);
+					ZEPHIR_CPY_WRT(&chunkSlice$$109, &chunkSlice$$109);
+					ZVAL_LONG(&_189$$119, 10);
+					ZEPHIR_CALL_FUNCTION(&chunkMarkSubset$$109, "array_slice", &_161, 279, &reversedMarkIds$$109, &chunkOffset$$109, &_189$$119);
 					zephir_check_call_status();
-					ZEPHIR_CPY_WRT(&chunkMarkSubset$$105, &chunkMarkSubset$$105);
-					ZEPHIR_INIT_NVAR(&chunkSliceMap$$105);
-					array_init(&chunkSliceMap$$105);
-					ZEPHIR_CPY_WRT(&chunkSliceMap$$105, &chunkSliceMap$$105);
-					zephir_is_iterable(&chunkMarkSubset$$105, 0, "phalcon/Mvc/Router.zep", 2411);
-					if (Z_TYPE_P(&chunkMarkSubset$$105) == IS_ARRAY) {
-						ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&chunkMarkSubset$$105), _182$$115)
+					ZEPHIR_CPY_WRT(&chunkMarkSubset$$109, &chunkMarkSubset$$109);
+					ZEPHIR_INIT_NVAR(&chunkSliceMap$$109);
+					array_init(&chunkSliceMap$$109);
+					ZEPHIR_CPY_WRT(&chunkSliceMap$$109, &chunkSliceMap$$109);
+					zephir_is_iterable(&chunkMarkSubset$$109, 0, "phalcon/Mvc/Router.zep", 2413);
+					if (Z_TYPE_P(&chunkMarkSubset$$109) == IS_ARRAY) {
+						ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&chunkMarkSubset$$109), _190$$119)
 						{
-							ZEPHIR_INIT_NVAR(&chunkMarkId$$105);
-							ZVAL_COPY(&chunkMarkId$$105, _182$$115);
-							zephir_array_fetch(&_183$$116, &combinedMark, &chunkMarkId$$105, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2408);
-							zephir_array_update_zval(&chunkSliceMap$$105, &chunkMarkId$$105, &_183$$116, PH_COPY | PH_SEPARATE);
+							ZEPHIR_INIT_NVAR(&chunkMarkId$$109);
+							ZVAL_COPY(&chunkMarkId$$109, _190$$119);
+							zephir_array_fetch(&_191$$120, &combinedMark, &chunkMarkId$$109, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2410);
+							zephir_array_update_zval(&chunkSliceMap$$109, &chunkMarkId$$109, &_191$$120, PH_COPY | PH_SEPARATE);
 						} ZEND_HASH_FOREACH_END();
 					} else {
-						ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$105, "rewind", NULL, 0);
+						ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$109, "rewind", NULL, 0);
 						zephir_check_call_status();
-						_185$$115 = 1;
+						_193$$119 = 1;
 						while (1) {
-							if (_185$$115) {
-								_185$$115 = 0;
+							if (_193$$119) {
+								_193$$119 = 0;
 							} else {
-								ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$105, "next", NULL, 0);
+								ZEPHIR_CALL_METHOD(NULL, &chunkMarkSubset$$109, "next", NULL, 0);
 								zephir_check_call_status();
 							}
-							ZEPHIR_CALL_METHOD(&_184$$115, &chunkMarkSubset$$105, "valid", NULL, 0);
+							ZEPHIR_CALL_METHOD(&_192$$119, &chunkMarkSubset$$109, "valid", NULL, 0);
 							zephir_check_call_status();
-							if (!zend_is_true(&_184$$115)) {
+							if (!zend_is_true(&_192$$119)) {
 								break;
 							}
-							ZEPHIR_CALL_METHOD(&chunkMarkId$$105, &chunkMarkSubset$$105, "current", NULL, 0);
+							ZEPHIR_CALL_METHOD(&chunkMarkId$$109, &chunkMarkSubset$$109, "current", NULL, 0);
 							zephir_check_call_status();
-								zephir_array_fetch(&_186$$117, &combinedMark, &chunkMarkId$$105, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2408);
-								zephir_array_update_zval(&chunkSliceMap$$105, &chunkMarkId$$105, &_186$$117, PH_COPY | PH_SEPARATE);
+								zephir_array_fetch(&_194$$121, &combinedMark, &chunkMarkId$$109, PH_NOISY | PH_READONLY, "phalcon/Mvc/Router.zep", 2410);
+								zephir_array_update_zval(&chunkSliceMap$$109, &chunkMarkId$$109, &_194$$121, PH_COPY | PH_SEPARATE);
 						}
 					}
-					ZEPHIR_INIT_NVAR(&chunkMarkId$$105);
-					ZEPHIR_INIT_NVAR(&_187$$115);
-					zephir_fast_join_str(&_187$$115, SL("|"), &chunkSlice$$105);
-					ZEPHIR_INIT_NVAR(&_188$$115);
-					ZEPHIR_CONCAT_SVS(&_188$$115, "#^(?|", &_187$$115, ")$#u");
-					zephir_array_append(&chunkedPatterns$$105, &_188$$115, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2411);
-					zephir_array_append(&chunkedMarkMaps$$105, &chunkSliceMap$$105, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2412);
-					ZEPHIR_INIT_NVAR(&_189$$115);
-					ZVAL_LONG(&_189$$115, 10);
-					ZEPHIR_ADD_ASSIGN(&chunkOffset$$105, &_189$$115);
+					ZEPHIR_INIT_NVAR(&chunkMarkId$$109);
+					ZEPHIR_INIT_NVAR(&_195$$119);
+					zephir_fast_join_str(&_195$$119, SL("|"), &chunkSlice$$109);
+					ZEPHIR_INIT_NVAR(&_196$$119);
+					ZEPHIR_CONCAT_SVS(&_196$$119, "#^(?|", &_195$$119, ")$#u");
+					zephir_array_append(&chunkedPatterns$$109, &_196$$119, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2413);
+					zephir_array_append(&chunkedMarkMaps$$109, &chunkSliceMap$$109, PH_SEPARATE, "phalcon/Mvc/Router.zep", 2414);
+					ZEPHIR_INIT_NVAR(&_197$$119);
+					ZVAL_LONG(&_197$$119, 10);
+					ZEPHIR_ADD_ASSIGN(&chunkOffset$$109, &_197$$119);
 				}
-				zephir_update_property_array(this_ptr, SL("combinedRegexByMethod"), &method, &chunkedPatterns$$105);
-				zephir_update_property_array(this_ptr, SL("combinedRegexMarkMap"), &method, &chunkedMarkMaps$$105);
+				zephir_update_property_array(this_ptr, SL("combinedRegexByMethod"), &method, &chunkedPatterns$$109);
+				zephir_update_property_array(this_ptr, SL("combinedRegexMarkMap"), &method, &chunkedMarkMaps$$109);
 		}
 	}
 	ZEPHIR_INIT_NVAR(&candidates);

--- a/phalcon/Cli/Router.zep
+++ b/phalcon/Cli/Router.zep
@@ -239,6 +239,14 @@ class Router extends AbstractInjectionAware implements RouterInterface
                 throw new RouterArgumentsInvalidType(gettype(arguments));
             }
 
+            /**
+             * A null subject makes preg_match() emit a deprecation, so use an
+             * empty string.
+             */
+            if arguments === null {
+                let arguments = "";
+            }
+
             for route in reverse this->routes {
                 /**
                  * If the route has parentheses use preg_match

--- a/phalcon/Db/Dialect.zep
+++ b/phalcon/Db/Dialect.zep
@@ -59,7 +59,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generate SQL to create a new savepoint
      */
-    public function createSavepoint( string name) -> string
+    public function createSavepoint(string name) -> string
     {
         return "SAVEPOINT " . name;
     }
@@ -67,7 +67,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Escape identifiers
      */
-    final public function escape( string str, string escapeChar = null) -> string
+    final public function escape(string str, string escapeChar = null) -> string
     {
         var parts, key, part, newParts;
 
@@ -105,7 +105,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Escape Schema
      */
-    final public function escapeSchema( string str, string escapeChar = null) -> string
+    final public function escapeSchema(string str, string escapeChar = null) -> string
     {
         if !Settings::get("db.escape_identifiers") {
             return str;
@@ -139,7 +139,7 @@ abstract class Dialect implements DialectInterface
      * echo $sql; // SELECT * FROM co_invoices FOR UPDATE SKIP LOCKED
      *```
      */
-    public function forUpdate( string sqlQuery, string modifier = "") -> string
+    public function forUpdate(string sqlQuery, string modifier = "") -> string
     {
         if modifier !== "" {
             return sqlQuery . " FOR UPDATE " . modifier;
@@ -160,7 +160,7 @@ abstract class Dialect implements DialectInterface
      * );
      * ```
      */
-    final public function getColumnList( array columnList, string escapeChar = null,  array bindCounts = []) -> string
+    final public function getColumnList(array columnList, string escapeChar = null,  array bindCounts = []) -> string
     {
         var column;
         array columns;
@@ -260,7 +260,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Transforms an intermediate representation for an expression into a database system valid expression
      */
-    public function getSqlExpression( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    public function getSqlExpression(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         int i;
         var type, times, postTimes, rawValue, value, nestedDefinition;
@@ -485,7 +485,7 @@ abstract class Dialect implements DialectInterface
      * );
      * ```
      */
-    public function limit( string sqlQuery, var number) -> string
+    public function limit(string sqlQuery, var number) -> string
     {
         /**
          * A bound placeholder (":name" / "?N") is emitted unchanged so it can
@@ -519,7 +519,9 @@ abstract class Dialect implements DialectInterface
             return value;
         }
 
-        return (string) (int) value;
+        let value = (int) value;
+
+        return (string) value;
     }
 
     /**
@@ -537,7 +539,7 @@ abstract class Dialect implements DialectInterface
      * (`CREATE MATERIALIZED VIEW name AS <sql>`). Other dialects inherit
      * this throw - MySQL and SQLite have no materialized-view concept.
      */
-    public function createMaterializedView( string viewName,  array definition, string schemaName = null) -> string
+    public function createMaterializedView(string viewName,  array definition, string schemaName = null) -> string
     {
         throw new MaterializedViewsNotSupported();
     }
@@ -545,7 +547,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generates SQL to drop a materialized view. Supported by PostgreSQL.
      */
-    public function dropMaterializedView( string viewName, string schemaName = null, bool ifExists = true) -> string
+    public function dropMaterializedView(string viewName, string schemaName = null, bool ifExists = true) -> string
     {
         throw new MaterializedViewsNotSupported();
     }
@@ -556,7 +558,7 @@ abstract class Dialect implements DialectInterface
      * CONCURRENTLY ...`, which avoids blocking concurrent SELECTs (requires
      * the view to have a unique index).
      */
-    public function refreshMaterializedView( string viewName, string schemaName = null, bool concurrent = false) -> string
+    public function refreshMaterializedView(string viewName, string schemaName = null, bool concurrent = false) -> string
     {
         throw new MaterializedViewsNotSupported();
     }
@@ -568,7 +570,7 @@ abstract class Dialect implements DialectInterface
      * MySQL overrides this method to throw because its `ON DUPLICATE KEY
      * UPDATE` has a different shape (deferred to parser item #23).
      */
-    public function onConflictUpdate( string sqlQuery,  array conflictColumns,  array updateColumns) -> string
+    public function onConflictUpdate(string sqlQuery,  array conflictColumns,  array updateColumns) -> string
     {
         var col;
         array assignments;
@@ -599,7 +601,7 @@ abstract class Dialect implements DialectInterface
      * names. The base implementation throws - MySQL inherits it because
      * MySQL has no RETURNING construct.
      */
-    public function returning( string sqlQuery,  array columns) -> string
+    public function returning(string sqlQuery,  array columns) -> string
     {
         throw new ReturningNotSupported();
     }
@@ -607,7 +609,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generate SQL to release a savepoint
      */
-    public function releaseSavepoint( string name) -> string
+    public function releaseSavepoint(string name) -> string
     {
         return "RELEASE SAVEPOINT " . name;
     }
@@ -615,7 +617,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Generate SQL to rollback a savepoint
      */
-    public function rollbackSavepoint( string name) -> string
+    public function rollbackSavepoint(string name) -> string
     {
         return "ROLLBACK TO SAVEPOINT " . name;
     }
@@ -623,7 +625,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Builds a SELECT statement
      */
-    public function select( array definition) -> string
+    public function select(array definition) -> string
     {
         var tables, columns, sql, distinct, joins, where, escapeChar, groupBy,
             having, orderBy, limit, forUpdate, bindCounts;
@@ -939,7 +941,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Resolve *
      */
-    final protected function getSqlExpressionAll( array expression, string escapeChar = null) -> string
+    final protected function getSqlExpressionAll(array expression, string escapeChar = null) -> string
     {
         var domain;
 
@@ -957,7 +959,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionBinaryOperations( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionBinaryOperations(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right, operator;
 
@@ -991,7 +993,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionCase( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionCase(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var whenClause, whenClauses;
         string sql;
@@ -1023,7 +1025,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionCastValue( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionCastValue(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right;
 
@@ -1051,7 +1053,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionConvertValue( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionConvertValue(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right;
 
@@ -1101,7 +1103,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionFunctionCall( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionFunctionCall(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var name, customFunction, arguments;
 
@@ -1177,7 +1179,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionHaving( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionHaving(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         return "HAVING " . this->getSqlExpression(expression, escapeChar, bindCounts);
     }
@@ -1294,7 +1296,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionList( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionList(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var item, values, separator;
         array items;
@@ -1331,7 +1333,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionObject( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionObject(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var domain = null, objectExpression;
 
@@ -1395,7 +1397,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Resolve qualified expressions
      */
-    final protected function getSqlExpressionQualified( array expression, string escapeChar = null) -> string
+    final protected function getSqlExpressionQualified(array expression, string escapeChar = null) -> string
     {
         var column, domain;
 
@@ -1418,7 +1420,7 @@ abstract class Dialect implements DialectInterface
      * @param string|null escapeChar
      * @param array bindCounts
      */
-    final protected function getSqlExpressionScalar( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionScalar(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var value;
 
@@ -1446,7 +1448,7 @@ abstract class Dialect implements DialectInterface
      *
      * @return string
      */
-    final protected function getSqlExpressionUnaryOperations( array expression, string escapeChar = null,  array bindCounts = []) -> string
+    final protected function getSqlExpressionUnaryOperations(array expression, string escapeChar = null,  array bindCounts = []) -> string
     {
         var left, right;
 
@@ -1492,7 +1494,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Prepares column for this RDBMS
      */
-    protected function prepareColumnAlias( string qualified, string alias = null, string escapeChar = null) -> string
+    protected function prepareColumnAlias(string qualified, string alias = null, string escapeChar = null) -> string
     {
         if alias != "" {
             return qualified . " AS " . this->escape(alias, escapeChar);
@@ -1504,7 +1506,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Prepares table for this RDBMS
      */
-    protected function prepareTable( string table, string schema = null, string alias = null, string escapeChar = null) -> string
+    protected function prepareTable(string table, string schema = null, string alias = null, string escapeChar = null) -> string
     {
         let table = this->escape(table, escapeChar);
 
@@ -1528,7 +1530,7 @@ abstract class Dialect implements DialectInterface
     /**
      * Prepares qualified for this RDBMS
      */
-    protected function prepareQualified( string column, string domain = null, string escapeChar = null) -> string
+    protected function prepareQualified(string column, string domain = null, string escapeChar = null) -> string
     {
         if domain != "" {
             return this->escape(domain . "." . column, escapeChar);

--- a/phalcon/Mvc/Router.zep
+++ b/phalcon/Mvc/Router.zep
@@ -2290,7 +2290,9 @@ class Router extends AbstractInjectionAware implements RouterInterface, EventsAw
                      * that shadowed it, so clear any stale shadow flag - the
                      * last-registered route must win.
                      */
-                    unset this->staticShadowedByMethod[method][bucketPattern];
+                    if isset this->staticShadowedByMethod[method][bucketPattern] {
+                        unset this->staticShadowedByMethod[method][bucketPattern];
+                    }
                 } else {
                     if fetch staticBucket, this->staticByMethod[method] {
                         for staticUri, staticRoutesList in staticBucket {

--- a/resources/phpunit.mariadb.xml
+++ b/resources/phpunit.mariadb.xml
@@ -4,6 +4,14 @@
          bootstrap="../tests/bootstrap.php"
          cacheDirectory="../tests/_output/.phpunit.result.cache"
          colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
          failOnWarning="true"
 >
     <testsuites>

--- a/resources/phpunit.mysql.xml
+++ b/resources/phpunit.mysql.xml
@@ -4,6 +4,14 @@
          bootstrap="../tests/bootstrap.php"
          cacheDirectory="../tests/_output/.phpunit.result.cache"
          colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
          failOnWarning="true"
 >
     <testsuites>

--- a/resources/phpunit.pgsql.xml
+++ b/resources/phpunit.pgsql.xml
@@ -4,6 +4,14 @@
          bootstrap="../tests/bootstrap.php"
          cacheDirectory="../tests/_output/.phpunit.result.cache"
          colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
          failOnWarning="true"
 >
     <testsuites>

--- a/resources/phpunit.sqlite.xml
+++ b/resources/phpunit.sqlite.xml
@@ -4,6 +4,14 @@
          bootstrap="../tests/bootstrap.php"
          cacheDirectory="../tests/_output/.phpunit.result.cache"
          colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
          failOnWarning="true"
 >
     <testsuites>

--- a/resources/phpunit.xml.dist
+++ b/resources/phpunit.xml.dist
@@ -4,6 +4,14 @@
          bootstrap="../tests/bootstrap.php"
          cacheDirectory="../tests/_output/.phpunit.result.cache"
          colors="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         failOnPhpunitDeprecation="true"
          failOnWarning="true"
 >
     <testsuites>

--- a/tests/database/DataMapper/Pdo/Connection/QuoteTest.php
+++ b/tests/database/DataMapper/Pdo/Connection/QuoteTest.php
@@ -64,4 +64,35 @@ final class QuoteTest extends AbstractDatabaseTestCase
         $actual   = $connection->quote($source);
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * The array branch of quote() must double the delimiter in every element,
+     * the same as the scalar branch (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    public function testDMPdoConnectionQuoteEscapesDelimiterInArray(): void
+    {
+        /** @var Connection $connection */
+        $connection = self::getDataMapperConnection();
+        $quotes     = $connection->getQuoteNames();
+
+        $source   = [
+            'a' . $quotes["find"] . 'b',
+            'c' . $quotes["find"] . 'd',
+        ];
+        $expected = $quotes["prefix"]
+            . 'a' . $quotes["replace"] . 'b'
+            . $quotes["suffix"] . ', '
+            . $quotes["prefix"]
+            . 'c' . $quotes["replace"] . 'd'
+            . $quotes["suffix"];
+        $actual   = $connection->quote($source);
+        $this->assertEquals($expected, $actual);
+
+        $this->assertStringNotContainsString(
+            $quotes["prefix"] . 'a' . $quotes["find"] . 'b' . $quotes["suffix"],
+            $actual
+        );
+    }
 }

--- a/tests/database/Db/Dialect/EscapeIntrospectionTest.php
+++ b/tests/database/Db/Dialect/EscapeIntrospectionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Database\Db\Dialect;
 
+use Phalcon\Db\Column;
 use Phalcon\Db\Dialect\Mysql;
 use Phalcon\Db\Dialect\Postgresql;
 use Phalcon\Db\Dialect\Sqlite;
@@ -32,6 +33,48 @@ final class EscapeIntrospectionTest extends AbstractDatabaseTestCase
             [Postgresql::class],
             [Sqlite::class],
         ];
+    }
+
+    /**
+     * ENUM/SET values are written into single-quoted SQL literals, so a quote
+     * in a value has to be escaped (doubled) or it breaks out of the literal
+     * (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    #[DataProvider('getDialects')]
+    public function testDbDialectGetColumnDefinitionEscapesTypeValues(
+        string $dialectClass
+    ): void {
+        /** @var Mysql $dialect */
+        $dialect = new $dialectClass();
+
+        $arrayColumn = new Column(
+            'status',
+            [
+                'type'       => 'ENUM',
+                'typeValues' => ["rob'ots", "kn'ives"],
+            ]
+        );
+        $scalarColumn = new Column(
+            'status',
+            [
+                'type'       => 'SET',
+                'typeValues' => "rob'ots",
+            ]
+        );
+
+        $this->assertSame(
+            "ENUM('rob''ots', 'kn''ives')",
+            $dialect->getColumnDefinition($arrayColumn)
+        );
+        $this->assertSame(
+            "SET('rob''ots')",
+            $dialect->getColumnDefinition($scalarColumn)
+        );
     }
 
     /**
@@ -71,6 +114,36 @@ final class EscapeIntrospectionTest extends AbstractDatabaseTestCase
     }
 
     /**
+     * A string DEFAULT is written into a single-quoted SQL literal, so MySQL
+     * has to escape both the quote and the backslash (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectMysqlAddColumnEscapesDefault(): void
+    {
+        $dialect = new Mysql();
+
+        $column = new Column(
+            'field_old',
+            [
+                'type'    => Column::TYPE_VARCHAR,
+                'size'    => 20,
+                'default' => "rob'ots\\x",
+                'notNull' => false,
+            ]
+        );
+
+        $this->assertSame(
+            'ALTER TABLE `schema`.`table` ADD `field_old` VARCHAR(20) NULL '
+            . "DEFAULT 'rob''ots\\\\x'",
+            $dialect->addColumn('table', 'schema', $column)
+        );
+    }
+
+    /**
      * MySQL treats the backslash as an escape character, so a backslash in the
      * name has to be doubled together with the quote.
      *
@@ -86,6 +159,179 @@ final class EscapeIntrospectionTest extends AbstractDatabaseTestCase
         $this->assertStringContainsString(
             "a\\\\b",
             $dialect->tableExists("a\\b")
+        );
+    }
+
+    /**
+     * The MySQL helpers that take an optional schema build the same literals in
+     * both branches, so the no-schema branch has to escape the quote too
+     * (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectMysqlIntrospectionEscapesQuotes(): void
+    {
+        $dialect = new Mysql();
+
+        $table  = "rob'ots";
+        $schema = "sch'ema";
+
+        // [statement, escaped literal, unescaped literal]
+        $checks = [
+            [$dialect->listViews($schema), "'sch''ema'", "'sch'ema'"],
+            [$dialect->tableOptions($table, $schema), "'sch''ema'", "'sch'ema'"],
+            [$dialect->tableOptions($table, $schema), "'rob''ots'", "'rob'ots'"],
+            [$dialect->tableOptions($table), "'rob''ots'", "'rob'ots'"],
+            [$dialect->viewExists($table), "'rob''ots'", "'rob'ots'"],
+            [$dialect->describeReferences($table), "'rob''ots'", "'rob'ots'"],
+        ];
+
+        foreach ($checks as $check) {
+            $this->assertStringContainsString($check[1], $check[0]);
+            $this->assertStringNotContainsString($check[2], $check[0]);
+        }
+    }
+
+    /**
+     * `listTables()` puts the schema name in a quoted identifier, so a backtick
+     * in the name has to be escaped (doubled) by `escape()` (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectMysqlListTablesEscapesIdentifier(): void
+    {
+        $dialect = new Mysql();
+
+        $this->assertSame(
+            'SHOW TABLES FROM `sch``ema`',
+            $dialect->listTables('sch`ema')
+        );
+    }
+
+    /**
+     * A string DEFAULT is written into a single-quoted SQL literal, so a quote
+     * in the value has to be escaped (doubled) (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectMysqlModifyColumnEscapesDefault(): void
+    {
+        $dialect = new Mysql();
+
+        $column = new Column(
+            'field_old',
+            [
+                'type'    => Column::TYPE_VARCHAR,
+                'size'    => 20,
+                'default' => "rob'ots",
+                'notNull' => false,
+            ]
+        );
+
+        $this->assertSame(
+            'ALTER TABLE `schema`.`table` MODIFY `field_old` VARCHAR(20) NULL '
+            . "DEFAULT 'rob''ots'",
+            $dialect->modifyColumn('table', 'schema', $column)
+        );
+    }
+
+    /**
+     * `castDefault()` wraps a string default in a single-quoted SQL literal.
+     * PostgreSQL doubles the quote; a backslash escape is not valid there
+     * (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectPostgresqlCastDefaultEscapesQuotes(): void
+    {
+        $dialect = new Postgresql();
+
+        $column = new Column(
+            'field',
+            [
+                'type'    => Column::TYPE_VARCHAR,
+                'size'    => 20,
+                'default' => "rob'ots",
+                'notNull' => false,
+            ]
+        );
+
+        $actual = $dialect->addColumn('table', 'schema', $column);
+
+        $this->assertSame(
+            'ALTER TABLE "schema"."table" ADD COLUMN "field" '
+            . "CHARACTER VARYING(20) DEFAULT 'rob''ots' NULL",
+            $actual
+        );
+        $this->assertStringNotContainsString("\\'", $actual);
+    }
+
+    /**
+     * The PostgreSQL index and catalog helpers concatenate the table/schema
+     * name into a single-quoted SQL literal, so a quote in the name has to be
+     * escaped (doubled) (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectPostgresqlIntrospectionEscapesQuotes(): void
+    {
+        $dialect = new Postgresql();
+
+        $table  = "rob'ots";
+        $schema = "sch'ema";
+
+        // [statement, escaped literal, unescaped literal]
+        $checks = [
+            [$dialect->describeIndexes($table), "'rob''ots'", "'rob'ots'"],
+            [$dialect->listTables($schema), "'sch''ema'", "'sch'ema'"],
+            [$dialect->listViews($schema), "'sch''ema'", "'sch'ema'"],
+            [$dialect->tableOptions($table, $schema), "'rob''ots'", "'rob'ots'"],
+            [$dialect->tableOptions($table, $schema), "'sch''ema'", "'sch'ema'"],
+        ];
+
+        foreach ($checks as $check) {
+            $this->assertStringContainsString($check[1], $check[0]);
+            $this->assertStringNotContainsString($check[2], $check[0]);
+        }
+    }
+
+    /**
+     * The SQLite PRAGMA helpers put the index/table name in a single-quoted SQL
+     * literal, so a quote in the name has to be escaped (doubled) (CWE-89).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     */
+    #[Group('mysql')]
+    #[Group('pgsql')]
+    #[Group('sqlite')]
+    public function testDbDialectSqliteIntrospectionEscapesQuotes(): void
+    {
+        $dialect = new Sqlite();
+
+        $payload = "rob'ots";
+
+        $this->assertSame(
+            "PRAGMA index_info('rob''ots')",
+            $dialect->describeIndex($payload)
+        );
+        $this->assertSame(
+            "PRAGMA index_list('rob''ots')",
+            $dialect->describeIndexes($payload)
         );
     }
 }

--- a/tests/unit/ADR/Middleware/CorsMiddleware/InvokeTest.php
+++ b/tests/unit/ADR/Middleware/CorsMiddleware/InvokeTest.php
@@ -103,6 +103,40 @@ final class InvokeTest extends AbstractUnitTestCase
         unset($_SERVER['HTTP_ORIGIN']);
     }
 
+    /**
+     * The preflight branch applies the same guard: a wildcard-matched origin
+     * is never reflected together with credentials (CWE-942).
+     */
+    public function testAdrMiddlewareCorsMiddlewareNoWildcardOriginWithCredentialsOnPreflight(): void
+    {
+        $_SERVER['HTTP_ORIGIN']    = 'https://evil.example';
+        $_SERVER['REQUEST_METHOD'] = 'OPTIONS';
+
+        $middleware = new CorsMiddleware(
+            [
+                'origins'     => ['*'],
+                'credentials' => true,
+            ]
+        );
+        $response = $middleware(new Request(), $this->next());
+
+        // The preflight answer is still produced.
+        $this->assertSame(204, $response->getStatusCode());
+        $this->assertSame(
+            'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+            $response->getHeaders()->get('Access-Control-Allow-Methods')
+        );
+
+        $this->assertFalse(
+            $response->getHeaders()->get('Access-Control-Allow-Origin')
+        );
+        $this->assertFalse(
+            $response->getHeaders()->get('Access-Control-Allow-Credentials')
+        );
+
+        unset($_SERVER['HTTP_ORIGIN'], $_SERVER['REQUEST_METHOD']);
+    }
+
     private function next(): Handler
     {
         return new class implements Handler {

--- a/tests/unit/ADR/Responder/Redirect/ConstructTest.php
+++ b/tests/unit/ADR/Responder/Redirect/ConstructTest.php
@@ -30,4 +30,21 @@ final class ConstructTest extends AbstractUnitTestCase
 
         $this->assertSame(302, (new Redirect('/x'))->status());
     }
+
+    /**
+     * Unit Tests Phalcon\ADR\Responder\Redirect :: external()
+     *
+     * A redirect is internal unless the flag is passed, so a request-derived
+     * target cannot become an open redirect (CWE-601).
+     */
+    public function testAdrResponderRedirectConstructExternal(): void
+    {
+        $this->assertFalse((new Redirect('/home'))->external());
+        $this->assertFalse((new Redirect('/home', 301))->external());
+        $this->assertFalse((new Redirect('/home', 301, false))->external());
+
+        $this->assertTrue(
+            (new Redirect('https://example.com', 302, true))->external()
+        );
+    }
 }

--- a/tests/unit/ADR/Responder/Redirect/NamedConstructorsTest.php
+++ b/tests/unit/ADR/Responder/Redirect/NamedConstructorsTest.php
@@ -29,4 +29,16 @@ final class NamedConstructorsTest extends AbstractUnitTestCase
 
         $this->assertSame('/a', Redirect::permanent('/a')->url());
     }
+
+    /**
+     * Unit Tests Phalcon\ADR\Responder\Redirect :: external() defaults
+     *
+     * No named constructor opts into an external redirect (CWE-601).
+     */
+    public function testAdrResponderRedirectNamedConstructorsAreInternal(): void
+    {
+        $this->assertFalse(Redirect::permanent('/a')->external());
+        $this->assertFalse(Redirect::temporary('/a')->external());
+        $this->assertFalse(Redirect::seeOther('/a')->external());
+    }
 }

--- a/tests/unit/ADR/Responder/StatusMapper/CompletenessTest.php
+++ b/tests/unit/ADR/Responder/StatusMapper/CompletenessTest.php
@@ -29,7 +29,6 @@ final class CompletenessTest extends AbstractUnitTestCase
         $mapper = new StatusMapper();
 
         $property = new ReflectionProperty($mapper, 'map');
-        $property->setAccessible(true);
         $map = $property->getValue($mapper);
 
         $statuses = (new ReflectionClass(Status::class))->getConstants();

--- a/tests/unit/Auth/Fake/FakeRequest.php
+++ b/tests/unit/Auth/Fake/FakeRequest.php
@@ -35,6 +35,8 @@ final class FakeRequest implements RequestInterface
      */
     private array $query = [];
 
+    private bool $secure = false;
+
     private string $userAgent = '';
 
     // -------------------------------------------------------------------------
@@ -304,7 +306,7 @@ final class FakeRequest implements RequestInterface
 
     public function isSecure(): bool
     {
-        return false;
+        return $this->secure;
     }
 
     public function isSoap(): bool
@@ -339,6 +341,11 @@ final class FakeRequest implements RequestInterface
     public function setQueryFake(string $key, mixed $value): void
     {
         $this->query[$key] = $value;
+    }
+
+    public function setSecureFake(bool $value): void
+    {
+        $this->secure = $value;
     }
 
     public function setUserAgentFake(string $value): void

--- a/tests/unit/Auth/Guard/SessionHardeningTest.php
+++ b/tests/unit/Auth/Guard/SessionHardeningTest.php
@@ -87,15 +87,78 @@ final class SessionHardeningTest extends AbstractUnitTestCase
         $this->assertFalse($cookie->getSecure());
     }
 
-    private function buildGuard(
-        FakeSessionManager $session,
-        FakeCookies $cookies,
-        SessionGuardConfig $config
-    ): Session {
-        $security = new Security();
-        $clock    = new FrozenClock(new DateTimeImmutable('@1700000000'));
+    /**
+     * On a secure request the remember cookie must carry the secure flag so
+     * the bearer credential never travels over a plaintext transport
+     * (CWE-614).
+     */
+    public function testRememberCookieIsSecureOnSecureRequest(): void
+    {
+        $cookies = new FakeCookies();
+        $request = new FakeRequest();
+        $request->setSecureFake(true);
 
-        $adapter = new FakeRememberAdapter(
+        $config = new SessionGuardConfig(null, null, null, 1209600);
+        $guard  = $this->buildGuard(
+            new FakeSessionManager(),
+            $cookies,
+            $config,
+            null,
+            $request
+        );
+
+        $result = $guard->attempt(
+            ['email' => 'alice@example.com', 'password' => 'secret'],
+            true
+        );
+
+        $this->assertTrue($result);
+
+        $cookie = $cookies->get($config->getRememberName());
+        $this->assertTrue($cookie->getSecure());
+    }
+
+    /**
+     * Promotion from the remember cookie is a privilege change, so the session
+     * id must rotate there too (CWE-384).
+     */
+    public function testUserFromRecallerRegeneratesSessionId(): void
+    {
+        $security = new Security();
+        $adapter  = $this->buildAdapter($security);
+        $cookies  = new FakeCookies();
+        $config   = new SessionGuardConfig(null, null, null, 1209600);
+
+        $guard = $this->buildGuard(
+            new FakeSessionManager(),
+            $cookies,
+            $config,
+            $adapter
+        );
+
+        $this->assertTrue(
+            $guard->attempt(
+                ['email' => 'alice@example.com', 'password' => 'secret'],
+                true
+            )
+        );
+
+        // A new session with no identity: only the remember cookie remains.
+        $session = new FakeSessionManager();
+        $guard   = $this->buildGuard($session, $cookies, $config, $adapter);
+
+        $this->assertSame(0, $session->regenerateIdCalls);
+
+        $user = $guard->user();
+
+        $this->assertNotNull($user);
+        $this->assertTrue($guard->viaRemember());
+        $this->assertGreaterThanOrEqual(1, $session->regenerateIdCalls);
+    }
+
+    private function buildAdapter(Security $security): FakeRememberAdapter
+    {
+        return new FakeRememberAdapter(
             $security,
             new MemoryAdapterConfig([
                 [
@@ -105,10 +168,20 @@ final class SessionHardeningTest extends AbstractUnitTestCase
                 ],
             ])
         );
+    }
+
+    private function buildGuard(
+        FakeSessionManager $session,
+        FakeCookies $cookies,
+        SessionGuardConfig $config,
+        ?FakeRememberAdapter $adapter = null,
+        ?FakeRequest $request = null
+    ): Session {
+        $clock = new FrozenClock(new DateTimeImmutable('@1700000000'));
 
         return new Session(
-            $adapter,
-            new FakeRequest(),
+            $adapter ?? $this->buildAdapter(new Security()),
+            $request ?? new FakeRequest(),
             $cookies,
             $session,
             $config,

--- a/tests/unit/Encryption/Crypt/PaddingOracleTest.php
+++ b/tests/unit/Encryption/Crypt/PaddingOracleTest.php
@@ -16,6 +16,7 @@ namespace Phalcon\Tests\Unit\Encryption\Crypt;
 use Phalcon\Encryption\Crypt;
 use Phalcon\Encryption\Crypt\Exception\Mismatch;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use Phalcon\Tests\Unit\Encryption\Fake\Crypt\FakeCryptHashHmacCounter;
 
 final class PaddingOracleTest extends AbstractUnitTestCase
 {
@@ -44,5 +45,40 @@ final class PaddingOracleTest extends AbstractUnitTestCase
         // distinct padding-failure exception.
         $this->expectException(Mismatch::class);
         $crypt->decrypt($tampered);
+    }
+    /**
+     * The signed decrypt path must compute the HMAC even when the OpenSSL
+     * decrypt fails, so that a padding failure and an HMAC mismatch cost the
+     * same and cannot be told apart (CWE-649).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testEncryptionCryptCbcTamperStillComputesHmac(): void
+    {
+        $crypt = new FakeCryptHashHmacCounter();
+        $crypt->setCipher('aes-256-cbc');
+        $crypt->setKey('0123456789abcdef0123456789abcdef');
+
+        $encrypted = $crypt->encrypt('a secret message that spans blocks');
+
+        // Flip the last ciphertext byte to break the PKCS7 padding.
+        $tampered     = $encrypted;
+        $tampered[-1] = $tampered[-1] ^ "\xFF";
+
+        FakeCryptHashHmacCounter::resetHashHmacCalls();
+
+        $caught = null;
+
+        try {
+            $crypt->decrypt($tampered);
+        } catch (Mismatch $ex) {
+            $caught = $ex;
+        }
+
+        $this->assertNotNull($caught);
+        $this->assertSame('Hash does not match.', $caught->getMessage());
+        // The HMAC ran although the OpenSSL decrypt failed.
+        $this->assertSame(1, FakeCryptHashHmacCounter::$hashHmacCalls);
     }
 }

--- a/tests/unit/Encryption/Fake/Crypt/FakeCryptHashHmacCounter.php
+++ b/tests/unit/Encryption/Fake/Crypt/FakeCryptHashHmacCounter.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the Phalcon Framework.
+ *
+ * (c) Phalcon Team <team@phalcon.io>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Phalcon\Tests\Unit\Encryption\Fake\Crypt;
+
+use Phalcon\Encryption\Crypt;
+
+/**
+ * Counts the HMAC calculations so a test can tell whether the signed decrypt
+ * path computes the HMAC even when the OpenSSL decrypt fails.
+ */
+class FakeCryptHashHmacCounter extends Crypt
+{
+    public static int $hashHmacCalls = 0;
+
+    public static function resetHashHmacCalls(): void
+    {
+        self::$hashHmacCalls = 0;
+    }
+
+    /**
+     * Generate a keyed hash value using the HMAC method
+     *
+     * @param string $algorithm
+     * @param string $data
+     * @param string $key
+     * @param bool   $binary
+     *
+     * @return string
+     *
+     * @link https://php.net/manual/en/function.hash-hmac.php
+     */
+    protected static function phpHashHmac(
+        string $algorithm,
+        string $data,
+        string $key,
+        bool $binary = false
+    ): string {
+        self::$hashHmacCalls++;
+
+        return parent::phpHashHmac($algorithm, $data, $key, $binary);
+    }
+}

--- a/tests/unit/Filter/Sanitize/UrlTest.php
+++ b/tests/unit/Filter/Sanitize/UrlTest.php
@@ -45,6 +45,31 @@ final class UrlTest extends AbstractUnitTestCase
     }
 
     /**
+     * Only a scheme on the allow-list survives; any other scheme is dropped.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testFilterSanitizeUrlAllowsOnlyListedSchemes(): void
+    {
+        $sanitizer = new Url();
+
+        $this->assertSame(
+            'ftp://example.com/file.txt',
+            $sanitizer('ftp://example.com/file.txt')
+        );
+        $this->assertSame(
+            'ftps://example.com/file.txt',
+            $sanitizer('ftps://example.com/file.txt')
+        );
+        $this->assertSame('tel:+15550100', $sanitizer('tel:+15550100'));
+
+        // Not on the allow-list.
+        $this->assertSame('', $sanitizer('file:///etc/passwd'));
+        $this->assertSame('', $sanitizer('ws://example.com/socket'));
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2026-08-24
      */
@@ -61,5 +86,38 @@ final class UrlTest extends AbstractUnitTestCase
         $this->assertSame('https://phalcon.io', $sanitizer('https://phalcon.io'));
         $this->assertSame('mailto:team@phalcon.io', $sanitizer('mailto:team@phalcon.io'));
         $this->assertSame('/relative/path', $sanitizer('/relative/path'));
+    }
+
+    /**
+     * The scheme allow-list is case-insensitive, so a mixed-case dangerous
+     * scheme is dropped as well.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testFilterSanitizeUrlBlocksMixedCaseScheme(): void
+    {
+        $sanitizer = new Url();
+
+        $this->assertSame('', $sanitizer('JavaScript:alert(1)'));
+        $this->assertSame('', $sanitizer('JAVASCRIPT:alert(1)'));
+        $this->assertSame('', $sanitizer('DATA:text/html,<script>alert(1)</script>'));
+        $this->assertSame('', $sanitizer('VbScript:msgbox(1)'));
+    }
+
+    /**
+     * filter_var() returns false for an input it cannot sanitize. The result
+     * is cast, so the sanitizer always gives back a string.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testFilterSanitizeUrlReturnsStringWhenFilterFails(): void
+    {
+        $sanitizer = new Url();
+
+        $expected = '';
+        $actual   = $sanitizer(['https://phalcon.io']);
+        $this->assertSame($expected, $actual);
     }
 }

--- a/tests/unit/Filter/Validation/SetDefaultMessagesTest.php
+++ b/tests/unit/Filter/Validation/SetDefaultMessagesTest.php
@@ -27,7 +27,6 @@ final class SetDefaultMessagesTest extends AbstractUnitTestCase
     protected function tearDown(): void
     {
         $property = new ReflectionProperty(Validation::class, 'defaultMessages');
-        $property->setAccessible(true);
         $property->setValue(null, []);
 
         parent::tearDown();

--- a/tests/unit/Flash/Direct/EscapeCssClassTest.php
+++ b/tests/unit/Flash/Direct/EscapeCssClassTest.php
@@ -36,4 +36,27 @@ final class EscapeCssClassTest extends AbstractUnitTestCase
 
         $this->assertStringNotContainsString('<script>', $html);
     }
+
+    /**
+     * A crafted css icon class must not break out of the class attribute of
+     * the `<i>` fragment.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testFlashEscapesCssIconClass(): void
+    {
+        $flash = new Direct();
+        $flash->setEscaperService(new Escaper());
+        $flash->setImplicitFlush(false);
+        $flash->setCssIconClasses(['error' => '" onmouseover="alert(1)']);
+
+        $html = $flash->error('hello');
+
+        $this->assertStringContainsString(
+            '<i class="&quot; onmouseover=&quot;alert(1)"></i>',
+            $html
+        );
+        $this->assertStringNotContainsString('onmouseover="', $html);
+    }
 }

--- a/tests/unit/Flash/Session/OutputTest.php
+++ b/tests/unit/Flash/Session/OutputTest.php
@@ -59,6 +59,69 @@ final class OutputTest extends AbstractUnitTestCase
     }
 
     /**
+     * A crafted css class must not break out of the class attribute.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testFlashSessionOutputEscapesCssClass(): void
+    {
+        $session = $this->container->getShared('session');
+        $session->start();
+
+        $flash = new Session();
+        $flash->setDI($this->container);
+        $flash->setCssClasses(['error' => '"><script>alert(1)</script>']);
+
+        $flash->error(uniqid('m-'));
+
+        ob_start();
+        $flash->output();
+        $actual = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertStringContainsString(
+            '<div class="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;">',
+            $actual
+        );
+        $this->assertStringNotContainsString('<script>', $actual);
+
+        $session->destroy();
+    }
+
+    /**
+     * A crafted css icon class must not break out of the class attribute of
+     * the `<i>` fragment.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testFlashSessionOutputEscapesCssIconClass(): void
+    {
+        $session = $this->container->getShared('session');
+        $session->start();
+
+        $flash = new Session();
+        $flash->setDI($this->container);
+        $flash->setCssIconClasses(['error' => '" onmouseover="alert(1)']);
+
+        $flash->error(uniqid('m-'));
+
+        ob_start();
+        $flash->output();
+        $actual = ob_get_contents();
+        ob_end_clean();
+
+        $this->assertStringContainsString(
+            '<i class="&quot; onmouseover=&quot;alert(1)"></i>',
+            $actual
+        );
+        $this->assertStringNotContainsString('onmouseover="', $actual);
+
+        $session->destroy();
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */

--- a/tests/unit/Html/Attributes/RenderTest.php
+++ b/tests/unit/Html/Attributes/RenderTest.php
@@ -45,4 +45,25 @@ final class RenderTest extends AbstractUnitTestCase
         $actual   = $attributes->render();
         $this->assertSame($expected, $actual);
     }
+
+    /**
+     * The key becomes an attribute name, so the characters that end a name
+     * must be removed or a crafted key adds an event handler (CWE-79).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testHtmlAttributesRenderStripsAttributeNameSplitters(): void
+    {
+        $attributes = new Attributes(
+            [
+                'x onclick=alert(1) y' => 'v',
+                'class'                => 'ok',
+            ]
+        );
+
+        $expected = 'class="ok" xonclickalert(1)y="v" ';
+        $actual   = $attributes->render();
+        $this->assertSame($expected, $actual);
+    }
 }

--- a/tests/unit/Html/Breadcrumbs/RenderTest.php
+++ b/tests/unit/Html/Breadcrumbs/RenderTest.php
@@ -57,6 +57,33 @@ final class RenderTest extends AbstractUnitTestCase
     }
 
     /**
+     * The last label of a list of many elements goes into a `<dt>`, so it
+     * must be escaped or a crafted label injects HTML (CWE-79).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testHtmlBreadcrumbsRenderEscapesLastLabel(): void
+    {
+        $breadcrumbs = new Breadcrumbs();
+        $breadcrumbs
+            ->add('Home', '/')
+            ->add('<b>x</b>')
+        ;
+
+        $expected = '<dl>'
+            . '<dt><a href="/">Home</a></dt>'
+            . '<dt> / </dt>'
+            . '<dt>&lt;b&gt;x&lt;/b&gt;</dt>'
+            . '</dl>';
+
+        $this->assertSame(
+            $expected,
+            $breadcrumbs->render()
+        );
+    }
+
+    /**
      * The link and label are placed into the markup, so they must be escaped
      * or a crafted value injects HTML (CWE-79).
      *
@@ -74,6 +101,31 @@ final class RenderTest extends AbstractUnitTestCase
 
         $this->assertStringNotContainsString('<script>', $actual);
         $this->assertStringNotContainsString('<b>x</b>', $actual);
+    }
+
+    /**
+     * A single element goes through the template branch, so the label and the
+     * url must both be escaped or a crafted value injects HTML (CWE-79).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testHtmlBreadcrumbsRenderEscapesSingleElement(): void
+    {
+        $breadcrumbs = new Breadcrumbs();
+        $breadcrumbs
+            ->add('<b>x</b>', '/a"><script>alert(1)</script>')
+        ;
+
+        $expected = '<dl>'
+            . '<dt><a href="/a&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;">'
+            . '&lt;b&gt;x&lt;/b&gt;</a></dt>'
+            . '</dl>';
+
+        $this->assertSame(
+            $expected,
+            $breadcrumbs->render()
+        );
     }
 
     /**

--- a/tests/unit/Html/Helper/Close/UnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/Close/UnderscoreInvokeTest.php
@@ -42,4 +42,21 @@ final class UnderscoreInvokeTest extends AbstractUnitTestCase
         $actual   = $factory->close("image");
         $this->assertSame($expected, $actual);
     }
+
+    /**
+     * The tag name must lose the characters that end a name, or a crafted
+     * name adds an attribute to the closing tag (CWE-79).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testHtmlHelperCloseUnderscoreInvokeStripsTagNameSplitters(): void
+    {
+        $escaper = new Escaper();
+        $helper  = new Close($escaper);
+
+        $expected = "</divonloadx>";
+        $actual   = $helper("div onload=x");
+        $this->assertSame($expected, $actual);
+    }
 }

--- a/tests/unit/Html/Helper/Input/CheckboxUnderscoreInvokeTest.php
+++ b/tests/unit/Html/Helper/Input/CheckboxUnderscoreInvokeTest.php
@@ -262,4 +262,18 @@ final class CheckboxUnderscoreInvokeTest extends AbstractUnitTestCase
 
         $this->assertStringNotContainsString('<script>', $html);
     }
+
+    public function testRadioLabelTextIsEscaped(): void
+    {
+        $radio = new Radio(new Escaper());
+
+        $html = (string) $radio('agree', '1', [])
+            ->label(['text' => '<script>alert(1)</script>']);
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString(
+            '&lt;script&gt;alert(1)&lt;/script&gt;',
+            $html
+        );
+    }
 }

--- a/tests/unit/Html/Helper/TagAndVoidTagTest.php
+++ b/tests/unit/Html/Helper/TagAndVoidTagTest.php
@@ -68,6 +68,16 @@ final class TagAndVoidTagTest extends AbstractUnitTestCase
         $this->assertNotContains('onclick', $names);
     }
 
+    public function testTagStripsTagNameSplittersPreventingInjection(): void
+    {
+        $tag = new Tag(new Escaper());
+
+        $this->assertSame(
+            '<xonloadalert(1)y>',
+            $tag('x onload=alert(1)/y')
+        );
+    }
+
     public function testVoidTagDefaultsToHtml5SelfClose(): void
     {
         $vt = new VoidTag(new Escaper(), new Doctype());

--- a/tests/unit/Http/Request/GetClientAddressTest.php
+++ b/tests/unit/Http/Request/GetClientAddressTest.php
@@ -171,6 +171,33 @@ final class GetClientAddressTest extends AbstractHttpBase
     }
 
     /**
+     * The plain-IP branch must also check every configured trusted proxy,
+     * not only the first one (CWE-290).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testHttpRequestGetClientAddressTrustsSecondExactProxy(): void
+    {
+        $container = new FactoryDefault();
+
+        // REMOTE_ADDR matches the SECOND trusted proxy, given as a plain IP.
+        $_SERVER['REMOTE_ADDR']          = '25.25.25.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8,25.25.25.1';
+
+        $request = new Request();
+        $request->setDI($container);
+        $request->setTrustedProxies([
+            '10.0.0.1',
+            '25.25.25.1',
+        ]);
+
+        $expected = '8.8.8.8';
+        $actual   = $request->getClientAddress(true);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
      * Every configured trusted proxy must be checked, not only the first one
      * (the peer can match any entry) (CWE-290).
      *

--- a/tests/unit/Image/Adapter/Gd/MaxPixelsTest.php
+++ b/tests/unit/Image/Adapter/Gd/MaxPixelsTest.php
@@ -98,7 +98,6 @@ final class MaxPixelsTest extends AbstractUnitTestCase
     private function getMaxPixels(Gd $adapter): int
     {
         $property = new ReflectionProperty(Gd::class, 'maxPixels');
-        $property->setAccessible(true);
 
         return (int) $property->getValue($adapter);
     }

--- a/tests/unit/Image/Adapter/Gd/MaxPixelsTest.php
+++ b/tests/unit/Image/Adapter/Gd/MaxPixelsTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Image\Adapter\Gd;
 
+use Phalcon\Image\Adapter\AbstractAdapter;
 use Phalcon\Image\Adapter\Gd;
 use Phalcon\Image\Exceptions\ImageTooLarge;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use Phalcon\Tests\Unit\Image\Fake\GdTrait;
+use ReflectionProperty;
 
 final class MaxPixelsTest extends AbstractUnitTestCase
 {
@@ -38,6 +40,43 @@ final class MaxPixelsTest extends AbstractUnitTestCase
     }
 
     /**
+     * Without an explicit limit the adapter falls back to the default cap
+     * instead of leaving the check disabled (CWE-409).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testImageAdapterGdMaxPixelsFallsBackToDefault(): void
+    {
+        $image = $this->getImages()['png'];
+
+        $gd = new Gd($image);
+
+        $this->assertSame(
+            AbstractAdapter::DEFAULT_MAX_PIXELS,
+            $this->getMaxPixels($gd)
+        );
+    }
+
+    /**
+     * A zero limit also falls back to the default cap (CWE-409).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testImageAdapterGdMaxPixelsFallsBackToDefaultOnZero(): void
+    {
+        $image = $this->getImages()['png'];
+
+        $gd = new Gd($image, null, null, 0);
+
+        $this->assertSame(
+            AbstractAdapter::DEFAULT_MAX_PIXELS,
+            $this->getMaxPixels($gd)
+        );
+    }
+
+    /**
      * An image whose header dimensions exceed the configured pixel limit is
      * rejected before the pixel buffer is allocated (CWE-409).
      *
@@ -50,6 +89,17 @@ final class MaxPixelsTest extends AbstractUnitTestCase
 
         $this->expectException(ImageTooLarge::class);
         // The example image is 82x82 = 6724 pixels; cap at 100.
+        $this->expectExceptionMessage(
+            'Image size 6724 pixels exceeds the maximum allowed 100 pixels'
+        );
         new Gd($image, null, null, 100);
+    }
+
+    private function getMaxPixels(Gd $adapter): int
+    {
+        $property = new ReflectionProperty(Gd::class, 'maxPixels');
+        $property->setAccessible(true);
+
+        return (int) $property->getValue($adapter);
     }
 }

--- a/tests/unit/Image/Adapter/Imagick/MaxPixelsTest.php
+++ b/tests/unit/Image/Adapter/Imagick/MaxPixelsTest.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace Phalcon\Tests\Unit\Image\Adapter\Imagick;
 
+use Phalcon\Image\Adapter\AbstractAdapter;
 use Phalcon\Image\Adapter\Imagick;
 use Phalcon\Image\Exceptions\ImageTooLarge;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use Phalcon\Talon\Talon;
 use Phalcon\Tests\Unit\Image\Fake\ImagickTrait;
+use ReflectionProperty;
 
 final class MaxPixelsTest extends AbstractUnitTestCase
 {
@@ -40,6 +42,45 @@ final class MaxPixelsTest extends AbstractUnitTestCase
     }
 
     /**
+     * Without an explicit limit the adapter falls back to the default cap
+     * instead of leaving the check disabled (CWE-409).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testImageAdapterImagickMaxPixelsFallsBackToDefault(): void
+    {
+        $source = Talon::settings()->supportPath('assets/images/example-jpg.jpg');
+        $source = str_replace('/', DIRECTORY_SEPARATOR, $source);
+
+        $image = new Imagick($source);
+
+        $this->assertSame(
+            AbstractAdapter::DEFAULT_MAX_PIXELS,
+            $this->getMaxPixels($image)
+        );
+    }
+
+    /**
+     * A zero limit also falls back to the default cap (CWE-409).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testImageAdapterImagickMaxPixelsFallsBackToDefaultOnZero(): void
+    {
+        $source = Talon::settings()->supportPath('assets/images/example-jpg.jpg');
+        $source = str_replace('/', DIRECTORY_SEPARATOR, $source);
+
+        $image = new Imagick($source, null, null, 0);
+
+        $this->assertSame(
+            AbstractAdapter::DEFAULT_MAX_PIXELS,
+            $this->getMaxPixels($image)
+        );
+    }
+
+    /**
      * An image whose header dimensions exceed the configured pixel limit is
      * rejected before readImage() decodes the pixel buffer (CWE-409).
      *
@@ -52,6 +93,18 @@ final class MaxPixelsTest extends AbstractUnitTestCase
         $source = str_replace('/', DIRECTORY_SEPARATOR, $source);
 
         $this->expectException(ImageTooLarge::class);
+        // The example image is 1820x694 = 1263080 pixels; cap at 100.
+        $this->expectExceptionMessage(
+            'Image size 1263080 pixels exceeds the maximum allowed 100 pixels'
+        );
         new Imagick($source, null, null, 100);
+    }
+
+    private function getMaxPixels(Imagick $adapter): int
+    {
+        $property = new ReflectionProperty(Imagick::class, 'maxPixels');
+        $property->setAccessible(true);
+
+        return (int) $property->getValue($adapter);
     }
 }

--- a/tests/unit/Image/Adapter/Imagick/MaxPixelsTest.php
+++ b/tests/unit/Image/Adapter/Imagick/MaxPixelsTest.php
@@ -103,7 +103,6 @@ final class MaxPixelsTest extends AbstractUnitTestCase
     private function getMaxPixels(Imagick $adapter): int
     {
         $property = new ReflectionProperty(Imagick::class, 'maxPixels');
-        $property->setAccessible(true);
 
         return (int) $property->getValue($adapter);
     }

--- a/tests/unit/Logger/Formatter/Line/FormatTest.php
+++ b/tests/unit/Logger/Formatter/Line/FormatTest.php
@@ -19,12 +19,28 @@ use Phalcon\Logger\Enum;
 use Phalcon\Logger\Formatter\Line;
 use Phalcon\Logger\Item;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use function date_default_timezone_get;
 use function uniqid;
 
 final class FormatTest extends AbstractUnitTestCase
 {
+    /**
+     * @return array<int, array<int, string>>
+     */
+    public static function getControlCharacterExamples(): array
+    {
+        return [
+            ["\x00", '\\x00'],
+            ["\x08", '\\x08'],
+            ["\x0B", '\\x0B'],
+            ["\x1B", '\\x1B'],
+            ["\x1F", '\\x1F'],
+            ["\x7F", '\\x7F'],
+        ];
+    }
+
     /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
@@ -146,6 +162,32 @@ final class FormatTest extends AbstractUnitTestCase
     }
 
     /**
+     * Each C0 control character, and DEL, becomes its \xNN escape.
+     *
+     * @author       Phalcon Team <team@phalcon.io>
+     * @since        2026-08-25
+     */
+    #[DataProvider('getControlCharacterExamples')]
+    public function testLoggerFormatterLineFormatEscapesControlCharacterRange(
+        string $character,
+        string $escaped
+    ): void {
+        $timezone  = date_default_timezone_get();
+        $datetime  = new DateTimeImmutable('now', new DateTimeZone($timezone));
+        $formatter = new Line('%message%');
+        $item      = new Item(
+            'a' . $character . 'b',
+            'debug',
+            Enum::DEBUG,
+            $datetime
+        );
+
+        $expected = 'a' . $escaped . 'b';
+        $actual   = $formatter->format($item);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
      * A message or context value carrying CR/LF must not forge extra log
      * lines (CWE-117); control characters are escaped, tab is preserved.
      *
@@ -171,5 +213,32 @@ final class FormatTest extends AbstractUnitTestCase
         $this->assertStringNotContainsString("\r", $actual);
         // The control bytes are escaped visibly; tab is kept.
         $this->assertSame('hello\x0D\x0ACRITICAL forged' . "\t" . 'keep', $actual);
+    }
+
+    /**
+     * A control character that arrives through a context value is escaped
+     * after interpolation, not before it.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testLoggerFormatterLineFormatEscapesControlCharactersFromContext(): void
+    {
+        $timezone  = date_default_timezone_get();
+        $datetime  = new DateTimeImmutable('now', new DateTimeZone($timezone));
+        $formatter = new Line('%message%');
+        $item      = new Item(
+            'user %name%',
+            'debug',
+            Enum::DEBUG,
+            $datetime,
+            ['name' => "a\x0Ab"]
+        );
+
+        $actual = $formatter->format($item);
+
+        // The context value cannot forge a second log line.
+        $this->assertStringNotContainsString("\n", $actual);
+        $this->assertSame('user a\\x0Ab', $actual);
     }
 }

--- a/tests/unit/Mvc/View/PartialTest.php
+++ b/tests/unit/Mvc/View/PartialTest.php
@@ -17,6 +17,14 @@ use Phalcon\Di\Di;
 use Phalcon\Mvc\View;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use Phalcon\Talon\Talon;
+use Throwable;
+
+use function file_put_contents;
+use function ob_end_clean;
+use function ob_get_clean;
+use function ob_get_level;
+use function ob_start;
+use function str_contains;
 
 class PartialTest extends AbstractUnitTestCase
 {
@@ -64,6 +72,77 @@ class PartialTest extends AbstractUnitTestCase
             Talon::settings()->supportPath('assets/views/partials/partial'),
             ['cool_var' => 'abcde']
         );
+        $actual = ob_get_clean();
+
+        $this->assertSame('Hey, this is a partial, also abcde', $actual);
+    }
+
+    /**
+     * A `..` in the partial path must not climb out of the partials directory
+     * to include a file the developer never exposed (CWE-22 / CWE-98).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testMvcViewPartialCannotTraverse(): void
+    {
+        // A partial two levels ABOVE the partials dir that a traversal reaches.
+        $secret = Talon::settings()->supportPath('assets/pwned-partial.phtml');
+        file_put_contents($secret, 'LEAKED-VIA-TRAVERSAL');
+
+        $container = new Di();
+        $view      = new View();
+
+        $view->setViewsDir(
+            $this->getDirSeparator(Talon::settings()->supportPath('assets/views'))
+        );
+        $view->setPartialsDir('partials/');
+        $view->setDI($container);
+
+        $leaked     = false;
+        $startLevel = ob_get_level();
+
+        ob_start();
+
+        try {
+            $view->partial('../../pwned-partial');
+
+            $leaked = str_contains(
+                (string) ob_get_clean(),
+                'LEAKED-VIA-TRAVERSAL'
+            );
+        } catch (Throwable $ex) {
+            // After the fix the path stays inside the partials dir and is not
+            // found, so rendering throws instead of leaking the outside file.
+            while (ob_get_level() > $startLevel) {
+                ob_end_clean();
+            }
+        }
+
+        $this->safeDeleteFile($secret);
+
+        $this->assertFalse($leaked);
+    }
+
+    /**
+     * Dropping the `.` and `..` segments must keep a legitimate sub-directory
+     * partial working.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testMvcViewPartialSubDirectory(): void
+    {
+        $container = new Di();
+        $view      = new View();
+
+        $view->setViewsDir(
+            $this->getDirSeparator(Talon::settings()->supportPath('assets/views'))
+        );
+        $view->setDI($container);
+
+        ob_start();
+        $view->partial('partials/partial', ['cool_var' => 'abcde']);
         $actual = ob_get_clean();
 
         $this->assertSame('Hey, this is a partial, also abcde', $actual);

--- a/tests/unit/Queue/Adapter/Beanstalk/BeanstalkConnectionTubeGuardTest.php
+++ b/tests/unit/Queue/Adapter/Beanstalk/BeanstalkConnectionTubeGuardTest.php
@@ -16,9 +16,44 @@ namespace Phalcon\Tests\Unit\Queue\Adapter\Beanstalk;
 use Phalcon\Queue\Adapter\Beanstalk\BeanstalkConnection;
 use Phalcon\Queue\Exceptions\Exception;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
+use ReflectionMethod;
+
+use function str_repeat;
 
 final class BeanstalkConnectionTubeGuardTest extends AbstractUnitTestCase
 {
+    /**
+     * A legal tube name must not be rejected: 200 bytes is the protocol
+     * maximum and the full punctuation set is allowed, with a hyphen in any
+     * position other than the first. The guard is checked on its own, so no
+     * socket is opened.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testTubeCommandsAcceptLegalNames(): void
+    {
+        $connection = new BeanstalkConnection();
+        $guard      = new ReflectionMethod(
+            BeanstalkConnection::class,
+            'assertValidTube'
+        );
+
+        $names = [
+            'default',
+            str_repeat('a', 200),
+            'tube+/;.$_()-name',
+        ];
+
+        $accepted = [];
+        foreach ($names as $name) {
+            $guard->invoke($connection, $name);
+            $accepted[] = $name;
+        }
+
+        $this->assertSame($names, $accepted);
+    }
+
     /**
      * A tube name carrying CR/LF would inject arbitrary Beanstalkd commands.
      * Every tube-bearing command must reject it before any socket write.
@@ -42,6 +77,32 @@ final class BeanstalkConnectionTubeGuardTest extends AbstractUnitTestCase
             try {
                 $operation();
                 $this->fail('Expected Exception for a CR/LF tube name');
+            } catch (Exception $exception) {
+                $this->assertSame('Invalid tube name', $exception->getMessage());
+            }
+        }
+    }
+
+    /**
+     * A leading hyphen and a name longer than the 200 byte protocol maximum
+     * are rejected before any socket write.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testTubeCommandsRejectLeadingHyphenAndOverlongName(): void
+    {
+        $connection = new BeanstalkConnection();
+
+        $payloads = [
+            '-tube',
+            str_repeat('a', 201),
+        ];
+
+        foreach ($payloads as $payload) {
+            try {
+                $connection->useTube($payload);
+                $this->fail('Expected Exception for an illegal tube name');
             } catch (Exception $exception) {
                 $this->assertSame('Invalid tube name', $exception->getMessage());
             }

--- a/tests/unit/Session/Adapter/Stream/TraversalTest.php
+++ b/tests/unit/Session/Adapter/Stream/TraversalTest.php
@@ -47,4 +47,81 @@ final class TraversalTest extends AbstractUnitTestCase
         @unlink($dir . '.._pwned-d8-escape');
         @unlink($escape);
     }
+
+    /**
+     * A session id carrying backslash separators is sanitized the same way, so
+     * a Windows style traversal cannot leave the session directory (CWE-22).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testSessionAdapterStreamWriteStripsBackslashSeparators(): void
+    {
+        $dir = Talon::settings()->outputPath('tests/session-d8/');
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        $raw       = '..\\..\\pwned-d8-backslash';
+        $sanitized = $dir . '.._.._pwned-d8-backslash';
+        @unlink($dir . $raw);
+        @unlink($sanitized);
+
+        $adapter = new Stream(['savePath' => $dir]);
+        $adapter->write($raw, 'payload');
+
+        // The raw id is never used as a name.
+        $this->assertFileDoesNotExist($dir . $raw);
+        // Each separator becomes an underscore, inside the session directory.
+        $this->assertFileExists($sanitized);
+        $this->assertSame(
+            realpath($dir),
+            dirname((string) realpath($sanitized))
+        );
+
+        @unlink($dir . $raw);
+        @unlink($sanitized);
+    }
+
+    /**
+     * A session id carrying colons is sanitized the same way, so a drive
+     * qualifier or a stream wrapper cannot leave the session directory
+     * (CWE-22).
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testSessionAdapterStreamWriteStripsColonSeparators(): void
+    {
+        $dir = Talon::settings()->outputPath('tests/session-d8/');
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+
+        $expected = [
+            'c:pwned-d8-colon'    => $dir . 'c_pwned-d8-colon',
+            'php://pwned-d8-wrap' => $dir . 'php___pwned-d8-wrap',
+        ];
+
+        foreach ($expected as $raw => $sanitized) {
+            @unlink($dir . $raw);
+            @unlink($sanitized);
+
+            $adapter = new Stream(['savePath' => $dir]);
+            $adapter->write($raw, 'payload');
+
+            // The raw id is never used as a name.
+            $this->assertFileDoesNotExist($dir . $raw);
+            // Each separator becomes an underscore, inside the session
+            // directory.
+            $this->assertFileExists($sanitized);
+            $this->assertSame(
+                realpath($dir),
+                dirname((string) realpath($sanitized))
+            );
+
+            @unlink($dir . $raw);
+            @unlink($sanitized);
+        }
+    }
 }

--- a/tests/unit/Storage/Adapter/GetFilepathTraversalTest.php
+++ b/tests/unit/Storage/Adapter/GetFilepathTraversalTest.php
@@ -19,27 +19,77 @@ use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use Phalcon\Talon\Talon;
 use ReflectionMethod;
 
+use function basename;
+
 final class GetFilepathTraversalTest extends AbstractUnitTestCase
 {
+    /**
+     * The key becomes the file name, so its case must survive. A lower-cased
+     * name no longer matches the file that was written.
+     */
+    public function testStorageAdapterStreamGetFilepathKeepsTheKeyCase(): void
+    {
+        $actual = $this->getFilepath('MyKey');
+
+        $this->assertSame('MyKey', basename($actual));
+        $this->assertStringNotContainsString('mykey', $actual);
+    }
+
+    /**
+     * A Windows style separator must not climb out of the storage directory
+     * either (CWE-22).
+     */
+    public function testStorageAdapterStreamGetFilepathNeutralizesBackslash(): void
+    {
+        $actual = $this->getFilepath('..\..\pwned');
+
+        $this->assertSame('.._.._pwned', basename($actual));
+        $this->assertStringNotContainsString('\\', $actual);
+        $this->assertStringStartsWith($this->getStorageDir(), $actual);
+    }
+
+    /**
+     * A `:` in the key must go as well, otherwise the file name turns into a
+     * stream wrapper URL.
+     */
+    public function testStorageAdapterStreamGetFilepathNeutralizesStreamWrapper(): void
+    {
+        $actual = $this->getFilepath('php://filter');
+
+        $this->assertSame('php___filter', basename($actual));
+        $this->assertStringNotContainsString(':', $actual);
+        $this->assertStringStartsWith($this->getStorageDir(), $actual);
+    }
+
     /**
      * A crafted key must not climb out of the storage directory: the key
      * becomes the file name, so its path separators have to be removed (CWE-22).
      */
     public function testStorageAdapterStreamGetFilepathNeutralizesTraversal(): void
     {
+        $actual = $this->getFilepath('../../../../pwned');
+
+        $this->assertStringNotContainsString('../', $actual);
+    }
+
+    private function getFilepath(string $key): string
+    {
         $serializer = new SerializerFactory();
         $adapter    = new Stream(
             $serializer,
             [
-                'storageDir' => Talon::settings()->outputPath() . '/',
+                'storageDir' => $this->getStorageDir(),
             ]
         );
 
         $method = new ReflectionMethod($adapter, 'getFilepath');
         $method->setAccessible(true);
 
-        $actual = $method->invoke($adapter, '../../../../pwned');
+        return $method->invoke($adapter, $key);
+    }
 
-        $this->assertStringNotContainsString('../', $actual);
+    private function getStorageDir(): string
+    {
+        return Talon::settings()->outputPath() . '/';
     }
 }

--- a/tests/unit/Storage/Adapter/GetFilepathTraversalTest.php
+++ b/tests/unit/Storage/Adapter/GetFilepathTraversalTest.php
@@ -83,7 +83,6 @@ final class GetFilepathTraversalTest extends AbstractUnitTestCase
         );
 
         $method = new ReflectionMethod($adapter, 'getFilepath');
-        $method->setAccessible(true);
 
         return $method->invoke($adapter, $key);
     }

--- a/tests/unit/Tag/RenderAttributesTest.php
+++ b/tests/unit/Tag/RenderAttributesTest.php
@@ -88,6 +88,38 @@ final class RenderAttributesTest extends AbstractTagTestCase
         );
     }
 
+    /**
+     * The key is an attribute name. A crafted key must not be able to add
+     * another attribute or close the tag.
+     */
+    public function testRenderAttributesStripsTheKeySeparators(): void
+    {
+        $actual = Tag::renderAttributes(
+            '<tag',
+            ['a" onmouseover=alert(1) x' => 'one']
+        );
+
+        $this->assertSame('<tag aonmouseoveralert(1)x="one"', $actual);
+        $this->assertStringNotContainsString('onmouseover=', $actual);
+    }
+
+    /**
+     * Every helper goes through renderAttributes(), so the same key is
+     * stripped when it arrives from one of them.
+     */
+    public function testRenderAttributesStripsTheKeySeparatorsViaTextField(): void
+    {
+        $actual = Tag::textField(
+            ['field', 'a" onmouseover=alert(1) x' => 'one']
+        );
+
+        $this->assertStringContainsString(
+            'aonmouseoveralert(1)x="one"',
+            $actual
+        );
+        $this->assertStringNotContainsString('onmouseover=', $actual);
+    }
+
     public function testRenderAttributesThrowsForAnArrayValue(): void
     {
         $this->expectException(Exception::class);

--- a/tests/unit/Translate/Interpolator/IndexedArray/ReplacePlaceholdersTest.php
+++ b/tests/unit/Translate/Interpolator/IndexedArray/ReplacePlaceholdersTest.php
@@ -35,6 +35,22 @@ final class ReplacePlaceholdersTest extends AbstractUnitTestCase
     }
 
     /**
+     * A translation whose format specifiers do not match the given arguments
+     * must not raise a ValueError (CWE-134); it is returned unchanged.
+     *
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-25
+     */
+    public function testTranslateInterpolatorIndexedarrayReplacePlaceholdersWithMismatchedFormat(): void
+    {
+        $interpolator = new IndexedArray();
+
+        $expected = '%9$s';
+        $actual   = $interpolator->replacePlaceholders('%9$s', ['only-one']);
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2020-09-09
      */


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17527 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

---
- The PHPUnit configuration now fails the run on notices, deprecations and PHPUnit deprecations, and prints the details of every triggering test.
- Added regression tests for the hardening changes released in 5.20.0 and 5.20.1 that had no failing-on-revert coverage.
- Fixed `Undefined index` notice emitted for every literal route when `Phalcon\Mvc\Router` rebuilds its per-method index. 

Thanks

