### PR TITLE
CP-17536 - fixing the options for checkbox/radio; removing dead code

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -2,6 +2,24 @@
 
 All notable changes are documented here. The format is based on [Keep a Changelog][keep_a_changelog] and this project adheres to [Semantic Versioning][semantic_versioning].
 
+## [5.20.4](https://github.com/phalcon/cphalcon/releases/tag/v5.20.4) (2026-xx-xx)
+
+### Tools
+
+- Zephir 1.3.0
+
+### Changed
+
+### Added
+
+### Fixed
+
+- `Phalcon\Forms\Element\CheckGroup` and `RadioGroup` storing their choices in the property `Phalcon\Forms\Element\AbstractElement` uses for user options, so `setUserOption()` added a choice and `setOptions()` removed every user option. [#17536](https://github.com/phalcon/cphalcon/issues/17536)
+- `Phalcon\Forms\Element\Select::addOption()` writing with an offset into an object or `null` options value; the write now happens only when the options value is an array (`null` becomes an empty array). [#17536](https://github.com/phalcon/cphalcon/issues/17536)
+
+### Removed
+
+
 ## [5.20.3](https://github.com/phalcon/cphalcon/releases/tag/v5.20.3) (2026-08-26)
 
 ### Tools

--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -14,8 +14,8 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 
 ### Fixed
 
-- `Phalcon\Forms\Element\CheckGroup` and `RadioGroup` storing their choices in the property `Phalcon\Forms\Element\AbstractElement` uses for user options, so `setUserOption()` added a choice and `setOptions()` removed every user option. [#17536](https://github.com/phalcon/cphalcon/issues/17536)
-- `Phalcon\Forms\Element\Select::addOption()` writing with an offset into an object or `null` options value; the write now happens only when the options value is an array (`null` becomes an empty array). [#17536](https://github.com/phalcon/cphalcon/issues/17536)
+- `Phalcon\Forms\Element\CheckGroup` and `RadioGroup` storing their choices in the property `Phalcon\Forms\Element\AbstractElement` uses for user options, so `setUserOption()` added a choice and `setOptions()` removed every user option. [#17536](https://github.com/phalcon/cphalcon/issues/17536) [[doc]](https://docs.phalcon.io/5.20/forms/)
+- `Phalcon\Forms\Element\Select::addOption()` writing with an offset into an object or `null` options value; the write now happens only when the options value is an array (`null` becomes an empty array). [#17536](https://github.com/phalcon/cphalcon/issues/17536) [[doc]](https://docs.phalcon.io/5.20/forms/)
 
 ### Removed
 

--- a/ext/phalcon/forms/element/abstractelement.zep.c
+++ b/ext/phalcon/forms/element/abstractelement.zep.c
@@ -177,48 +177,17 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, __toString)
  */
 PHP_METHOD(Phalcon_Forms_Element_AbstractElement, addFilter)
 {
-	zval _1$$5, _2$$6;
-	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
-	zval filter_zv, filters, _0;
+	zval filter_zv;
 	zend_string *filter = NULL;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&filter_zv);
-	ZVAL_UNDEF(&filters);
-	ZVAL_UNDEF(&_0);
-	ZVAL_UNDEF(&_1$$5);
-	ZVAL_UNDEF(&_2$$6);
-	static zend_string *_zephir_prop_0 = NULL;
-	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("filters", 7, 1);
-	}
-
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STR(filter)
 	ZEND_PARSE_PARAMETERS_END();
-	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
-	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
-	zephir_memory_observe(&filter_zv);
-	ZVAL_STR_COPY(&filter_zv, filter);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 20, PH_NOISY_CC | PH_READONLY);
-	ZEPHIR_CPY_WRT(&filters, &_0);
-	if (Z_TYPE_P(&filters) == IS_ARRAY) {
-		zephir_update_property_array_append(this_ptr, SL("filters"), &filter_zv);
-	} else {
-		if (Z_TYPE_P(&filters) == IS_STRING) {
-			ZEPHIR_INIT_VAR(&_1$$5);
-			zephir_create_array(&_1$$5, 2, 0);
-			zephir_array_fast_append(&_1$$5, &filters);
-			zephir_array_fast_append(&_1$$5, &filter_zv);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 20, &_1$$5);
-		} else {
-			ZEPHIR_INIT_VAR(&_2$$6);
-			zephir_create_array(&_2$$6, 1, 0);
-			zephir_array_fast_append(&_2$$6, &filter_zv);
-			zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 20, &_2$$6);
-		}
-	}
-	RETURN_THIS();
+	ZVAL_STR(&filter_zv, filter);
+	zephir_update_property_array_append(this_ptr, SL("filters"), &filter_zv);
+	RETURN_THISW();
 }
 
 /**
@@ -279,9 +248,9 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, addValidators)
 	if (UNEXPECTED(!merge)) {
 		ZEPHIR_INIT_VAR(&_0$$3);
 		array_init(&_0$$3);
-		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 21, &_0$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 20, &_0$$3);
 	}
-	zephir_is_iterable(&validators, 0, "phalcon/Forms/Element/AbstractElement.zep", 164);
+	zephir_is_iterable(&validators, 0, "phalcon/Forms/Element/AbstractElement.zep", 152);
 	if (Z_TYPE_P(&validators) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(&validators), _1)
 		{
@@ -373,7 +342,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, clear)
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 22, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 21, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&form, &_0);
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 17, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&name, &_0);
@@ -559,7 +528,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, getUserOption)
 		defaultValue = &__$null;
 	}
 	zephir_memory_observe(&value);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 23, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 22, PH_NOISY_CC | PH_READONLY);
 	if (!(zephir_array_isset_fetch(&value, &_0, &option_zv, 0))) {
 		RETVAL_ZVAL(defaultValue, 1, 0);
 		RETURN_MM();
@@ -617,7 +586,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, getValue)
 
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 17, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&name, &_0);
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 22, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 21, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&form, &_0);
 	ZEPHIR_INIT_VAR(&value);
 	ZVAL_NULL(&value);
@@ -627,7 +596,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, getValue)
 		RETURN_MM();
 	}
 	if (Z_TYPE_P(&value) == IS_NULL) {
-		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_2, 24, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$4, this_ptr, _zephir_prop_2, 23, PH_NOISY_CC | PH_READONLY);
 		ZEPHIR_CPY_WRT(&value, &_1$$4);
 	}
 	RETURN_CCTOR(&value);
@@ -708,7 +677,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, label)
 		zephir_array_update_string(&attributes, SL("for"), &name, PH_COPY | PH_SEPARATE);
 	}
 	zephir_memory_observe(&labelName);
-	zephir_read_property_cached(&labelName, this_ptr, _zephir_prop_2, 25, PH_NOISY_CC);
+	zephir_read_property_cached(&labelName, this_ptr, _zephir_prop_2, 24, PH_NOISY_CC);
 	_1 = zephir_is_true(&labelName);
 	if (!(_1)) {
 		_1 = zephir_is_numeric(&labelName);
@@ -774,7 +743,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, render)
 	ZEPHIR_CPY_WRT(&name, &_0);
 	ZEPHIR_CALL_METHOD(&value, this_ptr, "getvalue", NULL, 0);
 	zephir_check_call_status();
-	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 26, PH_NOISY_CC | PH_READONLY);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_1, 25, PH_NOISY_CC | PH_READONLY);
 	ZEPHIR_CPY_WRT(&method, &_0);
 	ZEPHIR_CALL_METHOD(&tagFactory, this_ptr, "getlocaltagfactory", NULL, 0);
 	zephir_check_call_status();
@@ -782,7 +751,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, render)
 	zephir_check_call_status();
 	if (zephir_array_isset_value_string(&attributes, SL("value"))) {
 		ZEPHIR_OBS_NVAR(&value);
-		zephir_array_fetch_string(&value, &attributes, SL("value"), PH_NOISY, "phalcon/Forms/Element/AbstractElement.zep", 392);
+		zephir_array_fetch_string(&value, &attributes, SL("value"), PH_NOISY, "phalcon/Forms/Element/AbstractElement.zep", 380);
 		zephir_array_unset_string(&attributes, SL("value"), PH_SEPARATE);
 	}
 	if (Z_TYPE_P(&value) != IS_NULL) {
@@ -865,7 +834,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setDefault)
 		Z_PARAM_ZVAL(value)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &value);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 24, value);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 23, value);
 	RETURN_THISW();
 }
 
@@ -906,7 +875,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setFilters)
 		object_init_ex(&_1$$3, phalcon_forms_exceptions_invalidfiltertype_ce);
 		ZEPHIR_CALL_METHOD(NULL, &_1$$3, "__construct", NULL, 15);
 		zephir_check_call_status();
-		zephir_throw_exception_debug(&_1$$3, "phalcon/Forms/Element/AbstractElement.zep", 445);
+		zephir_throw_exception_debug(&_1$$3, "phalcon/Forms/Element/AbstractElement.zep", 433);
 		ZEPHIR_MM_RESTORE();
 		return;
 	}
@@ -916,7 +885,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setFilters)
 		zephir_array_fast_append(&_2$$4, filters);
 		ZEPHIR_CPY_WRT(filters, &_2$$4);
 	}
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 20, filters);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 26, filters);
 	RETURN_THIS();
 }
 
@@ -938,7 +907,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setForm)
 		Z_PARAM_OBJECT_OF_CLASS(form, phalcon_forms_form_ce)
 	ZEND_PARSE_PARAMETERS_END();
 	zephir_fetch_params_without_memory_grow(1, 0, &form);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 22, form);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 21, form);
 	RETURN_THISW();
 }
 
@@ -961,7 +930,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setLabel)
 		Z_PARAM_STR(label)
 	ZEND_PARSE_PARAMETERS_END();
 	ZVAL_STR(&label_zv, label);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 25, &label_zv);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 24, &label_zv);
 	RETURN_THISW();
 }
 
@@ -1076,7 +1045,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, setUserOptions)
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &options_param);
 	zephir_get_arrval(&options, options_param);
-	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 23, &options);
+	zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 22, &options);
 	RETURN_THIS();
 }
 
@@ -1115,9 +1084,9 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, getLocalTagFactory)
 	ZVAL_NULL(&tagFactory);
 	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 27, PH_NOISY_CC | PH_READONLY);
 	if (UNEXPECTED(ZEPHIR_IS_EMPTY(&_0))) {
-		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 22, PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_cached(&_1$$3, this_ptr, _zephir_prop_1, 21, PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_1$$3) != IS_NULL) {
-			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 22, PH_NOISY_CC | PH_READONLY);
+			zephir_read_property_cached(&_2$$4, this_ptr, _zephir_prop_1, 21, PH_NOISY_CC | PH_READONLY);
 			ZEPHIR_CALL_METHOD(&tagFactory, &_2$$4, "gettagfactory", NULL, 0);
 			zephir_check_call_status();
 		}
@@ -1142,7 +1111,7 @@ PHP_METHOD(Phalcon_Forms_Element_AbstractElement, getLocalTagFactory)
 		if (UNEXPECTED(Z_TYPE_P(&tagFactory) == IS_NULL)) {
 			ZEPHIR_CALL_CE_STATIC(&_7$$7, phalcon_forms_exception_ce, "tagfactorynotfound", NULL, 0);
 			zephir_check_call_status();
-			zephir_throw_exception_debug(&_7$$7, "phalcon/Forms/Element/AbstractElement.zep", 556);
+			zephir_throw_exception_debug(&_7$$7, "phalcon/Forms/Element/AbstractElement.zep", 544);
 			ZEPHIR_MM_RESTORE();
 			return;
 		}

--- a/ext/phalcon/forms/element/checkgroup.zep.c
+++ b/ext/phalcon/forms/element/checkgroup.zep.c
@@ -47,7 +47,7 @@ ZEPHIR_INIT_CLASS(Phalcon_Forms_Element_CheckGroup)
 	/**
 	 * @var array
 	 */
-	zend_declare_property_null(phalcon_forms_element_checkgroup_ce, SL("options"), ZEND_ACC_PROTECTED);
+	zend_declare_property_null(phalcon_forms_element_checkgroup_ce, SL("optionsValues"), ZEND_ACC_PROTECTED);
 	phalcon_forms_element_checkgroup_ce->create_object = zephir_init_properties_Phalcon_Forms_Element_CheckGroup;
 
 	return SUCCESS;
@@ -75,7 +75,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, __construct)
 	ZVAL_UNDEF(&attributes);
 	static zend_string *_zephir_prop_0 = NULL;
 	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("options", 7, 1);
+		_zephir_prop_0 = zend_string_init("optionsValues", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(1, 3)
@@ -119,7 +119,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, __construct)
 PHP_METHOD(Phalcon_Forms_Element_CheckGroup, getOptions)
 {
 
-	RETURN_MEMBER_TYPED(getThis(), "options", IS_ARRAY);
+	RETURN_MEMBER_TYPED(getThis(), "optionsValues", IS_ARRAY);
 }
 
 /**
@@ -159,7 +159,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, render)
 		_zephir_prop_1 = zend_string_init("name", 4, 1);
 	}
 	if (UNEXPECTED(!_zephir_prop_2)) {
-		_zephir_prop_2 = zend_string_init("options", 7, 1);
+		_zephir_prop_2 = zend_string_init("optionsValues", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -211,7 +211,7 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, setOptions)
 	ZVAL_UNDEF(&options);
 	static zend_string *_zephir_prop_0 = NULL;
 	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("options", 7, 1);
+		_zephir_prop_0 = zend_string_init("optionsValues", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -227,16 +227,18 @@ PHP_METHOD(Phalcon_Forms_Element_CheckGroup, setOptions)
 
 zend_object *zephir_init_properties_Phalcon_Forms_Element_CheckGroup(zend_class_entry *class_type)
 {
-		zval _0, _2, _4, _6, _1$$3, _3$$4, _5$$5, _7$$6;
+		zval _0, _2, _4, _6, _8, _1$$3, _3$$4, _5$$5, _7$$6, _9$$7;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 		ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_2);
 	ZVAL_UNDEF(&_4);
 	ZVAL_UNDEF(&_6);
+	ZVAL_UNDEF(&_8);
 	ZVAL_UNDEF(&_1$$3);
 	ZVAL_UNDEF(&_3$$4);
 	ZVAL_UNDEF(&_5$$5);
 	ZVAL_UNDEF(&_7$$6);
+	ZVAL_UNDEF(&_9$$7);
 	
 
 		ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
@@ -251,23 +253,29 @@ zend_object *zephir_init_properties_Phalcon_Forms_Element_CheckGroup(zend_class_
 			array_init(&_1$$3);
 			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("validators"), &_1$$3);
 		}
-		zephir_read_property_ex(&_2, this_ptr, ZEND_STRL("filters"), PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_ex(&_2, this_ptr, ZEND_STRL("options"), PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_2) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_3$$4);
 			array_init(&_3$$4);
-			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("filters"), &_3$$4);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("options"), &_3$$4);
 		}
-		zephir_read_property_ex(&_4, this_ptr, ZEND_STRL("attributes"), PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_ex(&_4, this_ptr, ZEND_STRL("filters"), PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_4) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_5$$5);
 			array_init(&_5$$5);
-			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("attributes"), &_5$$5);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("filters"), &_5$$5);
 		}
-		zephir_read_property_ex(&_6, this_ptr, ZEND_STRL("options"), PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_ex(&_6, this_ptr, ZEND_STRL("attributes"), PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_6) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_7$$6);
 			array_init(&_7$$6);
-			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("options"), &_7$$6);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("attributes"), &_7$$6);
+		}
+		zephir_read_property_ex(&_8, this_ptr, ZEND_STRL("optionsValues"), PH_NOISY_CC | PH_READONLY);
+		if (Z_TYPE_P(&_8) == IS_NULL) {
+			ZEPHIR_INIT_VAR(&_9$$7);
+			array_init(&_9$$7);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("optionsValues"), &_9$$7);
 		}
 		ZEPHIR_MM_RESTORE();
 		return Z_OBJ_P(this_ptr);

--- a/ext/phalcon/forms/element/radiogroup.zep.c
+++ b/ext/phalcon/forms/element/radiogroup.zep.c
@@ -42,7 +42,7 @@ ZEPHIR_INIT_CLASS(Phalcon_Forms_Element_RadioGroup)
 	/**
 	 * @var array
 	 */
-	zend_declare_property_null(phalcon_forms_element_radiogroup_ce, SL("options"), ZEND_ACC_PROTECTED);
+	zend_declare_property_null(phalcon_forms_element_radiogroup_ce, SL("optionsValues"), ZEND_ACC_PROTECTED);
 	phalcon_forms_element_radiogroup_ce->create_object = zephir_init_properties_Phalcon_Forms_Element_RadioGroup;
 
 	return SUCCESS;
@@ -69,7 +69,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, __construct)
 	ZVAL_UNDEF(&attributes);
 	static zend_string *_zephir_prop_0 = NULL;
 	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("options", 7, 1);
+		_zephir_prop_0 = zend_string_init("optionsValues", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(1, 3)
@@ -114,7 +114,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, __construct)
 PHP_METHOD(Phalcon_Forms_Element_RadioGroup, getOptions)
 {
 
-	RETURN_MEMBER_TYPED(getThis(), "options", IS_ARRAY);
+	RETURN_MEMBER_TYPED(getThis(), "optionsValues", IS_ARRAY);
 }
 
 /**
@@ -154,7 +154,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, render)
 		_zephir_prop_1 = zend_string_init("name", 4, 1);
 	}
 	if (UNEXPECTED(!_zephir_prop_2)) {
-		_zephir_prop_2 = zend_string_init("options", 7, 1);
+		_zephir_prop_2 = zend_string_init("optionsValues", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(0, 1)
@@ -206,7 +206,7 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, setOptions)
 	ZVAL_UNDEF(&options);
 	static zend_string *_zephir_prop_0 = NULL;
 	if (UNEXPECTED(!_zephir_prop_0)) {
-		_zephir_prop_0 = zend_string_init("options", 7, 1);
+		_zephir_prop_0 = zend_string_init("optionsValues", 13, 1);
 	}
 
 	ZEND_PARSE_PARAMETERS_START(1, 1)
@@ -222,16 +222,18 @@ PHP_METHOD(Phalcon_Forms_Element_RadioGroup, setOptions)
 
 zend_object *zephir_init_properties_Phalcon_Forms_Element_RadioGroup(zend_class_entry *class_type)
 {
-		zval _0, _2, _4, _6, _1$$3, _3$$4, _5$$5, _7$$6;
+		zval _0, _2, _4, _6, _8, _1$$3, _3$$4, _5$$5, _7$$6, _9$$7;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 		ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_2);
 	ZVAL_UNDEF(&_4);
 	ZVAL_UNDEF(&_6);
+	ZVAL_UNDEF(&_8);
 	ZVAL_UNDEF(&_1$$3);
 	ZVAL_UNDEF(&_3$$4);
 	ZVAL_UNDEF(&_5$$5);
 	ZVAL_UNDEF(&_7$$6);
+	ZVAL_UNDEF(&_9$$7);
 	
 
 		ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
@@ -246,23 +248,29 @@ zend_object *zephir_init_properties_Phalcon_Forms_Element_RadioGroup(zend_class_
 			array_init(&_1$$3);
 			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("validators"), &_1$$3);
 		}
-		zephir_read_property_ex(&_2, this_ptr, ZEND_STRL("filters"), PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_ex(&_2, this_ptr, ZEND_STRL("options"), PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_2) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_3$$4);
 			array_init(&_3$$4);
-			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("filters"), &_3$$4);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("options"), &_3$$4);
 		}
-		zephir_read_property_ex(&_4, this_ptr, ZEND_STRL("attributes"), PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_ex(&_4, this_ptr, ZEND_STRL("filters"), PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_4) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_5$$5);
 			array_init(&_5$$5);
-			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("attributes"), &_5$$5);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("filters"), &_5$$5);
 		}
-		zephir_read_property_ex(&_6, this_ptr, ZEND_STRL("options"), PH_NOISY_CC | PH_READONLY);
+		zephir_read_property_ex(&_6, this_ptr, ZEND_STRL("attributes"), PH_NOISY_CC | PH_READONLY);
 		if (Z_TYPE_P(&_6) == IS_NULL) {
 			ZEPHIR_INIT_VAR(&_7$$6);
 			array_init(&_7$$6);
-			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("options"), &_7$$6);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("attributes"), &_7$$6);
+		}
+		zephir_read_property_ex(&_8, this_ptr, ZEND_STRL("optionsValues"), PH_NOISY_CC | PH_READONLY);
+		if (Z_TYPE_P(&_8) == IS_NULL) {
+			ZEPHIR_INIT_VAR(&_9$$7);
+			array_init(&_9$$7);
+			zephir_update_property_zval_ex(this_ptr, ZEND_STRL("optionsValues"), &_9$$7);
 		}
 		ZEPHIR_MM_RESTORE();
 		return Z_OBJ_P(this_ptr);

--- a/ext/phalcon/forms/element/select.zep.c
+++ b/ext/phalcon/forms/element/select.zep.c
@@ -106,66 +106,84 @@ PHP_METHOD(Phalcon_Forms_Element_Select, __construct)
  */
 PHP_METHOD(Phalcon_Forms_Element_Select, addOption)
 {
-	zend_bool _4$$3;
-	zend_string *_2$$3;
-	zend_ulong _1$$3;
+	zend_bool _7$$5;
+	zend_string *_5$$5;
+	zend_ulong _4$$5;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *option, option_sub, key, value, *_0$$3, _3$$3;
+	zval *option, option_sub, key, value, _0, _2, _1$$3, *_3$$5, _6$$5;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&option_sub);
 	ZVAL_UNDEF(&key);
 	ZVAL_UNDEF(&value);
-	ZVAL_UNDEF(&_3$$3);
+	ZVAL_UNDEF(&_0);
+	ZVAL_UNDEF(&_2);
+	ZVAL_UNDEF(&_1$$3);
+	ZVAL_UNDEF(&_6$$5);
+	static zend_string *_zephir_prop_0 = NULL;
+	if (UNEXPECTED(!_zephir_prop_0)) {
+		_zephir_prop_0 = zend_string_init("optionsValues", 13, 1);
+	}
+
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_ZVAL(option)
 	ZEND_PARSE_PARAMETERS_END();
 	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
 	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
 	zephir_fetch_params(1, 1, 0, &option);
-	if (Z_TYPE_P(option) == IS_ARRAY) {
-		zephir_is_iterable(option, 0, "phalcon/Forms/Element/Select.zep", 52);
+	zephir_read_property_cached(&_0, this_ptr, _zephir_prop_0, 782, PH_NOISY_CC | PH_READONLY);
+	if (Z_TYPE_P(&_0) == IS_NULL) {
+		ZEPHIR_INIT_VAR(&_1$$3);
+		array_init(&_1$$3);
+		zephir_update_property_zval_cached(this_ptr, _zephir_prop_0, 782, &_1$$3);
+	}
+	zephir_memory_observe(&_2);
+	zephir_read_property_cached(&_2, this_ptr, _zephir_prop_0, 782, PH_NOISY_CC);
+	if (Z_TYPE_P(&_2) == IS_ARRAY) {
 		if (Z_TYPE_P(option) == IS_ARRAY) {
-			ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(option), _1$$3, _2$$3, _0$$3)
-			{
-				ZEPHIR_INIT_NVAR(&key);
-				if (_2$$3 != NULL) { 
-					ZVAL_STR_COPY(&key, _2$$3);
-				} else {
-					ZVAL_LONG(&key, _1$$3);
-				}
-				ZEPHIR_INIT_NVAR(&value);
-				ZVAL_COPY(&value, _0$$3);
-				zephir_update_property_array(this_ptr, SL("optionsValues"), &key, &value);
-			} ZEND_HASH_FOREACH_END();
-		} else {
-			ZEPHIR_CALL_METHOD(NULL, option, "rewind", NULL, 0);
-			zephir_check_call_status();
-			_4$$3 = 1;
-			while (1) {
-				if (_4$$3) {
-					_4$$3 = 0;
-				} else {
-					ZEPHIR_CALL_METHOD(NULL, option, "next", NULL, 0);
-					zephir_check_call_status();
-				}
-				ZEPHIR_CALL_METHOD(&_3$$3, option, "valid", NULL, 0);
-				zephir_check_call_status();
-				if (!zend_is_true(&_3$$3)) {
-					break;
-				}
-				ZEPHIR_CALL_METHOD(&key, option, "key", NULL, 0);
-				zephir_check_call_status();
-				ZEPHIR_CALL_METHOD(&value, option, "current", NULL, 0);
-				zephir_check_call_status();
+			zephir_is_iterable(option, 0, "phalcon/Forms/Element/Select.zep", 57);
+			if (Z_TYPE_P(option) == IS_ARRAY) {
+				ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(option), _4$$5, _5$$5, _3$$5)
+				{
+					ZEPHIR_INIT_NVAR(&key);
+					if (_5$$5 != NULL) { 
+						ZVAL_STR_COPY(&key, _5$$5);
+					} else {
+						ZVAL_LONG(&key, _4$$5);
+					}
+					ZEPHIR_INIT_NVAR(&value);
+					ZVAL_COPY(&value, _3$$5);
 					zephir_update_property_array(this_ptr, SL("optionsValues"), &key, &value);
+				} ZEND_HASH_FOREACH_END();
+			} else {
+				ZEPHIR_CALL_METHOD(NULL, option, "rewind", NULL, 0);
+				zephir_check_call_status();
+				_7$$5 = 1;
+				while (1) {
+					if (_7$$5) {
+						_7$$5 = 0;
+					} else {
+						ZEPHIR_CALL_METHOD(NULL, option, "next", NULL, 0);
+						zephir_check_call_status();
+					}
+					ZEPHIR_CALL_METHOD(&_6$$5, option, "valid", NULL, 0);
+					zephir_check_call_status();
+					if (!zend_is_true(&_6$$5)) {
+						break;
+					}
+					ZEPHIR_CALL_METHOD(&key, option, "key", NULL, 0);
+					zephir_check_call_status();
+					ZEPHIR_CALL_METHOD(&value, option, "current", NULL, 0);
+					zephir_check_call_status();
+						zephir_update_property_array(this_ptr, SL("optionsValues"), &key, &value);
+				}
 			}
+			ZEPHIR_INIT_NVAR(&value);
+			ZEPHIR_INIT_NVAR(&key);
+		} else {
+			zephir_update_property_array_append(this_ptr, SL("optionsValues"), option);
 		}
-		ZEPHIR_INIT_NVAR(&value);
-		ZEPHIR_INIT_NVAR(&key);
-	} else {
-		zephir_update_property_array_append(this_ptr, SL("optionsValues"), option);
 	}
 	RETURN_THIS();
 }

--- a/phalcon/Forms/Element/AbstractElement.zep
+++ b/phalcon/Forms/Element/AbstractElement.zep
@@ -114,19 +114,7 @@ abstract class AbstractElement implements ElementInterface
      */
     public function addFilter(string filter) -> <ElementInterface>
     {
-        var filters;
-
-        let filters = this->filters;
-
-        if typeof filters == "array" {
-            let this->filters[] = filter;
-        } else {
-            if typeof filters == "string" {
-                let this->filters = [filters, filter];
-            } else {
-                let this->filters = [filter];
-            }
-        }
+        let this->filters[] = filter;
 
         return this;
     }

--- a/phalcon/Forms/Element/CheckGroup.zep
+++ b/phalcon/Forms/Element/CheckGroup.zep
@@ -28,7 +28,7 @@ class CheckGroup extends AbstractElement
     /**
      * @var array
      */
-    protected options = [];
+    protected optionsValues = [];
 
     /**
      * Constructor
@@ -46,7 +46,7 @@ class CheckGroup extends AbstractElement
             let name = name . "[]";
         }
 
-        let this->options = options;
+        let this->optionsValues = options;
 
         parent::__construct(name, attributes);
     }
@@ -58,7 +58,7 @@ class CheckGroup extends AbstractElement
      */
     public function getOptions() -> array
     {
-        return this->options;
+        return this->optionsValues;
     }
 
     /**
@@ -76,7 +76,7 @@ class CheckGroup extends AbstractElement
             merged = array_merge(this->attributes, attributes),
             helper = this->getLocalTagFactory()->newInstance("inputCheckboxGroup");
 
-        return (string) helper->__invoke(this->name, this->options, value, merged);
+        return (string) helper->__invoke(this->name, this->optionsValues, value, merged);
     }
 
     /**
@@ -88,7 +88,7 @@ class CheckGroup extends AbstractElement
      */
     public function setOptions(array options) -> <ElementInterface>
     {
-        let this->options = options;
+        let this->optionsValues = options;
 
         return this;
     }

--- a/phalcon/Forms/Element/RadioGroup.zep
+++ b/phalcon/Forms/Element/RadioGroup.zep
@@ -25,7 +25,7 @@ class RadioGroup extends AbstractElement
     /**
      * @var array
      */
-    protected options = [];
+    protected optionsValues = [];
 
     /**
      * Constructor
@@ -39,7 +39,7 @@ class RadioGroup extends AbstractElement
         array options = [],
         array attributes = []
     ) {
-        let this->options = options;
+        let this->optionsValues = options;
 
         parent::__construct(name, attributes);
     }
@@ -51,7 +51,7 @@ class RadioGroup extends AbstractElement
      */
     public function getOptions() -> array
     {
-        return this->options;
+        return this->optionsValues;
     }
 
     /**
@@ -69,7 +69,7 @@ class RadioGroup extends AbstractElement
             merged = array_merge(this->attributes, attributes),
             helper = this->getLocalTagFactory()->newInstance("inputRadioGroup");
 
-        return (string) helper->__invoke(this->name, this->options, value, merged);
+        return (string) helper->__invoke(this->name, this->optionsValues, value, merged);
     }
 
     /**
@@ -81,7 +81,7 @@ class RadioGroup extends AbstractElement
      */
     public function setOptions(array options) -> <ElementInterface>
     {
-        let this->options = options;
+        let this->optionsValues = options;
 
         return this;
     }

--- a/phalcon/Forms/Element/Select.zep
+++ b/phalcon/Forms/Element/Select.zep
@@ -45,12 +45,18 @@ class Select extends AbstractElement
     {
         var key, value;
 
-        if typeof option == "array" {
-            for key, value in option {
-                let this->optionsValues[key] = value;
+        if this->optionsValues === null {
+            let this->optionsValues = [];
+        }
+
+        if typeof this->optionsValues == "array" {
+            if typeof option == "array" {
+                for key, value in option {
+                    let this->optionsValues[key] = value;
+                }
+            } else {
+                let this->optionsValues[] = option;
             }
-        } else {
-            let this->optionsValues[] = option;
         }
 
         return this;

--- a/tests/unit/Forms/Element/Group/CheckGroupTest.php
+++ b/tests/unit/Forms/Element/Group/CheckGroupTest.php
@@ -125,6 +125,16 @@ final class CheckGroupTest extends AbstractUnitTestCase
         $this->assertSame($element, $result);
     }
 
+    public function testSetUserOptionDoesNotChangeOptions(): void
+    {
+        $element = new CheckGroup('colors', ['red' => 'Red']);
+        $element->setUserOption('foo', 'bar');
+        $element->setOptions(['blue' => 'Blue']);
+
+        $this->assertSame(['blue' => 'Blue'], $element->getOptions());
+        $this->assertSame(['foo' => 'bar'], $element->getUserOptions());
+    }
+
     public function testToStringEqualsRender(): void
     {
         $element = new CheckGroup('colors', ['red' => 'Red']);

--- a/tests/unit/Forms/Element/Group/RadioGroupTest.php
+++ b/tests/unit/Forms/Element/Group/RadioGroupTest.php
@@ -118,6 +118,16 @@ final class RadioGroupTest extends AbstractUnitTestCase
         $this->assertSame($element, $result);
     }
 
+    public function testSetUserOptionDoesNotChangeOptions(): void
+    {
+        $element = new RadioGroup('gender', ['m' => 'Male']);
+        $element->setUserOption('foo', 'bar');
+        $element->setOptions(['f' => 'Female']);
+
+        $this->assertSame(['f' => 'Female'], $element->getOptions());
+        $this->assertSame(['foo' => 'bar'], $element->getUserOptions());
+    }
+
     public function testToStringEqualsRender(): void
     {
         $element = new RadioGroup('gender', ['m' => 'Male']);


### PR DESCRIPTION
Hello!

* Type: bug fix 
* Link to issue: #17536 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

---
- `Phalcon\Forms\Element\CheckGroup` and `RadioGroup` storing their choices in the property `Phalcon\Forms\Element\AbstractElement` uses for user options, so `setUserOption()` added a choice and `setOptions()` removed every user option.
- `Phalcon\Forms\Element\Select::addOption()` writing with an offset into an object or `null` options value; the write now happens only when the options value is an array (`null` becomes an empty array). 

Thanks

