### PR TITLE
CP-17542 getimagesize

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -14,6 +14,7 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 
 ### Fixed
 
+- `Phalcon\Filter\Validation\Validator\File\Resolution\Equal`, `Max`, `Min` and `AspectRatio` not checking the `false` returned by `getimagesize()`; a file that is not a readable image is now rejected. [#17542](https://github.com/phalcon/cphalcon/issues/17542) [[doc]](https://docs.phalcon.io/5.20/filter-validation/)
 - `Phalcon\Forms\Element\CheckGroup` and `RadioGroup` storing their choices in the property `Phalcon\Forms\Element\AbstractElement` uses for user options, so `setUserOption()` added a choice and `setOptions()` removed every user option. [#17536](https://github.com/phalcon/cphalcon/issues/17536) [[doc]](https://docs.phalcon.io/5.20/forms/)
 - `Phalcon\Forms\Element\Select::addOption()` writing with an offset into an object or `null` options value; the write now happens only when the options value is an array (`null` becomes an empty array). [#17536](https://github.com/phalcon/cphalcon/issues/17536) [[doc]](https://docs.phalcon.io/5.20/forms/)
 

--- a/ext/phalcon/filter/filter.zep.c
+++ b/ext/phalcon/filter/filter.zep.c
@@ -44,7 +44,7 @@
  * @method string       lowerfirst(string $input)
  * @method mixed        regex(mixed $input, mixed $pattern, mixed $replace)
  * @method mixed        remove(mixed $input, mixed $replace)
- * @method mixed        replace(mixed $input, mixed $source, mixed $target)
+ * @method mixed        replace(mixed $input, mixed $from, mixed $to)
  * @method string       special(string $input)
  * @method string       specialfull(string $input)
  * @method string       string(string $input)

--- a/ext/phalcon/filter/sanitize/ip.zep.c
+++ b/ext/phalcon/filter/sanitize/ip.zep.c
@@ -88,7 +88,7 @@ PHP_METHOD(Phalcon_Filter_Sanitize_Ip, __invoke)
 	zephir_fast_trim(&ipInput, &input_zv, NULL , ZEPHIR_TRIM_BOTH);
 	if (zephir_memnstr_str(&ipInput, SL("/"), "phalcon/Filter/Sanitize/Ip.zep", 34)) {
 		ZEPHIR_INIT_VAR(&parts);
-		zephir_fast_explode_str(&parts, SL("/"), &input_zv, 2 );
+		zephir_fast_explode_str(&parts, SL("/"), &ipInput, 2 );
 		zephir_memory_observe(&ip);
 		zephir_array_fetch_long(&ip, &parts, 0, PH_NOISY, "phalcon/Filter/Sanitize/Ip.zep", 36);
 		zephir_memory_observe(&mask);

--- a/ext/phalcon/filter/validation/validator/file.zep.c
+++ b/ext/phalcon/filter/validation/validator/file.zep.c
@@ -265,7 +265,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File, __construct)
 		allowWildcards = zephir_get_boolval(&_3$$6);
 		zephir_array_unset_string(&options, SL("allowWildcards"), PH_SEPARATE);
 	}
-	zephir_is_iterable(&options, 1, "phalcon/Filter/Validation/Validator/File.zep", 308);
+	zephir_is_iterable(&options, 1, "phalcon/Filter/Validation/Validator/File.zep", 309);
 	if (Z_TYPE_P(&options) == IS_ARRAY) {
 		ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(&options), _6, _7, _5)
 		{
@@ -299,6 +299,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File, __construct)
 				zephir_array_update_string(&_19$$8, SL("included"), &included, PH_COPY | PH_SEPARATE);
 				ZEPHIR_CALL_METHOD(NULL, &validator, "__construct", &_20, 0, &_19$$8);
 				zephir_check_call_status();
+				zephir_array_unset_string(&options, SL("minSize"), PH_SEPARATE);
 				zephir_array_unset_string(&options, SL("messageMinSize"), PH_SEPARATE);
 				zephir_array_unset_string(&options, SL("includedMinSize"), PH_SEPARATE);
 			} else {
@@ -528,6 +529,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File, __construct)
 					zephir_array_update_string(&_54$$21, SL("included"), &included, PH_COPY | PH_SEPARATE);
 					ZEPHIR_CALL_METHOD(NULL, &validator, "__construct", &_38, 0, &_54$$21);
 					zephir_check_call_status();
+					zephir_array_unset_string(&options, SL("minSize"), PH_SEPARATE);
 					zephir_array_unset_string(&options, SL("messageMinSize"), PH_SEPARATE);
 					zephir_array_unset_string(&options, SL("includedMinSize"), PH_SEPARATE);
 				} else {

--- a/ext/phalcon/filter/validation/validator/file/abstractfile.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/abstractfile.zep.c
@@ -668,6 +668,63 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageVali
 }
 
 /**
+ * Appends the "file is not valid" message for the field
+ *
+ * @param Validation $validation
+ * @param string     $field
+ *
+ * @return void
+ * @throws Validation\Exception
+ */
+PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, appendMessageValid)
+{
+	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
+	zend_long ZEPHIR_LAST_CALL_STATUS;
+	zend_string *field = NULL;
+	zval *validation, validation_sub, field_zv, label, replacePairs, _0, _1, _2, _3, _4;
+	zval *this_ptr = getThis();
+
+	ZVAL_UNDEF(&validation_sub);
+	ZVAL_UNDEF(&field_zv);
+	ZVAL_UNDEF(&label);
+	ZVAL_UNDEF(&replacePairs);
+	ZVAL_UNDEF(&_0);
+	ZVAL_UNDEF(&_1);
+	ZVAL_UNDEF(&_2);
+	ZVAL_UNDEF(&_3);
+	ZVAL_UNDEF(&_4);
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
+		Z_PARAM_STR(field)
+	ZEND_PARSE_PARAMETERS_END();
+	ZEPHIR_METHOD_GLOBALS_PTR = pecalloc(1, sizeof(zephir_method_globals), 0);
+	zephir_memory_grow_stack(ZEPHIR_METHOD_GLOBALS_PTR, __func__);
+	validation = ZEND_CALL_ARG(execute_data, 1);
+	zephir_memory_observe(&field_zv);
+	ZVAL_STR_COPY(&field_zv, field);
+	ZEPHIR_CALL_METHOD(&label, this_ptr, "preparelabel", NULL, 0, validation, &field_zv);
+	zephir_check_call_status();
+	ZEPHIR_INIT_VAR(&replacePairs);
+	zephir_create_array(&replacePairs, 1, 0);
+	zephir_array_update_string(&replacePairs, SL(":field"), &label, PH_COPY | PH_SEPARATE);
+	ZEPHIR_INIT_VAR(&_0);
+	object_init_ex(&_0, phalcon_messages_message_ce);
+	ZEPHIR_CALL_METHOD(&_1, this_ptr, "getmessagevalid", NULL, 0);
+	zephir_check_call_status();
+	ZEPHIR_CALL_FUNCTION(&_2, "strtr", NULL, 4, &_1, &replacePairs);
+	zephir_check_call_status();
+	ZEPHIR_INIT_VAR(&_3);
+	zephir_get_class(&_3, this_ptr, 0);
+	ZEPHIR_CALL_METHOD(&_4, this_ptr, "preparecode", NULL, 0, &field_zv);
+	zephir_check_call_status();
+	ZEPHIR_CALL_METHOD(NULL, &_0, "__construct", NULL, 5, &_2, &field_zv, &_3, &_4);
+	zephir_check_call_status();
+	ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_0);
+	zephir_check_call_status();
+	ZEPHIR_MM_RESTORE();
+}
+
+/**
  * Checks if a file has been uploaded; Internal check that can be
  * overridden in a subclass if you do not want to check uploaded files
  *

--- a/ext/phalcon/filter/validation/validator/file/abstractfile.zep.h
+++ b/ext/phalcon/filter/validation/validator/file/abstractfile.zep.h
@@ -15,6 +15,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, isAllowEmpty);
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageFileEmpty);
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageIniSize);
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageValid);
+PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, appendMessageValid);
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkIsUploadedFile);
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_filter_validation_validator_file_abstractfile_checkupload, 0, 2, _IS_BOOL, 0)
@@ -70,6 +71,12 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_filter_validation_valida
 	ZEND_ARG_TYPE_INFO(0, message, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_filter_validation_validator_file_abstractfile_appendmessagevalid, 0, 2, IS_VOID, 0)
+
+	ZEND_ARG_OBJ_INFO(0, validation, Phalcon\\Filter\\Validation, 0)
+	ZEND_ARG_TYPE_INFO(0, field, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_phalcon_filter_validation_validator_file_abstractfile_checkisuploadedfile, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
@@ -87,6 +94,7 @@ ZEPHIR_INIT_FUNCS(phalcon_filter_validation_validator_file_abstractfile_method_e
 	PHP_ME(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageFileEmpty, arginfo_phalcon_filter_validation_validator_file_abstractfile_setmessagefileempty, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageIniSize, arginfo_phalcon_filter_validation_validator_file_abstractfile_setmessageinisize, ZEND_ACC_PUBLIC)
 	PHP_ME(Phalcon_Filter_Validation_Validator_File_AbstractFile, setMessageValid, arginfo_phalcon_filter_validation_validator_file_abstractfile_setmessagevalid, ZEND_ACC_PUBLIC)
+	PHP_ME(Phalcon_Filter_Validation_Validator_File_AbstractFile, appendMessageValid, arginfo_phalcon_filter_validation_validator_file_abstractfile_appendmessagevalid, ZEND_ACC_PROTECTED)
 	PHP_ME(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkIsUploadedFile, arginfo_phalcon_filter_validation_validator_file_abstractfile_checkisuploadedfile, ZEND_ACC_PROTECTED)
 	PHP_FE_END
 };

--- a/ext/phalcon/filter/validation/validator/file/resolution/aspectratio.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/aspectratio.zep.c
@@ -121,7 +121,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_AspectRatio, vali
 {
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS, ratioHeight = 0, ratioWidth = 0;
-	zval *validation, validation_sub, *field, field_sub, height, ratio, ratioArray, replacePairs, tmp, value, width, _0, _1, _2, _4, _5, _3$$4, _6$$5;
+	zval *validation, validation_sub, *field, field_sub, height, ratio, ratioArray, replacePairs, tmp, value, width, _0, _1, _2, _4, _5, _3$$5, _6$$6;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -138,8 +138,8 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_AspectRatio, vali
 	ZVAL_UNDEF(&_2);
 	ZVAL_UNDEF(&_4);
 	ZVAL_UNDEF(&_5);
-	ZVAL_UNDEF(&_3$$4);
-	ZVAL_UNDEF(&_6$$5);
+	ZVAL_UNDEF(&_3$$5);
+	ZVAL_UNDEF(&_6$$6);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -157,33 +157,38 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_AspectRatio, vali
 	zephir_array_fetch_string(&_1, &value, SL("tmp_name"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 91);
 	ZEPHIR_CALL_FUNCTION(&tmp, "getimagesize", NULL, 0, &_1);
 	zephir_check_call_status();
+	if (ZEPHIR_IS_FALSE_IDENTICAL(&tmp)) {
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "appendmessagevalid", NULL, 0, validation, field);
+		zephir_check_call_status();
+		RETURN_MM_BOOL(0);
+	}
 	zephir_memory_observe(&width);
-	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 92);
+	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 100);
 	zephir_memory_observe(&height);
-	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 93);
+	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 101);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "ratio");
 	ZEPHIR_CALL_METHOD(&ratio, this_ptr, "getoption", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&ratio) == IS_ARRAY) {
-		zephir_array_fetch(&_3$$4, &ratio, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 98);
-		ZEPHIR_CPY_WRT(&ratio, &_3$$4);
+		zephir_array_fetch(&_3$$5, &ratio, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 106);
+		ZEPHIR_CPY_WRT(&ratio, &_3$$5);
 	}
 	ZEPHIR_INIT_VAR(&ratioArray);
 	zephir_fast_explode_str(&ratioArray, SL("x"), &ratio, LONG_MAX);
 	zephir_memory_observe(&_4);
-	zephir_array_fetch_long(&_4, &ratioArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 102);
+	zephir_array_fetch_long(&_4, &ratioArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 110);
 	ratioWidth = zephir_get_intval(&_4);
 	zephir_memory_observe(&_5);
-	zephir_array_fetch_long(&_5, &ratioArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 103);
+	zephir_array_fetch_long(&_5, &ratioArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep", 111);
 	ratioHeight = zephir_get_intval(&_5);
 	if ((zephir_get_numberval(&width) * ratioHeight) != (zephir_get_numberval(&height) * ratioWidth)) {
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":ratio"), &ratio, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_6$$5, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_6$$6, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_6$$5);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_6$$6);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/ext/phalcon/filter/validation/validator/file/resolution/equal.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/equal.zep.c
@@ -118,7 +118,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 	zend_bool _5;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, height, equalHeight, equalWidth, resolution, resolutionArray, tmp, value, width, replacePairs, _0, _1, _2, _3$$4, _4$$5, _6$$6;
+	zval *validation, validation_sub, *field, field_sub, height, equalHeight, equalWidth, resolution, resolutionArray, tmp, value, width, replacePairs, _0, _1, _2, _3$$5, _4$$6, _6$$7;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -135,9 +135,9 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_1);
 	ZVAL_UNDEF(&_2);
-	ZVAL_UNDEF(&_3$$4);
-	ZVAL_UNDEF(&_4$$5);
-	ZVAL_UNDEF(&_6$$6);
+	ZVAL_UNDEF(&_3$$5);
+	ZVAL_UNDEF(&_4$$6);
+	ZVAL_UNDEF(&_6$$7);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -155,27 +155,32 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 	zephir_array_fetch_string(&_1, &value, SL("tmp_name"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 88);
 	ZEPHIR_CALL_FUNCTION(&tmp, "getimagesize", NULL, 0, &_1);
 	zephir_check_call_status();
+	if (ZEPHIR_IS_FALSE_IDENTICAL(&tmp)) {
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "appendmessagevalid", NULL, 0, validation, field);
+		zephir_check_call_status();
+		RETURN_MM_BOOL(0);
+	}
 	zephir_memory_observe(&width);
-	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 89);
+	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 97);
 	zephir_memory_observe(&height);
-	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 90);
+	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 98);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "resolution");
 	ZEPHIR_CALL_METHOD(&resolution, this_ptr, "getoption", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_3$$4, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 95);
-		ZEPHIR_CPY_WRT(&resolution, &_3$$4);
+		zephir_array_fetch(&_3$$5, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 103);
+		ZEPHIR_CPY_WRT(&resolution, &_3$$5);
 	}
 	ZEPHIR_INIT_VAR(&resolutionArray);
 	zephir_fast_explode_str(&resolutionArray, SL("x"), &resolution, LONG_MAX);
 	zephir_memory_observe(&equalWidth);
-	zephir_array_fetch_long(&equalWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 99);
+	zephir_array_fetch_long(&equalWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 107);
 	zephir_memory_observe(&equalHeight);
-	zephir_array_fetch_long(&equalHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 100);
+	zephir_array_fetch_long(&equalHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 108);
 	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_4$$5, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 103);
-		ZEPHIR_CPY_WRT(&resolution, &_4$$5);
+		zephir_array_fetch(&_4$$6, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 111);
+		ZEPHIR_CPY_WRT(&resolution, &_4$$6);
 	}
 	_5 = !ZEPHIR_IS_EQUAL(&width, &equalWidth);
 	if (!(_5)) {
@@ -185,9 +190,9 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":resolution"), &resolution, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_6$$6, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_6$$7, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_6$$6);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_6$$7);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/ext/phalcon/filter/validation/validator/file/resolution/max.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/max.zep.c
@@ -121,11 +121,11 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, __construct)
  */
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, validate)
 {
-	double _5$$5, _6$$6;
-	zend_bool result = 0, _7$$7, _8$$8;
+	double _5$$6, _6$$7;
+	zend_bool result = 0, _7$$8, _8$$9;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, height, maxHeight, maxWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$4, _4$$5, _9$$9, _10$$10;
+	zval *validation, validation_sub, *field, field_sub, height, maxHeight, maxWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$5, _4$$6, _9$$10, _10$$11;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -143,10 +143,10 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, validate)
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_1);
 	ZVAL_UNDEF(&_2);
-	ZVAL_UNDEF(&_3$$4);
-	ZVAL_UNDEF(&_4$$5);
-	ZVAL_UNDEF(&_9$$9);
-	ZVAL_UNDEF(&_10$$10);
+	ZVAL_UNDEF(&_3$$5);
+	ZVAL_UNDEF(&_4$$6);
+	ZVAL_UNDEF(&_9$$10);
+	ZVAL_UNDEF(&_10$$11);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -166,63 +166,68 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, validate)
 	zephir_array_fetch_string(&_1, &value, SL("tmp_name"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 94);
 	ZEPHIR_CALL_FUNCTION(&tmp, "getimagesize", NULL, 0, &_1);
 	zephir_check_call_status();
+	if (ZEPHIR_IS_FALSE_IDENTICAL(&tmp)) {
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "appendmessagevalid", NULL, 0, validation, field);
+		zephir_check_call_status();
+		RETURN_MM_BOOL(0);
+	}
 	zephir_memory_observe(&width);
-	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 95);
+	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 103);
 	zephir_memory_observe(&height);
-	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 96);
+	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 104);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "resolution");
 	ZEPHIR_CALL_METHOD(&resolution, this_ptr, "getoption", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_3$$4, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 101);
-		ZEPHIR_CPY_WRT(&resolution, &_3$$4);
+		zephir_array_fetch(&_3$$5, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 109);
+		ZEPHIR_CPY_WRT(&resolution, &_3$$5);
 	}
 	ZEPHIR_INIT_VAR(&resolutionArray);
 	zephir_fast_explode_str(&resolutionArray, SL("x"), &resolution, LONG_MAX);
 	zephir_memory_observe(&maxWidth);
-	zephir_array_fetch_long(&maxWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 105);
+	zephir_array_fetch_long(&maxWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 113);
 	zephir_memory_observe(&maxHeight);
-	zephir_array_fetch_long(&maxHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 106);
+	zephir_array_fetch_long(&maxHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 114);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "included");
 	ZEPHIR_CALL_METHOD(&included, this_ptr, "getoption", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&included) == IS_ARRAY) {
-		zephir_memory_observe(&_4$$5);
-		zephir_array_fetch(&_4$$5, &included, field, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 111);
-		_5$$5 = zephir_get_boolval(&_4$$5);
+		zephir_memory_observe(&_4$$6);
+		zephir_array_fetch(&_4$$6, &included, field, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 119);
+		_5$$6 = zephir_get_boolval(&_4$$6);
 		ZEPHIR_INIT_NVAR(&included);
-		ZVAL_BOOL(&included, _5$$5);
+		ZVAL_BOOL(&included, _5$$6);
 	} else {
-		_6$$6 = zephir_get_boolval(&included);
+		_6$$7 = zephir_get_boolval(&included);
 		ZEPHIR_INIT_NVAR(&included);
-		ZVAL_BOOL(&included, _6$$6);
+		ZVAL_BOOL(&included, _6$$7);
 	}
 	if (zephir_is_true(&included)) {
-		_7$$7 = ZEPHIR_GE(&width, &maxWidth);
-		if (!(_7$$7)) {
-			_7$$7 = ZEPHIR_GE(&height, &maxHeight);
+		_7$$8 = ZEPHIR_GE(&width, &maxWidth);
+		if (!(_7$$8)) {
+			_7$$8 = ZEPHIR_GE(&height, &maxHeight);
 		}
-		result = _7$$7;
+		result = _7$$8;
 	} else {
-		_8$$8 = ZEPHIR_GT(&width, &maxWidth);
-		if (!(_8$$8)) {
-			_8$$8 = ZEPHIR_GT(&height, &maxHeight);
+		_8$$9 = ZEPHIR_GT(&width, &maxWidth);
+		if (!(_8$$9)) {
+			_8$$9 = ZEPHIR_GT(&height, &maxHeight);
 		}
-		result = _8$$8;
+		result = _8$$9;
 	}
 	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_9$$9, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 123);
-		ZEPHIR_CPY_WRT(&resolution, &_9$$9);
+		zephir_array_fetch(&_9$$10, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 131);
+		ZEPHIR_CPY_WRT(&resolution, &_9$$10);
 	}
 	if (result) {
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":resolution"), &resolution, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_10$$10, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_10$$11, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_10$$10);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_10$$11);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/ext/phalcon/filter/validation/validator/file/resolution/min.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/min.zep.c
@@ -121,11 +121,11 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, __construct)
  */
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, validate)
 {
-	double _5$$5, _6$$6;
-	zend_bool result = 0, _7$$7, _8$$8;
+	double _5$$6, _6$$7;
+	zend_bool result = 0, _7$$8, _8$$9;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, height, minHeight, minWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$4, _4$$5, _9$$9, _10$$10;
+	zval *validation, validation_sub, *field, field_sub, height, minHeight, minWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$5, _4$$6, _9$$10, _10$$11;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -143,10 +143,10 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, validate)
 	ZVAL_UNDEF(&_0);
 	ZVAL_UNDEF(&_1);
 	ZVAL_UNDEF(&_2);
-	ZVAL_UNDEF(&_3$$4);
-	ZVAL_UNDEF(&_4$$5);
-	ZVAL_UNDEF(&_9$$9);
-	ZVAL_UNDEF(&_10$$10);
+	ZVAL_UNDEF(&_3$$5);
+	ZVAL_UNDEF(&_4$$6);
+	ZVAL_UNDEF(&_9$$10);
+	ZVAL_UNDEF(&_10$$11);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -166,63 +166,68 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, validate)
 	zephir_array_fetch_string(&_1, &value, SL("tmp_name"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 94);
 	ZEPHIR_CALL_FUNCTION(&tmp, "getimagesize", NULL, 0, &_1);
 	zephir_check_call_status();
+	if (ZEPHIR_IS_FALSE_IDENTICAL(&tmp)) {
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "appendmessagevalid", NULL, 0, validation, field);
+		zephir_check_call_status();
+		RETURN_MM_BOOL(0);
+	}
 	zephir_memory_observe(&width);
-	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 95);
+	zephir_array_fetch_long(&width, &tmp, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 103);
 	zephir_memory_observe(&height);
-	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 96);
+	zephir_array_fetch_long(&height, &tmp, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 104);
 	ZEPHIR_INIT_VAR(&_2);
 	ZVAL_STRING(&_2, "resolution");
 	ZEPHIR_CALL_METHOD(&resolution, this_ptr, "getoption", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_3$$4, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 101);
-		ZEPHIR_CPY_WRT(&resolution, &_3$$4);
+		zephir_array_fetch(&_3$$5, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 109);
+		ZEPHIR_CPY_WRT(&resolution, &_3$$5);
 	}
 	ZEPHIR_INIT_VAR(&resolutionArray);
 	zephir_fast_explode_str(&resolutionArray, SL("x"), &resolution, LONG_MAX);
 	zephir_memory_observe(&minWidth);
-	zephir_array_fetch_long(&minWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 105);
+	zephir_array_fetch_long(&minWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 113);
 	zephir_memory_observe(&minHeight);
-	zephir_array_fetch_long(&minHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 106);
+	zephir_array_fetch_long(&minHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 114);
 	ZEPHIR_INIT_NVAR(&_2);
 	ZVAL_STRING(&_2, "included");
 	ZEPHIR_CALL_METHOD(&included, this_ptr, "getoption", NULL, 0, &_2);
 	zephir_check_call_status();
 	if (Z_TYPE_P(&included) == IS_ARRAY) {
-		zephir_memory_observe(&_4$$5);
-		zephir_array_fetch(&_4$$5, &included, field, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 111);
-		_5$$5 = zephir_get_boolval(&_4$$5);
+		zephir_memory_observe(&_4$$6);
+		zephir_array_fetch(&_4$$6, &included, field, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 119);
+		_5$$6 = zephir_get_boolval(&_4$$6);
 		ZEPHIR_INIT_NVAR(&included);
-		ZVAL_BOOL(&included, _5$$5);
+		ZVAL_BOOL(&included, _5$$6);
 	} else {
-		_6$$6 = zephir_get_boolval(&included);
+		_6$$7 = zephir_get_boolval(&included);
 		ZEPHIR_INIT_NVAR(&included);
-		ZVAL_BOOL(&included, _6$$6);
+		ZVAL_BOOL(&included, _6$$7);
 	}
 	if (zephir_is_true(&included)) {
-		_7$$7 = ZEPHIR_LE(&width, &minWidth);
-		if (!(_7$$7)) {
-			_7$$7 = ZEPHIR_LE(&height, &minHeight);
+		_7$$8 = ZEPHIR_LE(&width, &minWidth);
+		if (!(_7$$8)) {
+			_7$$8 = ZEPHIR_LE(&height, &minHeight);
 		}
-		result = _7$$7;
+		result = _7$$8;
 	} else {
-		_8$$8 = ZEPHIR_LT(&width, &minWidth);
-		if (!(_8$$8)) {
-			_8$$8 = ZEPHIR_LT(&height, &minHeight);
+		_8$$9 = ZEPHIR_LT(&width, &minWidth);
+		if (!(_8$$9)) {
+			_8$$9 = ZEPHIR_LT(&height, &minHeight);
 		}
-		result = _8$$8;
+		result = _8$$9;
 	}
 	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_9$$9, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 123);
-		ZEPHIR_CPY_WRT(&resolution, &_9$$9);
+		zephir_array_fetch(&_9$$10, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 131);
+		ZEPHIR_CPY_WRT(&resolution, &_9$$10);
 	}
 	if (result) {
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":resolution"), &resolution, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_10$$10, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_10$$11, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_10$$10);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_10$$11);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/phalcon/Filter/Filter.zep
+++ b/phalcon/Filter/Filter.zep
@@ -50,7 +50,7 @@ use Phalcon\Filter\Sanitize\Url;
  * @method string       lowerfirst(string $input)
  * @method mixed        regex(mixed $input, mixed $pattern, mixed $replace)
  * @method mixed        remove(mixed $input, mixed $replace)
- * @method mixed        replace(mixed $input, mixed $source, mixed $target)
+ * @method mixed        replace(mixed $input, mixed $from, mixed $to)
  * @method string       special(string $input)
  * @method string       specialfull(string $input)
  * @method string       string(string $input)

--- a/phalcon/Filter/Sanitize/Ip.zep
+++ b/phalcon/Filter/Sanitize/Ip.zep
@@ -32,7 +32,7 @@ class Ip implements Sanitizer
 
         // CIDR notation (e.g., 192.168.1.0/24)
         if memstr(ipInput, "/") {
-            let parts       = explode("/", input, 2),
+            let parts       = explode("/", ipInput, 2),
                 ip          = parts[0],
                 mask        = parts[1];
 

--- a/phalcon/Filter/Validation/Validator/File.zep
+++ b/phalcon/Filter/Validation/Validator/File.zep
@@ -169,6 +169,7 @@ class File extends AbstractValidatorComposite
                     ]
                 );
 
+                unset options["minSize"];
                 unset options["messageMinSize"];
                 unset options["includedMinSize"];
             }

--- a/phalcon/Filter/Validation/Validator/File/AbstractFile.zep
+++ b/phalcon/Filter/Validation/Validator/File/AbstractFile.zep
@@ -379,6 +379,36 @@ abstract class AbstractFile extends AbstractValidator
     }
 
     /**
+     * Appends the "file is not valid" message for the field
+     *
+     * @param Validation $validation
+     * @param string     $field
+     *
+     * @return void
+     * @throws Validation\Exception
+     */
+    protected function appendMessageValid(
+        <Validation> validation,
+        string field
+    ) -> void {
+        var label, replacePairs;
+
+        let label        = this->prepareLabel(validation, field);
+        let replacePairs = [
+            ":field" : label
+        ];
+
+        validation->appendMessage(
+            new Message(
+                strtr(this->getMessageValid(), replacePairs),
+                field,
+                get_class(this),
+                this->prepareCode(field)
+            )
+        );
+    }
+
+    /**
      * Checks if a file has been uploaded; Internal check that can be
      * overridden in a subclass if you do not want to check uploaded files
      *

--- a/phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/AspectRatio.zep
@@ -87,9 +87,17 @@ class AspectRatio extends AbstractFile
             return false;
         }
 
-        let value  = validation->getValue(field),
-            tmp    = getimagesize(value["tmp_name"]),
-            width  = tmp[0],
+        let value = validation->getValue(field),
+            tmp   = getimagesize(value["tmp_name"]);
+
+        // The file cannot be read as an image
+        if (false === tmp) {
+            this->appendMessageValid(validation, field);
+
+            return false;
+        }
+
+        let width  = tmp[0],
             height = tmp[1];
 
         let ratio = this->getOption("ratio");

--- a/phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep
@@ -84,9 +84,17 @@ class Equal extends AbstractFile
             return false;
         }
 
-        let value  = validation->getValue(field),
-            tmp    = getimagesize(value["tmp_name"]),
-            width  = tmp[0],
+        let value = validation->getValue(field),
+            tmp   = getimagesize(value["tmp_name"]);
+
+        // The file cannot be read as an image
+        if (false === tmp) {
+            this->appendMessageValid(validation, field);
+
+            return false;
+        }
+
+        let width  = tmp[0],
             height = tmp[1];
 
         let resolution = this->getOption("resolution");
@@ -99,11 +107,7 @@ class Equal extends AbstractFile
             equalWidth = resolutionArray[0],
             equalHeight = resolutionArray[1];
 
-        if typeof resolution == "array" {
-            let resolution = resolution[field];
-        }
-
-        if width != equalWidth || height != equalHeight {
+       if width != equalWidth || height != equalHeight {
             let replacePairs = [
                 ":resolution" : resolution
             ];

--- a/phalcon/Filter/Validation/Validator/File/Resolution/Max.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/Max.zep
@@ -90,9 +90,17 @@ class Max extends AbstractFile
             return false;
         }
 
-        let value  = validation->getValue(field),
-            tmp    = getimagesize(value["tmp_name"]),
-            width  = tmp[0],
+        let value = validation->getValue(field),
+            tmp   = getimagesize(value["tmp_name"]);
+
+        // The file cannot be read as an image
+        if (false === tmp) {
+            this->appendMessageValid(validation, field);
+
+            return false;
+        }
+
+        let width  = tmp[0],
             height = tmp[1];
 
         let resolution = this->getOption("resolution");
@@ -117,10 +125,6 @@ class Max extends AbstractFile
             let result = width >= maxWidth || height >= maxHeight;
         } else {
             let result = width > maxWidth || height > maxHeight;
-        }
-
-        if typeof resolution == "array" {
-            let resolution = resolution[field];
         }
 
         if result {

--- a/phalcon/Filter/Validation/Validator/File/Resolution/Min.zep
+++ b/phalcon/Filter/Validation/Validator/File/Resolution/Min.zep
@@ -90,9 +90,17 @@ class Min extends AbstractFile
             return false;
         }
 
-        let value  = validation->getValue(field),
-            tmp    = getimagesize(value["tmp_name"]),
-            width  = tmp[0],
+        let value = validation->getValue(field),
+            tmp   = getimagesize(value["tmp_name"]);
+
+        // The file cannot be read as an image
+        if (false === tmp) {
+            this->appendMessageValid(validation, field);
+
+            return false;
+        }
+
+        let width  = tmp[0],
             height = tmp[1];
 
         let resolution = this->getOption("resolution");
@@ -117,10 +125,6 @@ class Min extends AbstractFile
             let result = width <= minWidth || height <= minHeight;
         } else {
             let result = width < minWidth || height < minHeight;
-        }
-
-        if typeof resolution == "array" {
-            let resolution = resolution[field];
         }
 
         if result {

--- a/tests/unit/Filter/Validation/Validator/File/Resolution/ValidateTest.php
+++ b/tests/unit/Filter/Validation/Validator/File/Resolution/ValidateTest.php
@@ -23,6 +23,7 @@ use Phalcon\Tests\Unit\Filter\Validation\Validator\File\Resolution\Fake\FakeMin;
 use PHPUnit\Framework\Attributes\BackupGlobals;
 use PHPUnit\Framework\Attributes\DataProvider;
 
+use function basename;
 use function filesize;
 
 #[BackupGlobals(true)]
@@ -90,6 +91,19 @@ final class ValidateTest extends AbstractUnitTestCase
     }
 
     /**
+     * @return array<array{string, array}>
+     */
+    public static function getExamplesNotAnImage(): array
+    {
+        return [
+            [FakeEqual::class, ['resolution' => '82x82']],
+            [FakeMax::class, ['resolution' => '100x100']],
+            [FakeMin::class, ['resolution' => '50x50']],
+            [FakeAspectRatio::class, ['ratio' => '1x1']],
+        ];
+    }
+
+    /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2026-06-06
      */
@@ -134,15 +148,47 @@ final class ValidateTest extends AbstractUnitTestCase
     }
 
     /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-31
+     */
+    #[DataProvider('getExamplesNotAnImage')]
+    public function testFilterValidationValidatorFileResolutionNotAnImage(
+        string $class,
+        array $options
+    ): void {
+        $_SERVER = ['REQUEST_METHOD' => 'POST'];
+        $_FILES  = [
+            'thumbnail' => $this->buildFile(
+                'assets/stream/mit.txt',
+                'text/plain'
+            ),
+        ];
+
+        $validator  = new $class($options);
+        $validation = new Validation();
+        $validation->add('thumbnail', $validator);
+
+        $messages = $validation->validate($_FILES);
+
+        $this->assertCount(1, $messages);
+        $this->assertSame(
+            'Field thumbnail is not valid',
+            $messages[0]->getMessage()
+        );
+    }
+
+    /**
      * @return array<string, mixed>
      */
-    private function buildFile(): array
-    {
-        $path = Talon::settings()->supportPath('assets/images/example-png.png');
+    private function buildFile(
+        string $relative = 'assets/images/example-png.png',
+        string $type = 'image/png'
+    ): array {
+        $path = Talon::settings()->supportPath($relative);
 
         return [
-            'name'     => 'example-png.png',
-            'type'     => 'image/png',
+            'name'     => basename($path),
+            'type'     => $type,
             'tmp_name' => $path,
             'error'    => 0,
             'size'     => filesize($path),


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #17542 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

`Phalcon\Filter\Validation\Validator\File\Resolution\Equal`, `Max`, `Min` and `AspectRatio` not checking the `false` returned by `getimagesize()`; a file that is not a readable image is now rejected. 


Thanks

