### PR TITLE
CP-17541 checkupload

### DIFF
--- a/CHANGELOG-5.0.md
+++ b/CHANGELOG-5.0.md
@@ -14,6 +14,7 @@ All notable changes are documented here. The format is based on [Keep a Changelo
 
 ### Fixed
 
+- `Phalcon\Filter\Validation\Validator\File\AbstractFile::checkUpload()` reporting success when the field value is not an uploaded file array; a missing file or a plain string now fails validation. [#17541](https://github.com/phalcon/cphalcon/issues/17541) [[doc]](https://docs.phalcon.io/5.20/filter-validation/)
 - `Phalcon\Filter\Validation\Validator\File\Resolution\Equal`, `Max`, `Min` and `AspectRatio` not checking the `false` returned by `getimagesize()`; a file that is not a readable image is now rejected. [#17542](https://github.com/phalcon/cphalcon/issues/17542) [[doc]](https://docs.phalcon.io/5.20/filter-validation/)
 - `Phalcon\Forms\Element\CheckGroup` and `RadioGroup` storing their choices in the property `Phalcon\Forms\Element\AbstractElement` uses for user options, so `setUserOption()` added a choice and `setOptions()` removed every user option. [#17536](https://github.com/phalcon/cphalcon/issues/17536) [[doc]](https://docs.phalcon.io/5.20/forms/)
 - `Phalcon\Forms\Element\Select::addOption()` writing with an offset into an object or `null` options value; the write now happens only when the options value is an array (`null` becomes an empty array). [#17536](https://github.com/phalcon/cphalcon/issues/17536) [[doc]](https://docs.phalcon.io/5.20/forms/)

--- a/ext/phalcon/filter/validation/validator/file/abstractfile.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/abstractfile.zep.c
@@ -184,27 +184,27 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkUploadIsE
 	ZVAL_STR_COPY(&field_zv, field);
 	ZEPHIR_CALL_METHOD(&value, validation, "getvalue", NULL, 0, &field_zv);
 	zephir_check_call_status();
-	_0 = Z_TYPE_P(&value) == IS_ARRAY;
-	if (_0) {
-		_1 = 1 != zephir_array_isset_value_string(&value, SL("error"));
-		if (!(_1)) {
-			_1 = 1 != zephir_array_isset_value_string(&value, SL("tmp_name"));
-		}
-		_2 = _1;
-		if (!(_2)) {
-			zephir_array_fetch_string(&_3, &value, SL("error"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 117);
-			_2 = !ZEPHIR_IS_LONG_IDENTICAL(&_3, 0);
-		}
-		_4 = _2;
-		if (!(_4)) {
-			zephir_array_fetch_string(&_6, &value, SL("tmp_name"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 118);
-			ZEPHIR_CALL_METHOD(&_5, this_ptr, "checkisuploadedfile", NULL, 0, &_6);
-			zephir_check_call_status();
-			_4 = !ZEPHIR_IS_TRUE_IDENTICAL(&_5);
-		}
-		_0 = _4;
+	_0 = 1 != Z_TYPE_P(&value) == IS_ARRAY;
+	if (!(_0)) {
+		_0 = 1 != zephir_array_isset_value_string(&value, SL("error"));
 	}
-	if (_0) {
+	_1 = _0;
+	if (!(_1)) {
+		_1 = 1 != zephir_array_isset_value_string(&value, SL("tmp_name"));
+	}
+	_2 = _1;
+	if (!(_2)) {
+		zephir_array_fetch_string(&_3, &value, SL("error"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 116);
+		_2 = !ZEPHIR_IS_LONG_IDENTICAL(&_3, 0);
+	}
+	_4 = _2;
+	if (!(_4)) {
+		zephir_array_fetch_string(&_6, &value, SL("tmp_name"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 117);
+		ZEPHIR_CALL_METHOD(&_5, this_ptr, "checkisuploadedfile", NULL, 0, &_6);
+		zephir_check_call_status();
+		_4 = !ZEPHIR_IS_TRUE_IDENTICAL(&_5);
+	}
+	if (_4) {
 		ZEPHIR_CALL_METHOD(&label, this_ptr, "preparelabel", NULL, 0, validation, &field_zv);
 		zephir_check_call_status();
 		ZEPHIR_INIT_VAR(&replacePairs);
@@ -244,19 +244,12 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkUploadIsV
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
 	zend_string *field = NULL;
-	zval *validation, validation_sub, field_zv, label, replacePairs, value, _3$$3, _4$$3, _5$$3, _6$$3, _7$$3;
+	zval *validation, validation_sub, field_zv, value;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
 	ZVAL_UNDEF(&field_zv);
-	ZVAL_UNDEF(&label);
-	ZVAL_UNDEF(&replacePairs);
 	ZVAL_UNDEF(&value);
-	ZVAL_UNDEF(&_3$$3);
-	ZVAL_UNDEF(&_4$$3);
-	ZVAL_UNDEF(&_5$$3);
-	ZVAL_UNDEF(&_6$$3);
-	ZVAL_UNDEF(&_7$$3);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_STR(field)
@@ -268,37 +261,20 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkUploadIsV
 	ZVAL_STR_COPY(&field_zv, field);
 	ZEPHIR_CALL_METHOD(&value, validation, "getvalue", NULL, 0, &field_zv);
 	zephir_check_call_status();
-	_0 = Z_TYPE_P(&value) == IS_ARRAY;
-	if (_0) {
-		_1 = 1 != zephir_array_isset_value_string(&value, SL("name"));
-		if (!(_1)) {
-			_1 = 1 != zephir_array_isset_value_string(&value, SL("type"));
-		}
-		_2 = _1;
-		if (!(_2)) {
-			_2 = 1 != zephir_array_isset_value_string(&value, SL("size"));
-		}
-		_0 = _2;
+	_0 = 1 != Z_TYPE_P(&value) == IS_ARRAY;
+	if (!(_0)) {
+		_0 = 1 != zephir_array_isset_value_string(&value, SL("name"));
 	}
-	if (_0) {
-		ZEPHIR_CALL_METHOD(&label, this_ptr, "preparelabel", NULL, 0, validation, &field_zv);
-		zephir_check_call_status();
-		ZEPHIR_INIT_VAR(&replacePairs);
-		zephir_create_array(&replacePairs, 1, 0);
-		zephir_array_update_string(&replacePairs, SL(":field"), &label, PH_COPY | PH_SEPARATE);
-		ZEPHIR_INIT_VAR(&_3$$3);
-		object_init_ex(&_3$$3, phalcon_messages_message_ce);
-		ZEPHIR_CALL_METHOD(&_4$$3, this_ptr, "getmessagevalid", NULL, 0);
-		zephir_check_call_status();
-		ZEPHIR_CALL_FUNCTION(&_5$$3, "strtr", NULL, 4, &_4$$3, &replacePairs);
-		zephir_check_call_status();
-		ZEPHIR_INIT_VAR(&_6$$3);
-		zephir_get_class(&_6$$3, this_ptr, 0);
-		ZEPHIR_CALL_METHOD(&_7$$3, this_ptr, "preparecode", NULL, 0, &field_zv);
-		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, &_3$$3, "__construct", NULL, 5, &_5$$3, &field_zv, &_6$$3, &_7$$3);
-		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_3$$3);
+	_1 = _0;
+	if (!(_1)) {
+		_1 = 1 != zephir_array_isset_value_string(&value, SL("type"));
+	}
+	_2 = _1;
+	if (!(_2)) {
+		_2 = 1 != zephir_array_isset_value_string(&value, SL("size"));
+	}
+	if (_2) {
+		ZEPHIR_CALL_METHOD(NULL, this_ptr, "appendmessagevalid", NULL, 0, validation, &field_zv);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}
@@ -378,11 +354,11 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkUploadMax
 	}
 	if (zephir_array_isset_value_string(&server, SL("REQUEST_METHOD"))) {
 		ZEPHIR_OBS_NVAR(&method);
-		zephir_array_fetch_string(&method, &server, SL("REQUEST_METHOD"), PH_NOISY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 218);
+		zephir_array_fetch_string(&method, &server, SL("REQUEST_METHOD"), PH_NOISY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 202);
 	}
 	if (zephir_array_isset_value_string(&server, SL("CONTENT_LENGTH"))) {
 		ZEPHIR_OBS_NVAR(&length);
-		zephir_array_fetch_string(&length, &server, SL("CONTENT_LENGTH"), PH_NOISY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 221);
+		zephir_array_fetch_string(&length, &server, SL("CONTENT_LENGTH"), PH_NOISY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 205);
 	}
 	ZEPHIR_INIT_VAR(&_0);
 	ZVAL_STRING(&_0, "POST");
@@ -406,7 +382,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, checkUploadMax
 		}
 		_6 = _5;
 		if (_6) {
-			zephir_array_fetch_string(&_7, &value, SL("error"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 232);
+			zephir_array_fetch_string(&_7, &value, SL("error"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 216);
 			_6 = ZEPHIR_IS_LONG_IDENTICAL(&_7, 1);
 		}
 		_4 = _6;
@@ -495,12 +471,12 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, getFileSizeInB
 	zephir_preg_match(&_3, &_2, &size_zv, &matches, 0, 0 , 0 );
 	if (1 == zephir_array_isset_value_long(&matches, 2)) {
 		ZEPHIR_OBS_NVAR(&unit);
-		zephir_array_fetch_long(&unit, &matches, 2, PH_NOISY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 288);
+		zephir_array_fetch_long(&unit, &matches, 2, PH_NOISY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 272);
 	}
-	zephir_array_fetch_long(&_4, &matches, 1, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 291);
+	zephir_array_fetch_long(&_4, &matches, 1, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 275);
 	ZEPHIR_CALL_FUNCTION(&_5, "floatval", NULL, 33, &_4);
 	zephir_check_call_status();
-	zephir_array_fetch(&_6, &byteUnits, &unit, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 291);
+	zephir_array_fetch(&_6, &byteUnits, &unit, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 275);
 	ZVAL_LONG(&_7, 2);
 	ZEPHIR_CALL_FUNCTION(&_8, "pow", NULL, 34, &_7, &_6);
 	zephir_check_call_status();
@@ -581,7 +557,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_AbstractFile, isAllowEmpty)
 		}
 		_2 = _1;
 		if (_2) {
-			zephir_array_fetch_string(&_3, &value, SL("error"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 342);
+			zephir_array_fetch_string(&_3, &value, SL("error"), PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/AbstractFile.zep", 326);
 			_2 = ZEPHIR_IS_LONG_IDENTICAL(&_3, 4);
 		}
 		_0 = _2;

--- a/ext/phalcon/filter/validation/validator/file/resolution/equal.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/equal.zep.c
@@ -115,10 +115,10 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, __construc
  */
 PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 {
-	zend_bool _5;
+	zend_bool _4;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, height, equalHeight, equalWidth, resolution, resolutionArray, tmp, value, width, replacePairs, _0, _1, _2, _3$$5, _4$$6, _6$$7;
+	zval *validation, validation_sub, *field, field_sub, height, equalHeight, equalWidth, resolution, resolutionArray, tmp, value, width, replacePairs, _0, _1, _2, _3$$5, _5$$6;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -136,8 +136,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 	ZVAL_UNDEF(&_1);
 	ZVAL_UNDEF(&_2);
 	ZVAL_UNDEF(&_3$$5);
-	ZVAL_UNDEF(&_4$$6);
-	ZVAL_UNDEF(&_6$$7);
+	ZVAL_UNDEF(&_5$$6);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -178,21 +177,17 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Equal, validate)
 	zephir_array_fetch_long(&equalWidth, &resolutionArray, 0, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 107);
 	zephir_memory_observe(&equalHeight);
 	zephir_array_fetch_long(&equalHeight, &resolutionArray, 1, PH_NOISY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 108);
-	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_4$$6, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Equal.zep", 111);
-		ZEPHIR_CPY_WRT(&resolution, &_4$$6);
+	_4 = !ZEPHIR_IS_EQUAL(&width, &equalWidth);
+	if (!(_4)) {
+		_4 = !ZEPHIR_IS_EQUAL(&height, &equalHeight);
 	}
-	_5 = !ZEPHIR_IS_EQUAL(&width, &equalWidth);
-	if (!(_5)) {
-		_5 = !ZEPHIR_IS_EQUAL(&height, &equalHeight);
-	}
-	if (_5) {
+	if (_4) {
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":resolution"), &resolution, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_6$$7, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_5$$6, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_6$$7);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_5$$6);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/ext/phalcon/filter/validation/validator/file/resolution/max.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/max.zep.c
@@ -125,7 +125,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, validate)
 	zend_bool result = 0, _7$$8, _8$$9;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, height, maxHeight, maxWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$5, _4$$6, _9$$10, _10$$11;
+	zval *validation, validation_sub, *field, field_sub, height, maxHeight, maxWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$5, _4$$6, _9$$10;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -146,7 +146,6 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, validate)
 	ZVAL_UNDEF(&_3$$5);
 	ZVAL_UNDEF(&_4$$6);
 	ZVAL_UNDEF(&_9$$10);
-	ZVAL_UNDEF(&_10$$11);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -217,17 +216,13 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Max, validate)
 		}
 		result = _8$$9;
 	}
-	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_9$$10, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Max.zep", 131);
-		ZEPHIR_CPY_WRT(&resolution, &_9$$10);
-	}
 	if (result) {
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":resolution"), &resolution, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_10$$11, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_9$$10, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_10$$11);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_9$$10);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/ext/phalcon/filter/validation/validator/file/resolution/min.zep.c
+++ b/ext/phalcon/filter/validation/validator/file/resolution/min.zep.c
@@ -125,7 +125,7 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, validate)
 	zend_bool result = 0, _7$$8, _8$$9;
 	zephir_method_globals *ZEPHIR_METHOD_GLOBALS_PTR = NULL;
 	zend_long ZEPHIR_LAST_CALL_STATUS;
-	zval *validation, validation_sub, *field, field_sub, height, minHeight, minWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$5, _4$$6, _9$$10, _10$$11;
+	zval *validation, validation_sub, *field, field_sub, height, minHeight, minWidth, resolution, resolutionArray, tmp, value, width, replacePairs, included, _0, _1, _2, _3$$5, _4$$6, _9$$10;
 	zval *this_ptr = getThis();
 
 	ZVAL_UNDEF(&validation_sub);
@@ -146,7 +146,6 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, validate)
 	ZVAL_UNDEF(&_3$$5);
 	ZVAL_UNDEF(&_4$$6);
 	ZVAL_UNDEF(&_9$$10);
-	ZVAL_UNDEF(&_10$$11);
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_OBJECT_OF_CLASS(validation, phalcon_filter_validation_ce)
 		Z_PARAM_ZVAL(field)
@@ -217,17 +216,13 @@ PHP_METHOD(Phalcon_Filter_Validation_Validator_File_Resolution_Min, validate)
 		}
 		result = _8$$9;
 	}
-	if (Z_TYPE_P(&resolution) == IS_ARRAY) {
-		zephir_array_fetch(&_9$$10, &resolution, field, PH_NOISY | PH_READONLY, "phalcon/Filter/Validation/Validator/File/Resolution/Min.zep", 131);
-		ZEPHIR_CPY_WRT(&resolution, &_9$$10);
-	}
 	if (result) {
 		ZEPHIR_INIT_VAR(&replacePairs);
 		zephir_create_array(&replacePairs, 1, 0);
 		zephir_array_update_string(&replacePairs, SL(":resolution"), &resolution, PH_COPY | PH_SEPARATE);
-		ZEPHIR_CALL_METHOD(&_10$$11, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
+		ZEPHIR_CALL_METHOD(&_9$$10, this_ptr, "messagefactory", NULL, 0, validation, field, &replacePairs);
 		zephir_check_call_status();
-		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_10$$11);
+		ZEPHIR_CALL_METHOD(NULL, validation, "appendmessage", NULL, 0, &_9$$10);
 		zephir_check_call_status();
 		RETURN_MM_BOOL(0);
 	}

--- a/phalcon/Filter/Validation/Validator/File/AbstractFile.zep
+++ b/phalcon/Filter/Validation/Validator/File/AbstractFile.zep
@@ -110,13 +110,11 @@ abstract class AbstractFile extends AbstractValidator
         let value = validation->getValue(field);
 
         if (
-            is_array(value) &&
-            (
-                true !== isset(value["error"]) ||
-                true !== isset(value["tmp_name"]) ||
-                value["error"] !== UPLOAD_ERR_OK ||
-                true !== this->checkIsUploadedFile(value["tmp_name"])
-            )
+            true !== is_array(value) ||
+            true !== isset(value["error"]) ||
+            true !== isset(value["tmp_name"]) ||
+            value["error"] !== UPLOAD_ERR_OK ||
+            true !== this->checkIsUploadedFile(value["tmp_name"])
         ) {
             let label        = this->prepareLabel(validation, field);
             let replacePairs = [
@@ -151,31 +149,17 @@ abstract class AbstractFile extends AbstractValidator
         <Validation> validation,
         string field
     ) -> bool {
-        var label, replacePairs, value;
+        var value;
 
         let value = validation->getValue(field);
 
         if (
-            is_array(value) &&
-            (
-                true !== isset(value["name"]) ||
-                true !== isset(value["type"]) ||
-                true !== isset(value["size"])
-            )
+            true !== is_array(value) ||
+            true !== isset(value["name"]) ||
+            true !== isset(value["type"]) ||
+            true !== isset(value["size"])
         ) {
-            let label        = this->prepareLabel(validation, field);
-            let replacePairs = [
-                ":field" : label
-            ];
-
-            validation->appendMessage(
-                new Message(
-                    strtr(this->getMessageValid(), replacePairs),
-                    field,
-                    get_class(this),
-                    this->prepareCode(field)
-                )
-            );
+            this->appendMessageValid(validation, field);
 
             return false;
         }

--- a/tests/unit/Filter/Validation/Validator/File/CheckUploadTest.php
+++ b/tests/unit/Filter/Validation/Validator/File/CheckUploadTest.php
@@ -18,6 +18,7 @@ use Phalcon\Filter\Validation\Validator\File\Size\Equal;
 use Phalcon\Talon\PHPUnit\AbstractUnitTestCase;
 use Phalcon\Tests\Unit\Filter\Validation\Validator\File\Fake\FakeMimeType;
 use PHPUnit\Framework\Attributes\BackupGlobals;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 use const UPLOAD_ERR_INI_SIZE;
 use const UPLOAD_ERR_PARTIAL;
@@ -25,6 +26,43 @@ use const UPLOAD_ERR_PARTIAL;
 #[BackupGlobals(true)]
 final class CheckUploadTest extends AbstractUnitTestCase
 {
+    /**
+     * @return array<array{mixed}>
+     */
+    public static function getExamplesNotAnUploadArray(): array
+    {
+        return [
+            // Field populated from $_POST instead of $_FILES
+            ['not-a-file'],
+            // Field not present in the request
+            [null],
+            [1234],
+        ];
+    }
+
+    /**
+     * @author Phalcon Team <team@phalcon.io>
+     * @since  2026-08-31
+     */
+    #[DataProvider('getExamplesNotAnUploadArray')]
+    public function testFilterValidationValidatorFileCheckUploadIsEmptyNotAnArray(
+        mixed $value
+    ): void {
+        $_SERVER['REQUEST_METHOD'] = 'POST';
+
+        $validator  = new FakeMimeType(['types' => ['image/jpeg']]);
+        $validation = new Validation();
+        $validation->add('file', $validator);
+
+        $messages = $validation->validate(['file' => $value]);
+
+        $this->assertCount(1, $messages, 'A non array value is not a file');
+        $this->assertSame(
+            'Field file must not be empty',
+            $messages[0]->getMessage()
+        );
+    }
+
     /**
      * @author Phalcon Team <team@phalcon.io>
      * @since  2018-11-13


### PR DESCRIPTION
Hello!

* Type: bug fix
* Link to issue: #17541 

**In raising this pull request, I confirm the following:**

- [x] I have read and understood the [Contributing Guidelines](https://github.com/phalcon/cphalcon/blob/master/CONTRIBUTING.md)
- [x] I have checked that another pull request for this purpose does not exist
- [x] I wrote some tests for this PR
- [x] I have updated the relevant CHANGELOG
- [ ] I have created a PR for the [documentation](https://github.com/phalcon/docs) about this change

`Phalcon\Filter\Validation\Validator\File\AbstractFile::checkUpload()` reporting success when the field value is not an uploaded file array; a missing file or a plain string now fails validation.

Thanks

